### PR TITLE
feat(ws): honor blueprint selection in websocket chat (launch-a-team-into-chat)

### DIFF
--- a/src/swarm/consumers.py
+++ b/src/swarm/consumers.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import uuid
+from urllib.parse import parse_qs
 
 from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
@@ -16,9 +17,22 @@ logger = logging.getLogger(__name__)
 IN_MEMORY_CONVERSATIONS = {}
 
 class DjangoChatConsumer(AsyncWebsocketConsumer):
+    """Websocket chat consumer.
+
+    Client -> server frames are JSON: ``{"message": "<text>"}`` with an
+    optional ``"blueprint": "<id>"`` field selecting which discovered
+    blueprint generates the reply. A connection-level default can also be
+    set via the ws URL query string (``?blueprint=<id>``); a per-message
+    ``blueprint`` field overrides it. When neither is given, the legacy
+    behaviour (server-configured OpenAI model) is preserved.
+    """
+
     async def connect(self):
         self.user = self.scope["user"]
         self.conversation_id = self.scope['url_route']['kwargs']['conversation_id']
+        # Optional connection-level default blueprint (?blueprint=<id>).
+        query_params = parse_qs(self.scope.get("query_string", b"").decode())
+        self.default_blueprint = (query_params.get("blueprint") or [None])[0]
 
         if self.user.is_authenticated:
             self.messages = await self.fetch_conversation(self.conversation_id)
@@ -45,6 +59,11 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
         if not message_text.strip():
             return
 
