### PR TITLE
v0.4.2 — grok (xAI) as the preferred CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 (nothing yet)
 
+## [0.4.2] - 2026-06-16
+
+### Added
+- **grok** (xAI's CLI, also installed as `agent`) added to the catalog: `grok -p {prompt} --output-format json --always-approve` → `json:.text`. Verified live.
+- `grok` is now the **preferred** single-agent CLI: `--init` (and the example config) make it the `cli_agent` default and the orchestrator router / map planner+reducer / fusion judge, while panels still include every installed CLI — so the other agents are only engaged for the multi-agent paths.
+
 ## [0.4.1] - 2026-06-16
 
 ### Added

--- a/docs/CLI_FUSION.md
+++ b/docs/CLI_FUSION.md
@@ -139,6 +139,7 @@ get a panelist that actually *does work*, pin down two flags from its `--help`:
 
 | CLI | Print/exec | Auto-approve (full-capability) | Structured output → `parse` |
 |---|---|---|---|
+| `grok` | `-p` / `--single` (also installed as `agent`) | `--always-approve` | `--output-format json` → `json:.text` |
 | `claude` | `-p` | `--dangerously-skip-permissions` | `--output-format json` → `json:.result` |
 | `gemini` | `-p` | `--yolo` | `-o json` → `json:.response` |
 | `codex` | `exec` | `--dangerously-bypass-approvals-and-sandbox` (or `--full-auto`) | text |

--- a/docs/examples/cli_fusion.swarm_config.json
+++ b/docs/examples/cli_fusion.swarm_config.json
@@ -11,6 +11,12 @@
   },
 
   "cli_agents": {
+    "grok": {
+      "cmd": ["grok", "-p", "{prompt}", "--output-format", "json", "--always-approve"],
+      "parse": "json:.text",
+      "mode": "write",
+      "timeout": 240
+    },
     "claude": {
       "cmd": ["claude", "-p", "{prompt}", "--output-format", "json",
               "--dangerously-skip-permissions"],
@@ -42,27 +48,27 @@
   },
 
   "cli_fusion": {
-    "default_cli": "claude",
+    "default_cli": "grok",
     "default_preset": "general-high",
     "max_rounds": 1,
     "isolate_workdir": true,
     "show_analysis": false,
     "presets": {
-      "general-high":   { "panel": ["claude", "gemini", "codex"], "judge": "claude" },
-      "general-budget": { "panel": ["gemini"],                    "judge": "gemini" }
+      "general-high":   { "panel": ["grok", "claude", "gemini", "codex"], "judge": "grok" },
+      "general-budget": { "panel": ["gemini"],                            "judge": "gemini" }
     }
   },
 
   "cli_orchestrator": {
-    "router": "claude",
-    "panel": ["claude", "gemini", "codex"],
-    "judge": "claude"
+    "router": "grok",
+    "panel": ["grok", "claude", "gemini", "codex"],
+    "judge": "grok"
   },
 
   "cli_map": {
-    "planner": "claude",
-    "workers": ["claude", "gemini", "codex"],
-    "reducer": "claude",
+    "planner": "grok",
+    "workers": ["grok", "claude", "gemini", "codex"],
+    "reducer": "grok",
     "max_items": 6
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-swarm"
-version = "0.4.1"
+version = "0.4.2"
 description = "Open Swarm: Orchestrating AI Agent Swarms with Django"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/swarm/core/cli_catalog.py
+++ b/src/swarm/core/cli_catalog.py
@@ -28,6 +28,15 @@ from typing import Any
 
 # name -> adapter config dict (same shape as one `cli_agents` entry).
 CATALOG: dict[str, dict[str, Any]] = {
+    "grok": {
+        # xAI's grok CLI (also installed as `agent`). -p/--single is the
+        # non-interactive print mode; --always-approve auto-approves tool use.
+        # Inherits the full env (auth is file-based, not a single known var).
+        "cmd": ["grok", "-p", "{prompt}", "--output-format", "json", "--always-approve"],
+        "parse": "json:.text",
+        "mode": "write",
+        "timeout": 240,
+    },
     "claude": {
         "cmd": ["claude", "-p", "{prompt}", "--output-format", "json",
                 "--dangerously-skip-permissions"],
@@ -77,11 +86,12 @@ def build_starter_config(installed: list[str] | None = None) -> dict[str, Any]:
     """A complete, ready-to-run swarm_config for the installed catalog CLIs.
 
     Wires every composition mode (cli_fusion / cli_orchestrator / cli_map) over
-    whatever catalog CLIs are present, preferring ``claude`` as the
-    judge/router/reducer/planner (it returns clean JSON) and falling back to the
-    first available. Includes a default ``llm`` block so the config passes
-    validation. When nothing is installed, returns just the llm + an empty
-    ``cli_agents`` block.
+    whatever catalog CLIs are present. The single-agent default and the
+    judge/router/reducer/planner roles prefer ``grok`` (then ``claude``, then the
+    first available); the panels include *every* installed CLI, so the other
+    agents are only engaged for the multi-agent paths. Includes a default ``llm``
+    block so the config passes validation. When nothing is installed, returns
+    just the llm + an empty ``cli_agents`` block.
     """
     if installed is None:
         installed = installed_catalog_clis()
@@ -99,7 +109,7 @@ def build_starter_config(installed: list[str] | None = None) -> dict[str, Any]:
         "cli_agents": agents,
     }
     if names:
-        primary = "claude" if "claude" in names else names[0]
+        primary = next((c for c in ("grok", "claude") if c in names), names[0])
         cfg["cli_fusion"] = {
             "default_cli": primary,
             "default_preset": "all",

--- a/tests/core/test_cli_catalog.py
+++ b/tests/core/test_cli_catalog.py
@@ -66,6 +66,23 @@ def test_build_starter_config_prefers_first_when_no_claude():
     assert cfg["cli_fusion"]["default_cli"] == "gemini"  # sorted-first fallback
 
 
+def test_grok_is_in_catalog():
+    e = cli_catalog.catalog_entry("grok")
+    assert e["cmd"][0] == "grok" and e["parse"] == "json:.text"
+    assert "--always-approve" in e["cmd"]
+
+
+def test_build_starter_config_prefers_grok_for_single_agent_roles():
+    cfg = cli_catalog.build_starter_config(["claude", "grok", "gemini"])
+    # grok preferred for every single-agent / judge role...
+    assert cfg["cli_fusion"]["default_cli"] == "grok"
+    assert cfg["cli_fusion"]["presets"]["all"]["judge"] == "grok"
+    assert cfg["cli_orchestrator"]["router"] == "grok"
+    assert cfg["cli_map"]["planner"] == "grok" and cfg["cli_map"]["reducer"] == "grok"
+    # ...but the panel includes every CLI (others tapped only for multi-agent)
+    assert set(cfg["cli_fusion"]["presets"]["all"]["panel"]) == {"claude", "grok", "gemini"}
+
+
 def test_build_starter_config_empty_host_still_valid():
     cfg = cli_catalog.build_starter_config([])
     assert cfg["cli_agents"] == {}

--- a/uv.lock
+++ b/uv.lock
@@ -1782,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "open-swarm"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Adds grok (xAI's CLI, also installed as `agent`) to the catalog and makes it the **preferred single-agent CLI** for every path — `cli_agent` default, orchestrator router, map planner/reducer, fusion judge — while panels keep every installed CLI so the others are only used for multi-agent (consensus) testing. Verified live through the adapter. Version 0.4.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)