### PR TITLE
fix(webui): navbar dropdowns rendered as empty white boxes

### DIFF
--- a/src/swarm/static/css/dropdown.css
+++ b/src/swarm/static/css/dropdown.css
@@ -1,5 +1,8 @@
-/* Dropdown Styling */
-.dropdown {
+/* Blueprint selector dropdown styling.
+   Scoped to .blueprint-select so it does not restyle Bootstrap navbar
+   dropdowns (li.nav-item.dropdown), which previously rendered as empty
+   white boxes with invisible white-on-white labels. */
+.blueprint-select.dropdown {
     width: 100%;
     background: #fff;
     border: 1px solid #ccc;
@@ -7,16 +10,16 @@
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.dropdown-item {
+.blueprint-select .dropdown-item {
     padding: 0.5rem 1rem;
     cursor: pointer;
 }
 
-.dropdown-item:hover {
+.blueprint-select .dropdown-item:hover {
     background: #f0f0f0;
 }
 
-.dropdown-description {
+.blueprint-select .dropdown-description {
     font-size: 0.8rem;
     color: #666;
 }

--- a/src/swarm/templates/base.html
+++ b/src/swarm/templates/base.html
@@ -41,7 +41,7 @@
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle" href="#" id="blueprintDropdown" role="button" data-bs-toggle="dropdown">
+                            <a class="nav-link dropdown-toggle" href="#" id="blueprintNavDropdown" role="button" data-bs-toggle="dropdown">
                                 📚 Blueprints
                             </a>
                             <ul class="dropdown-menu">
@@ -66,7 +66,7 @@
         </nav>
     </header>
     <main>
-        <div class="dropdown" hx-get="/v1/models" hx-trigger="click" hx-target="#blueprintDropdown" hx-swap="innerHTML">
+        <div class="dropdown blueprint-select" hx-get="/v1/models" hx-trigger="click" hx-target="#blueprintDropdown" hx-swap="innerHTML">
             <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton">
                 Select a Blueprint
             </button>


### PR DESCRIPTION
## Problem

On the Django template pages (e.g. `/teams/`), the navbar showed two empty white rounded boxes between "Team Launcher" and "Settings" — only a 🛠️ and a 📚 emoji visible, no labels.

## Root cause

`src/swarm/static/css/dropdown.css` declares a **global** `.dropdown` rule (`background: #fff; border; border-radius; width: 100%`) intended for the "Select a Blueprint" htmx selector in `base.html`'s `<main>`. It also matched Bootstrap's `li.nav-item.dropdown` elements in the `navbar-dark` navbar, where `.nav-link` text is `rgba(255,255,255,.55)` — white-ish text on a forced white background. The "Creators" and "Blueprints" labels were present in the DOM but invisible; only the emoji glyphs (which render in their own colors) showed. The `width: 100%` also squeezed the other nav items into wrapping.

## Fix

- Scope the `dropdown.css` rules under a new `.blueprint-select` class and add that class to the blueprint selector `div` it was written for, so the navbar is untouched.
- While touching that pair: rename the navbar Blueprints toggle id `blueprintDropdown` → `blueprintNavDropdown`. It duplicated the blueprint selector menu's id, so the selector's `hx-target="#blueprintDropdown"` resolved to the navbar anchor (first match in document order) and would have swapped `/v1/models` content into the navbar link. `static/js/dropdown.js` keys on the selector menu keeping the `blueprintDropdown` id, which it still does.

No destinations were invented — both dropdowns already had valid labels and menu links; they were just invisible.

## Verification

- Headless Chromium (Playwright) screenshots of `/teams/` and `/blueprint-library/`: both "🛠️ Creators" and "📚 Blueprints" now render as normal dark-navbar dropdown items; computed style on the `li`s went from `background rgb(255,255,255), 1px border` to `transparent, 0px`; `document.querySelectorAll('#blueprintDropdown').length` is now 1.
- `uv run pytest tests/views -q` — 144 passed.
- Diff touches only `src/swarm/templates/base.html` and `src/swarm/static/css/dropdown.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)