### PR TITLE
feat(ux): styled login page, dark-mode swap toggle, bordered blueprint cards

### DIFF
--- a/src/swarm/templates/account/login.html
+++ b/src/swarm/templates/account/login.html
@@ -2,21 +2,141 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Login</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Login &middot; Open Swarm</title>
+    <style>
+        :root {
+            --bg: #f3f4f6;
+            --card-bg: #ffffff;
+            --border: #e5e7eb;
+            --text: #111827;
+            --text-muted: #6b7280;
+            --primary: #4f46e5;
+            --primary-hover: #4338ca;
+            --error-bg: #fef2f2;
+            --error-border: #fecaca;
+            --error-text: #b91c1c;
+        }
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: var(--bg);
+            background-image: radial-gradient(circle at 1px 1px, #d1d5db 1px, transparent 0);
+            background-size: 24px 24px;
+            color: var(--text);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                "Helvetica Neue", Arial, sans-serif;
+        }
+        .login-card {
+            width: 100%;
+            max-width: 24rem;
+            margin: 1rem;
+            padding: 2rem 2rem 1.75rem;
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 0.75rem;
+            box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.08),
+                        0 4px 10px -6px rgba(0, 0, 0, 0.05);
+        }
+        .brand {
+            text-align: center;
+            margin-bottom: 1.5rem;
+        }
+        .brand-name {
+            margin: 0;
+            font-size: 1.5rem;
+            font-weight: 700;
+            letter-spacing: -0.025em;
+        }
+        .brand-sub {
+            margin: 0.25rem 0 0;
+            font-size: 0.875rem;
+            color: var(--text-muted);
+        }
+        .error-message {
+            margin: 0 0 1rem;
+            padding: 0.625rem 0.75rem;
+            background: var(--error-bg);
+            border: 1px solid var(--error-border);
+            border-radius: 0.5rem;
+            color: var(--error-text);
+            font-size: 0.875rem;
+        }
+        .field {
+            margin-bottom: 1rem;
+        }
+        label {
+            display: block;
+            margin-bottom: 0.375rem;
+            font-size: 0.875rem;
+            font-weight: 600;
+        }
+        input[type="text"],
+        input[type="password"] {
+            width: 100%;
+            padding: 0.5rem 0.75rem;
+            font-size: 1rem;
+            font-family: inherit;
+            color: var(--text);
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 0.5rem;
+        }
+        input[type="text"]:focus,
+        input[type="password"]:focus {
+            outline: 2px solid var(--primary);
+            outline-offset: 1px;
+            border-color: var(--primary);
+        }
+        button[type="submit"] {
+            width: 100%;
+            margin-top: 0.5rem;
+            padding: 0.625rem 0.75rem;
+            font-size: 1rem;
+            font-family: inherit;
+            font-weight: 600;
+            color: #ffffff;
+            background: var(--primary);
+            border: none;
+            border-radius: 0.5rem;
+            cursor: pointer;
+        }
+        button[type="submit"]:hover {
+            background: var(--primary-hover);
+        }
+        button[type="submit"]:focus-visible {
+            outline: 2px solid var(--primary);
+            outline-offset: 2px;
+        }
+    </style>
 </head>
 <body>
-    <h1>Login</h1>
-    {% if error %}
-        <p style="color: red;">{{ error }}</p>
-    {% endif %}
-    <form method="post" action="{% url 'custom_login' %}?next={{ request.GET.next }}">
-        {% csrf_token %}
-        <label for="username">Username:</label>
-        <input type="text" id="username" name="username" required><br>
-        <label for="password">Password:</label>
-        <input type="password" id="password" name="password" required><br>
-        <button type="submit">Login</button>
-    </form>
-    <p>Hint: Use "testuser" with password "testpass" for testing.</p>
+    <main class="login-card">
+        <div class="brand">
+            <h1 class="brand-name">Open Swarm</h1>
+            <p class="brand-sub">Sign in to continue</p>
+        </div>
+        {% if error %}
+            <p class="error-message" role="alert">{{ error }}</p>
+        {% endif %}
+        <form method="post" action="{% url 'custom_login' %}?next={{ request.GET.next }}">
+            {% csrf_token %}
+            <div class="field">
+                <label for="username">Username</label>
+                <input type="text" id="username" name="username" autocomplete="username" autofocus required>
+            </div>
+            <div class="field">
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password" autocomplete="current-password" required>
+            </div>
+            <button type="submit">Sign in</button>
+        </form>
+    </main>
 </body>
 </html>

