### PR TITLE
feat(spa): blueprint library management in the React SPA (/v1/library/)

### DIFF
--- a/src/swarm/urls.py
+++ b/src/swarm/urls.py
@@ -33,6 +33,7 @@ from swarm.views.blueprint_library_views import (
     remove_blueprint_from_library,
 )
 from swarm.views.chat_views import ChatCompletionsView
+from swarm.views.library_api import LibraryAPIView, LibraryDetailAPIView
 from swarm.views.settings_views import (
     environment_variables,
     settings_api,
@@ -74,6 +75,10 @@ urlpatterns = [
     path("v1/teams", TeamsAPIView.as_view(), name="teams-api-no-slash"),
     path("v1/teams/", TeamsAPIView.as_view(), name="teams-api"),
     path("v1/teams/<str:team_id>/", TeamDetailAPIView.as_view(), name="teams-api-detail"),
+    # JSON Blueprint Library API (REST counterpart to /blueprint-library/)
+    path("v1/library", LibraryAPIView.as_view(), name="library-api-no-slash"),
+    path("v1/library/", LibraryAPIView.as_view(), name="library-api"),
+    path("v1/library/<str:blueprint_name>/", LibraryDetailAPIView.as_view(), name="library-api-detail"),
     path("teams/launch", team_launcher, name="teams_launch_no_slash"),
     path("teams/launch/", team_launcher, name="teams_launch"),
     path("teams/", team_admin, name="teams_admin"),

--- a/src/swarm/views/library_api.py
+++ b/src/swarm/views/library_api.py
@@ -1,0 +1,142 @@
+"""
+JSON Blueprint Library API (SPA parity).
+
+REST endpoints over the same file-backed library used by the server-rendered
+/blueprint-library/ pages (swarm.views.blueprint_library_views). Storage is
+<user config dir>/blueprint_library.json with the shape
+{"installed": [name, ...], "custom": [...]}; this API manages the "installed"
+list (custom blueprints already have their own API at /v1/blueprints/custom/).
+
+Note: like the Django views it mirrors, the library is a single file per OS
+user / server deployment, not per Django user.
+
+Endpoints:
+    GET    /v1/library/         -> {"object": "list", "data": [entry, ...]}
+    POST   /v1/library/ {name}  -> 201 + entry (200 if already in library)
+    DELETE /v1/library/<name>/  -> 204 (404 if not in library)
+
+Permissions follow the project's API auth pattern (same as /v1/teams/): when
+API auth is enabled (API_AUTH_TOKEN/SWARM_API_KEY configured),
+HasValidTokenOrSession is required; otherwise AllowAny.
+"""
+
+import logging
+
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from swarm.core.blueprint_discovery import discover_blueprints
+from swarm.permissions import HasValidTokenOrSession
+from swarm.settings import BLUEPRINT_DIRECTORY, ENABLE_API_AUTH
+from swarm.views.blueprint_library_views import (
+    BLUEPRINT_METADATA,
+    get_user_blueprint_library,
+    save_user_blueprint_library,
+)
+
+logger = logging.getLogger(__name__)
+
+# Mirrors REST_FRAMEWORK DEFAULT_PERMISSION_CLASSES in swarm/settings.py.
+LIBRARY_API_PERMISSIONS = [HasValidTokenOrSession] if ENABLE_API_AUTH else [AllowAny]
+
+
+def _serialize_entry(blueprint_name: str) -> dict:
+    """Serialize a library entry, reusing the Django pages' metadata fallback."""
+    metadata = BLUEPRINT_METADATA.get(blueprint_name, {})
+    return {
+        "id": blueprint_name,
+        "object": "library.blueprint",
+        "name": metadata.get("name", blueprint_name.replace("_", " ").title()),
+        "description": metadata.get("description", f"Blueprint for {blueprint_name}"),
+    }
+
+
+class LibraryAPIView(APIView):
+    """
+    GET  /v1/library/  -> list blueprints in the user's library
+    POST /v1/library/  -> add a blueprint to the library
+    """
+
+    permission_classes = LIBRARY_API_PERMISSIONS
+
+    def get(self, request, *_args, **_kwargs):
+        try:
+            library = get_user_blueprint_library()
+            installed = library.get("installed", [])
+            data = [_serialize_entry(name) for name in installed]
+            return Response({"object": "list", "data": data}, status=status.HTTP_200_OK)
+        except Exception:
+            logger.exception("Error retrieving blueprint library.")
+            return Response(
+                {"error": "Failed to retrieve blueprint library."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+    def post(self, request, *_args, **_kwargs):
+        try:
+            body = request.data or {}
+            name = (body.get("name") or body.get("id") or "").strip()
+            if not name:
+                return Response(
+                    {"error": "Blueprint name is required."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            # Verify the blueprint exists, mirroring add_blueprint_to_library.
+            discovered = discover_blueprints(BLUEPRINT_DIRECTORY)
+            if name not in discovered:
+                return Response(
+                    {"error": f"Blueprint '{name}' not found."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+
+            library = get_user_blueprint_library()
+            installed = library.setdefault("installed", [])
+            if name in installed:
+                # Idempotent add: already in the library.
+                return Response(_serialize_entry(name), status=status.HTTP_200_OK)
+
+            installed.append(name)
+            if not save_user_blueprint_library(library):
+                return Response(
+                    {"error": "Failed to save blueprint library."},
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                )
+            return Response(_serialize_entry(name), status=status.HTTP_201_CREATED)
+        except Exception:
+            logger.exception("Error adding blueprint to library.")
+            return Response(
+                {"error": "Failed to add blueprint to library."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+
+class LibraryDetailAPIView(APIView):
+    """
+    DELETE /v1/library/<blueprint_name>/ -> remove a blueprint from the library
+    """
+
+    permission_classes = LIBRARY_API_PERMISSIONS
+
+    def delete(self, request, blueprint_name: str, *_args, **_kwargs):
+        try:
+            library = get_user_blueprint_library()
+            installed = library.get("installed", [])
+            if blueprint_name not in installed:
+                return Response({"error": "not found"}, status=status.HTTP_404_NOT_FOUND)
+
+            installed.remove(blueprint_name)
+            if not save_user_blueprint_library(library):
+                return Response(
+                    {"error": "Failed to save blueprint library."},
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                )
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except Exception:
+            logger.exception("Error removing blueprint '%s' from library.", blueprint_name)
+            return Response(
+                {"error": "Failed to remove blueprint from library."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )

--- a/tests/views/test_library_api.py
+++ b/tests/views/test_library_api.py
@@ -1,0 +1,370 @@
+"""
+Unit tests for src/swarm/views/library_api.py
+=============================================
+
+Tests for the JSON Blueprint Library API covering:
+- LibraryAPIView GET  /v1/library/        : list library in OpenAI-style envelope
+- LibraryAPIView POST /v1/library/        : add (validation, idempotency, 404)
+- LibraryDetailAPIView DELETE /v1/library/<name>/ : remove + 404 behaviour
+- Auth behaviour with HasValidTokenOrSession (token / session / anonymous)
+
+The file-backed library helpers are mocked so no real blueprint_library.json
+on disk is read or written.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from swarm.permissions import HasValidTokenOrSession
+from swarm.views.library_api import LibraryAPIView, LibraryDetailAPIView
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+@pytest.fixture
+def api_client():
+    """Return an API client for testing."""
+    return APIClient()
+
+
+@pytest.fixture
+def mock_library():
+    """Sample library as stored in blueprint_library.json."""
+    return {"installed": ["codey", "poets"], "custom": []}
+
+
+# =============================================================================
+# Tests for GET /v1/library/
+# =============================================================================
+
+class TestLibraryListView:
+    """Tests for listing the user's blueprint library."""
+
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_list_library(self, mock_get, api_client, mock_library):
+        """Library entries are returned in an OpenAI-style list envelope."""
+        mock_get.return_value = mock_library
+
+        response = api_client.get("/v1/library/")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["object"] == "list"
+        assert len(data["data"]) == 2
+        ids = [e["id"] for e in data["data"]]
+        assert ids == ["codey", "poets"]
+        for entry in data["data"]:
+            assert entry["object"] == "library.blueprint"
+            assert "name" in entry
+            assert "description" in entry
+
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_list_library_known_metadata(self, mock_get, api_client, mock_library):
+        """Entries reuse the Django pages' curated metadata when available."""
+        mock_get.return_value = mock_library
+
+        response = api_client.get("/v1/library/")
+
+        codey = response.json()["data"][0]
+        assert codey["name"] == "Codey"
+        assert "coding" in codey["description"].lower()
+
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_list_library_unknown_metadata_fallback(self, mock_get, api_client):
+        """Unknown blueprints get the same title-cased fallback as the Django UI."""
+        mock_get.return_value = {"installed": ["my_custom_thing"], "custom": []}
+
+        response = api_client.get("/v1/library/")
+
+        entry = response.json()["data"][0]
+        assert entry["name"] == "My Custom Thing"
+        assert entry["description"] == "Blueprint for my_custom_thing"
+
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_list_library_empty(self, mock_get, api_client):
+        """An empty library yields an empty list envelope."""
+        mock_get.return_value = {"installed": [], "custom": []}
+
+        response = api_client.get("/v1/library/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"object": "list", "data": []}
+
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_list_library_no_trailing_slash(self, mock_get, api_client, mock_library):
+        """The endpoint is reachable without a trailing slash too."""
+        mock_get.return_value = mock_library
+
+        response = api_client.get("/v1/library")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["object"] == "list"
+
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_list_library_error(self, mock_get, api_client):
+        """Storage errors surface as a 500 with an error body."""
+        mock_get.side_effect = Exception("disk error")
+
+        response = api_client.get("/v1/library/")
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert "error" in response.json()
+
+
+# =============================================================================
+# Tests for POST /v1/library/
+# =============================================================================
+
+class TestLibraryAddView:
+    """Tests for adding blueprints to the library."""
+
+    @patch("swarm.views.library_api.save_user_blueprint_library")
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    @patch("swarm.views.library_api.discover_blueprints")
+    def test_add_blueprint(self, mock_discover, mock_get, mock_save, api_client):
+        """A valid add persists the blueprint and returns 201 with the entry."""
+        mock_discover.return_value = {"codey": {"metadata": {}}}
+        mock_get.return_value = {"installed": [], "custom": []}
+        mock_save.return_value = True
+
+        response = api_client.post(
+            "/v1/library/", data={"name": "codey"}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["id"] == "codey"
+        assert data["object"] == "library.blueprint"
+        mock_save.assert_called_once_with({"installed": ["codey"], "custom": []})
+
+    @patch("swarm.views.library_api.save_user_blueprint_library")
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    @patch("swarm.views.library_api.discover_blueprints")
+    def test_add_blueprint_accepts_id_key(
+        self, mock_discover, mock_get, mock_save, api_client
+    ):
+        """The body may use "id" instead of "name" (matching /v1/teams/)."""
+        mock_discover.return_value = {"poets": {"metadata": {}}}
+        mock_get.return_value = {"installed": [], "custom": []}
+        mock_save.return_value = True
+
+        response = api_client.post(
+            "/v1/library/", data={"id": "poets"}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["id"] == "poets"
+
+    @patch("swarm.views.library_api.save_user_blueprint_library")
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    @patch("swarm.views.library_api.discover_blueprints")
+    def test_add_blueprint_already_in_library(
+        self, mock_discover, mock_get, mock_save, api_client, mock_library
+    ):
+        """Adding a blueprint already in the library is idempotent (200, no save)."""
+        mock_discover.return_value = {"codey": {"metadata": {}}}
+        mock_get.return_value = mock_library
+
+        response = api_client.post(
+            "/v1/library/", data={"name": "codey"}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["id"] == "codey"
+        mock_save.assert_not_called()
+
+    def test_add_blueprint_missing_name(self, api_client):
+        """Missing name returns 400."""
+        response = api_client.post("/v1/library/", data={}, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "error" in response.json()
+
+    @patch("swarm.views.library_api.discover_blueprints")
+    def test_add_blueprint_unknown(self, mock_discover, api_client):
+        """Adding a blueprint that isn't discovered on the server returns 404."""
+        mock_discover.return_value = {"codey": {"metadata": {}}}
+
+        response = api_client.post(
+            "/v1/library/", data={"name": "nonexistent"}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert "error" in response.json()
+
+    @patch("swarm.views.library_api.save_user_blueprint_library")
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    @patch("swarm.views.library_api.discover_blueprints")
+    def test_add_blueprint_save_failure(
+        self, mock_discover, mock_get, mock_save, api_client
+    ):
+        """A failed save surfaces as a 500."""
+        mock_discover.return_value = {"codey": {"metadata": {}}}
+        mock_get.return_value = {"installed": [], "custom": []}
+        mock_save.return_value = False
+
+        response = api_client.post(
+            "/v1/library/", data={"name": "codey"}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert "error" in response.json()
+
+    @patch("swarm.views.library_api.discover_blueprints")
+    def test_add_blueprint_discovery_error(self, mock_discover, api_client):
+        """Discovery errors surface as a 500."""
+        mock_discover.side_effect = Exception("discovery exploded")
+
+        response = api_client.post(
+            "/v1/library/", data={"name": "codey"}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+
+# =============================================================================
+# Tests for DELETE /v1/library/<name>/
+# =============================================================================
+
+class TestLibraryRemoveView:
+    """Tests for removing blueprints from the library."""
+
+    @patch("swarm.views.library_api.save_user_blueprint_library")
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_remove_blueprint(self, mock_get, mock_save, api_client, mock_library):
+        """Removing a blueprint in the library returns 204 and persists."""
+        mock_get.return_value = mock_library
+        mock_save.return_value = True
+
+        response = api_client.delete("/v1/library/codey/")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_save.assert_called_once_with({"installed": ["poets"], "custom": []})
+
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_remove_blueprint_not_in_library(self, mock_get, api_client, mock_library):
+        """Removing a blueprint not in the library returns 404."""
+        mock_get.return_value = mock_library
+
+        response = api_client.delete("/v1/library/nonexistent/")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert "error" in response.json()
+
+    @patch("swarm.views.library_api.save_user_blueprint_library")
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_remove_blueprint_save_failure(
+        self, mock_get, mock_save, api_client, mock_library
+    ):
+        """A failed save surfaces as a 500."""
+        mock_get.return_value = mock_library
+        mock_save.return_value = False
+
+        response = api_client.delete("/v1/library/codey/")
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_remove_blueprint_error(self, mock_get, api_client):
+        """Storage errors surface as a 500."""
+        mock_get.side_effect = Exception("disk error")
+
+        response = api_client.delete("/v1/library/codey/")
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+
+# =============================================================================
+# Tests for authentication behaviour
+# =============================================================================
+
+class TestLibraryAPIAuth:
+    """Auth behaviour for the library endpoints.
+
+    The views resolve their permission classes from ENABLE_API_AUTH at import
+    time (mirroring REST_FRAMEWORK DEFAULT_PERMISSION_CLASSES). These tests
+    pin the hardened permission class explicitly to exercise both outcomes.
+    """
+
+    def _authed_user(self):
+        user = MagicMock()
+        user.is_authenticated = True
+        return user
+
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_auth_disabled_allows_anonymous(self, mock_get, api_client):
+        """With auth disabled (no API token configured), anonymous access works."""
+        mock_get.return_value = {"installed": [], "custom": []}
+        with patch.object(LibraryAPIView, "permission_classes", []):
+            response = api_client.get("/v1/library/")
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_auth_enabled_rejects_anonymous(self, mock_get, api_client):
+        """With HasValidTokenOrSession enforced, anonymous requests are denied."""
+        mock_get.return_value = {"installed": [], "custom": []}
+        with patch.object(
+            LibraryAPIView, "permission_classes", [HasValidTokenOrSession]
+        ):
+            response = api_client.get("/v1/library/")
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_auth_enabled_rejects_anonymous_delete(self, mock_get, api_client):
+        """Mutating endpoints are denied for anonymous callers too."""
+        mock_get.return_value = {"installed": [], "custom": []}
+        with patch.object(
+            LibraryDetailAPIView, "permission_classes", [HasValidTokenOrSession]
+        ):
+            response = api_client.delete("/v1/library/anything/")
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    @override_settings(SWARM_API_KEY="test-token-123")
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_auth_enabled_accepts_valid_bearer_token(self, mock_get, api_client):
+        """A valid static Bearer token grants access."""
+        mock_get.return_value = {"installed": [], "custom": []}
+        api_client.credentials(HTTP_AUTHORIZATION="Bearer test-token-123")
+        with patch.object(
+            LibraryAPIView, "permission_classes", [HasValidTokenOrSession]
+        ):
+            response = api_client.get("/v1/library/")
+        assert response.status_code == status.HTTP_200_OK
+
+    @override_settings(SWARM_API_KEY="test-token-123")
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_auth_enabled_rejects_invalid_bearer_token(self, mock_get, api_client):
+        """An invalid static Bearer token is rejected."""
+        mock_get.return_value = {"installed": [], "custom": []}
+        api_client.credentials(HTTP_AUTHORIZATION="Bearer wrong-token")
+        with patch.object(
+            LibraryAPIView, "permission_classes", [HasValidTokenOrSession]
+        ):
+            response = api_client.get("/v1/library/")
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    @patch("swarm.views.library_api.get_user_blueprint_library")
+    def test_auth_enabled_accepts_session_user(self, mock_get, api_client):
+        """An authenticated session user grants access."""
+        mock_get.return_value = {"installed": [], "custom": []}
+        api_client.force_authenticate(user=self._authed_user())
+        with patch.object(
+            LibraryAPIView, "permission_classes", [HasValidTokenOrSession]
+        ):
+            response = api_client.get("/v1/library/")
+        assert response.status_code == status.HTTP_200_OK

--- a/webui/frontend/src/lib/api.ts
+++ b/webui/frontend/src/lib/api.ts
@@ -185,6 +185,18 @@ export interface CreateTeamRequest {
   llm_profile?: string
 }
 
+/**
+ * GET/POST /v1/library/ and DELETE /v1/library/<name>/
+ * (swarm/views/library_api.py). Backed by the same blueprint_library.json
+ * used by the server-rendered /blueprint-library/ pages.
+ */
+export interface LibraryEntry {
+  id: string
+  object: 'library.blueprint'
+  name: string
+  description: string
+}
+
 export function fetchBlueprints(): Promise<ListResponse<Blueprint>> {
   return apiGet<ListResponse<Blueprint>>('/v1/blueprints/')
 }
@@ -203,6 +215,18 @@ export function createTeam(team: CreateTeamRequest): Promise<Team> {
 
 export function deleteTeam(teamId: string): Promise<void> {
   return apiDelete(`/v1/teams/${encodeURIComponent(teamId)}/`)
+}
+
+export function fetchLibrary(): Promise<ListResponse<LibraryEntry>> {
+  return apiGet<ListResponse<LibraryEntry>>('/v1/library/')
+}
+
+export function addToLibrary(name: string): Promise<LibraryEntry> {
+  return apiPost<LibraryEntry>('/v1/library/', { name })
+}
+
+export function removeFromLibrary(name: string): Promise<void> {
+  return apiDelete(`/v1/library/${encodeURIComponent(name)}/`)
 }
 
 // ---------------------------------------------------------------------------

--- a/webui/frontend/src/pages/BlueprintsPage.tsx
+++ b/webui/frontend/src/pages/BlueprintsPage.tsx
@@ -1,20 +1,77 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { Button, Card, Alert, SkeletonCard } from '../components/DaisyUI';
-import { Book, Search, AlertCircle, Server } from 'lucide-react';
-import { fetchBlueprints, type Blueprint } from '../lib/api';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Button, Card, Alert, SkeletonCard, ToastProvider, useToast } from '../components/DaisyUI';
+import { Book, Search, AlertCircle, Server, BookmarkPlus, BookmarkCheck } from 'lucide-react';
+import {
+  addToLibrary,
+  fetchBlueprints,
+  fetchLibrary,
+  removeFromLibrary,
+  type Blueprint,
+} from '../lib/api';
 
-const BlueprintsPage = () => {
+/**
+ * Blueprint library page.
+ *
+ * The catalog comes from /v1/blueprints/; the per-deployment "My Library"
+ * (install) state comes from /v1/library/ (swarm/views/library_api.py), the
+ * JSON counterpart to the server-rendered /blueprint-library/ pages.
+ */
+const BlueprintsPageContent = () => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
   const [searchTerm, setSearchTerm] = useState('');
+  const [libraryOnly, setLibraryOnly] = useState(false);
 
   const { data, isPending, isError, error, refetch } = useQuery({
     queryKey: ['blueprints'],
     queryFn: fetchBlueprints,
   });
 
+  const libraryQuery = useQuery({
+    queryKey: ['library'],
+    queryFn: fetchLibrary,
+  });
+
+  const libraryIds = new Set(
+    (libraryQuery.data?.data ?? []).map((entry) => entry.id),
+  );
+
+  const addMutation = useMutation({
+    mutationFn: addToLibrary,
+    onSuccess: (entry) => {
+      queryClient.invalidateQueries({ queryKey: ['library'] });
+      toast.success('Added to library', `"${entry.name}" is now in your library.`);
+    },
+    onError: (err) => {
+      toast.error(
+        'Failed to add blueprint',
+        err instanceof Error ? err.message : 'Unknown error',
+      );
+    },
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: removeFromLibrary,
+    onSuccess: (_data, name) => {
+      queryClient.invalidateQueries({ queryKey: ['library'] });
+      toast.success('Removed from library', `"${name}" was removed from your library.`);
+    },
+    onError: (err) => {
+      toast.error(
+        'Failed to remove blueprint',
+        err instanceof Error ? err.message : 'Unknown error',
+      );
+    },
+  });
+
   const blueprints: Blueprint[] = data?.data ?? [];
 
   const filteredBlueprints = blueprints.filter((blueprint) => {
+    if (libraryOnly && !libraryIds.has(blueprint.id)) {
+      return false;
+    }
     const term = searchTerm.toLowerCase();
     return (
       blueprint.id.toLowerCase().includes(term) ||
@@ -22,6 +79,10 @@ const BlueprintsPage = () => {
       blueprint.description.toLowerCase().includes(term)
     );
   });
+
+  const isMutating = (id: string) =>
+    (addMutation.isPending && addMutation.variables === id) ||
+    (removeMutation.isPending && removeMutation.variables === id);
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -33,9 +94,9 @@ const BlueprintsPage = () => {
         <p className="text-base-content/70">Blueprints available on this server</p>
       </div>
 
-      {/* Search */}
+      {/* Search + library filter */}
       <Card bordered className="mb-6">
-        <div className="flex flex-col md:flex-row gap-4">
+        <div className="flex flex-col md:flex-row gap-4 md:items-end">
           <div className="flex-1">
             <label className="label">
               <span className="label-text">Search Blueprints</span>
@@ -53,7 +114,29 @@ const BlueprintsPage = () => {
               </button>
             </div>
           </div>
+          <div className="form-control pb-1">
+            <label className="label cursor-pointer gap-3">
+              <span className="label-text flex items-center gap-1">
+                <BookmarkCheck className="h-4 w-4" />
+                My Library only
+                {libraryQuery.isSuccess && <span>({libraryIds.size})</span>}
+              </span>
+              <input
+                type="checkbox"
+                className="toggle toggle-primary"
+                checked={libraryOnly}
+                onChange={(e) => setLibraryOnly(e.target.checked)}
+                disabled={libraryQuery.isError}
+                aria-label="Show only blueprints in my library"
+              />
+            </label>
+          </div>
         </div>
+        {libraryQuery.isError && (
+          <p className="text-xs text-warning mt-2">
+            Could not load your library state; add/remove is unavailable.
+          </p>
+        )}
       </Card>
 
       {/* Loading state */}
@@ -83,60 +166,93 @@ const BlueprintsPage = () => {
       {/* Blueprint grid */}
       {!isPending && !isError && filteredBlueprints.length > 0 && (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {filteredBlueprints.map((blueprint) => (
-            <div
-              key={blueprint.id}
-              className="card bg-base-100 border border-base-300 hover:shadow-md transition-shadow h-full"
-            >
-              <div className="card-body flex flex-col">
-                {/* flex-wrap + break-words: long unbroken names (e.g.
-                    WhiskeyTangoFoxtrotBlueprint) must not push the badge
-                    outside the card / widen the page on small screens. */}
-                <div className="flex flex-wrap justify-between items-start gap-2">
-                  <h3 className="card-title text-base leading-snug min-w-0 break-words">{blueprint.name}</h3>
-                  <span className="badge badge-neutral badge-sm font-mono shrink-0">
-                    {blueprint.abbreviation || blueprint.id}
-                  </span>
-                </div>
+          {filteredBlueprints.map((blueprint) => {
+            const inLibrary = libraryIds.has(blueprint.id);
+            return (
+              <div
+                key={blueprint.id}
+                className="card bg-base-100 border border-base-300 hover:shadow-md transition-shadow h-full"
+              >
+                <div className="card-body flex flex-col">
+                  {/* flex-wrap + break-words: long unbroken names (e.g.
+                      WhiskeyTangoFoxtrotBlueprint) must not push the badge
+                      outside the card / widen the page on small screens. */}
+                  <div className="flex flex-wrap justify-between items-start gap-2">
+                    <h3 className="card-title text-base leading-snug min-w-0 break-words">{blueprint.name}</h3>
+                    <span className="badge badge-neutral badge-sm font-mono shrink-0">
+                      {blueprint.abbreviation || blueprint.id}
+                    </span>
+                  </div>
 
-                <p className="text-xs text-base-content/50 font-mono">{blueprint.id}</p>
-                <p
-                  className="text-sm text-base-content/70 line-clamp-3"
-                  title={blueprint.description}
-                >
-                  {blueprint.description || 'No description provided.'}
-                </p>
+                  <p className="text-xs text-base-content/50 font-mono">{blueprint.id}</p>
+                  <p
+                    className="text-sm text-base-content/70 line-clamp-3"
+                    title={blueprint.description}
+                  >
+                    {blueprint.description || 'No description provided.'}
+                  </p>
 
-                <div className="mt-auto pt-3 space-y-2">
-                  {blueprint.tags.length > 0 && (
-                    <div className="flex flex-wrap gap-1">
-                      {blueprint.tags.map((tag) => (
-                        <span key={tag} className="badge badge-ghost badge-sm">
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-
-                  {blueprint.required_mcp_servers.length > 0 && (
-                    <div className="border-t border-base-300 pt-2 text-sm">
-                      <span className="flex items-center gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
-                        <Server className="h-3 w-3" />
-                        Required MCP servers
-                      </span>
-                      <div className="flex flex-wrap gap-1 mt-1.5">
-                        {blueprint.required_mcp_servers.map((server) => (
-                          <span key={server} className="badge badge-outline badge-sm font-mono">
-                            {server}
+                  <div className="mt-auto pt-3 space-y-2">
+                    {blueprint.tags.length > 0 && (
+                      <div className="flex flex-wrap gap-1">
+                        {blueprint.tags.map((tag) => (
+                          <span key={tag} className="badge badge-ghost badge-sm">
+                            {tag}
                           </span>
                         ))}
                       </div>
+                    )}
+
+                    {blueprint.required_mcp_servers.length > 0 && (
+                      <div className="border-t border-base-300 pt-2 text-sm">
+                        <span className="flex items-center gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
+                          <Server className="h-3 w-3" />
+                          Required MCP servers
+                        </span>
+                        <div className="flex flex-wrap gap-1 mt-1.5">
+                          {blueprint.required_mcp_servers.map((server) => (
+                            <span key={server} className="badge badge-outline badge-sm font-mono">
+                              {server}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+
+                    <div className="card-actions justify-end border-t border-base-300 pt-2">
+                      {inLibrary ? (
+                        <Button
+                          variant="outline"
+                          color="success"
+                          size="sm"
+                          loading={isMutating(blueprint.id)}
+                          disabled={isMutating(blueprint.id)}
+                          onClick={() => removeMutation.mutate(blueprint.id)}
+                          title="In your library — click to remove"
+                          aria-label={`Remove ${blueprint.name} from library`}
+                        >
+                          <BookmarkCheck className="h-4 w-4 mr-1" />
+                          In Library
+                        </Button>
+                      ) : (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          loading={isMutating(blueprint.id)}
+                          disabled={isMutating(blueprint.id) || libraryQuery.isError}
+                          onClick={() => addMutation.mutate(blueprint.id)}
+                          aria-label={`Add ${blueprint.name} to library`}
+                        >
+                          <BookmarkPlus className="h-4 w-4 mr-1" />
+                          Add to Library
+                        </Button>
+                      )}
                     </div>
-                  )}
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
 
@@ -148,15 +264,22 @@ const BlueprintsPage = () => {
           </div>
           <h3 className="text-xl font-semibold mb-2">No blueprints found</h3>
           <p className="text-base-content/70 mb-4">
-            {searchTerm
+            {searchTerm || libraryOnly
               ? 'No blueprints match your search criteria'
               : 'No blueprints are registered on this server'}
           </p>
-          {searchTerm && (
-            <div>
-              <Button variant="outline" onClick={() => setSearchTerm('')}>
-                Reset Search
-              </Button>
+          {(searchTerm || libraryOnly) && (
+            <div className="flex justify-center gap-2">
+              {searchTerm && (
+                <Button variant="outline" onClick={() => setSearchTerm('')}>
+                  Reset Search
+                </Button>
+              )}
+              {libraryOnly && (
+                <Button variant="outline" onClick={() => setLibraryOnly(false)}>
+                  Show All Blueprints
+                </Button>
+              )}
             </div>
           )}
         </Card>
@@ -164,5 +287,15 @@ const BlueprintsPage = () => {
     </div>
   );
 };
+
+/**
+ * The app shell does not mount a ToastProvider, so provide one locally for
+ * add/remove feedback (same pattern as TeamsPage).
+ */
+const BlueprintsPage = () => (
+  <ToastProvider>
+    <BlueprintsPageContent />
+  </ToastProvider>
+);
 
 export default BlueprintsPage;


### PR DESCRIPTION
## Summary

The SPA's /blueprints catalog was read-only; add/remove-to-library lived only in the server-rendered Django UI (`/blueprint-library/`). This PR brings library **management** to the SPA.

### Discovered semantics (Django `/blueprint-library/`)
- Persistence is a single file-backed store: `<user config dir>/blueprint_library.json` (e.g. `~/.config/OpenSwarm/swarm/blueprint_library.json`) with `{"installed": [...], "custom": [...]}` — **per OS user / deployment, not per Django user**. The JSON API mirrors that honestly.
- Add validates the name against `discover_blueprints(BLUEPRINT_DIRECTORY)` and appends to `installed`; remove pops it; `my_blueprints` renders `installed` + `custom`.
- Custom blueprints already have a JSON API (`/v1/blueprints/custom/`), and requirements status is already JSON (`/blueprint-library/requirements/`) — not duplicated here.
- **Django-only (not ported):** avatar generation / ComfyUI status (external ComfyUI dependency) and the HTML blueprint-creator form (template/LLM-placeholder flow).

### Backend — `src/swarm/views/library_api.py` (follows `teams_api.py` precedent)
| Endpoint | Behaviour |
|---|---|
| `GET /v1/library/` | `{"object": "list", "data": [{"id", "object": "library.blueprint", "name", "description"}]}` |
| `POST /v1/library/` `{name}` | 201 + entry; 200 if already present (idempotent); 400 missing name; 404 unknown blueprint |
| `DELETE /v1/library/<name>/` | 204; 404 if not in library |

Reuses `get_user_blueprint_library` / `save_user_blueprint_library` and the `BLUEPRINT_METADATA` name/description fallback. Permissions identical to `/v1/teams/`: `HasValidTokenOrSession` when API auth is enabled, else `AllowAny`. Routes registered in `swarm/urls.py` next to the teams API.

### Frontend
- `BlueprintsPage` cards get an **Add to Library** / **In Library** button (click again to remove) with toast feedback via a local `ToastProvider` (same pattern as `TeamsPage`); react-query mutations invalidate the `['library']` query.
- **My Library only** toggle (filter on the same page, no new route) with a count badge; empty state offers "Show All Blueprints".
- If the library query fails, the toggle/add buttons disable with a small notice instead of breaking the catalog.

## Evidence

Live smoke (runserver + isolated `XDG_CONFIG_HOME`):
```
GET  /v1/library/                  -> {"object":"list","data":[]}
POST /v1/library/ {"name":"codey"} -> 201 {"id":"codey","object":"library.blueprint","name":"Codey",...}
POST (unknown name)                -> 404
POST (again, idempotent)           -> 200
GET  /v1/library/                  -> 1 entry; blueprint_library.json -> {"installed":["codey"],"custom":[]}
DELETE /v1/library/codey/          -> 204; again -> 404 {"error":"not found"}
```

Playwright click-through (headless Chromium against Django-served SPA build): loaded /blueprints (14 cards with Add buttons), clicked Add on the codey card → green "Added to library" toast + button flipped to a green "In Library" state, enabled the My Library toggle → only the codey card remained (count "(1)" in the toggle label), clicked In Library → "Removed from library" toast and the filtered view showed the empty state. Screenshots verified visually at each step.

## Tests
- `tests/views/test_library_api.py`: 23 new tests (list/add/remove/auth), 100% coverage of the new module.
- Full suite: **928 passed, 9 skipped** (baseline 905 + 23 new).
- Frontend: `npm run type-check` and `npm run build` green (node 22); eslint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)