+        # Per-message blueprint selection wins over the connection default.
+        blueprint_id = text_data_json.get("blueprint") or getattr(
+            self, "default_blueprint", None
+        )
+
         self.messages.append(
             {
                 "role": "user",
@@ -66,6 +85,106 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
         )
         await self.send(text_data=system_message_html)
 
+        if blueprint_id:
+            await self.respond_with_blueprint(blueprint_id, contents_div_id)
+        else:
+            await self.respond_with_default_model(contents_div_id)
+
+    async def respond_with_blueprint(self, blueprint_id, contents_div_id):
+        """Generate the assistant reply by running a discovered blueprint.
+
+        Reuses the chunk-normalization semantics of the HTTP chat API
+        (swarm.views.chat_views): consume the blueprint's run() generator,
+        skip progress/spinner side-channel chunks, and keep the last (or
+        explicitly final) message as the answer. Unknown blueprints and
+        execution failures produce an error partial instead of crashing
+        the socket. Imported lazily so swarm.asgi/routing stay light.
+        """
+        from swarm.views.chat_views import (
+            _chunk_is_final,
+            _extract_message_from_chunk,
+        )
+        from swarm.views.utils import get_blueprint_instance
+
+        try:
+            blueprint_instance = await get_blueprint_instance(blueprint_id)
+        except Exception:
+            logger.error(
+                f"Error loading blueprint '{blueprint_id}'", exc_info=True
+            )
+            blueprint_instance = None
+
+        if blueprint_instance is None:
+            await self.send_error_message(
+                contents_div_id,
+                f"Error: blueprint '{blueprint_id}' was not found or could not be initialized.",
+            )
+            return
+
+        final_message = None
+        try:
+            async for chunk in blueprint_instance.run(self.messages):
+                message = _extract_message_from_chunk(chunk)
+                if message is None:
+                    continue
+                final_message = message
+                if _chunk_is_final(chunk):
+                    break
+        except Exception as e:
+            logger.error(
+                f"Error running blueprint '{blueprint_id}': {e}", exc_info=True
+            )
+            await self.send_error_message(
+                contents_div_id,
+                f"Error: blueprint '{blueprint_id}' failed while generating a reply.",
+            )
+            return
+
+        if not isinstance(final_message, dict) or final_message.get("content") is None:
+            await self.send_error_message(
+                contents_div_id,
+                f"Error: blueprint '{blueprint_id}' did not return a reply.",
+            )
+            return
+
+        full_message = final_message["content"]
+        chunk_html = f'<div hx-swap-oob="beforeend:#{contents_div_id}">{full_message}</div>'
+        await self.send(text_data=chunk_html)
+
+        self.messages.append(
+            {
+                "role": "assistant",
+                "content": full_message,
+            }
+        )
+
+        final_message_html = render_to_string(
+            "websocket_partials/final_system_message.html",
+            {
+                "contents_div_id": contents_div_id,
+                "message": full_message,
+            },
+        )
+        await self.send(text_data=final_message_html)
+
+    async def send_error_message(self, contents_div_id, error_text):
+        """Replace the streaming placeholder with an error partial.
+
+        Transport-level errors (unknown blueprint, execution failure) are
+        shown to the user but deliberately NOT appended to ``self.messages``
+        so they never pollute the model context of later turns.
+        """
+        error_html = render_to_string(
+            "websocket_partials/final_system_message.html",
+            {
+                "contents_div_id": contents_div_id,
+                "message": error_text,
+            },
+        )
+        await self.send(text_data=error_html)
+
+    async def respond_with_default_model(self, contents_div_id):
+        """Legacy reply path: server-configured model via the OpenAI client."""
         client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
         # --- PATCH: Enforce LiteLLM-only endpoint and suppress OpenAI tracing/telemetry ---

--- a/tests/test_asgi_routing.py
+++ b/tests/test_asgi_routing.py
@@ -18,6 +18,10 @@ Covered:
 - unknown ws paths do not route
 - authenticated session connects and completes a send -> stream -> receive
   round trip (OpenAI client mocked, real templates rendered)
+- blueprint selection: a "blueprint" field in the JSON frame (or a
+  ?blueprint= query param default) routes the reply through that
+  blueprint's run() (SWARM_TEST_MODE canned answers); unknown blueprints
+  produce an error partial without killing the socket
 - plain HTTP still works through the same application
 """
 
@@ -208,4 +212,146 @@ class TestWebsocketRoundTrip:
             final_html = await communicator.receive_from()
             assert "Hi there" in final_html
 
+            await communicator.disconnect()
+
+
+# =============================================================================
+# Blueprint selection over the websocket (SPA parity with /v1/chat/completions)
+# =============================================================================
+
+
+# jeeves' SWARM_TEST_MODE canned answer (see blueprint_jeeves.run):
+#   "[TEST-MODE] Jeeves at your service. You said: '<instruction>'"
+JEEVES_CANNED_MARKER = "Jeeves at your service"
+
+# First blueprint round trip pays for discovery + instantiation; be generous.
+BP_TIMEOUT = 30
+
+
+def _unique_ws_path(suffix=""):
+    """Per-test conversation id: the consumer persists a ChatConversation on
+    disconnect and conversation_id is unique, so tests must not share one."""
+    import uuid
+
+    return f"/ws/ai-demo/bp-{uuid.uuid4().hex[:12]}/{('?' + suffix) if suffix else ''}"
+
+
+@pytest.fixture
+def swarm_test_mode(monkeypatch):
+    """Run blueprints on their deterministic SWARM_TEST_MODE canned path."""
+    monkeypatch.setenv("SWARM_TEST_MODE", "1")
+    # Keyless CI: some blueprints construct an OpenAI client even on the
+    # test-mode path; a dummy key keeps things deterministic everywhere.
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-dummy-test-mode")
+
+
+async def _drain_reply(communicator, prompt):
+    """Send a prompt dict and collect (user_echo, placeholder, frames-until-final)."""
+    await communicator.send_to(text_data=json.dumps(prompt))
+    user_html = await communicator.receive_from(timeout=BP_TIMEOUT)
+    placeholder_html = await communicator.receive_from(timeout=BP_TIMEOUT)
+    match = re.search(r'id="(message-response-[0-9a-f]+)"', placeholder_html)
+    assert match, f"no contents div in placeholder: {placeholder_html!r}"
+    contents_div_id = match.group(1)
+    # Frames until the final partial (which replaces the container via
+    # hx-swap-oob="true" on the container id).
+    frames = []
+    while True:
+        frame = await communicator.receive_from(timeout=BP_TIMEOUT)
+        frames.append(frame)
+        if f'id="{contents_div_id}"' in frame and 'hx-swap-oob="true"' in frame:
+            break
+    return user_html, contents_div_id, frames
+
+
+class TestWebsocketBlueprintSelection:
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_blueprint_field_selects_that_blueprints_reply(
+        self, swarm_test_mode
+    ):
+        """{"message", "blueprint": "jeeves"} -> jeeves' canned test-mode answer."""
+        _, headers = await make_authenticated_headers("asgi-ws-bp-field")
+        communicator = WebsocketCommunicator(
+            application, _unique_ws_path(), headers=headers
+        )
+        connected, _ = await communicator.connect()
+        assert connected
+
+        user_html, contents_div_id, frames = await _drain_reply(
+            communicator, {"message": "ping", "blueprint": "jeeves"}
+        )
+        assert "ping" in user_html
+        # Both the streamed chunk and the final partial carry jeeves' answer.
+        assert any(JEEVES_CANNED_MARKER in frame for frame in frames[:-1])
+        assert JEEVES_CANNED_MARKER in frames[-1]
+        assert "ping" in frames[-1]
+
+        await communicator.disconnect()
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_blueprint_query_param_sets_connection_default(
+        self, swarm_test_mode
+    ):
+        """?blueprint=jeeves on the ws URL applies to plain {"message"} frames."""
+        _, headers = await make_authenticated_headers("asgi-ws-bp-query")
+        communicator = WebsocketCommunicator(
+            application, _unique_ws_path("blueprint=jeeves"), headers=headers
+        )
+        connected, _ = await communicator.connect()
+        assert connected
+
+        _, _, frames = await _drain_reply(communicator, {"message": "ping"})
+        assert JEEVES_CANNED_MARKER in frames[-1]
+
+        await communicator.disconnect()
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_unknown_blueprint_returns_error_partial(self, swarm_test_mode):
+        """An unknown blueprint id yields an error partial, not a crash, and
+        the same socket still answers a follow-up with a valid blueprint."""
+        _, headers = await make_authenticated_headers("asgi-ws-bp-unknown")
+        communicator = WebsocketCommunicator(
+            application, _unique_ws_path(), headers=headers
+        )
+        connected, _ = await communicator.connect()
+        assert connected
+
+        _, _, frames = await _drain_reply(
+            communicator, {"message": "hello", "blueprint": "no-such-blueprint"}
+        )
+        assert "no-such-blueprint" in frames[-1]
+        assert "not found" in frames[-1]
+
+        # The socket survived: a valid blueprint still answers afterwards.
+        _, _, frames = await _drain_reply(
+            communicator, {"message": "still alive?", "blueprint": "jeeves"}
+        )
+        assert JEEVES_CANNED_MARKER in frames[-1]
+
+        await communicator.disconnect()
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_no_blueprint_still_uses_default_model(self, monkeypatch):
+        """Backward compat: frames without a blueprint keep the legacy
+        OpenAI-client path (no blueprint involved)."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.setenv("OPENAI_MODEL", "test-model")
+        monkeypatch.delenv("LITELLM_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+        _, headers = await make_authenticated_headers("asgi-ws-bp-compat")
+        patcher, client = mock_openai_streaming(("legacy", " path"))
+        communicator = WebsocketCommunicator(
+            application, _unique_ws_path(), headers=headers
+        )
+        with patcher:
+            connected, _ = await communicator.connect()
+            assert connected
+            _, _, frames = await _drain_reply(communicator, {"message": "ping"})
+            assert "legacy path" in frames[-1]
+            client.chat.completions.create.assert_awaited_once()
             await communicator.disconnect()

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -2,9 +2,11 @@
 Unit tests for src/swarm/consumers.py
 
 Covers:
-- connect: authenticated vs unauthenticated
+- connect: authenticated vs unauthenticated, ?blueprint= query param default
 - disconnect: cleanup, save, delete empty conversations
 - receive: valid JSON, missing keys, invalid JSON, empty messages
+- blueprint selection: message field, connection default, override,
+  unknown-blueprint error partial
 - fetch_conversation: cache hit, DB hit, DoesNotExist
 - save_conversation: create/update
 - delete_conversation: existing, missing
@@ -147,11 +149,35 @@ class TestConnect:
         """Connect should set conversation_id from URL route."""
         with patch.object(consumer, 'fetch_conversation', new_callable=AsyncMock) as mock_fetch:
             mock_fetch.return_value = []
-            
+
             with patch.object(consumer, 'accept', new_callable=AsyncMock):
                 await consumer.connect()
-                
+
                 assert consumer.conversation_id == "test-conv-123"
+
+    @pytest.mark.asyncio
+    async def test_connect_without_query_string_has_no_default_blueprint(self, consumer):
+        """No ?blueprint= query param -> no connection-level default."""
+        with patch.object(consumer, 'fetch_conversation', new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = []
+
+            with patch.object(consumer, 'accept', new_callable=AsyncMock):
+                await consumer.connect()
+
+                assert consumer.default_blueprint is None
+
+    @pytest.mark.asyncio
+    async def test_connect_query_param_sets_default_blueprint(self, consumer):
+        """?blueprint=<id> on the ws URL becomes the connection default."""
+        consumer.scope["query_string"] = b"blueprint=jeeves"
+
+        with patch.object(consumer, 'fetch_conversation', new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = []
+
+            with patch.object(consumer, 'accept', new_callable=AsyncMock):
+                await consumer.connect()
+
+                assert consumer.default_blueprint == "jeeves"
 
 
 # =============================================================================
@@ -292,6 +318,149 @@ class TestReceive:
         
         with pytest.raises(json.JSONDecodeError):
             await consumer.receive(text_data)
+
+
+# =============================================================================
+# Blueprint Selection Tests
+# =============================================================================
+
+
+class TestBlueprintSelection:
+    """Tests for blueprint-aware reply routing in receive()."""
+
+    @pytest.mark.asyncio
+    async def test_receive_blueprint_field_routes_to_blueprint(self, consumer):
+        """{"message", "blueprint"} should dispatch to the blueprint path."""
+        consumer.messages = []
+        text_data = json.dumps({"message": "Hello", "blueprint": "jeeves"})
+
+        with patch('swarm.consumers.render_to_string', return_value="<div></div>"):
+            with patch.object(consumer, 'send', new_callable=AsyncMock):
+                with patch.object(consumer, 'respond_with_blueprint', new_callable=AsyncMock) as mock_bp:
+                    with patch.object(consumer, 'respond_with_default_model', new_callable=AsyncMock) as mock_default:
+                        await consumer.receive(text_data)
+
+                        mock_bp.assert_awaited_once()
+                        assert mock_bp.await_args.args[0] == "jeeves"
+                        mock_default.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_receive_without_blueprint_uses_default_model(self, consumer):
+        """Plain {"message"} frames keep the legacy default-model path."""
+        consumer.messages = []
+        text_data = json.dumps({"message": "Hello"})
+
+        with patch('swarm.consumers.render_to_string', return_value="<div></div>"):
+            with patch.object(consumer, 'send', new_callable=AsyncMock):
+                with patch.object(consumer, 'respond_with_blueprint', new_callable=AsyncMock) as mock_bp:
+                    with patch.object(consumer, 'respond_with_default_model', new_callable=AsyncMock) as mock_default:
+                        await consumer.receive(text_data)
+
+                        mock_default.assert_awaited_once()
+                        mock_bp.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_receive_uses_connection_default_blueprint(self, consumer):
+        """The ?blueprint= connection default applies to plain frames."""
+        consumer.messages = []
+        consumer.default_blueprint = "jeeves"
+        text_data = json.dumps({"message": "Hello"})
+
+        with patch('swarm.consumers.render_to_string', return_value="<div></div>"):
+            with patch.object(consumer, 'send', new_callable=AsyncMock):
+                with patch.object(consumer, 'respond_with_blueprint', new_callable=AsyncMock) as mock_bp:
+                    await consumer.receive(text_data)
+
+                    assert mock_bp.await_args.args[0] == "jeeves"
+
+    @pytest.mark.asyncio
+    async def test_receive_message_field_overrides_connection_default(self, consumer):
+        """A per-message blueprint field wins over the connection default."""
+        consumer.messages = []
+        consumer.default_blueprint = "jeeves"
+        text_data = json.dumps({"message": "Hello", "blueprint": "zeus"})
+
+        with patch('swarm.consumers.render_to_string', return_value="<div></div>"):
+            with patch.object(consumer, 'send', new_callable=AsyncMock):
+                with patch.object(consumer, 'respond_with_blueprint', new_callable=AsyncMock) as mock_bp:
+                    await consumer.receive(text_data)
+
+                    assert mock_bp.await_args.args[0] == "zeus"
+
+    @pytest.mark.asyncio
+    async def test_unknown_blueprint_sends_error_partial(self, consumer):
+        """Unknown blueprint -> error partial; no assistant message recorded."""
+        consumer.messages = [{"role": "user", "content": "Hello"}]
+
+        with patch('swarm.views.utils.get_blueprint_instance', new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = None
+            with patch.object(consumer, 'send', new_callable=AsyncMock) as mock_send:
+                await consumer.respond_with_blueprint("nope", "message-response-abc")
+
+                sent = "".join(
+                    call.kwargs.get("text_data") or call.args[0]
+                    for call in mock_send.await_args_list
+                )
+                assert "nope" in sent
+                assert "not found" in sent
+                # The error is transport-level: not appended to history.
+                assert all(m["role"] != "assistant" for m in consumer.messages)
+
+    @pytest.mark.asyncio
+    async def test_blueprint_reply_streams_chunk_and_final(self, consumer):
+        """A blueprint reply emits an OOB chunk + final partial and is
+        appended to the conversation history (last message wins, spinner
+        side-channel chunks skipped — same semantics as chat_views)."""
+        consumer.messages = [{"role": "user", "content": "Hello"}]
+
+        async def fake_run(messages, **kwargs):
+            yield {"type": "spinner_update", "spinner": "Generating."}
+            yield {"messages": [{"role": "assistant", "content": "BP reply"}]}
+
+        instance = MagicMock()
+        instance.run = fake_run
+
+        with patch('swarm.views.utils.get_blueprint_instance', new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = instance
+            with patch.object(consumer, 'send', new_callable=AsyncMock) as mock_send:
+                await consumer.respond_with_blueprint("jeeves", "message-response-abc")
+
+                frames = [
+                    call.kwargs.get("text_data") or call.args[0]
+                    for call in mock_send.await_args_list
+                ]
+                assert len(frames) == 2  # OOB chunk + final partial
+                assert 'hx-swap-oob="beforeend:#message-response-abc"' in frames[0]
+                assert "BP reply" in frames[0]
+                assert "BP reply" in frames[1]
+                assert consumer.messages[-1] == {
+                    "role": "assistant",
+                    "content": "BP reply",
+                }
+
+    @pytest.mark.asyncio
+    async def test_blueprint_run_failure_sends_error_partial(self, consumer):
+        """Exceptions from blueprint.run() surface as an error partial."""
+        consumer.messages = [{"role": "user", "content": "Hello"}]
+
+        async def failing_run(messages, **kwargs):
+            raise RuntimeError("boom")
+            yield  # pragma: no cover - makes this an async generator
+
+        instance = MagicMock()
+        instance.run = failing_run
+
+        with patch('swarm.views.utils.get_blueprint_instance', new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = instance
+            with patch.object(consumer, 'send', new_callable=AsyncMock) as mock_send:
+                await consumer.respond_with_blueprint("jeeves", "message-response-abc")
+
+                sent = "".join(
+                    call.kwargs.get("text_data") or call.args[0]
+                    for call in mock_send.await_args_list
+                )
+                assert "failed while generating" in sent
+                assert all(m["role"] != "assistant" for m in consumer.messages)
 
 
 # =============================================================================

--- a/webui/frontend/src/lib/chatWs.ts
+++ b/webui/frontend/src/lib/chatWs.ts
@@ -6,7 +6,12 @@
  *
  * - URL: ws(s)://<host>/ws/ai-demo/<conversation_id>/
  *   (the Django UI connects via HTMx: ws-connect="/ws/ai-demo/{{ conversation.id }}/")
- * - Client -> server: JSON text frames: {"message": "<user text>"}
+ *   An optional ?blueprint=<id> query param sets a connection-level default
+ *   blueprint on the server.
+ * - Client -> server: JSON text frames: {"message": "<user text>"} with an
+ *   optional "blueprint": "<id>" field selecting which discovered blueprint
+ *   answers (per-message field overrides the URL default; omitting both
+ *   falls back to the server-configured model).
  * - Server -> client: HTML partials with HTMx out-of-band swap attributes:
  *   1. user echo:        <div id="message-list" hx-swap-oob="beforeend">
  *                          <div class="user-message ...">{text}</div></div>
@@ -30,9 +35,22 @@ export type ChatWsEvent =
 const OOB_CHUNK_PREFIX = 'beforeend:#'
 const ASSISTANT_ID_PREFIX = 'message-response-'
 
-export function buildChatWsUrl(conversationId: string): string {
+export function buildChatWsUrl(
+  conversationId: string,
+  blueprintId?: string,
+): string {
   const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
-  return `${scheme}://${window.location.host}/ws/ai-demo/${encodeURIComponent(conversationId)}/`
+  const base = `${scheme}://${window.location.host}/ws/ai-demo/${encodeURIComponent(conversationId)}/`
+  return blueprintId
+    ? `${base}?blueprint=${encodeURIComponent(blueprintId)}`
+    : base
+}
+
+/** Build the JSON frame sent to DjangoChatConsumer.receive(). */
+export function buildChatWsFrame(message: string, blueprintId?: string): string {
+  return JSON.stringify(
+    blueprintId ? { message, blueprint: blueprintId } : { message },
+  )
 }
 
 export function newConversationId(): string {

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { AlertCircle, Info, MessageSquare, RefreshCw, Send } from 'lucide-react'
 import {
@@ -11,6 +11,7 @@ import {
 } from '../components/DaisyUI'
 import { fetchBlueprints, isAuthError } from '../lib/api'
 import {
+  buildChatWsFrame,
   buildChatWsUrl,
   newConversationId,
   parseChatWsMessage,
@@ -29,10 +30,14 @@ interface ChatMessage {
 }
 
 const ChatPage = () => {
+  // Teams/Blueprints pages link here as /chat?blueprint=<id> to preselect.
+  const [searchParams] = useSearchParams()
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState('')
   const [status, setStatus] = useState<ConnectionStatus>('connecting')
-  const [selectedBlueprint, setSelectedBlueprint] = useState('')
+  const [selectedBlueprint, setSelectedBlueprint] = useState(
+    () => searchParams.get('blueprint') ?? '',
+  )
   const [connectAttempt, setConnectAttempt] = useState(0)
 
   const wsRef = useRef<WebSocket | null>(null)
@@ -134,8 +139,10 @@ const ChatPage = () => {
     const text = input.trim()
     const ws = wsRef.current
     if (!text || !ws || ws.readyState !== WebSocket.OPEN) return
-    // Protocol from DjangoChatConsumer.receive(): {"message": "<text>"}
-    ws.send(JSON.stringify({ message: text }))
+    // Protocol from DjangoChatConsumer.receive():
+    // {"message": "<text>", "blueprint": "<id>"} — the blueprint field is
+    // optional and selects which blueprint generates the reply.
+    ws.send(buildChatWsFrame(text, selectedBlueprint || undefined))
     setInput('')
   }
 
@@ -191,7 +198,7 @@ const ChatPage = () => {
                 </span>
                 <span
                   className="tooltip tooltip-bottom before:max-w-[18rem] before:whitespace-normal"
-                  data-tip="The current websocket protocol does not take a blueprint parameter — replies come from the server-configured model."
+                  data-tip="Sent with every message — the selected blueprint generates the reply. Choose “Server default model” to use the server-configured model instead."
                 >
                   <Info
                     className="h-3.5 w-3.5 opacity-60"
@@ -205,9 +212,15 @@ const ChatPage = () => {
                 onChange={(e) => setSelectedBlueprint(e.target.value)}
                 aria-label="Blueprint"
               >
-                <option value="" disabled>
-                  Select a blueprint
-                </option>
+                <option value="">Server default model</option>
+                {/* Keep a ?blueprint= preselection visible even if it is not
+                    in the fetched list (e.g. a just-created team). */}
+                {selectedBlueprint &&
+                  !blueprints.some((bp) => bp.id === selectedBlueprint) && (
+                    <option value={selectedBlueprint}>
+                      {selectedBlueprint}
+                    </option>
+                  )}
                 {blueprints.map((bp) => (
                   <option key={bp.id} value={bp.id}>
                     {bp.name || bp.id}

--- a/webui/frontend/src/pages/TeamsPage.tsx
+++ b/webui/frontend/src/pages/TeamsPage.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   Alert,
@@ -12,7 +13,7 @@ import {
   ToastProvider,
   useToast,
 } from '../components/DaisyUI';
-import { AlertCircle, Plus, Trash2, Users } from 'lucide-react';
+import { AlertCircle, Plus, Rocket, Trash2, Users } from 'lucide-react';
 import { createTeam, deleteTeam, fetchTeams, type Team } from '../lib/api';
 
 /**
@@ -26,6 +27,7 @@ import { createTeam, deleteTeam, fetchTeams, type Team } from '../lib/api';
 const TeamsPageContent = () => {
   const queryClient = useQueryClient();
   const toast = useToast();
+  const navigate = useNavigate();
 
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [teamToDelete, setTeamToDelete] = useState<Team | null>(null);
@@ -152,6 +154,16 @@ const TeamsPageContent = () => {
                   {team.description || 'No description provided.'}
                 </p>
                 <div className="card-actions justify-end">
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() =>
+                      navigate(`/chat?blueprint=${encodeURIComponent(team.id)}`)
+                    }
+                  >
+                    <Rocket className="h-4 w-4 mr-1" />
+                    Launch
+                  </Button>
                   <Button
                     variant="outline"
                     color="error"


### PR DESCRIPTION
## Summary

SPA parity: the websocket chat consumer (`DjangoChatConsumer`) previously ignored which blueprint the user wanted — replies always came from the server-configured OpenAI model, and the ChatPage selector honestly admitted it did nothing. This PR makes the websocket honor blueprint selection end to end, completing the launch-a-team-into-chat flow.

## Protocol change (backward compatible)

- **Per-message field (preferred):** client frames may carry an optional `blueprint` field — `{"message": "<text>", "blueprint": "<id>"}`. The selected blueprint's `run()` generates the reply; switching blueprints needs no reconnect.
- **Connection default:** `?blueprint=<id>` on the ws URL (`/ws/ai-demo/<conversation_id>/?blueprint=jeeves`) sets a default; the per-message field overrides it.
- **Chunk semantics:** reuses the HTTP API's normalization helpers (`swarm.views.chat_views._extract_message_from_chunk` / `_chunk_is_final`): spinner/progress side-channel chunks are skipped, the last (or explicitly final) message wins, `SWARM_TEST_MODE` canned answers work.
- **Errors:** unknown blueprint ids and `run()` failures yield an error partial (final system message) — the socket stays open and is not appended to model context.
- **Backward compat:** frames without a blueprint keep the legacy default-model path byte-for-byte (all pre-existing consumer/asgi tests pass unmodified).

## Frontend

- **ChatPage:** the selector value is sent with every message; the "selection does nothing" tooltip is replaced with accurate text; an explicit "Server default model" option preserves the legacy path; `?blueprint=<id>` preselects (kept visible even if the id isn't in the fetched list, e.g. a just-created team).
- **TeamsPage:** every team card gets a **Launch** button → `/chat?blueprint=<id>`.
- **chatWs.ts:** `buildChatWsUrl()` takes an optional blueprint id; new `buildChatWsFrame()` encodes outgoing frames; protocol docs updated.

## Tests

- `tests/test_consumers.py` +9: `?blueprint=` query-param default at connect, dispatch routing (blueprint vs default model), message-field-overrides-default, unknown-blueprint error partial (not recorded in history), chunk+final streaming with spinner-skip, run() failure error path.
- `tests/test_asgi_routing.py` +4 (full ASGI stack, session auth, SWARM_TEST_MODE): blueprint message field returns *that* blueprint's canned answer; query-param default; unknown blueprint returns an error partial and the same socket then answers with a valid blueprint; legacy no-blueprint path still uses the mocked OpenAI client.
- **Full suite:** `uv run pytest -q --timeout=180 -p no:cacheprovider` → **905 passed, 9 skipped, 0 failed** (baseline 892 + 13 new).
- **Frontend:** `npm run type-check` and `npm run build` green (node 22).

## Live smoke (daphne, SWARM_TEST_MODE=1)

Authenticated session cookie over `ws://localhost:18931/ws/ai-demo/live-smoke-conv-1/`, sent `{"message": "ping", "blueprint": "jeeves"}`:

```
--- frame 3 ---
<div hx-swap-oob="beforeend:#message-response-dd382dc9...">[TEST-MODE] Jeeves at your service. You said: 'ping'</div>
--- frame 4 ---
<div id="message-response-dd382dc9..." class="assistant-message chatbot-text-system mb-2" hx-swap-oob="true">
    [TEST-MODE] Jeeves at your service. You said: &#x27;ping&#x27;
</div>
```

Unknown blueprint case (same server):

```
<div id="message-response-570ca297..." ... hx-swap-oob="true">
    Error: blueprint &#x27;no-such-bp&#x27; was not found or could not be initialized.
</div>
```
followed by a successful jeeves reply on the same socket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)