--- a/webui/frontend/src/App.tsx
+++ b/webui/frontend/src/App.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Home, Settings, Bot, Book, Users, PlusCircle, MessageSquare, ShieldAlert, Wand2, X } from 'lucide-react'
+import { Home, Settings, Bot, Book, Users, PlusCircle, MessageSquare, ShieldAlert, Wand2, X, Sun, Moon } from 'lucide-react'
 import { Button, Card, Alert, Badge, LoadingSpinner, ToastProvider } from './components/DaisyUI'
 import TeamsPage from './pages/TeamsPage'
 import BlueprintsPage from './pages/BlueprintsPage'
@@ -11,16 +11,24 @@ import AgentCreatorPage from './pages/AgentCreatorPage'
 import { fetchBlueprints, fetchModels } from './lib/api'
 import { AuthProvider, useAuth } from './lib/AuthContext'
 
+const THEME_STORAGE_KEY = 'swarm_theme'
+
 function App() {
-  const [darkMode, setDarkMode] = useState(false)
+  const [darkMode, setDarkMode] = useState(
+    () => localStorage.getItem(THEME_STORAGE_KEY) === 'dark'
+  )
+
+  useEffect(() => {
+    localStorage.setItem(THEME_STORAGE_KEY, darkMode ? 'dark' : 'light')
+  }, [darkMode])
 
   return (
     <Router>
       <AuthProvider>
         <ToastProvider>
-          <div className={`min-h-screen ${darkMode ? 'bg-gray-900 text-white' : 'bg-gray-50 text-gray-900'}`} data-theme={darkMode ? 'dark' : 'light'}>
+          <div className="min-h-screen bg-base-100 text-base-content" data-theme={darkMode ? 'dark' : 'light'}>
             {/* Navbar */}
-            <nav className="bg-base-200 shadow-sm border-b">
+            <nav className="bg-base-200 shadow-sm border-b border-base-300">
               <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="flex justify-between h-16">
                   <div className="flex items-center space-x-6">
@@ -48,12 +56,15 @@ function App() {
                     </div>
                   </div>
                   <div className="flex items-center space-x-4">
-                    <button
-                      onClick={() => setDarkMode(!darkMode)}
-                      className="btn btn-ghost btn-sm"
-                    >
-                      {darkMode ? 'Light Mode' : 'Dark Mode'}
-                    </button>
+                    <label className="btn btn-ghost btn-sm btn-circle swap swap-rotate" aria-label="Toggle dark mode">
+                      <input
+                        type="checkbox"
+                        checked={darkMode}
+                        onChange={() => setDarkMode(!darkMode)}
+                      />
+                      <Sun className="swap-on h-5 w-5" />
+                      <Moon className="swap-off h-5 w-5" />
+                    </label>
                     <Link to="/settings" className="btn btn-ghost btn-sm">
                       <Settings className="h-5 w-5" />
                     </Link>

--- a/webui/frontend/src/pages/BlueprintsPage.tsx
+++ b/webui/frontend/src/pages/BlueprintsPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Button, Card, Alert, Badge, SkeletonCard } from '../components/DaisyUI';
-import { Book, Search, AlertCircle } from 'lucide-react';
+import { Button, Card, Alert, SkeletonCard } from '../components/DaisyUI';
+import { Book, Search, AlertCircle, Server } from 'lucide-react';
 import { fetchBlueprints, type Blueprint } from '../lib/api';
 
 const BlueprintsPage = () => {
@@ -30,7 +30,7 @@ const BlueprintsPage = () => {
           <Book className="h-8 w-8" />
           Blueprint Library
         </h1>
-        <p className="text-gray-500">Blueprints available on this server</p>
+        <p className="text-base-content/70">Blueprints available on this server</p>
       </div>
 
       {/* Search */}
@@ -84,43 +84,55 @@ const BlueprintsPage = () => {
       {!isPending && !isError && filteredBlueprints.length > 0 && (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {filteredBlueprints.map((blueprint) => (
-            <Card key={blueprint.id} bordered className="hover:shadow-lg transition-shadow">
-              <div className="card-body">
-                <div className="flex justify-between items-start mb-2 gap-2">
-                  <h3 className="card-title">{blueprint.name}</h3>
-                  {blueprint.abbreviation && (
-                    <Badge type="info" size="sm">{blueprint.abbreviation}</Badge>
-                  )}
+            <div
+              key={blueprint.id}
+              className="card bg-base-100 border border-base-300 hover:shadow-md transition-shadow h-full"
+            >
+              <div className="card-body flex flex-col">
+                <div className="flex justify-between items-start gap-2">
+                  <h3 className="card-title text-base leading-snug">{blueprint.name}</h3>
+                  <span className="badge badge-neutral badge-sm font-mono shrink-0">
+                    {blueprint.abbreviation || blueprint.id}
+                  </span>
                 </div>
 
-                <p className="text-xs text-gray-400 font-mono mb-2">{blueprint.id}</p>
-                <p className="text-sm text-gray-500 mb-4 whitespace-pre-line">
+                <p className="text-xs text-base-content/50 font-mono">{blueprint.id}</p>
+                <p
+                  className="text-sm text-base-content/70 line-clamp-3"
+                  title={blueprint.description}
+                >
                   {blueprint.description || 'No description provided.'}
                 </p>
 
-                {blueprint.tags.length > 0 && (
-                  <div className="flex flex-wrap gap-1 mb-2">
-                    {blueprint.tags.map((tag) => (
-                      <Badge key={tag} type="neutral" size="sm">{tag}</Badge>
-                    ))}
-                  </div>
-                )}
+                <div className="mt-auto pt-3 space-y-2">
+                  {blueprint.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      {blueprint.tags.map((tag) => (
+                        <span key={tag} className="badge badge-ghost badge-sm">
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
 
-                {blueprint.required_mcp_servers.length > 0 && (
-                  <>
-                    <div className="divider my-2"></div>
-                    <div className="text-sm">
-                      <span className="text-gray-500">Required MCP servers:</span>
-                      <div className="flex flex-wrap gap-1 mt-1">
+                  {blueprint.required_mcp_servers.length > 0 && (
+                    <div className="border-t border-base-300 pt-2 text-sm">
+                      <span className="flex items-center gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
+                        <Server className="h-3 w-3" />
+                        Required MCP servers
+                      </span>
+                      <div className="flex flex-wrap gap-1 mt-1.5">
                         {blueprint.required_mcp_servers.map((server) => (
-                          <Badge key={server} type="warning" size="sm">{server}</Badge>
+                          <span key={server} className="badge badge-outline badge-sm font-mono">
+                            {server}
+                          </span>
                         ))}
                       </div>
                     </div>
-                  </>
-                )}
+                  )}
+                </div>
               </div>
-            </Card>
+            </div>
           ))}
         </div>
       )}
@@ -129,10 +141,10 @@ const BlueprintsPage = () => {
       {!isPending && !isError && filteredBlueprints.length === 0 && (
         <Card bordered className="text-center py-12">
           <div className="mb-4">
-            <Book className="h-16 w-16 mx-auto text-gray-400" />
+            <Book className="h-16 w-16 mx-auto text-base-content/40" />
           </div>
           <h3 className="text-xl font-semibold mb-2">No blueprints found</h3>
-          <p className="text-gray-500 mb-4">
+          <p className="text-base-content/70 mb-4">
             {searchTerm
               ? 'No blueprints match your search criteria'
               : 'No blueprints are registered on this server'}


### PR DESCRIPTION
## Summary

Three targeted UI/UX improvements in one PR.

### 1. Login page (`src/swarm/templates/account/login.html`)
- Was completely unstyled raw HTML (default Times serif, bare inputs) and carried the stale hint `Use "testuser" with password "testpass"` — the hardcoded password was previously removed from the login view (the dev auto-login is gated behind `ALLOW_TESTUSER_AUTOLOGIN` + `DJANGO_DEBUG`), so the hint was misleading and looked like a leaked credential. **Hint removed entirely.**
- Rebuilt as a self-contained styled page (inline `<style>`, no external deps): centered card on a subtle dotted background, "Open Swarm" branding, labeled inputs with focus rings, primary sign-in button, styled error alert with `role="alert"`.
- Form action (`{% url 'custom_login' %}?next=…`), field names, `{% csrf_token %}` and `{{ error }}` rendering unchanged.

### 2. SPA theme correctness + dark toggle (`webui/frontend/src/App.tsx`)
- Removed hardcoded `bg-gray-900 text-white` / `bg-gray-50 text-gray-900` that fought DaisyUI tokens; root is now `bg-base-100 text-base-content` with `data-theme` driving all colors.
- Replaced the "Dark Mode"/"Light Mode" text button with a DaisyUI `swap swap-rotate` Sun/Moon icon toggle (`aria-label="Toggle dark mode"`).
- Theme persists to `localStorage('swarm_theme')` and initializes from it (verified to survive reload).
- Navbar `border-b` given an explicit `border-base-300` (Tailwind v4 defaults borders to currentColor).

### 3. Blueprints catalog cards (`webui/frontend/src/pages/BlueprintsPage.tsx`)
- Cards now `border border-base-300 hover:shadow-md transition-shadow` with `h-full` for consistent grid heights.
- Clear title row: name + small mono abbreviation badge; mono blueprint id below.
- Description clamped to 3 lines (`line-clamp-3`, full text in `title` tooltip).
- `required_mcp_servers` rendered as labeled `badge badge-outline` mono chips under a "Required MCP servers" heading with icon; tags as subtle ghost badges, pinned to the card footer.
- Gray-scale text replaced with theme-aware `text-base-content/*` so cards read correctly in both themes. No fabricated data added.

## Verification

- `npm run type-check` and `npm run build` green; built CSS **98.55 kB** (> 50 kB gate).
- `uv run pytest tests/views -q` → **144 passed** (includes `test_login_routing.py`).
- Playwright (chromium) against `runserver 8431` with a fresh build, screenshots in `/tmp/ux-after-preview/`:
  - **login.png** — centered white card on dotted light-gray background, "Open Swarm / Sign in to continue" heading, labeled Username/Password inputs, indigo "Sign in" button; computed body font is the system sans stack (not Times); no testuser/testpass text anywhere.
  - **dashboard-light.png / dashboard-dark.png** — clicking the swap toggle flips `data-theme` light→dark and root background `oklch(1 0 0)` → `oklch(0.2533 0.016 252.42)`; navbar, alert, stats, quick-action buttons and status card all restyle; toggle shows Moon in light and Sun in dark; `swarm_theme` persisted and restored after reload.
  - **blueprints.png / blueprints-viewport.png (+dark)** — 14 cards in a 3-col grid with visible 1px rounded borders (computed `border-top-width: 1px`), aligned heights per row, mono id under each title, clamped descriptions (ellipsis visible on PoetsBlueprint), and "REQUIRED MCP SERVERS" sections with 19 outline chips (e.g. memory, filesystem, sqlite). Renders correctly in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)