### PR TITLE
feat: per-CLI auth autodiscovery — cli-agents --check-auth (v0.4.0 PR 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Turn the agentic CLIs you already have installed (`claude`, `gemini`, `codex`,
 - Full-capability (auto-approve) example adapters, replacing the read-only defaults
 - Per-panelist workdir isolation (`cli_fusion.isolate_workdir` / per-request `isolate`): each write-capable panelist gets a throwaway `git worktree` (or temp dir) so parallel fan-out can't corrupt the source tree
 - Built-in adapter catalog + `swarm-cli cli-agents --suggest`: paste-ready config for supported CLIs installed but not yet configured
+- Catalog defaults encode known per-CLI gotchas so they run non-interactively out of the box: `gemini --skip-trust` (untrusted-dir gate), `opencode --model` (no usable built-in default) — verified live
 - Non-interactive smoke probe + `swarm-cli cli-agents --smoke`: catches a misconfigured `cmd` that hangs instead of returning (ok/hang/error/not_installed)
 - Machine-readable `swarm-cli cli-agents --json` (agents/smoke/suggestions) for CI and scripting
 - `cli_agent` streams CLI stdout incrementally for `parse: "text"` adapters when `stream: true` (json-parse adapters fall back to one-shot)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Turn the agentic CLIs you already have installed (`claude`, `gemini`, `codex`,
 - Non-interactive smoke probe + `swarm-cli cli-agents --smoke`: catches a misconfigured `cmd` that hangs instead of returning (ok/hang/error/not_installed)
 - Machine-readable `swarm-cli cli-agents --json` (agents/smoke/suggestions) for CI and scripting
 - `cli_agent` streams CLI stdout incrementally for `parse: "text"` adapters when `stream: true` (json-parse adapters fall back to one-shot)
+- Failover & graceful degradation: `cli_agent` fails over down a candidate chain (`params.fallback`, or auto to other installed adapters; `failover: false` for strict) when a CLI is missing/broken/hung; `cli_fusion` drops failed panelists and reaches consensus from the survivors
 - End-to-end API coverage: real panel→synthesize and `params`-driven selection over `/v1/chat/completions`
 
 ## [0.3.3] - 2026-06-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Added — CLI Agent Fusion (v0.4.0 line, in progress)
+(nothing yet)
+
+## [0.4.0] - 2026-06-16
+
+### Added — CLI Agent Fusion
 
 Turn the agentic CLIs you already have installed (`claude`, `gemini`, `codex`,
 `opencode`, …) into one-shot, OpenAI-API-addressable subagents — single

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-(nothing yet)
+### Added — CLI Agent Fusion (v0.4.0 line, in progress)
+
+Turn the agentic CLIs you already have installed (`claude`, `gemini`, `codex`,
+`opencode`, …) into one-shot, OpenAI-API-addressable subagents — single
+(`cli_agent`) or a parallel panel a judge synthesizes (`cli_fusion`). See
+[docs/CLI_FUSION.md](docs/CLI_FUSION.md).
+
+- `CliAdapter` one-shot layer + `cli_agent`/`cli_fusion` blueprints (panel → judge → synthesize, bounded master plan) (#116, #117)
+- Autodiscovery: `swarm-cli cli-agents` reports install status; `--check-auth` probes each CLI's `auth_check`
+- Full-capability (auto-approve) example adapters, replacing the read-only defaults
+- Per-panelist workdir isolation (`cli_fusion.isolate_workdir` / per-request `isolate`): each write-capable panelist gets a throwaway `git worktree` (or temp dir) so parallel fan-out can't corrupt the source tree
+- Built-in adapter catalog + `swarm-cli cli-agents --suggest`: paste-ready config for supported CLIs installed but not yet configured
+- Non-interactive smoke probe + `swarm-cli cli-agents --smoke`: catches a misconfigured `cmd` that hangs instead of returning (ok/hang/error/not_installed)
+- End-to-end API coverage: real panel→synthesize and `params`-driven selection over `/v1/chat/completions`
 
 ## [0.3.3] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Turn the agentic CLIs you already have installed (`claude`, `gemini`, `codex`,
 - Machine-readable `swarm-cli cli-agents --json` (agents/smoke/suggestions) for CI and scripting
 - `cli_agent` streams CLI stdout incrementally for `parse: "text"` adapters when `stream: true` (json-parse adapters fall back to one-shot)
 - Failover & graceful degradation: `cli_agent` fails over down a candidate chain (`params.fallback`, or auto to other installed adapters; `failover: false` for strict) when a CLI is missing/broken/hung; `cli_fusion` drops failed panelists and reaches consensus from the survivors
+- Reusable consensus service (`swarm.core.consensus.run_consensus`) extracted from the `cli_fusion` blueprint; consensus-first synthesis (no-judge fallback now picks the **most-corroborated** panel answer, not the longest)
+- New `cli_orchestrator` blueprint — granular consensus: a cheap router CLI answers directly and escalates only high-stakes questions to a consensus panel (fusion as an on-demand tool, not a whole-request mode)
+- Cleanup: removed dead `progress_text()` and `CliResult.as_dict()`
 - End-to-end API coverage: real panel→synthesize and `params`-driven selection over `/v1/chat/completions`
 
 ## [0.3.3] - 2026-06-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Turn the agentic CLIs you already have installed (`claude`, `gemini`, `codex`,
 - Reusable consensus service (`swarm.core.consensus.run_consensus`) extracted from the `cli_fusion` blueprint; consensus-first synthesis (no-judge fallback now picks the **most-corroborated** panel answer, not the longest)
 - New `cli_orchestrator` blueprint — granular consensus: a cheap router CLI answers directly and escalates only high-stakes questions to a consensus panel (fusion as an on-demand tool, not a whole-request mode)
 - Cleanup: removed dead `progress_text()` and `CliResult.as_dict()`
+- Agent-tool layer (`swarm.core.cli_tools`): `cli_persona(adapter)` and `consensus_fn(panel, judge)` callables, `as_function_tool()` to hand either to an openai-agents `Agent` — so a real agent can call `consensus()` granularly mid-reasoning
+- New `cli_map` blueprint — decompose → distribute → reduce: a planner CLI splits one task into subtasks, workers run them in parallel (round-robin), a reducer combines (complements `cli_fusion`'s consensus)
 - End-to-end API coverage: real panel→synthesize and `params`-driven selection over `/v1/chat/completions`
 
 ## [0.3.3] - 2026-06-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Turn the agentic CLIs you already have installed (`claude`, `gemini`, `codex`,
 - Cleanup: removed dead `progress_text()` and `CliResult.as_dict()`
 - Agent-tool layer (`swarm.core.cli_tools`): `cli_persona(adapter)` and `consensus_fn(panel, judge)` callables, `as_function_tool()` to hand either to an openai-agents `Agent` — so a real agent can call `consensus()` granularly mid-reasoning
 - New `cli_map` blueprint — decompose → distribute → reduce: a planner CLI splits one task into subtasks, workers run them in parallel (round-robin), a reducer combines (complements `cli_fusion`'s consensus)
+- Web UI **API Access** panel (Settings) — surfaces the live base URL, token, model list, and copy-paste snippets (curl / OpenAI SDK / Open WebUI) to plug any OpenAI client into the server
 - End-to-end API coverage: real panel→synthesize and `params`-driven selection over `/v1/chat/completions`
 
 ## [0.3.3] - 2026-06-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Turn the agentic CLIs you already have installed (`claude`, `gemini`, `codex`,
 - Per-panelist workdir isolation (`cli_fusion.isolate_workdir` / per-request `isolate`): each write-capable panelist gets a throwaway `git worktree` (or temp dir) so parallel fan-out can't corrupt the source tree
 - Built-in adapter catalog + `swarm-cli cli-agents --suggest`: paste-ready config for supported CLIs installed but not yet configured
 - Non-interactive smoke probe + `swarm-cli cli-agents --smoke`: catches a misconfigured `cmd` that hangs instead of returning (ok/hang/error/not_installed)
+- Machine-readable `swarm-cli cli-agents --json` (agents/smoke/suggestions) for CI and scripting
+- `cli_agent` streams CLI stdout incrementally for `parse: "text"` adapters when `stream: true` (json-parse adapters fall back to one-shot)
 - End-to-end API coverage: real panel→synthesize and `params`-driven selection over `/v1/chat/completions`
 
 ## [0.3.3] - 2026-06-12

--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -121,6 +121,27 @@ Import check: every module below imported successfully via `uv run python -c "im
 
 ---
 
+## 11. CLI Agent Fusion — ✅ 8 (v0.4.0 line, in progress)
+
+Turns installed agentic CLIs (`claude`, `gemini`, `codex`, `opencode`, …) into
+one-shot, API-addressable subagents. See `docs/CLI_FUSION.md`.
+
+| Feature | Status | Evidence |
+|---|---|---|
+| CliAdapter one-shot layer | ✅ | `src/swarm/core/cli_adapter.py`; argv/stdin prompt modes, text/`json:<path>` parse, process-group timeout kill; `tests/core/test_cli_adapter.py` |
+| `cli_agent` / `cli_fusion` blueprints | ✅ | `src/swarm/blueprints/cli_{agent,fusion}/`; panel→judge→synthesize + bounded master plan; `tests/blueprints/test_cli_{agent,fusion}.py` |
+| Install autodiscovery | ✅ | `CliAdapterRegistry.discover()` + `swarm-cli cli-agents` (PR 2) |
+| Auth autodiscovery | ✅ | `CliAgentConfig.auth_check` + `discover_auth()` + `--check-auth` (PR 3) |
+| Full-capability panelists + workdir isolation | ✅ | Yolo-flag example adapters; `cli_fusion.isolate_workdir` git-worktree/temp-dir isolation (PR 4); isolation tests incl. real-git end-to-end |
+| Built-in adapter catalog + `--suggest` | ✅ | `src/swarm/core/cli_catalog.py`; `swarm-cli cli-agents --suggest`; `tests/core/test_cli_catalog.py` (PR 5) |
+| Non-interactive smoke probe + `--smoke` | ✅ | `CliAdapter.smoke_check()` / `smoke_check_all()`; classifies ok/hang/error/not_installed (PR 6) |
+| End-to-end API coverage | ✅ | `tests/api/test_cli_fusion_api.py`: real panel→synthesize and `params` selection over `/v1/chat/completions` (PR 7) |
+
+Remaining v0.4.0 work (PRs 8–13): not yet specced; version bump + CHANGELOG + tag
+deferred to the release PR.
+
+---
+
 ## Regeneration
 
 This doc decays fast (a cleanup wave was rewriting the tree while it was generated). Before acting on any row, re-verify:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -136,6 +136,24 @@ parity is reached.
 - [ ] Demote or archive non-flagship blueprints to an examples/contrib area
 - [ ] Restore or formally drop legacy CLI commands old docs reference (`wizard`, `config`, `add`)
 
+### 3.5b CLI Agent Fusion (v0.4.0 feature line)
+
+Turns the agentic CLIs an operator already has installed (`claude`, `gemini`,
+`codex`, `opencode`, …) into one-shot, OpenAI-API-addressable subagents — single
+(`cli_agent`) or a parallel panel that a judge synthesizes (`cli_fusion`). Full
+design in [docs/CLI_FUSION.md](./docs/CLI_FUSION.md). Shipped via a PR series
+tagged `v0.4.0 PR n/13` in the commit log.
+
+- [ ] CLI Agent Fusion shipped as v0.4.0
+  - [x] Foundation: `CliAdapter` one-shot layer + `cli_agent`/`cli_fusion` blueprints (PR 1)
+  - [x] Install autodiscovery: `Registry.discover()` + `swarm-cli cli-agents` (PR 2)
+  - [x] Auth autodiscovery: `auth_check` probe + `--check-auth` (PR 3)
+  - [x] Full-capability panelists (auto-approve flags) + per-panelist workdir isolation (git worktree / temp dir) (PR 4)
+  - [x] Built-in adapter catalog + `swarm-cli cli-agents --suggest` (PR 5)
+  - [x] Non-interactive smoke probe + `--smoke` (PR 6)
+  - [x] End-to-end API coverage over `/v1/chat/completions` (PR 7)
+  - [ ] Remaining PRs 8–13 (not yet specced) + version bump, CHANGELOG, tag in the release PR
+
 ### 3.6 Release engineering
 
 - [ ] First tagged FOSS release on PyPI

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -139,20 +139,22 @@ parity is reached.
 ### 3.5b CLI Agent Fusion (v0.4.0 feature line)
 
 Turns the agentic CLIs an operator already has installed (`claude`, `gemini`,
-`codex`, `opencode`, …) into one-shot, OpenAI-API-addressable subagents — single
-(`cli_agent`) or a parallel panel that a judge synthesizes (`cli_fusion`). Full
-design in [docs/CLI_FUSION.md](./docs/CLI_FUSION.md). Shipped via a PR series
-tagged `v0.4.0 PR n/13` in the commit log.
+`codex`, `opencode`, …) into one-shot, OpenAI-API-addressable subagents, composed
+four ways: single (`cli_agent`), consensus panel (`cli_fusion`), granular
+consensus (`cli_orchestrator`), and decompose-and-distribute (`cli_map`). Full
+design in [docs/CLI_FUSION.md](./docs/CLI_FUSION.md). Built as a PR series in the
+commit log; version bumped to 0.4.0.
 
-- [ ] CLI Agent Fusion shipped as v0.4.0
-  - [x] Foundation: `CliAdapter` one-shot layer + `cli_agent`/`cli_fusion` blueprints (PR 1)
-  - [x] Install autodiscovery: `Registry.discover()` + `swarm-cli cli-agents` (PR 2)
-  - [x] Auth autodiscovery: `auth_check` probe + `--check-auth` (PR 3)
-  - [x] Full-capability panelists (auto-approve flags) + per-panelist workdir isolation (git worktree / temp dir) (PR 4)
-  - [x] Built-in adapter catalog + `swarm-cli cli-agents --suggest` (PR 5)
-  - [x] Non-interactive smoke probe + `--smoke` (PR 6)
-  - [x] End-to-end API coverage over `/v1/chat/completions` (PR 7)
-  - [ ] Remaining PRs 8–13 (not yet specced) + version bump, CHANGELOG, tag in the release PR
+- [x] CLI Agent Fusion built for v0.4.0 (code complete; tag + PyPI publish pending)
+  - [x] Foundation: `CliAdapter` one-shot layer + `cli_agent`/`cli_fusion` blueprints
+  - [x] Install + auth autodiscovery: `swarm-cli cli-agents` (`--check-auth`/`--smoke`/`--suggest`/`--json`)
+  - [x] Full-capability panelists (auto-approve) + per-panelist workdir isolation (git worktree / temp dir)
+  - [x] Built-in adapter catalog with per-CLI gotchas baked in (gemini `--skip-trust`, opencode `--model`)
+  - [x] Incremental streaming (`cli_agent`) + failover/graceful degradation
+  - [x] Reusable `swarm.core.consensus` service (consensus-first synthesis) + `swarm.core.cli_tools` agent-tool layer (`as_tool()`)
+  - [x] `cli_orchestrator` (granular consensus) + `cli_map` (decompose → distribute → reduce) blueprints
+  - [x] End-to-end API coverage; verified live over claude+gemini+opencode
+  - [ ] Tag `v0.4.0` + PyPI publish (manual release step — owner action)
 
 ### 3.6 Release engineering
 

--- a/docs/CLI_FUSION.md
+++ b/docs/CLI_FUSION.md
@@ -49,7 +49,8 @@ curl -sf http://localhost:8000/v1/chat/completions \
 See which of your configured CLIs are actually installed on the host:
 
 ```bash
-swarm-cli cli-agents          # uses the usual config search
+swarm-cli cli-agents               # install status only (fast)
+swarm-cli cli-agents --check-auth  # also probe each CLI's auth_check
 swarm-cli cli-agents --config ./swarm_config.json
 ```
 
@@ -79,6 +80,7 @@ string.
 | `env_allowlist` | list[str] \| null | **null (default):** child inherits the full environment (convenient, but every panelist sees every API key). **Set it:** child gets only these vars plus essentials (`PATH`, `HOME`, …) — isolates each CLI's secrets. |
 | `timeout` | number | Seconds before the CLI (and its whole process group) is killed. Default 180. |
 | `mode` | str | Free-text label documenting safety posture (`"readonly"`, `"write"`). Advisory. |
+| `auth_check` | list[str] | Optional argv probe for `swarm-cli cli-agents --check-auth`. Exit 0 ⇒ authenticated. Should be cheap and not consume quota (capped at 30s). |
 
 > ⚠️ **Exact flags and JSON shapes vary by CLI version.** The snippets below are
 > starting points — run the CLI's `--help` and confirm its non-interactive flag,

--- a/docs/CLI_FUSION.md
+++ b/docs/CLI_FUSION.md
@@ -51,8 +51,16 @@ See which of your configured CLIs are actually installed on the host:
 ```bash
 swarm-cli cli-agents               # install status only (fast)
 swarm-cli cli-agents --check-auth  # also probe each CLI's auth_check
+swarm-cli cli-agents --suggest     # propose config for installed-but-unconfigured CLIs
 swarm-cli cli-agents --config ./swarm_config.json
 ```
+
+`--suggest` checks a built-in catalog of known-good adapter configs against your
+host and prints a ready-to-paste `cli_agents` block for every supported CLI
+(`claude`, `gemini`, `codex`, `opencode`) that is installed but not yet in your
+config — so getting started is "install the CLI, run `--suggest`, paste". The
+suggested flags track each CLI's non-interactive + auto-approve mode; verify them
+against the CLI's own `--help`, since flags drift by version.
 
 ```
 AGENT            STATUS     MODE       EXECUTABLE

--- a/docs/CLI_FUSION.md
+++ b/docs/CLI_FUSION.md
@@ -250,6 +250,28 @@ prompt ─► panel: N CLIs run in PARALLEL (asyncio.gather), each one-shot
 
 ---
 
+## Decompose & distribute — `cli_map`
+
+The complement to consensus. `cli_fusion` sends the *same* question to a panel;
+`cli_map` splits *one task* into independent subtasks, distributes them across
+worker CLIs in parallel (round-robin), and reduces the results into one answer —
+divide-and-conquer for scale.
+
+```jsonc
+"cli_map": {
+  "planner": "claude",
+  "workers": ["claude", "gemini", "opencode"],
+  "reducer": "claude",
+  "max_items": 6
+}
+```
+
+A **planner** CLI decomposes the prompt into a JSON subtask list (or pass
+`params.items` to skip planning), workers run the subtasks concurrently, and a
+**reducer** combines them (falling back to a labeled concatenation if no reducer
+is configured). Falls back to `cli_fusion` config when the `cli_map` block is
+omitted.
+
 ## Granular consensus — `cli_orchestrator`
 
 `cli_fusion` fans out on *every* request. `cli_orchestrator` makes consensus

--- a/docs/CLI_FUSION.md
+++ b/docs/CLI_FUSION.md
@@ -139,7 +139,7 @@ get a panelist that actually *does work*, pin down two flags from its `--help`:
     "timeout": 240
   },
   "gemini": {
-    "cmd": ["gemini", "-p", "{prompt}", "-o", "json", "--yolo"],
+    "cmd": ["gemini", "-p", "{prompt}", "-o", "json", "--yolo", "--skip-trust"],
     "parse": "json:.response",
     "mode": "write"
   },
@@ -149,12 +149,26 @@ get a panelist that actually *does work*, pin down two flags from its `--help`:
     "mode": "write"
   },
   "opencode": {
-    "cmd": ["opencode", "run", "{prompt}"],
+    "cmd": ["opencode", "run", "{prompt}", "--model", "opencode/big-pickle"],
     "parse": "text",
     "mode": "write"
   }
 }
 ```
+
+### Known per-CLI gotchas (baked into the defaults)
+
+These bite the moment you run a CLI non-interactively; the catalog and the
+examples above already include the fixes (verified live 2026-06-16):
+
+| CLI | Gotcha | Fix (already applied) |
+|---|---|---|
+| `gemini` | refuses to run in an "untrusted" directory | `--skip-trust` (or `GEMINI_CLI_TRUST_WORKSPACE=true`) |
+| `opencode` | built-in default model errors as "not supported" | explicit `--model` (e.g. `opencode/big-pickle`) — run `opencode models` to pick one available to your account |
+| `claude` | none for read/answer; writes need the auto-approve flag | `--dangerously-skip-permissions` (already in the write config) |
+
+The `--model` value for `opencode` is account/version-specific — it's the one
+place you'll likely need to adjust. Everything else runs as shipped.
 
 These panelists run at **full capability** — they can read, write, and run
 commands. The one real hazard of fanning several write-capable agents out in

--- a/docs/CLI_FUSION.md
+++ b/docs/CLI_FUSION.md
@@ -53,8 +53,13 @@ swarm-cli cli-agents               # install status only (fast)
 swarm-cli cli-agents --check-auth  # also probe each CLI's auth_check
 swarm-cli cli-agents --suggest     # propose config for installed-but-unconfigured CLIs
 swarm-cli cli-agents --smoke       # run one trivial one-shot per CLI to confirm it returns
+swarm-cli cli-agents --json        # machine-readable output (for CI / scripts / Open WebUI)
 swarm-cli cli-agents --config ./swarm_config.json
 ```
+
+`--json` emits one JSON object on stdout (logs stay on stderr, so `| jq` is
+clean): `{"agents": [...]}`, plus `"smoke"` and `"suggestions"` keys when
+`--smoke` / `--suggest` are combined. Use it to wire discovery into automation.
 
 `--smoke` is the counterpart to `--check-auth`: auth tells you the CLI is logged
 in; smoke tells you its configured `cmd` actually **returns** in non-interactive

--- a/docs/CLI_FUSION.md
+++ b/docs/CLI_FUSION.md
@@ -56,9 +56,9 @@ swarm-cli cli-agents --config ./swarm_config.json
 
 ```
 AGENT            STATUS     MODE       EXECUTABLE
-claude           installed  readonly   /home/you/.local/bin/claude
-codex            missing    readonly   -
-gemini           installed  readonly   /home/you/.nvm/.../gemini
+claude           installed  write      /home/you/.local/bin/claude
+codex            missing    write      -
+gemini           installed  write      /home/you/.nvm/.../gemini
 3/4 configured CLI agents installed on this host.
 ```
 
@@ -84,8 +84,26 @@ string.
 
 > ⚠️ **Exact flags and JSON shapes vary by CLI version.** The snippets below are
 > starting points — run the CLI's `--help` and confirm its non-interactive flag,
-> its read-only/approval mode, and (if using `json:` parse) the actual key in its
-> JSON output. When in doubt, use `parse: "text"`.
+> its auto-approve flag, and (if using `json:` parse) the actual key in its JSON
+> output. When in doubt, use `parse: "text"`.
+
+### Non-interactive mode is the whole game
+
+The adapter runs each CLI with stdin closed and a timeout. The flag that makes or
+breaks a run is the **auto-approve** one: in non-interactive mode an agentic CLI
+will otherwise stop mid-task to ask "may I write this file / run this command?",
+and since there's no one to answer, it blocks until the timeout kills it. So to
+get a panelist that actually *does work*, pin down two flags from its `--help`:
+
+1. its **print/exec/run** flag (one-shot, non-interactive), and
+2. its **auto-approve / skip-permissions** flag (so it never waits on a prompt).
+
+| CLI | Print/exec | Auto-approve (full-capability) | Structured output → `parse` |
+|---|---|---|---|
+| `claude` | `-p` | `--dangerously-skip-permissions` | `--output-format json` → `json:.result` |
+| `gemini` | `-p` | `--yolo` | `-o json` → `json:.response` |
+| `codex` | `exec` | `--dangerously-bypass-approvals-and-sandbox` (or `--full-auto`) | text |
+| `opencode` | `run` | (none needed — `run` acts without an approval gate) | text |
 
 ### Example adapters
 
@@ -93,30 +111,34 @@ string.
 "cli_agents": {
   "claude": {
     "cmd": ["claude", "-p", "{prompt}", "--output-format", "json",
-            "--allowedTools", "Read,Grep,Glob"],
+            "--dangerously-skip-permissions"],
     "parse": "json:.result",
-    "mode": "readonly",
+    "mode": "write",
     "timeout": 240
   },
   "gemini": {
-    "cmd": ["gemini", "-p", "{prompt}", "-o", "json", "--approval-mode", "plan"],
+    "cmd": ["gemini", "-p", "{prompt}", "-o", "json", "--yolo"],
     "parse": "json:.response",
-    "mode": "readonly"
+    "mode": "write"
   },
   "codex": {
-    "cmd": ["codex", "exec", "{prompt}"],
-    "parse": "text"
+    "cmd": ["codex", "exec", "{prompt}", "--dangerously-bypass-approvals-and-sandbox"],
+    "parse": "text",
+    "mode": "write"
   },
   "opencode": {
     "cmd": ["opencode", "run", "{prompt}"],
-    "parse": "text"
+    "parse": "text",
+    "mode": "write"
   }
 }
 ```
 
-`--allowedTools Read,Grep,Glob` (claude) and `--approval-mode plan` (gemini) keep
-panelists **read-only** — strongly recommended when fanning out in parallel (see
-[Safety](#safety)).
+These panelists run at **full capability** — they can read, write, and run
+commands. The one real hazard of fanning several write-capable agents out in
+parallel is that they stomp each other's edits in a shared tree; `cli_fusion`
+solves that by giving each panelist its own working copy — see
+[Workdir isolation](#workdir-isolation).
 
 ---
 
@@ -129,6 +151,7 @@ panelists **read-only** — strongly recommended when fanning out in parallel (s
 | `default_preset` | str | Preset used by `cli_fusion` when the request doesn't specify a panel/preset. |
 | `max_rounds` | int | Master-plan rounds (default 1, hard-capped at 5). |
 | `max_concurrency` | int | Max CLI subprocesses launched at once per round (default 8). |
+| `isolate_workdir` | bool \| null | Give each panelist its own working copy so parallel writes don't collide. **null (default):** auto — isolate when the request's `workdir` is a git repo and the panel has >1 member. **true:** always isolate. **false:** never (all panelists share one workdir). See [Workdir isolation](#workdir-isolation). |
 | `show_analysis` | bool | Append the judge's consensus/contradictions/gaps footer to the answer. |
 
 ```jsonc
@@ -136,6 +159,7 @@ panelists **read-only** — strongly recommended when fanning out in parallel (s
   "default_cli": "claude",
   "default_preset": "general-high",
   "max_rounds": 1,
+  "isolate_workdir": true,
   "show_analysis": false,
   "presets": {
     "general-high":   { "panel": ["claude", "gemini", "codex"], "judge": "claude" },
@@ -153,6 +177,7 @@ panelists **read-only** — strongly recommended when fanning out in parallel (s
 | `preset` | cli_fusion | Named preset to use. |
 | `judge` | cli_fusion | Judge adapter (overrides preset's). |
 | `max_rounds` | cli_fusion | Override master-plan rounds (capped at 5). |
+| `isolate` | cli_fusion | Override `isolate_workdir` for this request (`true`/`false`). |
 | `show_analysis` | cli_fusion | Override the analysis footer. |
 | `timeout` | both | Override every adapter's timeout for this request. |
 | `workdir` | both | Working directory for the CLI(s). |
@@ -187,18 +212,38 @@ prompt ─► panel: N CLIs run in PARALLEL (asyncio.gather), each one-shot
 
 ---
 
+## Workdir isolation
+
+Panelists run at full capability, so a panel of N write-capable agents fanned out
+over the *same* `workdir` will stomp each other's edits. `cli_fusion` defuses this
+by giving each panelist its own working copy for the duration of a round:
+
+- **git repo (the common case):** each panelist gets a throwaway
+  `git worktree` checked out at `HEAD`, so it sees the full repo cheaply and its
+  edits never touch the source tree or the other panelists. The worktrees are
+  removed (`--force`, discarding scratch edits) when the round ends.
+- **non-repo `workdir` (or none):** each panelist gets a fresh empty temp
+  directory as scratch space.
+
+Controlled by `cli_fusion.isolate_workdir` (config) or the per-request `isolate`
+param. The default (`null`) auto-isolates when `workdir` is a git repo and the
+panel has more than one member; set it `true` to always isolate or `false` to
+share one workdir. The **judge** always runs in the base `workdir` (it only reads
+and compares the panel's text answers). Fusion synthesizes a single *text* answer
+— it does not merge the panelists' divergent trees, so the isolated edits are
+treated as scratch work, not a deliverable.
+
 ## Safety
 
 CLI agents can read files, run commands, and reach the network. Treat them as
 untrusted, side-effecting processes:
 
-- **Read-only panelists by default.** Use each CLI's plan/read-only mode
-  (`--approval-mode plan`, `--allowedTools Read,Grep,…`). Only opt specific
-  adapters into write mode, and avoid running several write-mode CLIs in the same
-  `workdir` in parallel — give them separate `workdir`s.
+- **Workdir isolation.** Keep `isolate_workdir` on (the default auto-isolates git
+  repos) so parallel write-capable panelists can't corrupt the source tree or
+  collide — see above.
 - **Timeouts always.** Interactive CLIs hang waiting for input if you get the
-  non-interactive flag wrong. Every adapter has a `timeout`; on expiry the whole
-  process group is killed (SIGTERM → SIGKILL).
+  non-interactive or auto-approve flag wrong. Every adapter has a `timeout`; on
+  expiry the whole process group is killed (SIGTERM → SIGKILL).
 - **Secret isolation.** By default every panelist inherits the full environment.
   Set `env_allowlist` per adapter so each CLI sees only the keys it needs.
 - **Recursion guard.** If a panelist CLI is itself pointed back at this Open

--- a/docs/CLI_FUSION.md
+++ b/docs/CLI_FUSION.md
@@ -234,6 +234,17 @@ prompt ─► panel: N CLIs run in PARALLEL (asyncio.gather), each one-shot
 
 ---
 
+## Streaming
+
+`cli_agent` streams the CLI's stdout **incrementally** when the request sets
+`"stream": true` and the adapter uses `parse: "text"` — each delta is forwarded
+as a `chat.completion.chunk`, so an OpenAI streaming client sees output as the
+CLI produces it instead of waiting for the whole run. `json:`-parse adapters
+can't stream (the value only exists once the full document is read), so they
+fall back to a single one-shot chunk. Non-streaming requests are unchanged: one
+full answer. `cli_fusion` does not stream panelists — the judge needs each
+panelist's complete answer before it can compare them.
+
 ## Workdir isolation
 
 Panelists run at full capability, so a panel of N write-capable agents fanned out

--- a/docs/CLI_FUSION.md
+++ b/docs/CLI_FUSION.md
@@ -208,7 +208,9 @@ solves that by giving each panelist its own working copy — see
 
 | Param | Applies to | Meaning |
 |---|---|---|
-| `cli` | cli_agent | Which adapter to run. |
+| `cli` | cli_agent | Which adapter to run (the failover primary). |
+| `fallback` | cli_agent | Explicit ordered list of adapters to try if the primary fails. |
+| `failover` | cli_agent | Auto-failover to other installed adapters when the primary fails (default `true`; set `false` for strict single-CLI — never silently switch models). |
 | `panel` | cli_fusion | Explicit list of adapter names (overrides preset). |
 | `preset` | cli_fusion | Named preset to use. |
 | `judge` | cli_fusion | Judge adapter (overrides preset's). |
@@ -247,6 +249,25 @@ prompt ─► panel: N CLIs run in PARALLEL (asyncio.gather), each one-shot
   pollutes the synthesized answer.
 
 ---
+
+## Failover & graceful degradation
+
+Not every CLI is installed and working on every host, so the blueprints assume
+some will fail and route around them:
+
+- **`cli_agent` fails over.** It tries the primary CLI, and on failure (not
+  installed, not authenticated, non-zero exit, or hang→timeout) moves to the next
+  candidate. The chain is the primary plus either an explicit `params.fallback`
+  list or — by default — every other *installed* adapter. Each failover is
+  surfaced as a progress event. Set `params.failover: false` for strict
+  single-CLI behaviour that never silently switches models. (Streaming commits to
+  the first installed candidate — no mid-stream failover, since sent bytes can't
+  be unsent.)
+- **`cli_fusion` degrades.** A broken or missing panelist never sinks the round:
+  failures are dropped (and reported), and the judge synthesizes consensus from
+  the survivors. Only when *every* panelist fails does the round error out. So a
+  panel of `[claude, gemini, codex]` on a host missing `codex` still returns a
+  two-CLI consensus.
 
 ## Streaming
 

--- a/docs/CLI_FUSION.md
+++ b/docs/CLI_FUSION.md
@@ -52,8 +52,17 @@ See which of your configured CLIs are actually installed on the host:
 swarm-cli cli-agents               # install status only (fast)
 swarm-cli cli-agents --check-auth  # also probe each CLI's auth_check
 swarm-cli cli-agents --suggest     # propose config for installed-but-unconfigured CLIs
+swarm-cli cli-agents --smoke       # run one trivial one-shot per CLI to confirm it returns
 swarm-cli cli-agents --config ./swarm_config.json
 ```
+
+`--smoke` is the counterpart to `--check-auth`: auth tells you the CLI is logged
+in; smoke tells you its configured `cmd` actually **returns** in non-interactive
+mode instead of hanging on a prompt. Each probe runs one trivial one-shot
+(`status` of `ok` / `hang` / `error` / `not_installed`) — a `hang` almost always
+means a missing or wrong non-interactive/auto-approve flag. Unlike auth, the
+smoke probe invokes the model once per CLI, so it costs a little quota; it's
+opt-in for that reason.
 
 `--suggest` checks a built-in catalog of known-good adapter configs against your
 host and prints a ready-to-paste `cli_agents` block for every supported CLI

--- a/docs/CLI_FUSION.md
+++ b/docs/CLI_FUSION.md
@@ -250,6 +250,32 @@ prompt ─► panel: N CLIs run in PARALLEL (asyncio.gather), each one-shot
 
 ---
 
+## Granular consensus — `cli_orchestrator`
+
+`cli_fusion` fans out on *every* request. `cli_orchestrator` makes consensus
+*granular*: a cheap **router** CLI runs a single inference, answers directly, and
+escalates to a consensus panel **only** when it judges the question high-stakes
+(correctness-critical, security/production-impacting, contested). Single
+inference by default, consensus on demand.
+
+```jsonc
+"cli_orchestrator": {
+  "router": "claude",
+  "panel": ["claude", "gemini", "opencode"],
+  "judge": "claude"
+}
+```
+
+```bash
+curl -sf localhost:8000/v1/chat/completions -H "Authorization: Bearer $TOKEN" \
+  -d '{"model":"cli_orchestrator","messages":[{"role":"user","content":"Is this migration safe?"}]}'
+```
+
+Falls back to `cli_fusion.default_cli` (router) and `default_preset` (panel/judge)
+when the `cli_orchestrator` block is omitted. The shared loop lives in
+`swarm.core.consensus.run_consensus()`, so the same panel→judge→synthesize
+primitive backs both blueprints (and can be wrapped as an agent tool).
+
 ## Failover & graceful degradation
 
 Not every CLI is installed and working on every host, so the blueprints assume

--- a/docs/examples/cli_fusion.swarm_config.json
+++ b/docs/examples/cli_fusion.swarm_config.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Example Open Swarm config for the cli_agent and cli_fusion blueprints. Copy the cli_agents / cli_fusion blocks into your ~/.config/swarm/swarm_config.json. Flags and JSON-parse paths vary by CLI version — verify with each CLI's --help. See docs/CLI_FUSION.md.",
+  "_comment": "Example Open Swarm config for the cli_agent and cli_fusion blueprints. Copy the cli_agents / cli_fusion blocks into your ~/.config/swarm/swarm_config.json. Panelists run in FULL-CAPABILITY (non-interactive auto-approve) mode — they can read, write, and run commands. The non-negotiable flag per CLI is the one that skips approval prompts; without it the CLI blocks on a prompt and is killed on timeout. Flags and JSON-parse paths vary by CLI version — verify with each CLI's --help. See docs/CLI_FUSION.md.",
 
   "llm": {
     "default": {
@@ -13,29 +13,30 @@
   "cli_agents": {
     "claude": {
       "cmd": ["claude", "-p", "{prompt}", "--output-format", "json",
-              "--allowedTools", "Read,Grep,Glob"],
+              "--dangerously-skip-permissions"],
       "parse": "json:.result",
-      "mode": "readonly",
+      "mode": "write",
       "timeout": 240,
       "env_allowlist": ["ANTHROPIC_API_KEY"]
     },
     "gemini": {
-      "cmd": ["gemini", "-p", "{prompt}", "-o", "json", "--approval-mode", "plan"],
+      "cmd": ["gemini", "-p", "{prompt}", "-o", "json", "--yolo"],
       "parse": "json:.response",
-      "mode": "readonly",
+      "mode": "write",
       "timeout": 240,
       "env_allowlist": ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
     },
     "codex": {
-      "cmd": ["codex", "exec", "{prompt}"],
+      "cmd": ["codex", "exec", "{prompt}", "--dangerously-bypass-approvals-and-sandbox"],
       "parse": "text",
-      "mode": "readonly",
+      "mode": "write",
       "timeout": 240,
       "env_allowlist": ["OPENAI_API_KEY"]
     },
     "opencode": {
       "cmd": ["opencode", "run", "{prompt}"],
       "parse": "text",
+      "mode": "write",
       "timeout": 240
     }
   },
@@ -44,6 +45,7 @@
     "default_cli": "claude",
     "default_preset": "general-high",
     "max_rounds": 1,
+    "isolate_workdir": true,
     "show_analysis": false,
     "presets": {
       "general-high":   { "panel": ["claude", "gemini", "codex"], "judge": "claude" },

--- a/docs/examples/cli_fusion.swarm_config.json
+++ b/docs/examples/cli_fusion.swarm_config.json
@@ -20,7 +20,7 @@
       "env_allowlist": ["ANTHROPIC_API_KEY"]
     },
     "gemini": {
-      "cmd": ["gemini", "-p", "{prompt}", "-o", "json", "--yolo"],
+      "cmd": ["gemini", "-p", "{prompt}", "-o", "json", "--yolo", "--skip-trust"],
       "parse": "json:.response",
       "mode": "write",
       "timeout": 240,
@@ -34,7 +34,7 @@
       "env_allowlist": ["OPENAI_API_KEY"]
     },
     "opencode": {
-      "cmd": ["opencode", "run", "{prompt}"],
+      "cmd": ["opencode", "run", "{prompt}", "--model", "opencode/big-pickle"],
       "parse": "text",
       "mode": "write",
       "timeout": 240

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-swarm"
-version = "0.3.3"
+version = "0.4.0"
 description = "Open Swarm: Orchestrating AI Agent Swarms with Django"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
+++ b/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
@@ -18,7 +18,6 @@ from typing import Any, ClassVar
 
 from swarm.blueprints.common import cli_fusion_support as support
 from swarm.core.blueprint_base import BlueprintBase
-from swarm.core.cli_adapter import CliAdapterError
 
 logger = logging.getLogger(__name__)
 
@@ -60,8 +59,8 @@ class CliAgentBlueprint(BlueprintBase):
             return
 
         registry = support.apply_overrides(support.build_registry(self._config), params)
-        name = support.select_single_cli(self._config, params, registry)
-        if not name:
+        chain = support.resolve_failover_chain(self._config, params, registry)
+        if not chain:
             yield support.message_chunk(
                 "No CLI agents are configured. Add a 'cli_agents' block to your "
                 "swarm config (see docs/CLI_FUSION.md).",
@@ -69,43 +68,47 @@ class CliAgentBlueprint(BlueprintBase):
             )
             return
 
-        try:
-            adapter = registry.get(name)
-        except CliAdapterError as exc:
-            yield support.message_chunk(str(exc), final=True)
-            return
-
         workdir = params.get(support.PARAM_WORKDIR)
-        yield support.progress_chunk(f"_Running CLI agent `{name}`…_")
 
-        # Stream the CLI's stdout incrementally only when the caller wants a
-        # stream AND the adapter returns plain text (a `json:` parse can't be
-        # resolved until the whole document is read). Otherwise run one-shot.
-        if kwargs.get("stream") and (adapter.config.parse or "text") == "text":
-            result = None
-            async for chunk in adapter.stream_run(prompt, workdir=workdir):
-                if chunk.final:
-                    result = chunk.result
-                elif chunk.delta:
-                    yield support.message_chunk(chunk.delta)  # incremental delta
-            if result is None or not result.ok:
-                err = (result.error if result else None) or "unknown error"
-                yield support.message_chunk(support.format_cli_error(adapter, err), final=True)
-            elif result.parse_error:
-                logger.warning("CLI %s parse issue: %s", name, result.parse_error)
-            # On success the content was already streamed as deltas; the API view
-            # appends the [DONE] terminator, so nothing more to yield.
-            return
+        # Streaming-text fast path: stream the first *installed* candidate
+        # incrementally. No mid-stream failover — once bytes are on the wire we
+        # can't unsend them — so this commits to one CLI.
+        if kwargs.get("stream"):
+            target = next((n for n in chain if registry.get(n).is_available()), None)
+            if target is not None and (registry.get(target).config.parse or "text") == "text":
+                adapter = registry.get(target)
+                yield support.progress_chunk(f"_Streaming CLI agent `{target}`…_")
+                result = None
+                async for chunk in adapter.stream_run(prompt, workdir=workdir):
+                    if chunk.final:
+                        result = chunk.result
+                    elif chunk.delta:
+                        yield support.message_chunk(chunk.delta)  # incremental delta
+                if result is None or not result.ok:
+                    err = (result.error if result else None) or "unknown error"
+                    yield support.message_chunk(support.format_cli_error(adapter, err), final=True)
+                elif result.parse_error:
+                    logger.warning("CLI %s parse issue: %s", target, result.parse_error)
+                # On success the content was already streamed as deltas.
+                return
+            # json-parse target (or nothing installed): fall through to failover.
 
-        result = await adapter.run(prompt, workdir=workdir)
-        if not result.ok:
-            yield support.message_chunk(
-                support.format_cli_error(adapter, result.error or "unknown error"),
-                final=True,
-            )
-            return
+        # Non-streaming (and json-in-stream): try each candidate, first ok wins.
+        last: tuple[str, str] | None = None
+        for name in chain:
+            adapter = registry.get(name)
+            if not adapter.is_available():
+                yield support.progress_chunk(f"_Skipping `{name}` (not installed); failing over…_")
+                continue
+            yield support.progress_chunk(f"_Running CLI agent `{name}`…_")
+            result = await adapter.run(prompt, workdir=workdir)
+            if result.ok:
+                if result.parse_error:
+                    logger.warning("CLI %s parse issue: %s", name, result.parse_error)
+                yield support.message_chunk(result.text, final=True)
+                return
+            last = (name, result.error or "unknown error")
+            yield support.progress_chunk(f"_`{name}` failed: {last[1]} — failing over…_")
 
-        content = result.text
-        if result.parse_error:
-            logger.warning("CLI %s parse issue: %s", name, result.parse_error)
-        yield support.message_chunk(content, final=True)
+        detail = f" (last — {last[0]}: {last[1]})" if last else ""
+        yield support.message_chunk(f"All CLI candidates failed{detail}.", final=True)

--- a/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
+++ b/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
@@ -77,8 +77,27 @@ class CliAgentBlueprint(BlueprintBase):
 
         workdir = params.get(support.PARAM_WORKDIR)
         yield support.progress_chunk(f"_Running CLI agent `{name}`…_")
-        result = await adapter.run(prompt, workdir=workdir)
 
+        # Stream the CLI's stdout incrementally only when the caller wants a
+        # stream AND the adapter returns plain text (a `json:` parse can't be
+        # resolved until the whole document is read). Otherwise run one-shot.
+        if kwargs.get("stream") and (adapter.config.parse or "text") == "text":
+            result = None
+            async for chunk in adapter.stream_run(prompt, workdir=workdir):
+                if chunk.final:
+                    result = chunk.result
+                elif chunk.delta:
+                    yield support.message_chunk(chunk.delta)  # incremental delta
+            if result is None or not result.ok:
+                err = (result.error if result else None) or "unknown error"
+                yield support.message_chunk(support.format_cli_error(adapter, err), final=True)
+            elif result.parse_error:
+                logger.warning("CLI %s parse issue: %s", name, result.parse_error)
+            # On success the content was already streamed as deltas; the API view
+            # appends the [DONE] terminator, so nothing more to yield.
+            return
+
+        result = await adapter.run(prompt, workdir=workdir)
         if not result.ok:
             yield support.message_chunk(
                 support.format_cli_error(adapter, result.error or "unknown error"),

--- a/src/swarm/blueprints/cli_fusion/blueprint_cli_fusion.py
+++ b/src/swarm/blueprints/cli_fusion/blueprint_cli_fusion.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import json
 import logging
 import os
 import re
@@ -28,6 +27,8 @@ from typing import Any, AsyncIterator, ClassVar
 from swarm.blueprints.common import cli_fusion_support as support
 from swarm.core.blueprint_base import BlueprintBase
 from swarm.core.cli_adapter import CliAdapterRegistry, CliResult
+from swarm.core.consensus import run_consensus
+from swarm.core.consensus import safe_json as _safe_json  # re-exported for callers/tests
 
 logger = logging.getLogger(__name__)
 
@@ -37,46 +38,6 @@ MAX_ROUNDS_CEILING = 5
 DEFAULT_MAX_CONCURRENCY = 8
 # Env flag used to stop a panelist that is itself a swarm fusion from re-fusing.
 DEPTH_ENV = "SWARM_CLI_FUSION_DEPTH"
-
-JUDGE_TEMPLATE = """You are the JUDGE in a multi-agent panel. The user's request was:
-
-<request>
-{prompt}
-</request>
-
-Several independent agents answered it. Compare (do NOT merely concatenate) their answers below.
-
-{panel}
-
-Return ONLY a JSON object with these keys:
-- "consensus": list of points the agents agree on
-- "contradictions": list of points where they disagree
-- "gaps": list of things no agent covered
-- "unique_insights": list of valuable points raised by a single agent
-- "answer": a single best synthesized answer combining the strongest reasoning from all agents
-- "done": boolean — true if "answer" fully resolves the request, false if another round of work is needed
-- "next_step": if not done, one concrete instruction for the next round (else "")
-"""
-
-
-def _safe_json(text: str) -> dict[str, Any] | None:
-    """Parse a JSON object from CLI output, tolerating surrounding prose."""
-    text = (text or "").strip()
-    if not text:
-        return None
-    try:
-        obj = json.loads(text)
-        return obj if isinstance(obj, dict) else None
-    except json.JSONDecodeError:
-        pass
-    start, end = text.find("{"), text.rfind("}")
-    if 0 <= start < end:
-        try:
-            obj = json.loads(text[start : end + 1])
-            return obj if isinstance(obj, dict) else None
-        except json.JSONDecodeError:
-            return None
-    return None
 
 
 # --- Per-panelist workdir isolation --------------------------------------- #
@@ -208,57 +169,6 @@ class CliFusionBlueprint(BlueprintBase):
             n = 1
         return max(1, min(n, MAX_ROUNDS_CEILING))
 
-    async def _run_panel(
-        self,
-        registry: CliAdapterRegistry,
-        panel_names: list[str],
-        prompt: str,
-        workdirs: dict[str, str | None],
-        child_env: dict[str, str],
-        max_concurrency: int,
-    ) -> list[CliResult]:
-        panel = registry.resolve_panel(panel_names)
-        sem = asyncio.Semaphore(max(1, max_concurrency))
-
-        async def _bounded(adapter):
-            async with sem:
-                return await adapter.run(
-                    prompt, workdir=workdirs.get(adapter.name), extra_env=child_env
-                )
-
-        return await asyncio.gather(*(_bounded(a) for a in panel))
-
-    async def _judge(
-        self,
-        registry: CliAdapterRegistry,
-        judge_name: str | None,
-        prompt: str,
-        results: list[CliResult],
-        workdir: str | None,
-        child_env: dict[str, str],
-    ) -> dict[str, Any] | None:
-        if not judge_name:
-            return None
-        try:
-            judge = registry.get(judge_name)
-        except Exception:
-            return None
-        panel_text = "\n\n".join(f"### Agent: {r.name}\n{r.text}" for r in results)
-        judge_prompt = JUDGE_TEMPLATE.format(prompt=prompt, panel=panel_text)
-        res = await judge.run(judge_prompt, workdir=workdir, extra_env=child_env)
-        if not res.ok:
-            logger.warning("Judge %s failed: %s", judge_name, res.error)
-            return None
-        return _safe_json(res.text)
-
-    @staticmethod
-    def _synthesize(analysis: dict[str, Any] | None, results: list[CliResult]) -> str:
-        if analysis and isinstance(analysis.get("answer"), str) and analysis["answer"].strip():
-            return analysis["answer"].strip()
-        # No usable judge analysis: fall back to the longest successful answer.
-        best = max(results, key=lambda r: len(r.text or ""))
-        return best.text
-
     def _format_final(
         self,
         params: dict[str, Any],
@@ -344,26 +254,28 @@ class CliFusionBlueprint(BlueprintBase):
                 yield support.progress_chunk(
                     f"_Isolating {len(panel_names)} panelist(s) into private workdirs…_"
                 )
-            # Fresh per-panelist workspaces each round; torn down before judging
-            # (the judge runs in the base workdir, only comparing text answers).
+            panel = registry.resolve_panel(panel_names)
+            judge = registry.get(judge_name) if judge_name else None
+            # Fresh per-panelist workspaces each round; torn down after the round.
             async with _panel_workspaces(workdir, panel_names, isolate) as workdirs:
-                results = await self._run_panel(
-                    registry, panel_names, current_prompt, workdirs, child_env, max_concurrency
+                if judge is not None:
+                    workdirs.setdefault(judge.name, workdir)  # judge runs in the base workdir
+                cons = await run_consensus(
+                    current_prompt, panel, judge,
+                    workdirs=workdirs, child_env=child_env, max_concurrency=max_concurrency,
                 )
-            for r in results:
+            for r in cons.results:
                 if not r.ok:
                     yield support.progress_chunk(f"_• {r.name} failed: {r.error}_")
-            ok_results = [r for r in results if r.ok]
+            ok_results = cons.ok_results
             if not ok_results:
                 yield support.message_chunk("All CLI panelists failed.", final=True)
                 return
 
             if judge_name:
                 yield support.progress_chunk(f"_Judging {len(ok_results)} response(s) with `{judge_name}`…_")
-            analysis = await self._judge(
-                registry, judge_name, current_prompt, ok_results, workdir, child_env
-            )
-            answer = self._synthesize(analysis, ok_results)
+            analysis = cons.analysis
+            answer = cons.answer
             done = bool(analysis.get("done", True)) if analysis else True
 
             if done or round_i == max_rounds - 1:

--- a/src/swarm/blueprints/cli_fusion/blueprint_cli_fusion.py
+++ b/src/swarm/blueprints/cli_fusion/blueprint_cli_fusion.py
@@ -16,10 +16,14 @@ Request model: ``model: "cli_fusion"``. Per-request ``params`` may set
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
-from typing import Any, ClassVar
+import re
+import shutil
+import tempfile
+from typing import Any, AsyncIterator, ClassVar
 
 from swarm.blueprints.common import cli_fusion_support as support
 from swarm.core.blueprint_base import BlueprintBase
@@ -75,6 +79,100 @@ def _safe_json(text: str) -> dict[str, Any] | None:
     return None
 
 
+# --- Per-panelist workdir isolation --------------------------------------- #
+
+_SLUG_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def _slug(name: str) -> str:
+    """A filesystem-safe fragment for temp-dir names."""
+    return _SLUG_RE.sub("-", name)[:40] or "panel"
+
+
+async def _run_git(*args: str) -> tuple[int, str]:
+    """Run ``git`` and return (returncode, combined output). Never raises."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git", *args,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+    except (OSError, ValueError):
+        return 127, ""
+    out, _ = await proc.communicate()
+    return (proc.returncode or 0), (out or b"").decode("utf-8", errors="replace")
+
+
+async def _is_git_repo(path: str) -> bool:
+    rc, out = await _run_git("-C", path, "rev-parse", "--is-inside-work-tree")
+    return rc == 0 and out.strip() == "true"
+
+
+async def _worktree_add(repo: str, path: str) -> bool:
+    rc, _ = await _run_git("-C", repo, "worktree", "add", "--detach", "--quiet", path, "HEAD")
+    return rc == 0
+
+
+async def _worktree_remove(repo: str, path: str) -> None:
+    await _run_git("-C", repo, "worktree", "remove", "--force", path)
+
+
+async def _should_isolate(
+    base_workdir: str | None, panel_names: list[str], setting: bool | None
+) -> bool:
+    """Decide whether panelists get private workdirs.
+
+    ``setting`` is the resolved ``isolate`` value: ``False`` never isolates,
+    ``True`` always isolates, ``None`` (auto) isolates only a multi-panelist run
+    whose ``workdir`` is a git repo (cheap, safe worktrees; nothing to gain on a
+    single panelist).
+    """
+    if setting is False:
+        return False
+    if setting is True:
+        return True
+    return len(panel_names) > 1 and bool(base_workdir) and await _is_git_repo(base_workdir)
+
+
+@contextlib.asynccontextmanager
+async def _panel_workspaces(
+    base_workdir: str | None, panel_names: list[str], isolate: bool
+) -> AsyncIterator[dict[str, str | None]]:
+    """Yield a ``name -> workdir`` map, isolating panelists when asked.
+
+    When isolating: a git ``base_workdir`` gives each panelist a throwaway
+    ``git worktree`` at HEAD (sees the repo, edits stay private); otherwise each
+    gets a fresh empty temp dir. All scratch is removed on exit. When not
+    isolating, every panelist shares ``base_workdir``.
+    """
+    if not isolate:
+        yield {name: base_workdir for name in panel_names}
+        return
+
+    is_repo = bool(base_workdir) and await _is_git_repo(base_workdir)
+    roots: list[str] = []
+    worktrees: list[tuple[str, str]] = []
+    mapping: dict[str, str | None] = {}
+    try:
+        for name in panel_names:
+            root = tempfile.mkdtemp(prefix=f"swarm-fusion-{_slug(name)}-")
+            roots.append(root)
+            if is_repo:
+                tree = os.path.join(root, "tree")
+                if await _worktree_add(base_workdir, tree):  # type: ignore[arg-type]
+                    mapping[name] = tree
+                    worktrees.append((base_workdir, tree))  # type: ignore[arg-type]
+                    continue
+            mapping[name] = root  # non-repo (or worktree failed): empty scratch dir
+        yield mapping
+    finally:
+        for repo, tree in worktrees:
+            await _worktree_remove(repo, tree)
+        for root in roots:
+            shutil.rmtree(root, ignore_errors=True)
+
+
 class CliFusionBlueprint(BlueprintBase):
     """Panel → judge → synthesize, with an optional bounded master-plan loop."""
 
@@ -115,7 +213,7 @@ class CliFusionBlueprint(BlueprintBase):
         registry: CliAdapterRegistry,
         panel_names: list[str],
         prompt: str,
-        workdir: str | None,
+        workdirs: dict[str, str | None],
         child_env: dict[str, str],
         max_concurrency: int,
     ) -> list[CliResult]:
@@ -124,7 +222,9 @@ class CliFusionBlueprint(BlueprintBase):
 
         async def _bounded(adapter):
             async with sem:
-                return await adapter.run(prompt, workdir=workdir, extra_env=child_env)
+                return await adapter.run(
+                    prompt, workdir=workdirs.get(adapter.name), extra_env=child_env
+                )
 
         return await asyncio.gather(*(_bounded(a) for a in panel))
 
@@ -205,6 +305,9 @@ class CliFusionBlueprint(BlueprintBase):
 
         fusion_cfg = (self._config or {}).get("cli_fusion") or {}
         workdir = params.get(support.PARAM_WORKDIR)
+        isolate_setting = params.get(support.PARAM_ISOLATE)
+        if isolate_setting is None:
+            isolate_setting = fusion_cfg.get("isolate_workdir")  # may stay None (=auto)
         try:
             max_concurrency = int(
                 params.get("max_concurrency", fusion_cfg.get("max_concurrency", DEFAULT_MAX_CONCURRENCY))
@@ -229,15 +332,24 @@ class CliFusionBlueprint(BlueprintBase):
             max_rounds = self._max_rounds(params, fusion_cfg)
         child_env = {DEPTH_ENV: str(depth + 1)}
 
+        isolate = await _should_isolate(workdir, panel_names, isolate_setting)
+
         current_prompt = prompt
         for round_i in range(max_rounds):
             yield support.progress_chunk(
                 f"_Round {round_i + 1}/{max_rounds}: consulting {len(panel_names)} "
                 f"CLI agent(s): {', '.join(panel_names)}…_"
             )
-            results = await self._run_panel(
-                registry, panel_names, current_prompt, workdir, child_env, max_concurrency
-            )
+            if isolate:
+                yield support.progress_chunk(
+                    f"_Isolating {len(panel_names)} panelist(s) into private workdirs…_"
+                )
+            # Fresh per-panelist workspaces each round; torn down before judging
+            # (the judge runs in the base workdir, only comparing text answers).
+            async with _panel_workspaces(workdir, panel_names, isolate) as workdirs:
+                results = await self._run_panel(
+                    registry, panel_names, current_prompt, workdirs, child_env, max_concurrency
+                )
             for r in results:
                 if not r.ok:
                     yield support.progress_chunk(f"_• {r.name} failed: {r.error}_")

--- a/src/swarm/blueprints/cli_map/blueprint_cli_map.py
+++ b/src/swarm/blueprints/cli_map/blueprint_cli_map.py
@@ -1,0 +1,187 @@
+"""CLI Map blueprint — decompose → distribute → reduce.
+
+The complement to ``cli_fusion``. Where fusion sends the *same* question to a
+panel and finds consensus, map splits *one task* into independent subtasks,
+distributes them across worker CLIs in parallel, and reduces the results into a
+single answer. Divide-and-conquer for scale, not redundancy for confidence.
+
+Request model: ``model: "cli_map"``. Config block ``cli_map``:
+``{ "planner": <cli>, "workers": [<cli>...] (or "worker": <cli>), "reducer": <cli>,
+"max_items": int }`` (falls back to ``cli_fusion`` config). Per-request ``params``
+may set ``items`` (explicit subtasks, skipping the planner), ``planner``,
+``workers``/``worker``, ``reducer``, ``max_items``, ``workdir``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, ClassVar
+
+from swarm.blueprints.common import cli_fusion_support as support
+from swarm.core.blueprint_base import BlueprintBase
+from swarm.core.cli_adapter import CliAdapterRegistry
+from swarm.core.consensus import safe_json
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_ITEMS = 6
+DEFAULT_MAX_CONCURRENCY = 8
+
+PLAN_TEMPLATE = """Decompose the user's task into a list of INDEPENDENT subtasks that can each be
+done separately and then combined. Return ONLY a JSON object:
+{{"subtasks": ["<subtask 1>", "<subtask 2>", ...]}}
+Use at most {max_items} subtasks; fewer is fine. If the task is atomic, return one.
+
+Task:
+{prompt}
+"""
+
+REDUCE_TEMPLATE = """The user's original task was:
+<task>
+{prompt}
+</task>
+
+It was split into subtasks, each completed independently by a worker agent:
+
+{results}
+
+Combine these into a single, coherent answer to the ORIGINAL task. Resolve any
+overlap or contradiction. Return only the combined answer.
+"""
+
+
+class CliMapBlueprint(BlueprintBase):
+    """Plan → map across workers → reduce."""
+
+    metadata: ClassVar[dict[str, Any]] = {
+        "name": "cli_map",
+        "title": "CLI Map (decompose & distribute)",
+        "description": (
+            "Split one task into subtasks, distribute them across worker CLIs in "
+            "parallel, and reduce the results into a single answer. Divide-and-"
+            "conquer, complementing cli_fusion's consensus."
+        ),
+        "version": "0.1.0",
+        "author": "Open Swarm Team",
+        "tags": ["cli", "map-reduce", "decompose", "multi-agent", "openai-compatible"],
+        "required_mcp_servers": [],
+        "env_vars": [],
+    }
+
+    def __init__(self, blueprint_id: str = "cli_map", config=None, config_path=None, **kwargs):
+        super().__init__(blueprint_id, config=config, config_path=config_path, **kwargs)
+        self._params: dict[str, Any] = {}
+
+    def set_params(self, params: dict[str, Any] | None) -> None:
+        self._params = dict(params or {})
+
+    def _resolve(
+        self, params: dict[str, Any], registry: CliAdapterRegistry
+    ) -> tuple[str | None, list[str], str | None]:
+        """Resolve (planner, workers, reducer), falling back to cli_fusion config."""
+        mc = (self._config or {}).get("cli_map") or {}
+        fusion = (self._config or {}).get("cli_fusion") or {}
+
+        planner = params.get("planner") or mc.get("planner") or fusion.get("default_cli")
+        reducer = params.get("reducer") or mc.get("reducer") or fusion.get("default_cli")
+        workers = params.get("workers") or mc.get("workers")
+        if not workers:
+            single = params.get("worker") or mc.get("worker")
+            if single:
+                workers = [single]
+            else:
+                preset = (fusion.get("presets") or {}).get(fusion.get("default_preset")) or {}
+                workers = preset.get("panel") or registry.available() or registry.names()
+
+        known = set(registry.names())
+        workers = [w for w in (workers or []) if w in known]
+        if planner and planner not in known:
+            planner = None
+        if reducer and reducer not in known:
+            reducer = None
+        return planner, workers, reducer
+
+    def _max_items(self, params: dict[str, Any]) -> int:
+        raw = params.get("max_items", ((self._config or {}).get("cli_map") or {}).get("max_items", DEFAULT_MAX_ITEMS))
+        try:
+            return max(1, min(int(raw), 20))
+        except (TypeError, ValueError):
+            return DEFAULT_MAX_ITEMS
+
+    async def run(self, messages: list[dict[str, Any]], **kwargs) -> Any:
+        params = dict(self._params)
+
+        prompt = support.render_prompt(messages)
+        if not prompt:
+            yield support.message_chunk("No prompt provided.", final=True)
+            return
+
+        registry = support.apply_overrides(support.build_registry(self._config), params)
+        planner, workers, reducer = self._resolve(params, registry)
+        if not workers:
+            yield support.message_chunk(
+                "No worker CLIs are configured for map. Add a 'cli_map' block (or a "
+                "'cli_fusion' preset) to your swarm config (see docs/CLI_FUSION.md).",
+                final=True,
+            )
+            return
+
+        workdir = params.get(support.PARAM_WORKDIR)
+        max_items = self._max_items(params)
+
+        # 1. Decompose — explicit items, else the planner.
+        items = params.get("items")
+        if isinstance(items, list) and items:
+            subtasks = [str(x) for x in items][:max_items]
+            yield support.progress_chunk(f"_Using {len(subtasks)} explicit subtask(s)._")
+        elif planner:
+            yield support.progress_chunk(f"_Planning with `{planner}`…_")
+            pres = await registry.get(planner).run(
+                PLAN_TEMPLATE.format(prompt=prompt, max_items=max_items), workdir=workdir
+            )
+            plan = safe_json(pres.text) if pres.ok else None
+            subtasks = [str(s) for s in (plan or {}).get("subtasks", []) if str(s).strip()][:max_items]
+            if not subtasks:
+                yield support.message_chunk("Planner produced no subtasks.", final=True)
+                return
+            yield support.progress_chunk(f"_Planned {len(subtasks)} subtask(s)._")
+        else:
+            yield support.message_chunk(
+                "No planner is configured and no explicit `items` were provided.", final=True
+            )
+            return
+
+        # 2. Map — distribute subtasks across workers (round-robin), in parallel.
+        yield support.progress_chunk(
+            f"_Mapping {len(subtasks)} subtask(s) across {', '.join(workers)}…_"
+        )
+        sem = asyncio.Semaphore(DEFAULT_MAX_CONCURRENCY)
+
+        async def _do(index: int, subtask: str):
+            worker = registry.get(workers[index % len(workers)])
+            async with sem:
+                res = await worker.run(subtask, workdir=workdir)
+            return subtask, worker.name, res
+
+        mapped = await asyncio.gather(*(_do(i, s) for i, s in enumerate(subtasks)))
+        for subtask, wname, res in mapped:
+            if not res.ok:
+                yield support.progress_chunk(f"_• {wname} failed on a subtask: {res.error}_")
+        ok = [(s, w, r) for s, w, r in mapped if r.ok]
+        if not ok:
+            yield support.message_chunk("All map workers failed.", final=True)
+            return
+
+        # 3. Reduce — a reducer CLI combines, else labeled concatenation.
+        block = "\n\n".join(f"### Subtask: {s}\n_(by {w})_\n{r.text}" for s, w, r in ok)
+        if reducer:
+            yield support.progress_chunk(f"_Reducing {len(ok)} result(s) with `{reducer}`…_")
+            rres = await registry.get(reducer).run(
+                REDUCE_TEMPLATE.format(prompt=prompt, results=block), workdir=workdir
+            )
+            if rres.ok and rres.text.strip():
+                yield support.message_chunk(rres.text, final=True)
+                return
+            yield support.progress_chunk(f"_Reducer failed ({rres.error}); returning subtask results._")
+        yield support.message_chunk(block, final=True)

--- a/src/swarm/blueprints/cli_orchestrator/blueprint_cli_orchestrator.py
+++ b/src/swarm/blueprints/cli_orchestrator/blueprint_cli_orchestrator.py
@@ -1,0 +1,146 @@
+"""CLI Orchestrator blueprint — granular consensus.
+
+The prototype of "fusion as a composable primitive". A cheap **router** CLI runs
+a single inference and answers directly; when it judges the question high-stakes
+(correctness-critical, security/production, contested) it *escalates that one
+question* to a cross-model **consensus** check over a panel — instead of fanning
+out on every request. Single inference by default, consensus on demand.
+
+Request model: ``model: "cli_orchestrator"``. Config block ``cli_orchestrator``:
+``{ "router": <cli>, "panel": [<cli>...], "judge": <cli> }`` (falls back to the
+``cli_fusion`` default_cli / default_preset). Per-request ``params`` may override
+``router`` / ``panel`` / ``judge`` / ``workdir``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar
+
+from swarm.blueprints.common import cli_fusion_support as support
+from swarm.core.blueprint_base import BlueprintBase
+from swarm.core.cli_adapter import CliAdapterRegistry
+from swarm.core.consensus import run_consensus, safe_json
+
+logger = logging.getLogger(__name__)
+
+ROUTER_TEMPLATE = """You are a fast router agent. Answer the user's question directly and concisely.
+Then decide whether the question is high-stakes enough to warrant a cross-model
+consensus check — i.e. correctness-critical, security- or production-impacting,
+genuinely contested, or where being wrong is costly. Routine/low-stakes questions
+should NOT escalate.
+
+Return ONLY a JSON object:
+{{"answer": "<your direct answer>", "escalate": true_or_false, "reason": "<one short line>"}}
+
+Question:
+{prompt}
+"""
+
+
+class CliOrchestratorBlueprint(BlueprintBase):
+    """Single-inference router that escalates hard questions to consensus."""
+
+    metadata: ClassVar[dict[str, Any]] = {
+        "name": "cli_orchestrator",
+        "title": "CLI Orchestrator (granular consensus)",
+        "description": (
+            "A cheap router CLI answers directly and escalates only high-stakes "
+            "questions to a cross-model consensus panel. Fusion as a granular "
+            "tool, not a whole-request mode."
+        ),
+        "version": "0.1.0",
+        "author": "Open Swarm Team",
+        "tags": ["cli", "orchestrator", "consensus", "routing", "openai-compatible"],
+        "required_mcp_servers": [],
+        "env_vars": [],
+    }
+
+    def __init__(self, blueprint_id: str = "cli_orchestrator", config=None, config_path=None, **kwargs):
+        super().__init__(blueprint_id, config=config, config_path=config_path, **kwargs)
+        self._params: dict[str, Any] = {}
+
+    def set_params(self, params: dict[str, Any] | None) -> None:
+        self._params = dict(params or {})
+
+    def _resolve(
+        self, params: dict[str, Any], registry: CliAdapterRegistry
+    ) -> tuple[str | None, list[str], str | None]:
+        """Resolve (router, panel, judge), falling back to cli_fusion config."""
+        oc = (self._config or {}).get("cli_orchestrator") or {}
+        fusion = (self._config or {}).get("cli_fusion") or {}
+
+        router = params.get("router") or oc.get("router") or fusion.get("default_cli")
+        panel = params.get("panel") or oc.get("panel")
+        judge = params.get("judge") or oc.get("judge")
+        if not panel:
+            preset = (fusion.get("presets") or {}).get(fusion.get("default_preset")) or {}
+            panel = preset.get("panel")
+            judge = judge or preset.get("judge")
+        if not router:
+            available = registry.available() or registry.names()
+            router = available[0] if available else None
+
+        known = set(registry.names())
+        panel = [n for n in (panel or []) if n in known]
+        if judge and judge not in known:
+            judge = None
+        if router and router not in known:
+            router = None
+        return router, panel, judge
+
+    async def run(self, messages: list[dict[str, Any]], **kwargs) -> Any:
+        params = dict(self._params)
+
+        prompt = support.render_prompt(messages)
+        if not prompt:
+            yield support.message_chunk("No prompt provided.", final=True)
+            return
+
+        registry = support.apply_overrides(support.build_registry(self._config), params)
+        router, panel_names, judge_name = self._resolve(params, registry)
+        if not router:
+            yield support.message_chunk(
+                "No router CLI is configured. Add a 'cli_orchestrator' block (or a "
+                "'cli_fusion.default_cli') to your swarm config (see docs/CLI_FUSION.md).",
+                final=True,
+            )
+            return
+
+        workdir = params.get(support.PARAM_WORKDIR)
+
+        # 1. Single routing inference.
+        yield support.progress_chunk(f"_Routing with `{router}` (single inference)…_")
+        rres = await registry.get(router).run(ROUTER_TEMPLATE.format(prompt=prompt), workdir=workdir)
+        decision = safe_json(rres.text) if rres.ok else None
+        quick = ((decision or {}).get("answer") or "").strip() or (rres.text if rres.ok else "")
+        escalate = bool((decision or {}).get("escalate"))
+        reason = str((decision or {}).get("reason") or "").strip()
+
+        # 2. Resolve directly unless the router escalated (and a panel exists).
+        if rres.ok and not escalate:
+            yield support.progress_chunk(f"_Resolved directly — no consensus needed ({reason or 'low-stakes'})._")
+            yield support.message_chunk(quick, final=True)
+            return
+        if not panel_names:
+            yield support.message_chunk(
+                quick or "Router produced no answer and no consensus panel is configured.",
+                final=True,
+            )
+            return
+
+        # 3. Escalate this one question to a consensus panel.
+        yield support.progress_chunk(
+            f"_Escalating to consensus over {', '.join(panel_names)} "
+            f"({reason or 'router flagged high-stakes'})…_"
+        )
+        panel = registry.resolve_panel(panel_names)
+        judge = registry.get(judge_name) if judge_name else None
+        cons = await run_consensus(prompt, panel, judge, workdirs={n: workdir for n in registry.names()})
+        for r in cons.results:
+            if not r.ok:
+                yield support.progress_chunk(f"_• {r.name} failed: {r.error}_")
+        if not cons.ok:
+            yield support.message_chunk(quick or "All consensus panelists failed.", final=True)
+            return
+        yield support.message_chunk(cons.answer, final=True)

--- a/src/swarm/blueprints/common/cli_fusion_support.py
+++ b/src/swarm/blueprints/common/cli_fusion_support.py
@@ -22,6 +22,8 @@ PARAM_JUDGE = "judge"        # fusion: judge adapter/profile
 PARAM_TIMEOUT = "timeout"    # override adapter timeout (seconds)
 PARAM_WORKDIR = "workdir"    # working directory for the CLI(s)
 PARAM_ISOLATE = "isolate"    # fusion: per-panelist workdir isolation (bool)
+PARAM_FALLBACK = "fallback"  # single-CLI: explicit ordered failover list
+PARAM_FAILOVER = "failover"  # single-CLI: enable auto-failover (default True)
 
 
 def render_prompt(messages: list[dict[str, Any]]) -> str:
@@ -109,6 +111,45 @@ def resolve_panel(
     if judge and judge not in known:
         judge = None
     return panel, judge
+
+
+def resolve_failover_chain(
+    config: dict[str, Any] | None,
+    params: dict[str, Any] | None,
+    registry: CliAdapterRegistry,
+) -> list[str]:
+    """Ordered adapter names the single-CLI blueprint should try, in order.
+
+    The primary is :func:`select_single_cli`. Then, unless failover is disabled:
+
+    * an explicit ``params['fallback']`` list is appended in order, **or**
+    * if no explicit list and ``params['failover']`` isn't ``False``, every other
+      *installed* adapter is appended (auto-failover) so a missing/broken primary
+      degrades to whatever the host actually has.
+
+    Names are deduped (order preserved) and filtered to configured adapters.
+    Returns ``[]`` when nothing is configured. Set ``failover: False`` for strict
+    single-CLI behaviour (never silently switch to a different model).
+    """
+    params = params or {}
+    primary = select_single_cli(config, params, registry)
+    if not primary:
+        return []
+    chain = [primary]
+    fallback = params.get(PARAM_FALLBACK)
+    if isinstance(fallback, list):
+        chain.extend(str(n) for n in fallback)
+    elif params.get(PARAM_FAILOVER, True):
+        chain.extend(n for n in registry.available() if n not in chain)
+
+    known = set(registry.names())
+    seen: set[str] = set()
+    out: list[str] = []
+    for n in chain:
+        if n in known and n not in seen:
+            seen.add(n)
+            out.append(n)
+    return out
 
 
 def apply_overrides(

--- a/src/swarm/blueprints/common/cli_fusion_support.py
+++ b/src/swarm/blueprints/common/cli_fusion_support.py
@@ -189,12 +189,5 @@ def progress_chunk(content: str) -> dict:
     return {"type": PROGRESS_TYPE, "content": content}
 
 
-def progress_text(chunk: dict) -> str | None:
-    """Return the text of a progress chunk, or None if it isn't one."""
-    if isinstance(chunk, dict) and chunk.get("type") == PROGRESS_TYPE:
-        return chunk.get("content")
-    return None
-
-
 def format_cli_error(adapter: CliAdapter, error: str) -> str:
     return f"[{adapter.name}] failed: {error}"

--- a/src/swarm/blueprints/common/cli_fusion_support.py
+++ b/src/swarm/blueprints/common/cli_fusion_support.py
@@ -21,6 +21,7 @@ PARAM_PRESET = "preset"      # fusion: named preset
 PARAM_JUDGE = "judge"        # fusion: judge adapter/profile
 PARAM_TIMEOUT = "timeout"    # override adapter timeout (seconds)
 PARAM_WORKDIR = "workdir"    # working directory for the CLI(s)
+PARAM_ISOLATE = "isolate"    # fusion: per-panelist workdir isolation (bool)
 
 
 def render_prompt(messages: list[dict[str, Any]]) -> str:

--- a/src/swarm/core/cli_adapter.py
+++ b/src/swarm/core/cli_adapter.py
@@ -38,6 +38,14 @@ WORKDIR_TOKEN = "{workdir}"
 DEFAULT_TIMEOUT = 180.0
 # Grace period between SIGTERM and SIGKILL when reaping a timed-out agent.
 TERM_GRACE = 5.0
+# Auth probes should be quick; cap them well under a normal run timeout.
+AUTH_TIMEOUT = 30.0
+
+# Authentication states reported by discovery.
+AUTH_AUTHENTICATED = "authenticated"
+AUTH_UNAUTHENTICATED = "unauthenticated"
+AUTH_UNKNOWN = "unknown"  # no auth_check configured, or the probe was inconclusive
+AUTH_NOT_INSTALLED = "not_installed"
 
 
 class CliAdapterError(Exception):
@@ -93,6 +101,7 @@ class CliAgentConfig:
     env_allowlist: list[str] | None = None
     timeout: float = DEFAULT_TIMEOUT
     mode: str = "default"
+    auth_check: list[str] | None = None
 
     def __post_init__(self) -> None:
         if not self.cmd:
@@ -106,6 +115,14 @@ class CliAgentConfig:
             raise CliAdapterError(
                 f"CLI adapter '{self.name}': prompt_mode 'arg' requires a "
                 f"'{PROMPT_TOKEN}' token somewhere in cmd"
+            )
+        if self.auth_check is not None and (
+            not isinstance(self.auth_check, list)
+            or not all(isinstance(p, str) for p in self.auth_check)
+            or not self.auth_check
+        ):
+            raise CliAdapterError(
+                f"CLI adapter '{self.name}': auth_check must be a non-empty list of strings"
             )
 
 
@@ -186,6 +203,7 @@ class CliAdapter:
             env_allowlist=raw.get("env_allowlist"),
             timeout=float(raw.get("timeout", DEFAULT_TIMEOUT)),
             mode=raw.get("mode", "default"),
+            auth_check=raw.get("auth_check"),
         )
         return cls(cfg)
 
@@ -328,6 +346,39 @@ class CliAdapter:
             env.update(extra_env)
         return env
 
+    async def check_auth(self) -> str:
+        """Probe whether this CLI is authenticated.
+
+        Returns one of AUTH_NOT_INSTALLED (executable missing), AUTH_UNKNOWN
+        (no ``auth_check`` configured, or the probe errored/timed out),
+        AUTH_AUTHENTICATED (``auth_check`` exited 0), or AUTH_UNAUTHENTICATED.
+        Never raises.
+        """
+        cfg = self.config
+        if not self.is_available():
+            return AUTH_NOT_INSTALLED
+        if not cfg.auth_check:
+            return AUTH_UNKNOWN
+        workdir = os.getcwd()
+        argv = [_apply_tokens(p, "", workdir) for p in cfg.auth_check]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=self._build_env("", workdir, None),
+                start_new_session=True,
+            )
+        except (OSError, ValueError):
+            return AUTH_UNKNOWN
+        try:
+            await asyncio.wait_for(proc.communicate(), timeout=min(cfg.timeout, AUTH_TIMEOUT))
+        except asyncio.TimeoutError:
+            await self._terminate(proc)
+            return AUTH_UNKNOWN
+        return AUTH_AUTHENTICATED if proc.returncode == 0 else AUTH_UNAUTHENTICATED
+
     @staticmethod
     async def _terminate(proc: asyncio.subprocess.Process) -> None:
         """Kill a timed-out process group: SIGTERM, grace, then SIGKILL."""
@@ -357,6 +408,7 @@ class CliDiscovery:
     installed: bool
     executable: str | None
     mode: str
+    authenticated: str = AUTH_UNKNOWN
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -364,6 +416,7 @@ class CliDiscovery:
             "installed": self.installed,
             "executable": self.executable,
             "mode": self.mode,
+            "authenticated": self.authenticated,
         }
 
 
@@ -416,6 +469,20 @@ class CliAdapterRegistry:
                 )
             )
         return out
+
+    async def discover_auth(self) -> list[CliDiscovery]:
+        """Like discover(), but also probe each adapter's authentication state.
+
+        Runs every adapter's ``auth_check`` concurrently. Slower than
+        :meth:`discover` (it launches subprocesses), so it is opt-in.
+        """
+        rows = self.discover()
+
+        async def _fill(row: CliDiscovery) -> CliDiscovery:
+            row.authenticated = await self._adapters[row.name].check_auth()
+            return row
+
+        return list(await asyncio.gather(*(_fill(r) for r in rows)))
 
     def resolve_panel(self, names: list[str]) -> list[CliAdapter]:
         """Resolve a list of adapter names to adapters (raises on unknown)."""

--- a/src/swarm/core/cli_adapter.py
+++ b/src/swarm/core/cli_adapter.py
@@ -20,6 +20,7 @@ Design notes
 from __future__ import annotations
 
 import asyncio
+import codecs
 import json
 import logging
 import os
@@ -27,7 +28,7 @@ import shutil
 import signal
 import time
 from dataclasses import dataclass, field, replace
-from typing import Any
+from typing import Any, AsyncIterator
 
 logger = logging.getLogger(__name__)
 
@@ -186,6 +187,19 @@ class SmokeResult:
             "detail": self.detail,
             "duration": round(self.duration, 3),
         }
+
+
+@dataclass
+class CliStreamChunk:
+    """One event from :meth:`CliAdapter.stream_run`.
+
+    Either an incremental output delta (``delta`` set, ``final=False``) or the
+    terminal event (``final=True``) carrying the assembled :class:`CliResult`.
+    """
+
+    delta: str = ""
+    final: bool = False
+    result: CliResult | None = None
 
 
 def _apply_tokens(value: str, prompt: str, workdir: str) -> str:
@@ -360,6 +374,167 @@ class CliAdapter:
         return CliResult(
             name=cfg.name, ok=True, text=text, returncode=0, duration=duration,
             parse_error=parse_error, stderr=stderr.strip(),
+        )
+
+    async def stream_run(
+        self,
+        prompt: str,
+        *,
+        workdir: str | None = None,
+        extra_env: dict[str, str] | None = None,
+    ) -> AsyncIterator[CliStreamChunk]:
+        """Like :meth:`run`, but yield stdout incrementally as it arrives.
+
+        Yields :class:`CliStreamChunk` deltas while the CLI produces output, then
+        a single terminal chunk (``final=True``) carrying the full
+        :class:`CliResult`. The terminal result's ``text`` is parsed per the
+        adapter's ``parse`` spec; for ``json:`` adapters the deltas are raw stdout
+        (the parsed value only exists once the whole document is read), so callers
+        that need clean incremental text should stream only ``parse="text"``
+        adapters. Never raises for runtime failures.
+        """
+        cfg = self.config
+        effective_workdir = (
+            _apply_tokens(cfg.cwd, prompt, workdir or os.getcwd())
+            if cfg.cwd
+            else (workdir or os.getcwd())
+        )
+        argv, stdin_bytes = self._build_invocation(prompt, effective_workdir)
+        env = self._build_env(prompt, effective_workdir, extra_env)
+
+        if not self.is_available():
+            yield CliStreamChunk(
+                final=True,
+                result=CliResult(
+                    name=cfg.name, ok=False, text="",
+                    error=f"executable not found on PATH: {cfg.cmd[0]!r}",
+                ),
+            )
+            return
+
+        start = time.monotonic()
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdin=asyncio.subprocess.PIPE if stdin_bytes is not None else asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=effective_workdir,
+                env=env,
+                start_new_session=True,
+            )
+        except (OSError, ValueError) as exc:
+            yield CliStreamChunk(
+                final=True,
+                result=CliResult(
+                    name=cfg.name, ok=False, text="",
+                    error=f"failed to launch: {exc}", duration=time.monotonic() - start,
+                ),
+            )
+            return
+
+        if stdin_bytes is not None and proc.stdin is not None:
+            try:
+                proc.stdin.write(stdin_bytes)
+                await proc.stdin.drain()
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                pass
+            finally:
+                try:
+                    proc.stdin.close()
+                except OSError:
+                    pass
+
+        # Drain stderr concurrently so its pipe can never fill and deadlock the
+        # process while we are only reading stdout.
+        stderr_buf: list[bytes] = []
+
+        async def _drain_stderr() -> None:
+            assert proc.stderr is not None
+            try:
+                while True:
+                    blob = await proc.stderr.read(4096)
+                    if not blob:
+                        break
+                    stderr_buf.append(blob)
+            except (asyncio.CancelledError, OSError):
+                pass
+
+        stderr_task = asyncio.ensure_future(_drain_stderr())
+
+        decoder = codecs.getincrementaldecoder("utf-8")("replace")
+        out_parts: list[str] = []
+        timed_out = False
+        deadline = start + cfg.timeout
+        assert proc.stdout is not None
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                break
+            try:
+                blob = await asyncio.wait_for(proc.stdout.read(4096), timeout=remaining)
+            except asyncio.TimeoutError:
+                timed_out = True
+                break
+            if not blob:  # EOF
+                break
+            text = decoder.decode(blob)
+            if text:
+                out_parts.append(text)
+                yield CliStreamChunk(delta=text)
+
+        tail = decoder.decode(b"", final=True)
+        if tail:
+            out_parts.append(tail)
+            yield CliStreamChunk(delta=tail)
+
+        duration = time.monotonic() - start
+        stdout = "".join(out_parts)
+
+        if timed_out:
+            await self._terminate(proc)
+            stderr_task.cancel()
+            try:
+                await stderr_task
+            except asyncio.CancelledError:
+                pass
+            stderr = b"".join(stderr_buf).decode("utf-8", errors="replace")
+            yield CliStreamChunk(
+                final=True,
+                result=CliResult(
+                    name=cfg.name, ok=False, text=stdout.strip(), returncode=proc.returncode,
+                    duration=duration, timed_out=True, stderr=stderr.strip(),
+                    error=f"timed out after {cfg.timeout}s",
+                ),
+            )
+            return
+
+        await proc.wait()
+        try:
+            await stderr_task
+        except asyncio.CancelledError:
+            pass
+        stderr = b"".join(stderr_buf).decode("utf-8", errors="replace")
+
+        if proc.returncode != 0:
+            yield CliStreamChunk(
+                final=True,
+                result=CliResult(
+                    name=cfg.name, ok=False, text=stdout.strip(), returncode=proc.returncode,
+                    duration=duration, stderr=stderr.strip(),
+                    error=f"exited {proc.returncode}: {stderr.strip()[:500]}",
+                ),
+            )
+            return
+
+        text, parse_error = self._parse_output(stdout)
+        yield CliStreamChunk(
+            final=True,
+            result=CliResult(
+                name=cfg.name, ok=True, text=text, returncode=0, duration=duration,
+                parse_error=parse_error, stderr=stderr.strip(),
+            ),
         )
 
     # Always-passed vars so a locked-down CLI can still run and resolve itself.

--- a/src/swarm/core/cli_adapter.py
+++ b/src/swarm/core/cli_adapter.py
@@ -153,19 +153,6 @@ class CliResult:
     error: str | None = None
     stderr: str = ""
 
-    def as_dict(self) -> dict[str, Any]:
-        return {
-            "name": self.name,
-            "ok": self.ok,
-            "text": self.text,
-            "returncode": self.returncode,
-            "duration": round(self.duration, 3),
-            "timed_out": self.timed_out,
-            "parse_error": self.parse_error,
-            "error": self.error,
-            "stderr": self.stderr,
-        }
-
 
 @dataclass
 class SmokeResult:

--- a/src/swarm/core/cli_adapter.py
+++ b/src/swarm/core/cli_adapter.py
@@ -292,76 +292,17 @@ class CliAdapter:
         """Launch the CLI, await its answer, and parse the result.
 
         Never raises for runtime failures — a non-zero exit, timeout, or missing
-        executable comes back as a :class:`CliResult` with ``ok=False``.
+        executable comes back as a :class:`CliResult` with ``ok=False``. The
+        one-shot and streaming paths share a single launch/timeout/parse
+        implementation: this drains :meth:`stream_run` and returns its terminal
+        result (``stream_run`` always emits exactly one ``final`` chunk).
         """
-        cfg = self.config
-        effective_workdir = (
-            _apply_tokens(cfg.cwd, prompt, workdir or os.getcwd())
-            if cfg.cwd
-            else (workdir or os.getcwd())
-        )
-        argv, stdin_bytes = self._build_invocation(prompt, effective_workdir)
-
-        env = self._build_env(prompt, effective_workdir, extra_env)
-
-        if not self.is_available():
-            return CliResult(
-                name=cfg.name,
-                ok=False,
-                text="",
-                error=f"executable not found on PATH: {cfg.cmd[0]!r}",
-            )
-
-        start = time.monotonic()
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                *argv,
-                stdin=asyncio.subprocess.PIPE if stdin_bytes is not None else asyncio.subprocess.DEVNULL,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=effective_workdir,
-                env=env,
-                start_new_session=True,  # own process group, so we can kill the tree
-            )
-        except (OSError, ValueError) as exc:
-            return CliResult(
-                name=cfg.name, ok=False, text="",
-                error=f"failed to launch: {exc}", duration=time.monotonic() - start,
-            )
-
-        timed_out = False
-        try:
-            stdout_b, stderr_b = await asyncio.wait_for(
-                proc.communicate(input=stdin_bytes), timeout=cfg.timeout
-            )
-        except asyncio.TimeoutError:
-            timed_out = True
-            await self._terminate(proc)
-            stdout_b, stderr_b = b"", b""
-        duration = time.monotonic() - start
-
-        stdout = (stdout_b or b"").decode("utf-8", errors="replace")
-        stderr = (stderr_b or b"").decode("utf-8", errors="replace")
-
-        if timed_out:
-            return CliResult(
-                name=cfg.name, ok=False, text=stdout.strip(), returncode=proc.returncode,
-                duration=duration, timed_out=True, stderr=stderr.strip(),
-                error=f"timed out after {cfg.timeout}s",
-            )
-
-        if proc.returncode != 0:
-            return CliResult(
-                name=cfg.name, ok=False, text=stdout.strip(), returncode=proc.returncode,
-                duration=duration, stderr=stderr.strip(),
-                error=f"exited {proc.returncode}: {stderr.strip()[:500]}",
-            )
-
-        text, parse_error = self._parse_output(stdout)
-        return CliResult(
-            name=cfg.name, ok=True, text=text, returncode=0, duration=duration,
-            parse_error=parse_error, stderr=stderr.strip(),
-        )
+        result: CliResult | None = None
+        async for chunk in self.stream_run(prompt, workdir=workdir, extra_env=extra_env):
+            if chunk.final:
+                result = chunk.result
+        assert result is not None  # stream_run guarantees a terminal chunk
+        return result
 
     async def stream_run(
         self,

--- a/src/swarm/core/cli_adapter.py
+++ b/src/swarm/core/cli_adapter.py
@@ -47,6 +47,18 @@ AUTH_UNAUTHENTICATED = "unauthenticated"
 AUTH_UNKNOWN = "unknown"  # no auth_check configured, or the probe was inconclusive
 AUTH_NOT_INSTALLED = "not_installed"
 
+# Smoke-probe states: does the configured cmd actually *return* in print mode?
+SMOKE_OK = "ok"                          # produced output and exited 0 in time
+SMOKE_HANG = "hang"                      # timed out — almost always a wrong/missing
+                                         # non-interactive flag (the CLI waited on input)
+SMOKE_ERROR = "error"                    # ran but exited non-zero or produced nothing
+SMOKE_NOT_INSTALLED = "not_installed"
+
+# A trivial prompt for the smoke probe; cheap, but DOES invoke the model once.
+DEFAULT_SMOKE_PROMPT = "Reply with the single word: OK"
+# Smoke probes should be quick; cap well under a normal run.
+SMOKE_TIMEOUT = 60.0
+
 
 class CliAdapterError(Exception):
     """Raised for configuration/lookup problems (not runtime CLI failures)."""
@@ -151,6 +163,28 @@ class CliResult:
             "parse_error": self.parse_error,
             "error": self.error,
             "stderr": self.stderr,
+        }
+
+
+@dataclass
+class SmokeResult:
+    """Outcome of a non-interactive smoke probe (see :meth:`CliAdapter.smoke_check`)."""
+
+    name: str
+    status: str
+    detail: str = ""
+    duration: float = 0.0
+
+    @property
+    def ok(self) -> bool:
+        return self.status == SMOKE_OK
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "detail": self.detail,
+            "duration": round(self.duration, 3),
         }
 
 
@@ -379,6 +413,34 @@ class CliAdapter:
             return AUTH_UNKNOWN
         return AUTH_AUTHENTICATED if proc.returncode == 0 else AUTH_UNAUTHENTICATED
 
+    async def smoke_check(
+        self, *, prompt: str = DEFAULT_SMOKE_PROMPT, timeout: float | None = None
+    ) -> SmokeResult:
+        """Run one trivial one-shot to confirm the cmd *returns* in print mode.
+
+        Unlike :meth:`check_auth` (a cheap exit-code probe), this actually
+        invokes the CLI — and therefore the model — once, so it consumes a small
+        amount of quota. It exists to catch the most common misconfiguration: a
+        missing/wrong non-interactive flag, which makes the CLI block on input
+        and hang until the timeout. Returns a :class:`SmokeResult`; never raises.
+        """
+        if not self.is_available():
+            return SmokeResult(self.name, SMOKE_NOT_INSTALLED)
+        t = timeout if timeout is not None else min(self.config.timeout, SMOKE_TIMEOUT)
+        probe = CliAdapter(replace(self.config, timeout=t))
+        res = await probe.run(prompt)
+        if res.timed_out:
+            return SmokeResult(
+                self.name, SMOKE_HANG,
+                "no output before timeout — check the non-interactive flag",
+                res.duration,
+            )
+        if not res.ok:
+            return SmokeResult(self.name, SMOKE_ERROR, (res.error or "")[:200], res.duration)
+        if not (res.text or "").strip():
+            return SmokeResult(self.name, SMOKE_ERROR, "exited 0 but produced no output", res.duration)
+        return SmokeResult(self.name, SMOKE_OK, "", res.duration)
+
     @staticmethod
     async def _terminate(proc: asyncio.subprocess.Process) -> None:
         """Kill a timed-out process group: SIGTERM, grace, then SIGKILL."""
@@ -483,6 +545,20 @@ class CliAdapterRegistry:
             return row
 
         return list(await asyncio.gather(*(_fill(r) for r in rows)))
+
+    async def smoke_check_all(
+        self, *, names: list[str] | None = None, timeout: float | None = None
+    ) -> list[SmokeResult]:
+        """Smoke-probe adapters concurrently (all configured, or a subset).
+
+        Each probe runs one trivial one-shot, so this consumes a little quota per
+        installed adapter — it is opt-in, not part of plain :meth:`discover`.
+        """
+        target = names if names is not None else self.names()
+        adapters = [self._adapters[n] for n in target if n in self._adapters]
+        return list(
+            await asyncio.gather(*(a.smoke_check(timeout=timeout) for a in adapters))
+        )
 
     def resolve_panel(self, names: list[str]) -> list[CliAdapter]:
         """Resolve a list of adapter names to adapters (raises on unknown)."""

--- a/src/swarm/core/cli_catalog.py
+++ b/src/swarm/core/cli_catalog.py
@@ -1,0 +1,97 @@
+"""Built-in catalog of known-good CLI adapter configs.
+
+Starting-point ``cli_agents`` configs for popular agentic CLIs. Lets
+``swarm-cli cli-agents --suggest`` propose a ready-to-paste config block for any
+supported CLI that is installed on the host but not yet in the user's swarm
+config.
+
+Each entry runs the CLI **one-shot, non-interactive, auto-approve** (full
+capability) — the flag that matters is the auto-approve one, without which the
+CLI blocks on a permission prompt and is killed on timeout (see
+``docs/CLI_FUSION.md``). Exact flags and JSON shapes drift by CLI version, so
+these are suggestions to verify with each CLI's ``--help``, not guarantees.
+"""
+
+from __future__ import annotations
+
+import shutil
+from typing import Any
+
+# name -> adapter config dict (same shape as one `cli_agents` entry).
+CATALOG: dict[str, dict[str, Any]] = {
+    "claude": {
+        "cmd": ["claude", "-p", "{prompt}", "--output-format", "json",
+                "--dangerously-skip-permissions"],
+        "parse": "json:.result",
+        "mode": "write",
+        "timeout": 240,
+        "env_allowlist": ["ANTHROPIC_API_KEY"],
+    },
+    "gemini": {
+        "cmd": ["gemini", "-p", "{prompt}", "-o", "json", "--yolo"],
+        "parse": "json:.response",
+        "mode": "write",
+        "timeout": 240,
+        "env_allowlist": ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+    },
+    "codex": {
+        "cmd": ["codex", "exec", "{prompt}", "--dangerously-bypass-approvals-and-sandbox"],
+        "parse": "text",
+        "mode": "write",
+        "timeout": 240,
+        "env_allowlist": ["OPENAI_API_KEY"],
+    },
+    "opencode": {
+        "cmd": ["opencode", "run", "{prompt}"],
+        "parse": "text",
+        "mode": "write",
+        "timeout": 240,
+    },
+}
+
+
+def catalog_names() -> list[str]:
+    """Names of every CLI the catalog knows about (sorted)."""
+    return sorted(CATALOG)
+
+
+def catalog_entry(name: str) -> dict[str, Any] | None:
+    """A copy of the catalog config for ``name`` (None if unknown)."""
+    entry = CATALOG.get(name)
+    return _deepcopy(entry) if entry is not None else None
+
+
+def executable_for(name: str) -> str | None:
+    """The executable (``cmd[0]``) a catalog entry runs, or None if unknown."""
+    entry = CATALOG.get(name)
+    return entry["cmd"][0] if entry else None
+
+
+def suggest_unconfigured(
+    configured_names: list[str] | None,
+    *,
+    installed_only: bool = True,
+) -> dict[str, dict[str, Any]]:
+    """Return ``{name: config}`` for catalog CLIs not already configured.
+
+    Skips any name already present in ``configured_names``. When
+    ``installed_only`` (default), also skips CLIs whose executable does not
+    resolve on PATH — so suggestions are actionable on *this* host.
+    """
+    configured = set(configured_names or ())
+    out: dict[str, dict[str, Any]] = {}
+    for name, cfg in CATALOG.items():
+        if name in configured:
+            continue
+        if installed_only and shutil.which(cfg["cmd"][0]) is None:
+            continue
+        out[name] = _deepcopy(cfg)
+    return out
+
+
+def _deepcopy(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Shallow structure with copied list/dict values (configs are 1 level deep)."""
+    return {
+        k: (list(v) if isinstance(v, list) else dict(v) if isinstance(v, dict) else v)
+        for k, v in cfg.items()
+    }

--- a/src/swarm/core/cli_catalog.py
+++ b/src/swarm/core/cli_catalog.py
@@ -10,6 +10,15 @@ capability) — the flag that matters is the auto-approve one, without which the
 CLI blocks on a permission prompt and is killed on timeout (see
 ``docs/CLI_FUSION.md``). Exact flags and JSON shapes drift by CLI version, so
 these are suggestions to verify with each CLI's ``--help``, not guarantees.
+
+Known per-CLI gotchas are encoded here so the defaults *just run* (verified live
+2026-06-16):
+
+* **gemini** refuses to run in an "untrusted" directory — ``--skip-trust`` (or
+  ``GEMINI_CLI_TRUST_WORKSPACE=true``) is required for non-interactive use.
+* **opencode** has no usable default model in ``run`` mode (its built-in default
+  errors as "not supported"), so an explicit ``--model`` is required. The value
+  below is account/version-specific — run ``opencode models`` to pick one.
 """
 
 from __future__ import annotations
@@ -28,7 +37,8 @@ CATALOG: dict[str, dict[str, Any]] = {
         "env_allowlist": ["ANTHROPIC_API_KEY"],
     },
     "gemini": {
-        "cmd": ["gemini", "-p", "{prompt}", "-o", "json", "--yolo"],
+        # --skip-trust: gemini refuses to run in an untrusted dir without it.
+        "cmd": ["gemini", "-p", "{prompt}", "-o", "json", "--yolo", "--skip-trust"],
         "parse": "json:.response",
         "mode": "write",
         "timeout": 240,
@@ -42,7 +52,10 @@ CATALOG: dict[str, dict[str, Any]] = {
         "env_allowlist": ["OPENAI_API_KEY"],
     },
     "opencode": {
-        "cmd": ["opencode", "run", "{prompt}"],
+        # --model: opencode's built-in default errors as "not supported"; an
+        # explicit model is required. This value is account/version-specific —
+        # run `opencode models` to pick one available to you.
+        "cmd": ["opencode", "run", "{prompt}", "--model", "opencode/big-pickle"],
         "parse": "text",
         "mode": "write",
         "timeout": 240,

--- a/src/swarm/core/cli_tools.py
+++ b/src/swarm/core/cli_tools.py
@@ -1,0 +1,85 @@
+"""Expose CLI adapters and consensus as agent tools.
+
+The composable layer over :mod:`swarm.core.consensus` and
+:mod:`swarm.core.cli_adapter`: turn a CLI persona or a whole consensus panel into
+something an openai-agents ``Agent`` can call mid-reasoning. This is what makes
+fusion *granular* — an orchestrating agent runs a single inference and reaches
+for ``consensus(...)`` only on the hard sub-question, instead of fanning out on
+everything.
+
+Each factory returns a plain ``async`` callable (directly awaitable and testable);
+wrap it with :func:`as_function_tool` to hand it to an ``Agent(tools=[...])``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Awaitable, Callable
+
+from swarm.core.cli_adapter import CliAdapter
+from swarm.core.consensus import run_consensus
+
+try:  # openai-agents is a core dep, but keep import failures non-fatal for tooling
+    from agents import function_tool
+except Exception:  # pragma: no cover
+    function_tool = None  # type: ignore[assignment]
+
+_SLUG_RE = re.compile(r"[^A-Za-z0-9_]+")
+
+
+def _ident(name: str) -> str:
+    """A safe Python identifier fragment for a tool name."""
+    return _SLUG_RE.sub("_", name).strip("_") or "cli"
+
+
+def cli_persona(adapter: CliAdapter) -> Callable[[str], Awaitable[str]]:
+    """An async callable that asks one CLI a question and returns its answer.
+
+    On failure it returns a short ``[<name> unavailable: …]`` note rather than
+    raising, so an orchestrating agent can react instead of crashing.
+    """
+
+    async def ask(question: str) -> str:
+        res = await adapter.run(question)
+        return res.text if res.ok else f"[{adapter.name} unavailable: {res.error}]"
+
+    ask.__name__ = f"ask_{_ident(adapter.name)}"
+    ask.__doc__ = f"Ask the '{adapter.name}' CLI agent a question and return its answer."
+    return ask
+
+
+def consensus_fn(
+    panel: list[CliAdapter], judge: CliAdapter | None = None
+) -> Callable[[str], Awaitable[str]]:
+    """An async callable that runs a consensus panel and returns the agreed answer.
+
+    Returns the synthesized consensus, or ``(no consensus reached)`` if every
+    panelist failed.
+    """
+
+    async def consensus(question: str) -> str:
+        res = await run_consensus(question, panel, judge)
+        return res.answer or "(no consensus reached)"
+
+    consensus.__doc__ = (
+        "Get a cross-model consensus answer to a high-stakes question: a panel of "
+        "independent CLI agents deliberate and a judge synthesizes their agreement."
+    )
+    return consensus
+
+
+def as_function_tool(
+    fn: Callable[..., Awaitable[str]], *, name: str | None = None, description: str | None = None
+):
+    """Wrap an async callable as an openai-agents ``FunctionTool``.
+
+    Raises if openai-agents is unavailable. The callable's name/docstring become
+    the tool's name/description unless overridden.
+    """
+    if function_tool is None:  # pragma: no cover
+        raise RuntimeError("openai-agents is not installed; cannot build a function tool")
+    if name:
+        fn.__name__ = name
+    if description:
+        fn.__doc__ = description
+    return function_tool(fn)

--- a/src/swarm/core/consensus.py
+++ b/src/swarm/core/consensus.py
@@ -1,0 +1,156 @@
+"""Reusable consensus service: panel → judge → synthesize.
+
+Extracted from the ``cli_fusion`` blueprint so the same panel→judge→synthesize
+loop can be driven from anywhere — a blueprint, the websocket front-end, or as an
+``as_tool()`` an orchestrating agent calls *granularly* (escalate one hard
+sub-question to a cross-model consensus check). One call = one round; the
+master-plan loop stays in the caller.
+
+Consensus-first: when a judge is configured the synthesized answer is grounded in
+what the panel agrees on (dissent flagged, not blended away). With no usable
+judge the fallback is the **most-corroborated** panel answer — the one sharing the
+most content with the others — never simply the longest.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from swarm.core.cli_adapter import CliAdapter, CliResult
+
+DEFAULT_MAX_CONCURRENCY = 8
+
+JUDGE_TEMPLATE = """You are the JUDGE in a multi-agent panel. The user's request was:
+
+<request>
+{prompt}
+</request>
+
+Several independent agents answered it. Compare (do NOT merely concatenate) their answers below.
+
+{panel}
+
+Return ONLY a JSON object with these keys:
+- "consensus": list of points the agents agree on
+- "contradictions": list of points where they disagree
+- "gaps": list of things no agent covered
+- "unique_insights": list of valuable points raised by a single agent
+- "answer": a single best answer GROUNDED IN THE PANEL'S CONSENSUS — lead with what the agents agree on, and explicitly flag any material disagreement rather than blending it away
+- "done": boolean — true if "answer" fully resolves the request, false if another round of work is needed
+- "next_step": if not done, one concrete instruction for the next round (else "")
+"""
+
+
+def safe_json(text: str) -> dict[str, Any] | None:
+    """Parse a JSON object from CLI output, tolerating surrounding prose."""
+    text = (text or "").strip()
+    if not text:
+        return None
+    try:
+        obj = json.loads(text)
+        return obj if isinstance(obj, dict) else None
+    except json.JSONDecodeError:
+        pass
+    start, end = text.find("{"), text.rfind("}")
+    if 0 <= start < end:
+        try:
+            obj = json.loads(text[start : end + 1])
+            return obj if isinstance(obj, dict) else None
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+@dataclass
+class ConsensusResult:
+    """Outcome of one consensus round."""
+
+    answer: str
+    analysis: dict[str, Any] | None  # judge JSON: consensus/contradictions/gaps/…/done/next_step
+    results: list[CliResult] = field(default_factory=list)  # every panelist (incl. failures)
+
+    @property
+    def ok_results(self) -> list[CliResult]:
+        return [r for r in self.results if r.ok]
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.ok_results)
+
+
+def _tokens(text: str) -> set[str]:
+    return set(re.findall(r"[a-z0-9]+", (text or "").lower()))
+
+
+def most_corroborated(results: list[CliResult]) -> str:
+    """The panel answer sharing the most content with the others (consensus-first).
+
+    This replaces "pick the longest answer", which rewarded verbosity over
+    agreement. With one survivor, that survivor wins by definition.
+    """
+    ok = [r for r in results if r.ok]
+    if not ok:
+        return ""
+    if len(ok) == 1:
+        return ok[0].text
+    toks = [(r, _tokens(r.text)) for r in ok]
+    def corroboration(item: tuple[CliResult, set[str]]) -> int:
+        _, mine = item
+        return sum(len(mine & other) for r2, other in toks if r2 is not item[0])
+    best, _ = max(toks, key=corroboration)
+    return best.text
+
+
+def synthesize(analysis: dict[str, Any] | None, results: list[CliResult]) -> str:
+    """The consensus answer: judge's grounded answer, else most-corroborated."""
+    if analysis and isinstance(analysis.get("answer"), str) and analysis["answer"].strip():
+        return analysis["answer"].strip()
+    return most_corroborated(results)
+
+
+async def run_consensus(
+    prompt: str,
+    panel: list[CliAdapter],
+    judge: CliAdapter | None = None,
+    *,
+    workdirs: dict[str, str | None] | None = None,
+    child_env: dict[str, str] | None = None,
+    max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+) -> ConsensusResult:
+    """Run one panel→judge→synthesize round.
+
+    ``panel`` runs concurrently (bounded by ``max_concurrency``); failures come
+    back as not-ok :class:`CliResult` rows (never raises). The judge compares only
+    the successful answers. Returns a :class:`ConsensusResult`; when every
+    panelist failed, ``answer`` is empty and ``ok`` is False.
+    """
+    workdirs = workdirs or {}
+    sem = asyncio.Semaphore(max(1, max_concurrency))
+
+    async def _one(adapter: CliAdapter) -> CliResult:
+        async with sem:
+            return await adapter.run(
+                prompt, workdir=workdirs.get(adapter.name), extra_env=child_env
+            )
+
+    results = list(await asyncio.gather(*(_one(a) for a in panel)))
+    ok = [r for r in results if r.ok]
+    if not ok:
+        return ConsensusResult(answer="", analysis=None, results=results)
+
+    analysis: dict[str, Any] | None = None
+    if judge is not None:
+        panel_text = "\n\n".join(f"### Agent: {r.name}\n{r.text}" for r in ok)
+        jr = await judge.run(
+            JUDGE_TEMPLATE.format(prompt=prompt, panel=panel_text),
+            workdir=workdirs.get(judge.name),
+            extra_env=child_env,
+        )
+        if jr.ok:
+            analysis = safe_json(jr.text)
+
+    return ConsensusResult(answer=synthesize(analysis, ok), analysis=analysis, results=results)

--- a/src/swarm/core/swarm_cli.py
+++ b/src/swarm/core/swarm_cli.py
@@ -277,6 +277,7 @@ def cli_agents(
     check_auth: bool = typer.Option(False, "--check-auth", help="Also probe each installed CLI's authentication (runs its configured auth_check)."),
     suggest: bool = typer.Option(False, "--suggest", help="Suggest ready-to-paste config blocks for supported CLIs that are installed but not yet configured."),
     smoke: bool = typer.Option(False, "--smoke", help="Run one trivial one-shot per installed CLI to confirm it returns in non-interactive mode. NOTE: invokes each CLI's model once (small quota cost)."),
+    output_json: bool = typer.Option(False, "--json", help="Emit a single machine-readable JSON object instead of tables (honors --check-auth/--smoke/--suggest)."),
 ):
     """Autodiscover configured CLI agents: which are installed (and optionally authenticated)."""
     import asyncio
@@ -290,6 +291,19 @@ def cli_agents(
     config = load_config(cfg_file) if cfg_file else {}
     registry = CliAdapterRegistry.from_config(config)
     rows = asyncio.run(registry.discover_auth()) if check_auth else registry.discover()
+
+    if output_json:
+        payload: dict = {"agents": [d.as_dict() for d in rows]}
+        if smoke:
+            smoke_names = [d.name for d in rows if d.installed]
+            payload["smoke"] = [
+                s.as_dict() for s in asyncio.run(registry.smoke_check_all(names=smoke_names))
+            ]
+        if suggest:
+            payload["suggestions"] = cli_catalog.suggest_unconfigured(registry.names())
+        typer.echo(json.dumps(payload, indent=2))
+        raise typer.Exit(code=0)
+
     if not rows:
         typer.echo("No CLI agents configured. Add a 'cli_agents' block to your swarm config (see docs/CLI_FUSION.md).")
     elif check_auth:

--- a/src/swarm/core/swarm_cli.py
+++ b/src/swarm/core/swarm_cli.py
@@ -275,11 +275,14 @@ def list_blueprints(
 def cli_agents(
     config_path: str = typer.Option(None, "--config", help="Path to swarm_config.json (defaults to the usual search)."),
     check_auth: bool = typer.Option(False, "--check-auth", help="Also probe each installed CLI's authentication (runs its configured auth_check)."),
+    suggest: bool = typer.Option(False, "--suggest", help="Suggest ready-to-paste config blocks for supported CLIs that are installed but not yet configured."),
 ):
     """Autodiscover configured CLI agents: which are installed (and optionally authenticated)."""
     import asyncio
+    import json
 
     from swarm.core.cli_adapter import CliAdapterRegistry
+    from swarm.core import cli_catalog
     from swarm.core.config_loader import find_config_file, load_config
 
     cfg_file = find_config_file(specific_path=config_path)
@@ -288,9 +291,7 @@ def cli_agents(
     rows = asyncio.run(registry.discover_auth()) if check_auth else registry.discover()
     if not rows:
         typer.echo("No CLI agents configured. Add a 'cli_agents' block to your swarm config (see docs/CLI_FUSION.md).")
-        raise typer.Exit(code=0)
-
-    if check_auth:
+    elif check_auth:
         typer.echo(f"{'AGENT':16} {'STATUS':10} {'AUTH':16} {'MODE':10} EXECUTABLE")
         for d in rows:
             status = "installed" if d.installed else "missing"
@@ -300,8 +301,20 @@ def cli_agents(
         for d in rows:
             status = "installed" if d.installed else "missing"
             typer.echo(f"{d.name:16} {status:10} {d.mode:10} {d.executable or '-'}")
-    installed = sum(1 for d in rows if d.installed)
-    typer.echo(f"\n{installed}/{len(rows)} configured CLI agents installed on this host.")
+    if rows:
+        installed = sum(1 for d in rows if d.installed)
+        typer.echo(f"\n{installed}/{len(rows)} configured CLI agents installed on this host.")
+
+    if suggest:
+        suggestions = cli_catalog.suggest_unconfigured(registry.names())
+        typer.echo("")
+        if not suggestions:
+            typer.echo("No suggestions: every supported CLI installed on this host is already configured.")
+        else:
+            names = ", ".join(sorted(suggestions))
+            typer.echo(f"Suggested cli_agents for installed-but-unconfigured CLIs ({names}):")
+            typer.echo("Verify each CLI's flags with --help before use; see docs/CLI_FUSION.md.\n")
+            typer.echo(json.dumps({"cli_agents": suggestions}, indent=2))
 
 
 if __name__ == "__main__":

--- a/src/swarm/core/swarm_cli.py
+++ b/src/swarm/core/swarm_cli.py
@@ -276,6 +276,7 @@ def cli_agents(
     config_path: str = typer.Option(None, "--config", help="Path to swarm_config.json (defaults to the usual search)."),
     check_auth: bool = typer.Option(False, "--check-auth", help="Also probe each installed CLI's authentication (runs its configured auth_check)."),
     suggest: bool = typer.Option(False, "--suggest", help="Suggest ready-to-paste config blocks for supported CLIs that are installed but not yet configured."),
+    smoke: bool = typer.Option(False, "--smoke", help="Run one trivial one-shot per installed CLI to confirm it returns in non-interactive mode. NOTE: invokes each CLI's model once (small quota cost)."),
 ):
     """Autodiscover configured CLI agents: which are installed (and optionally authenticated)."""
     import asyncio
@@ -304,6 +305,18 @@ def cli_agents(
     if rows:
         installed = sum(1 for d in rows if d.installed)
         typer.echo(f"\n{installed}/{len(rows)} configured CLI agents installed on this host.")
+
+    if smoke:
+        installed = [d.name for d in rows if d.installed]
+        typer.echo("")
+        if not installed:
+            typer.echo("No installed CLI agents to smoke-test.")
+        else:
+            typer.echo(f"Smoke-testing {len(installed)} installed CLI(s) (one trivial one-shot each)…")
+            results = asyncio.run(registry.smoke_check_all(names=installed))
+            typer.echo(f"\n{'AGENT':16} {'SMOKE':6} {'TIME':>7}  DETAIL")
+            for s in results:
+                typer.echo(f"{s.name:16} {s.status:6} {s.duration:6.1f}s  {s.detail}")
 
     if suggest:
         suggestions = cli_catalog.suggest_unconfigured(registry.names())

--- a/src/swarm/core/swarm_cli.py
+++ b/src/swarm/core/swarm_cli.py
@@ -274,23 +274,32 @@ def list_blueprints(
 @app.command(name="cli-agents")
 def cli_agents(
     config_path: str = typer.Option(None, "--config", help="Path to swarm_config.json (defaults to the usual search)."),
+    check_auth: bool = typer.Option(False, "--check-auth", help="Also probe each installed CLI's authentication (runs its configured auth_check)."),
 ):
-    """Autodiscover configured CLI agents and show which are installed on this host."""
+    """Autodiscover configured CLI agents: which are installed (and optionally authenticated)."""
+    import asyncio
+
     from swarm.core.cli_adapter import CliAdapterRegistry
     from swarm.core.config_loader import find_config_file, load_config
 
     cfg_file = find_config_file(specific_path=config_path)
     config = load_config(cfg_file) if cfg_file else {}
     registry = CliAdapterRegistry.from_config(config)
-    rows = registry.discover()
+    rows = asyncio.run(registry.discover_auth()) if check_auth else registry.discover()
     if not rows:
         typer.echo("No CLI agents configured. Add a 'cli_agents' block to your swarm config (see docs/CLI_FUSION.md).")
         raise typer.Exit(code=0)
 
-    typer.echo(f"{'AGENT':16} {'STATUS':10} {'MODE':10} EXECUTABLE")
-    for d in rows:
-        status = "installed" if d.installed else "missing"
-        typer.echo(f"{d.name:16} {status:10} {d.mode:10} {d.executable or '-'}")
+    if check_auth:
+        typer.echo(f"{'AGENT':16} {'STATUS':10} {'AUTH':16} {'MODE':10} EXECUTABLE")
+        for d in rows:
+            status = "installed" if d.installed else "missing"
+            typer.echo(f"{d.name:16} {status:10} {d.authenticated:16} {d.mode:10} {d.executable or '-'}")
+    else:
+        typer.echo(f"{'AGENT':16} {'STATUS':10} {'MODE':10} EXECUTABLE")
+        for d in rows:
+            status = "installed" if d.installed else "missing"
+            typer.echo(f"{d.name:16} {status:10} {d.mode:10} {d.executable or '-'}")
     installed = sum(1 for d in rows if d.installed)
     typer.echo(f"\n{installed}/{len(rows)} configured CLI agents installed on this host.")
 

--- a/tests/api/test_cli_fusion_api.py
+++ b/tests/api/test_cli_fusion_api.py
@@ -72,3 +72,46 @@ def test_cli_agent_respects_cli_param_over_api(client, fake_cli_config):
     resp = _post(client, "cli_agent", "pick", params={"cli": "b"})
     assert resp.status_code == 200, resp.content[:300]
     assert _content(resp) == "B:pick"
+
+
+def _sse_text(response):
+    import asyncio as _asyncio
+
+    stream = response.streaming_content
+    if hasattr(stream, "__aiter__"):
+        async def _collect():
+            return b"".join([c async for c in stream])
+
+        return _asyncio.run(_collect()).decode()
+    return b"".join(stream).decode()
+
+
+@pytest.fixture
+def streaming_cli_config(monkeypatch):
+    code = "import sys; sys.stdout.write('alpha\\nbeta\\n')"
+    cfg = {
+        "cli_agents": {"s": {"cmd": [PY, "-c", code, "{prompt}"], "parse": "text"}},
+        "cli_fusion": {"default_cli": "s"},
+    }
+    monkeypatch.setattr(apps.get_app_config("swarm"), "config", cfg, raising=False)
+    monkeypatch.setenv("SWARM_TEST_MODE", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-dummy-test-mode")
+    return cfg
+
+
+@pytest.mark.django_db
+def test_cli_agent_streams_incremental_deltas_over_api(client, streaming_cli_config):
+    body = {
+        "model": "cli_agent",
+        "messages": [{"role": "user", "content": "go"}],
+        "stream": True,
+    }
+    resp = client.post("/v1/chat/completions", data=json.dumps(body), content_type="application/json")
+    assert resp.status_code == 200
+    sse = _sse_text(resp)
+    assert "data: [DONE]" in sse
+    # The streamed deltas reassemble to the CLI's stdout.
+    import re
+
+    deltas = "".join(re.findall(r'"content":\s*"([^"]*)"', sse))
+    assert "alpha" in deltas and "beta" in deltas

--- a/tests/api/test_cli_fusion_api.py
+++ b/tests/api/test_cli_fusion_api.py
@@ -22,6 +22,18 @@ def _echo(prefix: str) -> dict:
     return {"cmd": [PY, "-c", f"import sys; print('{prefix}:' + sys.argv[1])", "{prompt}"]}
 
 
+@pytest.fixture(autouse=True)
+def _isolate_blueprint_cache():
+    # Param-less requests reuse get_blueprint_instance()'s instance cache. Clear
+    # it before AND after each test so neither a stale empty-config instance from
+    # an earlier test leaks in, nor our fake-config instance leaks out.
+    from swarm.views import utils as view_utils
+
+    view_utils._blueprint_instance_cache.clear()
+    yield
+    view_utils._blueprint_instance_cache.clear()
+
+
 @pytest.fixture
 def fake_cli_config(monkeypatch):
     cfg = {

--- a/tests/api/test_cli_fusion_api.py
+++ b/tests/api/test_cli_fusion_api.py
@@ -1,0 +1,74 @@
+"""End-to-end API tests for the CLI fusion blueprints over /v1/chat/completions.
+
+The per-blueprint smoke matrix proves cli_agent/cli_fusion are *reachable*, but
+only with an empty config (so they answer "no CLI agents configured"). These
+tests inject fake echo-based adapters via the swarm AppConfig and assert a real
+panel -> synthesize flow — and that per-request `params` (cli/panel) drive
+selection — across the OpenAI-compatible surface.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+from django.apps import apps
+
+PY = sys.executable
+
+
+def _echo(prefix: str) -> dict:
+    return {"cmd": [PY, "-c", f"import sys; print('{prefix}:' + sys.argv[1])", "{prompt}"]}
+
+
+@pytest.fixture
+def fake_cli_config(monkeypatch):
+    cfg = {
+        "cli_agents": {"a": _echo("A"), "b": _echo("B")},
+        "cli_fusion": {
+            "default_cli": "a",
+            "default_preset": "p",
+            "presets": {"p": {"panel": ["a", "b"]}},
+        },
+    }
+    app = apps.get_app_config("swarm")
+    monkeypatch.setattr(app, "config", cfg, raising=False)
+    monkeypatch.setenv("SWARM_TEST_MODE", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-dummy-test-mode")
+    return cfg
+
+
+def _post(client, model, content, params=None):
+    body = {"model": model, "messages": [{"role": "user", "content": content}]}
+    if params is not None:
+        body["params"] = params
+    return client.post("/v1/chat/completions", data=json.dumps(body), content_type="application/json")
+
+
+def _content(response):
+    return response.json()["choices"][0]["message"]["content"].strip()
+
+
+@pytest.mark.django_db
+def test_cli_fusion_panel_synthesizes_over_api(client, fake_cli_config):
+    # No judge configured -> synthesize falls back to the longest panel answer.
+    resp = _post(client, "cli_fusion", "hello", params={"panel": ["a", "b"]})
+    assert resp.status_code == 200, resp.content[:300]
+    assert resp.json().get("object") == "chat.completion"
+    assert _content(resp) in ("A:hello", "B:hello")
+
+
+@pytest.mark.django_db
+def test_cli_fusion_uses_default_preset_without_params(client, fake_cli_config):
+    resp = _post(client, "cli_fusion", "world")
+    assert resp.status_code == 200, resp.content[:300]
+    assert _content(resp) in ("A:world", "B:world")
+
+
+@pytest.mark.django_db
+def test_cli_agent_respects_cli_param_over_api(client, fake_cli_config):
+    # The single-CLI blueprint should run exactly the adapter named in params.
+    resp = _post(client, "cli_agent", "pick", params={"cli": "b"})
+    assert resp.status_code == 200, resp.content[:300]
+    assert _content(resp) == "B:pick"

--- a/tests/blueprints/test_cli_agent.py
+++ b/tests/blueprints/test_cli_agent.py
@@ -117,3 +117,60 @@ async def test_blueprint_reports_cli_failure():
     bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
     chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
     assert "failed" in _final_content(chunks)
+
+
+# --------------------------------------------------------------------------- #
+# Streaming (stream=True)
+# --------------------------------------------------------------------------- #
+
+def _message_contents(chunks):
+    return [
+        c["messages"][0]["content"]
+        for c in chunks
+        if isinstance(c, dict) and c.get("messages") and c["messages"][0].get("content") is not None
+    ]
+
+
+def _stream_config():
+    code = "import sys; sys.stdout.write('line1\\nline2\\n')"
+    return {
+        "cli_agents": {"s": {"cmd": [PY, "-c", code, "{prompt}"], "parse": "text"}},
+        "cli_fusion": {"default_cli": "s"},
+    }
+
+
+async def test_blueprint_streams_deltas_without_duplication():
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=_stream_config())
+    chunks = await _collect(bp.run([{"role": "user", "content": "go"}], stream=True))
+    # The concatenated deltas reproduce the output exactly — no final full resend.
+    assert "".join(_message_contents(chunks)) == "line1\nline2\n"
+
+
+async def test_blueprint_non_streaming_still_single_full_message():
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=_stream_config())
+    chunks = await _collect(bp.run([{"role": "user", "content": "go"}], stream=False))
+    # Non-streaming yields exactly one content message (the full answer).
+    assert _message_contents(chunks) == ["line1\nline2"]
+    assert chunks[-1].get("final") is True
+
+
+async def test_blueprint_streaming_reports_failure():
+    cfg = {
+        "cli_agents": {"boom": {"cmd": [PY, "-c", "import sys; sys.exit(2)", "{prompt}"]}},
+        "cli_fusion": {"default_cli": "boom"},
+    }
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "x"}], stream=True))
+    assert "failed" in _final_content(chunks)
+
+
+async def test_blueprint_streaming_json_adapter_falls_back_to_oneshot():
+    code = "print('{\"result\": \"answer\"}')"
+    cfg = {
+        "cli_agents": {"j": {"cmd": [PY, "-c", code, "{prompt}"], "parse": "json:.result"}},
+        "cli_fusion": {"default_cli": "j"},
+    }
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "x"}], stream=True))
+    # json: can't stream incrementally -> one-shot fallback returns the parsed value.
+    assert _final_content(chunks) == "answer"

--- a/tests/blueprints/test_cli_agent.py
+++ b/tests/blueprints/test_cli_agent.py
@@ -174,3 +174,94 @@ async def test_blueprint_streaming_json_adapter_falls_back_to_oneshot():
     chunks = await _collect(bp.run([{"role": "user", "content": "x"}], stream=True))
     # json: can't stream incrementally -> one-shot fallback returns the parsed value.
     assert _final_content(chunks) == "answer"
+
+
+# --------------------------------------------------------------------------- #
+# Failover (single-agent resilience to broken/missing CLIs)
+# --------------------------------------------------------------------------- #
+
+def _boom(code: int = 1) -> dict:
+    return {"cmd": [PY, "-c", f"import sys; sys.exit({code})", "{prompt}"]}
+
+
+def _ok(prefix: str) -> dict:
+    return {"cmd": [PY, "-c", f"import sys; print('{prefix}: ' + sys.argv[1])", "{prompt}"]}
+
+
+async def test_failover_primary_fails_uses_explicit_fallback():
+    cfg = {
+        "cli_agents": {"boom": _boom(), "backup": _ok("BACKUP")},
+        "cli_fusion": {"default_cli": "boom"},
+    }
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    bp.set_params({"cli": "boom", "fallback": ["backup"]})
+    chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
+    assert _final_content(chunks) == "BACKUP: ping"
+
+
+async def test_failover_auto_uses_other_available_when_primary_fails():
+    # No explicit fallback -> auto-failover to other available adapters.
+    cfg = {
+        "cli_agents": {"boom": _boom(), "good": _ok("GOOD")},
+        "cli_fusion": {"default_cli": "boom"},
+    }
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
+    assert _final_content(chunks) == "GOOD: ping"
+
+
+async def test_failover_primary_success_does_not_fall_over():
+    cfg = {
+        "cli_agents": {"primary": _ok("PRIMARY"), "backup": _ok("BACKUP")},
+        "cli_fusion": {"default_cli": "primary"},
+    }
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
+    assert _final_content(chunks) == "PRIMARY: ping"
+
+
+async def test_failover_all_candidates_fail_reports_cleanly():
+    cfg = {
+        "cli_agents": {"boom1": _boom(), "boom2": _boom(2)},
+        "cli_fusion": {"default_cli": "boom1"},
+    }
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    bp.set_params({"cli": "boom1", "fallback": ["boom2"]})
+    chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
+    assert "failed" in _final_content(chunks).lower()
+
+
+async def test_failover_disabled_is_strict_single_cli():
+    cfg = {
+        "cli_agents": {"boom": _boom(), "good": _ok("GOOD")},
+        "cli_fusion": {"default_cli": "boom"},
+    }
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    bp.set_params({"cli": "boom", "failover": False})
+    chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
+    # Strict: it fails on the primary and does NOT silently switch models.
+    assert "GOOD" not in _final_content(chunks)
+    assert "failed" in _final_content(chunks).lower()
+
+
+async def test_failover_skips_not_installed_primary():
+    cfg = {
+        "cli_agents": {
+            "ghost": {"cmd": ["definitely-not-a-real-cli-zzz", "{prompt}"]},
+            "real": _ok("REAL"),
+        },
+        "cli_fusion": {"default_cli": "ghost"},
+    }
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
+    assert _final_content(chunks) == "REAL: ping"
+
+
+def test_resolve_failover_chain_orders_and_dedups():
+    cfg = {"cli_agents": {"a": _ok("A"), "b": _ok("B"), "c": _ok("C")}}
+    reg = CliAdapterRegistry.from_config(cfg)
+    # explicit primary + fallback, deduped, order preserved
+    chain = support.resolve_failover_chain(cfg, {"cli": "a", "fallback": ["b", "a", "c"]}, reg)
+    assert chain == ["a", "b", "c"]
+    # failover disabled -> primary only
+    assert support.resolve_failover_chain(cfg, {"cli": "a", "failover": False}, reg) == ["a"]

--- a/tests/blueprints/test_cli_fusion.py
+++ b/tests/blueprints/test_cli_fusion.py
@@ -3,16 +3,22 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import subprocess
 import sys
 
 import pytest
 
 from swarm.blueprints.cli_fusion.blueprint_cli_fusion import (
     CliFusionBlueprint,
+    _panel_workspaces,
     _safe_json,
+    _should_isolate,
 )
 
 PY = sys.executable
+GIT = shutil.which("git")
 
 
 def _echo(name_prefix: str) -> dict:
@@ -190,3 +196,100 @@ async def test_show_analysis_footer():
     final = _final_content(chunks)
     assert "core" in final
     assert "consensus" in final
+
+
+# --------------------------------------------------------------------------- #
+# Workdir isolation
+# --------------------------------------------------------------------------- #
+
+def _writer(marker: str) -> dict:
+    # Panelist that writes a marker file into its CWD and prints the CWD.
+    code = (
+        "import os, sys; "
+        "open(os.path.join(os.getcwd(), sys.argv[2]), 'w').close(); "
+        "print(os.getcwd())"
+    )
+    return {"cmd": [PY, "-c", code, "{prompt}", marker]}
+
+
+def _git_init(path) -> None:
+    subprocess.run([GIT, "init", "-q", str(path)], check=True)
+    (path / "README").write_text("seed\n")
+    env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run([GIT, "-C", str(path), "add", "-A"], check=True)
+    subprocess.run([GIT, "-C", str(path), "commit", "-q", "-m", "init"], check=True, env=env)
+
+
+def _worktree_count(path) -> int:
+    out = subprocess.run(
+        [GIT, "-C", str(path), "worktree", "list"], check=True, capture_output=True, text=True
+    ).stdout
+    return len([ln for ln in out.splitlines() if ln.strip()])
+
+
+async def test_should_isolate_explicit_true_overrides_everything():
+    assert await _should_isolate(None, ["a", "b"], True) is True
+    assert await _should_isolate("/no/such/dir", ["a"], True) is True
+
+
+async def test_should_isolate_explicit_false_overrides_everything():
+    assert await _should_isolate("/tmp", ["a", "b"], False) is False
+
+
+async def test_should_isolate_auto_skips_non_repo(tmp_path):
+    # Auto (None) + a plain dir that isn't a git repo -> no isolation.
+    assert await _should_isolate(str(tmp_path), ["a", "b"], None) is False
+
+
+async def test_should_isolate_auto_skips_single_panelist():
+    assert await _should_isolate(None, ["a"], None) is False
+
+
+async def test_workspaces_no_isolation_shares_base():
+    async with _panel_workspaces("/base", ["a", "b"], False) as m:
+        assert m == {"a": "/base", "b": "/base"}
+
+
+async def test_workspaces_isolation_non_repo_gives_distinct_dirs(tmp_path):
+    async with _panel_workspaces(str(tmp_path), ["a", "b"], True) as m:
+        assert set(m) == {"a", "b"}
+        assert m["a"] != m["b"]
+        assert os.path.isdir(m["a"]) and os.path.isdir(m["b"])
+        scratch = list(m.values())
+    # Scratch dirs are removed once the context exits.
+    assert all(not os.path.exists(d) for d in scratch)
+
+
+@pytest.mark.skipif(not GIT, reason="git not available")
+async def test_isolation_worktree_keeps_base_tree_clean(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+    cfg = {
+        "cli_agents": {"a": _writer("MARK_A"), "b": _writer("MARK_B")},
+        "cli_fusion": {"presets": {"p": {"panel": ["a", "b"]}}, "default_preset": "p"},
+    }
+    bp = CliFusionBlueprint(config=cfg)
+    bp.set_params({"workdir": str(repo), "isolate": True})
+    await _collect(bp.run([{"role": "user", "content": "q"}]))
+    # Panelist writes happened in throwaway worktrees, not the source tree.
+    assert not (repo / "MARK_A").exists()
+    assert not (repo / "MARK_B").exists()
+    # Worktrees were torn down (only the main worktree remains).
+    assert _worktree_count(repo) == 1
+
+
+async def test_no_isolation_writes_land_in_shared_workdir(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    cfg = {
+        "cli_agents": {"a": _writer("MARK_A"), "b": _writer("MARK_B")},
+        "cli_fusion": {"presets": {"p": {"panel": ["a", "b"]}}, "default_preset": "p"},
+    }
+    bp = CliFusionBlueprint(config=cfg)
+    bp.set_params({"workdir": str(work), "isolate": False})
+    await _collect(bp.run([{"role": "user", "content": "q"}]))
+    # Without isolation both panelists share the workdir and their writes persist.
+    assert (work / "MARK_A").exists()
+    assert (work / "MARK_B").exists()

--- a/tests/blueprints/test_cli_fusion.py
+++ b/tests/blueprints/test_cli_fusion.py
@@ -176,6 +176,34 @@ async def test_fusion_all_panel_fail():
     assert "All CLI panelists failed" in _final_content(chunks)
 
 
+async def test_fusion_degrades_to_surviving_panelist():
+    # A broken panelist must not sink the round — consensus comes from survivors.
+    cfg = {
+        "cli_agents": {
+            "boom": {"cmd": [PY, "-c", "import sys; sys.exit(1)", "{prompt}"]},
+            "a": _echo("A"),
+        },
+        "cli_fusion": {"presets": {"p": {"panel": ["boom", "a"]}}, "default_preset": "p"},
+    }
+    bp = CliFusionBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+    assert _final_content(chunks) == "A:hi"  # survivor's answer
+    assert "boom failed" in _all_progress(chunks)  # failure surfaced, not hidden
+
+
+async def test_fusion_degrades_past_not_installed_panelist():
+    cfg = {
+        "cli_agents": {
+            "ghost": {"cmd": ["definitely-not-a-real-cli-zzz", "{prompt}"]},
+            "a": _echo("A"),
+        },
+        "cli_fusion": {"presets": {"p": {"panel": ["ghost", "a"]}}, "default_preset": "p"},
+    }
+    bp = CliFusionBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+    assert _final_content(chunks) == "A:hi"  # missing CLI skipped, survivor answers
+
+
 async def test_recursion_guard_degrades(monkeypatch):
     monkeypatch.setenv("SWARM_CLI_FUSION_DEPTH", "1")
     cfg = _config(judge_obj={"answer": "should-not-be-used", "done": True}, panel=("a", "b"))

--- a/tests/blueprints/test_cli_map.py
+++ b/tests/blueprints/test_cli_map.py
@@ -1,0 +1,111 @@
+"""Tests for the cli_map blueprint (decompose → distribute → reduce)."""
+
+from __future__ import annotations
+
+import sys
+
+from swarm.blueprints.cli_map.blueprint_cli_map import CliMapBlueprint
+
+PY = sys.executable
+
+
+def _worker(name: str) -> dict:
+    # Echoes "<name>:<subtask>" so worker assignment is visible in output.
+    return {"cmd": [PY, "-c", f"import sys; print('{name}:' + sys.argv[1])", "{prompt}"]}
+
+
+def _planner(*subtasks: str) -> dict:
+    import json
+    j = json.dumps({"subtasks": list(subtasks)})
+    return {"cmd": [PY, "-c", "import sys; print(sys.argv[2])", "{prompt}", j], "parse": "text"}
+
+
+def _reducer(text: str = "REDUCED") -> dict:
+    return {"cmd": [PY, "-c", f"print({text!r})", "{prompt}"], "parse": "text"}
+
+
+async def _collect(gen):
+    return [c async for c in gen]
+
+
+def _final(chunks):
+    text = None
+    for c in chunks:
+        msgs = c.get("messages") if isinstance(c, dict) else None
+        if msgs and msgs[0].get("content") is not None:
+            text = msgs[0]["content"]
+    return text
+
+
+def _progress(chunks):
+    return "\n".join(c["content"] for c in chunks if isinstance(c, dict) and c.get("type") == "fusion_progress")
+
+
+async def test_explicit_items_map_and_reduce():
+    cfg = {
+        "cli_agents": {"w": _worker("W"), "r": _reducer("COMBINED")},
+        "cli_map": {"worker": "w", "reducer": "r"},
+    }
+    bp = CliMapBlueprint(config=cfg)
+    bp.set_params({"items": ["task one", "task two"]})
+    chunks = await _collect(bp.run([{"role": "user", "content": "big task"}]))
+    assert _final(chunks) == "COMBINED"
+    assert "Using 2 explicit subtask" in _progress(chunks)
+
+
+async def test_planner_decomposes_then_maps_and_reduces():
+    cfg = {
+        "cli_agents": {"p": _planner("s1", "s2", "s3"), "w": _worker("W"), "r": _reducer("DONE")},
+        "cli_map": {"planner": "p", "worker": "w", "reducer": "r"},
+    }
+    bp = CliMapBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "decompose me"}]))
+    assert _final(chunks) == "DONE"
+    assert "Planned 3 subtask" in _progress(chunks)
+
+
+async def test_no_reducer_falls_back_to_labeled_concatenation():
+    cfg = {
+        "cli_agents": {"w": _worker("W")},
+        "cli_map": {"worker": "w"},  # no reducer
+    }
+    bp = CliMapBlueprint(config=cfg)
+    bp.set_params({"items": ["alpha", "beta"]})
+    final = _final(await _collect(bp.run([{"role": "user", "content": "t"}])))
+    assert "W:alpha" in final and "W:beta" in final  # both subtask results present
+
+
+async def test_round_robin_distributes_across_workers():
+    cfg = {
+        "cli_agents": {"a": _worker("A"), "b": _worker("B")},
+        "cli_map": {"workers": ["a", "b"]},
+    }
+    bp = CliMapBlueprint(config=cfg)
+    bp.set_params({"items": ["x", "y", "z"]})
+    final = _final(await _collect(bp.run([{"role": "user", "content": "t"}])))
+    # subtasks x,y,z -> workers a,b,a
+    assert "A:x" in final and "B:y" in final and "A:z" in final
+
+
+async def test_all_workers_fail():
+    cfg = {
+        "cli_agents": {"boom": {"cmd": [PY, "-c", "import sys; sys.exit(1)", "{prompt}"]}},
+        "cli_map": {"worker": "boom"},
+    }
+    bp = CliMapBlueprint(config=cfg)
+    bp.set_params({"items": ["x"]})
+    assert "All map workers failed" in _final(await _collect(bp.run([{"role": "user", "content": "t"}])))
+
+
+async def test_no_workers_configured():
+    bp = CliMapBlueprint(config={})
+    assert "No worker CLIs are configured" in _final(await _collect(bp.run([{"role": "user", "content": "t"}])))
+
+
+async def test_planner_empty_subtasks():
+    cfg = {
+        "cli_agents": {"p": _planner(), "w": _worker("W")},
+        "cli_map": {"planner": "p", "worker": "w"},
+    }
+    bp = CliMapBlueprint(config=cfg)
+    assert "no subtasks" in _final(await _collect(bp.run([{"role": "user", "content": "t"}]))).lower()

--- a/tests/blueprints/test_cli_orchestrator.py
+++ b/tests/blueprints/test_cli_orchestrator.py
@@ -1,0 +1,86 @@
+"""Tests for the cli_orchestrator blueprint (granular consensus routing)."""
+
+from __future__ import annotations
+
+import sys
+
+from swarm.blueprints.cli_orchestrator.blueprint_cli_orchestrator import CliOrchestratorBlueprint
+
+PY = sys.executable
+
+
+def _router(escalate: bool, answer: str = "ROUTER_ANSWER") -> dict:
+    j = '{"answer": "%s", "escalate": %s, "reason": "t"}' % (
+        answer, "true" if escalate else "false"
+    )
+    # Echo a fixed JSON decision regardless of the prompt (argv[2] = the json).
+    return {"cmd": [PY, "-c", "import sys; print(sys.argv[2])", "{prompt}", j], "parse": "text"}
+
+
+def _echo(prefix: str) -> dict:
+    return {"cmd": [PY, "-c", f"import sys; print('{prefix}:' + sys.argv[1])", "{prompt}"]}
+
+
+def _judge(answer: str = "CONSENSUS") -> dict:
+    j = '{"answer": "%s", "done": true}' % answer
+    return {"cmd": [PY, "-c", "import sys; print(sys.argv[2])", "{prompt}", j], "parse": "text"}
+
+
+def _config(*, escalate: bool, with_panel: bool = True, router_answer: str = "ROUTER_ANSWER") -> dict:
+    agents = {"router": _router(escalate, router_answer), "a": _echo("A"), "b": _echo("B"), "judge": _judge()}
+    oc: dict = {"router": "router"}
+    if with_panel:
+        oc["panel"] = ["a", "b"]
+        oc["judge"] = "judge"
+    return {"cli_agents": agents, "cli_orchestrator": oc}
+
+
+async def _collect(gen):
+    return [c async for c in gen]
+
+
+def _final(chunks):
+    text = None
+    for c in chunks:
+        msgs = c.get("messages") if isinstance(c, dict) else None
+        if msgs and msgs[0].get("content") is not None:
+            text = msgs[0]["content"]
+    return text
+
+
+def _progress(chunks):
+    return "\n".join(c["content"] for c in chunks if isinstance(c, dict) and c.get("type") == "fusion_progress")
+
+
+async def test_router_resolves_directly_without_consensus():
+    # escalate=false -> returns the router's own answer; panel is NOT consulted.
+    bp = CliOrchestratorBlueprint(config=_config(escalate=False))
+    chunks = await _collect(bp.run([{"role": "user", "content": "what's 2+2?"}]))
+    assert _final(chunks) == "ROUTER_ANSWER"
+    assert "no consensus needed" in _progress(chunks).lower()
+
+
+async def test_router_escalates_to_consensus():
+    # escalate=true -> consensus panel runs; judge's answer is returned.
+    bp = CliOrchestratorBlueprint(config=_config(escalate=True))
+    chunks = await _collect(bp.run([{"role": "user", "content": "is this migration safe?"}]))
+    assert _final(chunks) == "CONSENSUS"
+    assert "escalating to consensus" in _progress(chunks).lower()
+
+
+async def test_escalate_without_panel_falls_back_to_router_answer():
+    bp = CliOrchestratorBlueprint(config=_config(escalate=True, with_panel=False))
+    chunks = await _collect(bp.run([{"role": "user", "content": "q"}]))
+    assert _final(chunks) == "ROUTER_ANSWER"
+
+
+async def test_no_router_configured_reports_cleanly():
+    bp = CliOrchestratorBlueprint(config={})
+    chunks = await _collect(bp.run([{"role": "user", "content": "q"}]))
+    assert "No router CLI is configured" in _final(chunks)
+
+
+async def test_empty_prompt():
+    bp = CliOrchestratorBlueprint(config=_config(escalate=False))
+    chunks = await _collect(bp.run([]))
+    assert "No prompt provided" in _final(chunks)

--- a/tests/cli/test_cli_agents_command.py
+++ b/tests/cli/test_cli_agents_command.py
@@ -1,0 +1,81 @@
+"""Tests for the `swarm-cli cli-agents` command (discovery + --json/--suggest)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+
+import pytest
+from typer.testing import CliRunner
+
+from swarm.core.swarm_cli import app
+
+PY = sys.executable
+runner = CliRunner(mix_stderr=False)  # keep logging (stderr) out of the JSON on stdout
+
+
+@pytest.fixture(autouse=True)
+def _quiet_logging():
+    # CliRunner swaps and closes stdout/stderr around each invoke; pytest's live
+    # log handlers then write to the closed stream ("I/O operation on closed
+    # file"). Silence logging for the duration of these CLI invocations.
+    logging.disable(logging.CRITICAL)
+    try:
+        yield
+    finally:
+        logging.disable(logging.NOTSET)
+
+
+def _write_config(tmp_path, cli_agents):
+    cfg = tmp_path / "swarm_config.json"
+    cfg.write_text(
+        json.dumps(
+            {
+                "llm": {"default": {"provider": "openai", "model": "gpt-4o", "api_key": "x"}},
+                "cli_agents": cli_agents,
+            }
+        )
+    )
+    return str(cfg)
+
+
+def test_json_empty_config_emits_empty_agents(tmp_path):
+    cfg = _write_config(tmp_path, {})
+    result = runner.invoke(app, ["cli-agents", "--json", "--config", cfg])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {"agents": []}
+
+
+def test_json_lists_configured_agents(tmp_path):
+    cfg = _write_config(
+        tmp_path,
+        {"echo": {"cmd": [PY, "-c", "print(1)", "{prompt}"], "mode": "write"}},
+    )
+    result = runner.invoke(app, ["cli-agents", "--json", "--config", cfg])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert [a["name"] for a in payload["agents"]] == ["echo"]
+    assert payload["agents"][0]["installed"] is True  # python is on PATH
+    assert payload["agents"][0]["mode"] == "write"
+
+
+def test_json_suggest_includes_suggestions(tmp_path, monkeypatch):
+    from swarm.core import cli_catalog
+
+    monkeypatch.setattr(cli_catalog.shutil, "which", lambda exe: "/usr/bin/" + exe)
+    cfg = _write_config(tmp_path, {})
+    result = runner.invoke(app, ["cli-agents", "--json", "--suggest", "--config", cfg])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert set(payload["suggestions"]) == set(cli_catalog.catalog_names())
+
+
+def test_table_output_without_json(tmp_path):
+    cfg = _write_config(
+        tmp_path, {"echo": {"cmd": [PY, "-c", "print(1)", "{prompt}"]}}
+    )
+    result = runner.invoke(app, ["cli-agents", "--config", cfg])
+    assert result.exit_code == 0
+    assert "AGENT" in result.stdout and "echo" in result.stdout
+    assert "1/1 configured CLI agents installed" in result.stdout

--- a/tests/core/test_cli_adapter.py
+++ b/tests/core/test_cli_adapter.py
@@ -190,13 +190,6 @@ async def test_no_allowlist_inherits_full_env(monkeypatch):
     assert res.text == "topsecret"
 
 
-def test_result_as_dict_includes_stderr():
-    from swarm.core.cli_adapter import CliResult
-
-    d = CliResult(name="x", ok=False, text="", stderr="boom").as_dict()
-    assert d["stderr"] == "boom"
-
-
 # --------------------------------------------------------------------------- #
 # Parallel panel semantics
 # --------------------------------------------------------------------------- #

--- a/tests/core/test_cli_adapter.py
+++ b/tests/core/test_cli_adapter.py
@@ -266,6 +266,57 @@ def test_discover_empty_registry():
     assert CliAdapterRegistry.from_config({}).discover() == []
 
 
+# --------------------------------------------------------------------------- #
+# Authentication probe
+# --------------------------------------------------------------------------- #
+
+def test_auth_check_must_be_nonempty_list():
+    with pytest.raises(CliAdapterError):
+        CliAgentConfig(name="x", cmd=[PY, "-c", "print(1)", "{prompt}"], auth_check=[])
+
+
+async def test_check_auth_authenticated():
+    adapter = CliAdapter.from_config(
+        "a", {**_echo_cfg(), "auth_check": [PY, "-c", "import sys; sys.exit(0)"]}
+    )
+    assert await adapter.check_auth() == "authenticated"
+
+
+async def test_check_auth_unauthenticated():
+    adapter = CliAdapter.from_config(
+        "a", {**_echo_cfg(), "auth_check": [PY, "-c", "import sys; sys.exit(1)"]}
+    )
+    assert await adapter.check_auth() == "unauthenticated"
+
+
+async def test_check_auth_unknown_without_probe():
+    adapter = CliAdapter.from_config("a", _echo_cfg())
+    assert await adapter.check_auth() == "unknown"
+
+
+async def test_check_auth_not_installed():
+    adapter = CliAdapter.from_config(
+        "ghost", {"cmd": ["definitely-not-a-real-cli-zzz", "{prompt}"], "auth_check": ["true"]}
+    )
+    assert await adapter.check_auth() == "not_installed"
+
+
+async def test_discover_auth_fills_status():
+    reg = CliAdapterRegistry.from_config(
+        {
+            "cli_agents": {
+                "good": {**_echo_cfg(), "auth_check": [PY, "-c", "import sys; sys.exit(0)"]},
+                "bad": {**_echo_cfg(), "auth_check": [PY, "-c", "import sys; sys.exit(1)"]},
+                "plain": _echo_cfg(),
+            }
+        }
+    )
+    rows = {d.name: d for d in await reg.discover_auth()}
+    assert rows["good"].authenticated == "authenticated"
+    assert rows["bad"].authenticated == "unauthenticated"
+    assert rows["plain"].authenticated == "unknown"
+
+
 def test_with_overrides_is_non_mutating():
     reg = CliAdapterRegistry.from_config({"cli_agents": {"echo": _echo_cfg(timeout=5)}})
     reg2 = reg.with_overrides({"echo": {"timeout": 99}})

--- a/tests/core/test_cli_adapter.py
+++ b/tests/core/test_cli_adapter.py
@@ -379,3 +379,58 @@ async def test_smoke_check_all_runs_subset():
     results = {r.name: r for r in await reg.smoke_check_all(names=["a", "c"])}
     assert set(results) == {"a", "c"}
     assert all(r.status == SMOKE_OK for r in results.values())
+
+
+# --------------------------------------------------------------------------- #
+# Streaming (stream_run)
+# --------------------------------------------------------------------------- #
+
+async def _collect_stream(adapter, prompt="x"):
+    deltas, result = [], None
+    async for ch in adapter.stream_run(prompt):
+        if ch.final:
+            result = ch.result
+        elif ch.delta:
+            deltas.append(ch.delta)
+    return deltas, result
+
+
+async def test_stream_run_yields_deltas_then_result():
+    adapter = CliAdapter.from_config(
+        "s", {"cmd": [PY, "-c", "import sys; sys.stdout.write('hello\\nworld\\n')", "{prompt}"]}
+    )
+    deltas, result = await _collect_stream(adapter)
+    assert "".join(deltas) == "hello\nworld\n"  # streamed verbatim
+    assert result.ok and result.text == "hello\nworld"  # parse() strips trailing ws
+
+
+async def test_stream_run_error_exit_reported_in_final():
+    adapter = CliAdapter.from_config(
+        "b", {"cmd": [PY, "-c", "import sys; sys.exit(3)", "{prompt}"]}
+    )
+    _, result = await _collect_stream(adapter)
+    assert result is not None and not result.ok and result.returncode == 3
+
+
+async def test_stream_run_not_installed_single_final_chunk():
+    adapter = CliAdapter.from_config("ghost", {"cmd": ["definitely-not-a-real-cli-zzz", "{prompt}"]})
+    chunks = [ch async for ch in adapter.stream_run("x")]
+    assert len(chunks) == 1 and chunks[0].final and not chunks[0].result.ok
+
+
+async def test_stream_run_timeout():
+    adapter = CliAdapter.from_config(
+        "sleeper", {"cmd": [PY, "-c", "import time; time.sleep(30)", "{prompt}"], "timeout": 0.5}
+    )
+    _, result = await _collect_stream(adapter)
+    assert result.timed_out and not result.ok
+
+
+async def test_stream_run_json_parse_streams_raw_but_parses_final():
+    adapter = CliAdapter.from_config(
+        "j",
+        {"cmd": [PY, "-c", "print('{\"result\": \"deep\"}')", "{prompt}"], "parse": "json:.result"},
+    )
+    deltas, result = await _collect_stream(adapter)
+    assert result.ok and result.text == "deep"  # final value is parsed
+    assert "deep" in "".join(deltas)  # deltas are the raw JSON document

--- a/tests/core/test_cli_adapter.py
+++ b/tests/core/test_cli_adapter.py
@@ -14,6 +14,10 @@ import time
 import pytest
 
 from swarm.core.cli_adapter import (
+    SMOKE_ERROR,
+    SMOKE_HANG,
+    SMOKE_NOT_INSTALLED,
+    SMOKE_OK,
     CliAdapter,
     CliAdapterError,
     CliAdapterRegistry,
@@ -322,3 +326,56 @@ def test_with_overrides_is_non_mutating():
     reg2 = reg.with_overrides({"echo": {"timeout": 99}})
     assert reg.get("echo").config.timeout == 5
     assert reg2.get("echo").config.timeout == 99
+
+
+# --------------------------------------------------------------------------- #
+# Non-interactive smoke probe
+# --------------------------------------------------------------------------- #
+
+async def test_smoke_ok():
+    adapter = CliAdapter.from_config("echo", _echo_cfg())
+    res = await adapter.smoke_check()
+    assert res.status == SMOKE_OK
+    assert res.ok is True
+
+
+async def test_smoke_error_on_nonzero_exit():
+    adapter = CliAdapter.from_config(
+        "boom", {"cmd": [PY, "-c", "import sys; sys.exit(2)", "{prompt}"]}
+    )
+    res = await adapter.smoke_check()
+    assert res.status == SMOKE_ERROR
+    assert res.ok is False
+
+
+async def test_smoke_error_on_empty_output():
+    # Exits 0 but prints nothing -> not a usable answer.
+    adapter = CliAdapter.from_config("quiet", {"cmd": [PY, "-c", "pass", "{prompt}"]})
+    res = await adapter.smoke_check()
+    assert res.status == SMOKE_ERROR
+    assert "no output" in res.detail
+
+
+async def test_smoke_hang_times_out():
+    # A CLI that never returns (e.g. wrong non-interactive flag -> waits on input).
+    adapter = CliAdapter.from_config(
+        "sleeper", {"cmd": [PY, "-c", "import time; time.sleep(30)", "{prompt}"]}
+    )
+    res = await adapter.smoke_check(timeout=0.5)
+    assert res.status == SMOKE_HANG
+    assert "non-interactive flag" in res.detail
+
+
+async def test_smoke_not_installed():
+    adapter = CliAdapter.from_config("ghost", {"cmd": ["definitely-not-a-real-cli-zzz", "{prompt}"]})
+    res = await adapter.smoke_check()
+    assert res.status == SMOKE_NOT_INSTALLED
+
+
+async def test_smoke_check_all_runs_subset():
+    reg = CliAdapterRegistry.from_config(
+        {"cli_agents": {"a": _echo_cfg(), "b": _echo_cfg(), "c": _echo_cfg()}}
+    )
+    results = {r.name: r for r in await reg.smoke_check_all(names=["a", "c"])}
+    assert set(results) == {"a", "c"}
+    assert all(r.status == SMOKE_OK for r in results.values())

--- a/tests/core/test_cli_catalog.py
+++ b/tests/core/test_cli_catalog.py
@@ -38,6 +38,17 @@ def test_executable_for():
     assert cli_catalog.executable_for("gemini") == "gemini"
 
 
+def test_gemini_default_includes_skip_trust_gotcha():
+    # gemini refuses to run in an untrusted dir without this; regression guard.
+    assert "--skip-trust" in cli_catalog.catalog_entry("gemini")["cmd"]
+
+
+def test_opencode_default_pins_a_model_gotcha():
+    # opencode's built-in default model errors as "not supported".
+    cmd = cli_catalog.catalog_entry("opencode")["cmd"]
+    assert "--model" in cmd and cmd[cmd.index("--model") + 1]
+
+
 def test_suggest_skips_already_configured():
     s = cli_catalog.suggest_unconfigured(["claude", "gemini"], installed_only=False)
     assert "claude" not in s and "gemini" not in s

--- a/tests/core/test_cli_catalog.py
+++ b/tests/core/test_cli_catalog.py
@@ -1,0 +1,66 @@
+"""Tests for the built-in CLI adapter catalog (swarm-cli cli-agents --suggest)."""
+
+from __future__ import annotations
+
+from swarm.core import cli_catalog
+from swarm.core.cli_adapter import CliAdapter
+
+
+def test_catalog_names_are_sorted_and_known():
+    names = cli_catalog.catalog_names()
+    assert names == sorted(names)
+    assert {"claude", "gemini", "codex", "opencode"} <= set(names)
+
+
+def test_every_catalog_entry_is_a_valid_adapter_config():
+    # The catalog must never ship a config the adapter layer would reject.
+    for name in cli_catalog.catalog_names():
+        adapter = CliAdapter.from_config(name, cli_catalog.catalog_entry(name))
+        assert adapter.name == name
+        assert adapter.config.cmd[0]  # has an executable
+
+
+def test_catalog_entry_returns_a_copy():
+    a = cli_catalog.catalog_entry("claude")
+    a["cmd"].append("--mutated")
+    a["mode"] = "tampered"
+    b = cli_catalog.catalog_entry("claude")
+    assert "--mutated" not in b["cmd"]
+    assert b["mode"] == "write"
+
+
+def test_catalog_entry_unknown_is_none():
+    assert cli_catalog.catalog_entry("nope-not-real") is None
+    assert cli_catalog.executable_for("nope-not-real") is None
+
+
+def test_executable_for():
+    assert cli_catalog.executable_for("gemini") == "gemini"
+
+
+def test_suggest_skips_already_configured():
+    s = cli_catalog.suggest_unconfigured(["claude", "gemini"], installed_only=False)
+    assert "claude" not in s and "gemini" not in s
+    assert "codex" in s and "opencode" in s
+
+
+def test_suggest_all_when_nothing_configured():
+    s = cli_catalog.suggest_unconfigured([], installed_only=False)
+    assert set(s) == set(cli_catalog.catalog_names())
+
+
+def test_suggest_installed_only_filters_by_path(monkeypatch):
+    # Only 'codex' resolves on PATH -> only codex is suggested.
+    def fake_which(exe):
+        return "/usr/bin/codex" if exe == "codex" else None
+
+    monkeypatch.setattr(cli_catalog.shutil, "which", fake_which)
+    s = cli_catalog.suggest_unconfigured([], installed_only=True)
+    assert set(s) == {"codex"}
+
+
+def test_suggest_returns_deep_copies(monkeypatch):
+    monkeypatch.setattr(cli_catalog.shutil, "which", lambda exe: "/x")
+    s = cli_catalog.suggest_unconfigured([], installed_only=True)
+    s["claude"]["cmd"].append("--mutated")
+    assert "--mutated" not in cli_catalog.CATALOG["claude"]["cmd"]

--- a/tests/core/test_cli_tools.py
+++ b/tests/core/test_cli_tools.py
@@ -1,0 +1,54 @@
+"""Tests for the agent-tool layer (swarm.core.cli_tools)."""
+
+from __future__ import annotations
+
+import sys
+
+from swarm.core.cli_adapter import CliAdapter
+from swarm.core.cli_tools import as_function_tool, cli_persona, consensus_fn
+
+PY = sys.executable
+
+
+def _echo(name: str) -> CliAdapter:
+    return CliAdapter.from_config(
+        name, {"cmd": [PY, "-c", f"import sys; print('{name}:' + sys.argv[1])", "{prompt}"]}
+    )
+
+
+def _judge() -> CliAdapter:
+    return CliAdapter.from_config(
+        "judge", {"cmd": [PY, "-c", "print('{\"answer\": \"AGREED\", \"done\": true}')", "{prompt}"]}
+    )
+
+
+async def test_cli_persona_returns_answer():
+    ask = cli_persona(_echo("claude"))
+    assert await ask("hi") == "claude:hi"
+
+
+async def test_cli_persona_reports_failure_without_raising():
+    boom = CliAdapter.from_config("boom", {"cmd": [PY, "-c", "import sys; sys.exit(1)", "{prompt}"]})
+    out = await cli_persona(boom)("hi")
+    assert out.startswith("[boom unavailable:")
+
+
+def test_cli_persona_tool_name_is_safe_identifier():
+    ask = cli_persona(_echo("gpt-4o cli"))
+    assert ask.__name__ == "ask_gpt_4o_cli"
+
+
+async def test_consensus_fn_returns_judged_answer():
+    fn = consensus_fn([_echo("a"), _echo("b")], _judge())
+    assert await fn("q") == "AGREED"
+
+
+async def test_consensus_fn_all_fail_message():
+    boom = CliAdapter.from_config("boom", {"cmd": [PY, "-c", "import sys; sys.exit(1)", "{prompt}"]})
+    assert await consensus_fn([boom])("q") == "(no consensus reached)"
+
+
+def test_as_function_tool_builds_named_tool():
+    tool = as_function_tool(cli_persona(_echo("claude")), name="ask_claude")
+    # openai-agents FunctionTool exposes a .name; the wrap should succeed and name it.
+    assert getattr(tool, "name", None) == "ask_claude"

--- a/tests/core/test_consensus.py
+++ b/tests/core/test_consensus.py
@@ -1,0 +1,90 @@
+"""Tests for the reusable consensus service (swarm.core.consensus)."""
+
+from __future__ import annotations
+
+import sys
+
+from swarm.core.cli_adapter import CliAdapter, CliResult
+from swarm.core.consensus import (
+    most_corroborated,
+    run_consensus,
+    safe_json,
+    synthesize,
+)
+
+PY = sys.executable
+
+
+def _r(name: str, text: str, ok: bool = True) -> CliResult:
+    return CliResult(name=name, ok=ok, text=text)
+
+
+def _echo(name: str) -> CliAdapter:
+    return CliAdapter.from_config(
+        name, {"cmd": [PY, "-c", f"import sys; print('{name}:' + sys.argv[1])", "{prompt}"]}
+    )
+
+
+# --- synthesis: consensus-first, not longest ------------------------------- #
+
+def test_most_corroborated_prefers_agreement_over_length():
+    a = _r("a", "use create index concurrently to avoid write locks")
+    b = _r("b", "avoid write locks with create index concurrently")  # agrees with a
+    c = _r("c", "completely unrelated verbose tangent " * 20)        # the longest, an outlier
+    pick = most_corroborated([a, b, c])
+    assert pick in (a.text, b.text)  # the corroborated pair...
+    assert pick != c.text            # ...NOT the longest answer
+
+
+def test_most_corroborated_single_survivor_wins():
+    assert most_corroborated([_r("a", "only one")]) == "only one"
+
+
+def test_most_corroborated_no_survivors():
+    assert most_corroborated([_r("a", "x", ok=False)]) == ""
+
+
+def test_synthesize_prefers_judge_answer():
+    out = synthesize({"answer": "JUDGED"}, [_r("a", "short"), _r("b", "a much longer answer here")])
+    assert out == "JUDGED"
+
+
+def test_synthesize_without_judge_uses_corroborated():
+    a = _r("a", "alpha beta gamma")
+    b = _r("b", "alpha beta delta")
+    c = _r("c", "zzz " * 40)
+    assert synthesize(None, [a, b, c]) in (a.text, b.text)
+
+
+def test_safe_json_tolerates_prose():
+    assert safe_json('here:\n{"answer": "x"}\nthanks') == {"answer": "x"}
+    assert safe_json("no json") is None
+
+
+# --- run_consensus (real subprocesses) ------------------------------------- #
+
+async def test_run_consensus_with_judge():
+    judge = CliAdapter.from_config(
+        "j", {"cmd": [PY, "-c", "print('{\"answer\": \"JUDGED\", \"done\": true}')", "{prompt}"]}
+    )
+    res = await run_consensus("q", [_echo("a"), _echo("b")], judge)
+    assert res.ok and res.answer == "JUDGED"
+    assert len(res.results) == 2 and len(res.ok_results) == 2
+
+
+async def test_run_consensus_no_judge_uses_corroborated_survivor():
+    res = await run_consensus("hi", [_echo("a"), _echo("b")], None)
+    assert res.ok and res.answer in ("a:hi", "b:hi")
+
+
+async def test_run_consensus_drops_failures_and_uses_survivor():
+    boom = CliAdapter.from_config("boom", {"cmd": [PY, "-c", "import sys; sys.exit(1)", "{prompt}"]})
+    res = await run_consensus("hi", [boom, _echo("good")], None)
+    assert res.ok and res.answer == "good:hi"
+    assert any(not r.ok for r in res.results)  # the failure is still reported
+
+
+async def test_run_consensus_all_fail_is_not_ok():
+    boom = CliAdapter.from_config("boom", {"cmd": [PY, "-c", "import sys; sys.exit(1)", "{prompt}"]})
+    res = await run_consensus("q", [boom], None)
+    assert not res.ok and res.answer == ""

--- a/uv.lock
+++ b/uv.lock
@@ -1782,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "open-swarm"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/webui/frontend/src/components/ApiAccessPanel.tsx
+++ b/webui/frontend/src/components/ApiAccessPanel.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react'
+
+export interface ApiAccessPanelProps {
+  /** OpenAI-compatible base URL, e.g. `http://localhost:8000/v1`. */
+  baseUrl: string
+  /** Bearer token, or null when the server runs with auth disabled. */
+  token: string | null
+  /** Available model ids (blueprints) from `/v1/models`. */
+  models: string[]
+}
+
+export interface Snippets {
+  curl: string
+  python: string
+  openWebUI: string
+}
+
+/** Ready-to-paste client snippets, pre-filled with the live base URL + model. */
+export function buildSnippets(baseUrl: string, token: string | null, model: string): Snippets {
+  const key = token && token.length > 0 ? token : 'not-needed'
+  return {
+    curl: [
+      `curl -sf ${baseUrl}/chat/completions \\`,
+      `  -H "Authorization: Bearer ${key}" \\`,
+      `  -H "Content-Type: application/json" \\`,
+      `  -d '{"model":"${model}","messages":[{"role":"user","content":"ping"}]}'`,
+    ].join('\n'),
+    python: [
+      'from openai import OpenAI',
+      `client = OpenAI(base_url="${baseUrl}", api_key="${key}")`,
+      'resp = client.chat.completions.create(',
+      `    model="${model}",`,
+      '    messages=[{"role": "user", "content": "ping"}],',
+      ')',
+      'print(resp.choices[0].message.content)',
+    ].join('\n'),
+    openWebUI: [
+      'Open WebUI → Settings → Connections → OpenAI API',
+      `  Base URL: ${baseUrl}`,
+      `  API Key:  ${key}`,
+    ].join('\n'),
+  }
+}
+
+function CopyBlock({ label, code }: { label: string; code: string }) {
+  const [copied, setCopied] = useState(false)
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard?.writeText(code)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* clipboard unavailable (insecure context) — silently ignore */
+    }
+  }
+  return (
+    <div className="mt-3">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">{label}</span>
+        <button type="button" className="btn btn-xs" onClick={onCopy} aria-label={`Copy ${label} snippet`}>
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+      <pre className="bg-base-300 rounded p-3 text-xs overflow-x-auto">
+        <code>{code}</code>
+      </pre>
+    </div>
+  )
+}
+
+/**
+ * "Connect any OpenAI client" — surfaces the live base URL, token, model list,
+ * and copy-paste snippets so the server can be plugged into Open WebUI, Cursor,
+ * the OpenAI SDK, or curl with no guesswork.
+ */
+export function ApiAccessPanel({ baseUrl, token, models }: ApiAccessPanelProps) {
+  const fallback = models[0] ?? 'cli_fusion'
+  const [selected, setSelected] = useState(fallback)
+  const model = models.includes(selected) ? selected : fallback
+  const snippets = buildSnippets(baseUrl, token, model)
+
+  return (
+    <div>
+      <p className="text-sm text-gray-500">
+        Point any OpenAI-compatible client at this server. The <code>model</code> field selects the
+        blueprint (e.g. <code>cli_fusion</code>).{' '}
+        {token ? 'Use your API token as the key.' : 'Auth is disabled — any key works.'}
+      </p>
+
+      <div className="grid gap-2 sm:grid-cols-2 mt-3 text-sm">
+        <div>
+          <span className="font-semibold">Base URL:</span> <code>{baseUrl}</code>
+        </div>
+        <div>
+          <span className="font-semibold">API key:</span>{' '}
+          <code>{token ? `…${token.slice(-4)}` : 'any (auth disabled)'}</code>
+        </div>
+      </div>
+
+      {models.length > 0 && (
+        <label className="form-control mt-3 max-w-xs">
+          <span className="label-text text-xs">Model</span>
+          <select
+            className="select select-sm select-bordered"
+            value={model}
+            aria-label="Model"
+            onChange={(e) => setSelected(e.target.value)}
+          >
+            {models.map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      <CopyBlock label="curl" code={snippets.curl} />
+      <CopyBlock label="OpenAI Python SDK" code={snippets.python} />
+      <CopyBlock label="Open WebUI" code={snippets.openWebUI} />
+    </div>
+  )
+}

--- a/webui/frontend/src/components/__tests__/ApiAccessPanel.test.tsx
+++ b/webui/frontend/src/components/__tests__/ApiAccessPanel.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { ApiAccessPanel, buildSnippets } from '../ApiAccessPanel'
+
+describe('buildSnippets', () => {
+  it('embeds base url, model, and token in every snippet', () => {
+    const s = buildSnippets('http://host:8000/v1', 'sk-secret', 'cli_fusion')
+    expect(s.curl).toContain('http://host:8000/v1/chat/completions')
+    expect(s.curl).toContain('Bearer sk-secret')
+    expect(s.curl).toContain('"model":"cli_fusion"')
+    expect(s.python).toContain('base_url="http://host:8000/v1"')
+    expect(s.python).toContain('model="cli_fusion"')
+    expect(s.openWebUI).toContain('Base URL: http://host:8000/v1')
+  })
+
+  it('uses a placeholder key when auth is disabled (no token)', () => {
+    const s = buildSnippets('http://host/v1', null, 'm')
+    expect(s.curl).toContain('Bearer not-needed')
+    expect(s.python).toContain('api_key="not-needed"')
+  })
+})
+
+describe('ApiAccessPanel', () => {
+  it('renders the base URL, model options, and copy blocks', () => {
+    render(
+      <ApiAccessPanel
+        baseUrl="http://localhost:8000/v1"
+        token={null}
+        models={['cli_fusion', 'cli_agent']}
+      />,
+    )
+    expect(screen.getByText('http://localhost:8000/v1')).toBeInTheDocument()
+    expect(screen.getByText(/any key works/i)).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'cli_fusion' })).toBeInTheDocument()
+    expect(screen.getAllByText('Copy').length).toBe(3)
+  })
+
+  it('shows the token suffix when a token is set', () => {
+    render(<ApiAccessPanel baseUrl="http://x/v1" token="sk-12345678" models={['cli_fusion']} />)
+    expect(screen.getByText('…5678')).toBeInTheDocument()
+  })
+})

--- a/webui/frontend/src/pages/SettingsPage.tsx
+++ b/webui/frontend/src/pages/SettingsPage.tsx
@@ -1,10 +1,12 @@
 import { useState, type FormEvent } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { AlertCircle, Eye, EyeOff, KeyRound, ServerCog, TerminalSquare } from 'lucide-react'
+import { AlertCircle, Eye, EyeOff, KeyRound, Plug, ServerCog, TerminalSquare } from 'lucide-react'
 import { Alert, Button, Card, Input, LoadingSpinner, useToast } from '../components/DaisyUI'
+import { ApiAccessPanel } from '../components/ApiAccessPanel'
 import { useAuth } from '../lib/AuthContext'
 import {
   fetchEnvironmentVariables,
+  fetchModels,
   fetchServerSettings,
   type ServerSettingsGroup,
 } from '../lib/api'
@@ -33,6 +35,9 @@ const SettingsPage = () => {
   const { token, setToken, clearAuthError } = useAuth()
   const [draft, setDraft] = useState('')
   const [showDraft, setShowDraft] = useState(false)
+  const modelsQuery = useQuery({ queryKey: ['models'], queryFn: fetchModels })
+  const modelIds = (modelsQuery.data?.data ?? []).map((m) => m.id)
+  const apiBaseUrl = `${window.location.origin}/v1`
   const queryClient = useQueryClient()
   const toast = useToast()
 
@@ -62,6 +67,15 @@ const SettingsPage = () => {
       <h1 className="text-3xl font-bold mb-6">Settings</h1>
 
       <div className="space-y-6">
+        {/* API access — connect any OpenAI client */}
+        <Card bordered>
+          <h2 className="card-title flex items-center gap-2">
+            <Plug className="h-5 w-5" />
+            API Access
+          </h2>
+          <ApiAccessPanel baseUrl={apiBaseUrl} token={token} models={modelIds} />
+        </Card>
+
         {/* API authentication */}
         <Card bordered>
           <h2 className="card-title flex items-center gap-2">


### PR DESCRIPTION
## Per-CLI authentication autodiscovery (Release v0.4.0, PR 3)

Completes autodiscovery: report not just whether a CLI is **installed**, but whether it's **authenticated**.

### What's in this PR
- `CliAgentConfig.auth_check` — optional argv probe (e.g. a cheap status subcommand). Validated as a non-empty list of strings.
- `CliAdapter.check_auth()` → `authenticated` (exit 0) / `unauthenticated` (non-zero) / `unknown` (no probe / errored / timed out) / `not_installed`. Capped at 30s, runs in its own process group, never raises.
- `CliAdapterRegistry.discover_auth()` — probes all adapters concurrently; `CliDiscovery` gains an `authenticated` field.
- `swarm-cli cli-agents --check-auth` — adds the AUTH column (install-only remains the fast default).
- Documented in `docs/CLI_FUSION.md` (schema row + command).

### Tests
30 adapter tests green (auth states, validation, concurrent discovery). Verified live: `--check-auth` shows `claude`/`gemini`/`opencode` installed (AUTH `unknown` until presets define `auth_check`, which lands in the per-CLI PRs) and `codex` `not_installed`.

### Next
PRs 4–11: one adapter-preset PR per CLI (claude, gemini, codex, opencode, letta, vibe, kilocode, agy), each defining a sensible `auth_check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
