### PR TITLE
v0.4.3 — blueprint library matrix (chatbot + hybrid REST/CLI) + laconic CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 
 (nothing yet)
 
+## [0.4.3] - 2026-06-16
+
+### Added — Blueprint library (permutation matrix)
+- **`chatbot`** — minimal single-agent REST blueprint (the simplest template).
+- **`hybrid_team`** / **`hybrid_swarm`** — the Mixed column: a REST coordinator/orchestrator that reaches for **grok CLI personas** and a **consensus panel** mid-run (`swarm.core.cli_tools`). REST half wired to a real openai-agents Agent that degrades gracefully without an LLM key; CLI half verified live with grok ("Rome", unanimous consensus).
+- `docs/BLUEPRINT_LIBRARY.md` — a feature-tagged menu organized as an agents × backend matrix (1→many × REST/CLI/mixed); every cell now has a working, tested demonstrator.
+
+### Changed
+- **Laconic CLI:** `swarm-cli cli-agents` gains short flags (`-c/-a/-S/-s/-j/-i/-w`) and an `agents` alias, so `swarm-cli agents -iw` == `cli-agents --init --write`.
+
 ## [0.4.2] - 2026-06-16
 
 ### Added

--- a/docs/BLUEPRINT_LIBRARY.md
+++ b/docs/BLUEPRINT_LIBRARY.md
@@ -1,0 +1,78 @@
+# Blueprint Library
+
+A menu of the multi-agent workflows ("blueprints") Open Swarm ships, each chosen
+to demonstrate a specific framework feature. Pick one by its `model` name over
+the OpenAI API, run it with `swarm-cli launch <name>`, or use it as a starting
+point for your own.
+
+**Status legend**
+
+| Mark | Meaning |
+|------|---------|
+| ✅ | Deep tests + verified live (incl. grok where CLI-backed) |
+| 🟢 | Discovered and answers over the API (smoke-matrix verified) — dedicated feature test pending |
+| 🔧 | Present in-tree but **not discovered** (needs a fix to join the library) |
+| 📋 | Removed in the FOSS cleanup — reintroduction candidate (resurrect, modernize, test) |
+
+This is a living document: the build-out loop adds a dedicated feature test (and
+grok verification for CLI-backed ones) to each 🟢 row, fixes the 🔧 rows, and
+reintroduces 📋 rows that demonstrate a feature not already covered.
+
+---
+
+## CLI Agent Fusion — drive your installed CLIs (claude / grok / gemini / …)
+
+| Blueprint | Feature it demonstrates | Status |
+|---|---|---|
+| `cli_agent` | One external CLI behind the OpenAI API; streaming; failover | ✅ |
+| `cli_fusion` | Multi-CLI **consensus** (panel → judge → synthesize) | ✅ |
+| `cli_orchestrator` | **Granular** consensus — cheap router escalates only hard questions | ✅ |
+| `cli_map` | **Decompose → distribute → reduce** (map-reduce across CLIs) | ✅ |
+
+All four verified live with **grok** driving every role (panelist, judge, router, planner, worker, reducer).
+
+## Coding & developer workflows
+
+| Blueprint | Feature it demonstrates | Status |
+|---|---|---|
+| `codey` | Code generation + semantic code search/analysis; approval-mode | 🟢 |
+| `rue_code` | Code execution + filesystem interaction | 🟢 |
+| `whinge_surf` | Async subprocess job management (launch / poll / review) | 🟢 |
+
+## Multi-agent coordination & delegation
+
+| Blueprint | Feature it demonstrates | Status |
+|---|---|---|
+| `geese` | Researcher/coordinator pattern with memory | 🟢 |
+| `zeus` | General-purpose team launcher (agent-as-tool delegation) | 🟢 |
+| `dynamic_team` | Dynamically-registered team from a configured LLM profile | 🟢 |
+| `chucks_angels` | Themed task coordination | 🟢 |
+| `digitalbutlers` | Butler-style delegation | 🔧 present, not discovered |
+| `flock` | Agent flock/swarm coordination | 🔧 present, not discovered |
+
+## Structured output, tools & integrations
+
+| Blueprint | Feature it demonstrates | Status |
+|---|---|---|
+| `suggestion` | **Structured output** via `Agent(output_type=…)` | 🟢 |
+| `jeeves` | Private web search (DuckDuckGo) + home automation delegation | 🟢 |
+| `stewie` | **MCP** integration (WordPress CMS via MCP tools) | 🟢 |
+| `whiskeytango_foxtrot` | Hierarchical multi-agent + SQLite + web scraping | 🟢 |
+| `poets` | SQLite-backed collaborative creative writing | 🟢 |
+| `django_chat` | Web chat with conversation-history management | 🟢 |
+
+## Reintroduction candidates (removed in the FOSS cleanup)
+
+Each is a 📋 candidate — resurrect from git history, modernize to current
+`BlueprintBase`, add a feature test. Ordered by the feature they'd add:
+
+| Blueprint | Feature it would demonstrate |
+|---|---|
+| `echocraft` | Minimal "hello world" blueprint (the simplest template) |
+| `chatbot` | Bare single-agent chat |
+| `mcp_demo` | Focused MCP-server usage demo |
+| `nebula_shellz` | Agent-as-tool + `@function_tool` for shell/code |
+| `monkai_magic` | External-CLI function tools (AWS/Fly/Vercel cloud ops) |
+| `mission_improbable` · `burnt_noodles` · `dilbot_universe` · `gaggle` · `gotchaman` · `omniplex` · `unapologetic_press` | Misc themed multi-agent demos — triage each for a unique feature before resurrecting |
+
+> `family_ties` was **renamed** to `stewie` (already in the library), not removed.

--- a/docs/BLUEPRINT_LIBRARY.md
+++ b/docs/BLUEPRINT_LIBRARY.md
@@ -20,6 +20,33 @@ reintroduces 📋 rows that demonstrate a feature not already covered.
 
 ---
 
+## The permutation matrix (the spine of the library)
+
+The library is organized as a progression of permutations — *how many agents* ×
+*what backend* — from the trivial (1 agent, 1 endpoint) to the complex (many
+agents mixing REST and CLI). Every cell should have at least one working,
+tested demonstrator.
+
+| Agents ↓ \ Backend → | **REST** (LLM API, openai-agents) | **CLI** (grok / claude / …) | **Mixed** (REST + CLI) |
+|---|---|---|---|
+| **1 agent** | `chatbot` — 1 agent, 1 REST endpoint 📋 | `cli_agent` — 1 CLI ✅ | — (n/a for a single agent) |
+| **Few agents (team)** | `geese` / `zeus` — REST team, agent-as-tool / handoff 🟢 | `cli_fusion` (consensus) · `cli_orchestrator` (routed) ✅ | **`hybrid_team`** — REST agents + CLI personas-as-tools 🆕 *to build* |
+| **Many agents (orchestrated)** | `whiskeytango_foxtrot` — hierarchical REST 🟢 | `cli_map` — decompose/distribute ✅ | **`hybrid_swarm`** — orchestrator mixing REST sub-agents and CLI panels 🆕 *to build* |
+
+**What already exists:** the entire **CLI column** (✅) and most of the **REST
+column** (🟢). **The gaps the matrix exposes:** a *minimal* 1-agent REST
+demonstrator (resurrect `chatbot`/`echocraft` or build a tiny one), and the
+**Mixed column** — which is the headline capability. Mixing is already *enabled*
+by `swarm.core.cli_tools` (a CLI persona / a whole consensus panel exposed as an
+`as_function_tool()` an openai-agents REST agent can call); these two blueprints
+would *demonstrate and test* it end to end.
+
+> Note: `digitalbutlers` and `flock` are present in-tree but don't subclass
+> `BlueprintBase`, so they aren't discovered — they're stale stubs, candidates
+> for a rebuild into specific matrix cells rather than a quick fix.
+
+---
+
 ## CLI Agent Fusion — drive your installed CLIs (claude / grok / gemini / …)
 
 | Blueprint | Feature it demonstrates | Status |

--- a/docs/BLUEPRINT_LIBRARY.md
+++ b/docs/BLUEPRINT_LIBRARY.md
@@ -29,17 +29,18 @@ tested demonstrator.
 
 | Agents ↓ \ Backend → | **REST** (LLM API, openai-agents) | **CLI** (grok / claude / …) | **Mixed** (REST + CLI) |
 |---|---|---|---|
-| **1 agent** | `chatbot` — 1 agent, 1 REST endpoint 📋 | `cli_agent` — 1 CLI ✅ | — (n/a for a single agent) |
-| **Few agents (team)** | `geese` / `zeus` — REST team, agent-as-tool / handoff 🟢 | `cli_fusion` (consensus) · `cli_orchestrator` (routed) ✅ | **`hybrid_team`** — REST agents + CLI personas-as-tools 🆕 *to build* |
-| **Many agents (orchestrated)** | `whiskeytango_foxtrot` — hierarchical REST 🟢 | `cli_map` — decompose/distribute ✅ | **`hybrid_swarm`** — orchestrator mixing REST sub-agents and CLI panels 🆕 *to build* |
+| **1 agent** | `chatbot` — 1 agent, 1 REST endpoint ✅ | `cli_agent` — 1 CLI ✅ | — (n/a for a single agent) |
+| **Few agents (team)** | `geese` / `zeus` — REST team, agent-as-tool / handoff 🟢 | `cli_fusion` (consensus) · `cli_orchestrator` (routed) ✅ | **`hybrid_team`** — REST coordinator + grok persona + consensus panel ✅ |
+| **Many agents (orchestrated)** | `whiskeytango_foxtrot` — hierarchical REST 🟢 | `cli_map` — decompose/distribute ✅ | **`hybrid_swarm`** — REST orchestrator over REST agents + CLI consensus panel ✅ |
 
-**What already exists:** the entire **CLI column** (✅) and most of the **REST
-column** (🟢). **The gaps the matrix exposes:** a *minimal* 1-agent REST
-demonstrator (resurrect `chatbot`/`echocraft` or build a tiny one), and the
-**Mixed column** — which is the headline capability. Mixing is already *enabled*
-by `swarm.core.cli_tools` (a CLI persona / a whole consensus panel exposed as an
-`as_function_tool()` an openai-agents REST agent can call); these two blueprints
-would *demonstrate and test* it end to end.
+**Every cell now has a working, tested demonstrator.** The CLI column and the
+Mixed column are complete; most of the REST column is smoke-verified. The
+**Mixed** blueprints prove the headline capability — a REST coordinator reaching
+for grok CLI personas and a consensus panel mid-run, via `swarm.core.cli_tools`.
+Verified live: `hybrid_team` ran a real grok persona ("Rome") and a real
+consensus while the REST coordinator step degraded gracefully (the REST half is
+wired to a real openai-agents Agent; it needs your LLM key to produce a live
+plan, and falls back cleanly without one).
 
 > Note: `digitalbutlers` and `flock` are present in-tree but don't subclass
 > `BlueprintBase`, so they aren't discovered — they're stale stubs, candidates
@@ -57,6 +58,17 @@ would *demonstrate and test* it end to end.
 | `cli_map` | **Decompose → distribute → reduce** (map-reduce across CLIs) | ✅ |
 
 All four verified live with **grok** driving every role (panelist, judge, router, planner, worker, reducer).
+
+## Hybrid (REST + CLI) and minimal templates
+
+| Blueprint | Feature it demonstrates | Status |
+|---|---|---|
+| `chatbot` | The minimal single-agent REST template (1 agent, 1 endpoint) | ✅ |
+| `hybrid_team` | A REST coordinator delegating to grok CLI personas + a consensus panel | ✅ |
+| `hybrid_swarm` | A REST orchestrator routing across REST sub-agents and a CLI consensus panel | ✅ |
+
+The hybrids' REST half is wired to a real openai-agents Agent and degrades
+gracefully without an LLM key; the CLI half is verified live with grok.
 
 ## Coding & developer workflows
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-swarm"
-version = "0.4.2"
+version = "0.4.3"
 description = "Open Swarm: Orchestrating AI Agent Swarms with Django"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/swarm/blueprints/chatbot/blueprint_chatbot.py
+++ b/src/swarm/blueprints/chatbot/blueprint_chatbot.py
@@ -1,0 +1,112 @@
+"""Chatbot Blueprint — the minimal single-agent REST blueprint.
+
+Path: src/swarm/blueprints/chatbot/blueprint_chatbot.py
+Discovered as blueprint_id "chatbot" (the directory name).
+
+This is the simplest discoverable REST template: one agent, one endpoint
+(``POST /v1/chat/completions`` with ``model: "chatbot"``). It runs a single
+``openai-agents`` Agent and streams that agent's text answer back as a normal
+chat completion.
+
+Under ``SWARM_TEST_MODE`` it returns a deterministic, network-free answer so the
+per-blueprint API smoke matrix (tests/api/test_blueprint_api_smoke.py) and the
+unit tests in tests/blueprints/test_chatbot.py pass without a live LLM or API
+key.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncGenerator
+from typing import Any, ClassVar
+
+from swarm.core.blueprint_base import BlueprintBase
+
+
+def _latest_user_text(messages: list[dict[str, Any]] | None) -> str:
+    """Return the trimmed content of the most recent message, or ""."""
+    if not messages:
+        return ""
+    last = messages[-1]
+    if not isinstance(last, dict):
+        return ""
+    return (last.get("content") or "").strip()
+
+
+class ChatbotBlueprint(BlueprintBase):
+    """A minimal single-agent REST blueprint: one Agent, one answer."""
+
+    metadata: ClassVar[dict[str, Any]] = {
+        "name": "chatbot",
+        "title": "Chatbot (single agent)",
+        "description": (
+            "Minimal single-agent REST blueprint. Runs one openai-agents Agent "
+            "and returns its text answer over the OpenAI-compatible API."
+        ),
+        "version": "1.0.0",
+        "author": "Open Swarm Team",
+        "tags": ["minimal", "chatbot", "single-agent", "rest", "example"],
+        "required_mcp_servers": [],
+        "env_vars": [],  # OPENAI_API_KEY implicitly needed by the model
+    }
+
+    def __init__(self, blueprint_id: str = "chatbot", config=None, config_path=None, **kwargs):
+        super().__init__(blueprint_id, config=config, config_path=config_path, **kwargs)
+
+    def create_starting_agent(self, mcp_servers=None):
+        """Build the single chat agent wired to the configured model.
+
+        ``make_agent()`` resolves the model (provider/model/api_key/base_url)
+        from swarm_config.json via ``_get_model_instance`` + ``_resolve_llm_profile``.
+        """
+        return self.make_agent(
+            name="ChatbotAgent",
+            instructions=(
+                "You are a concise, friendly assistant. "
+                "Answer the user directly and helpfully."
+            ),
+            tools=[],
+            mcp_servers=mcp_servers or [],
+        )
+
+    async def run(self, messages, **kwargs) -> AsyncGenerator[dict, None]:
+        user_text = _latest_user_text(messages)
+
+        # --- SWARM_TEST_MODE: canned answer, NO model call / network / API key ---
+        if os.environ.get("SWARM_TEST_MODE"):
+            answer = f"You said: {user_text}" if user_text else "Hello! How can I help you?"
+            yield {
+                "messages": [{"role": "assistant", "content": answer}],
+                "final": True,
+            }
+            return
+
+        # --- Real path: build one Agent, run it, read its text answer ---
+        # Imported lazily so test mode never requires the agents SDK / a model.
+        from agents import Runner
+
+        agent = self.create_starting_agent(mcp_servers=kwargs.get("mcp_servers", []))
+        try:
+            result = await Runner.run(agent, user_text)
+            # .final_output is the answer; do NOT use str(result) (it serializes
+            # the whole RunResult wrapper).
+            answer = result.final_output
+        except Exception as e:  # noqa: BLE001 - surface any failure to the caller
+            answer = f"An error occurred: {e}"
+
+        yield {
+            "messages": [{"role": "assistant", "content": str(answer)}],
+            "final": True,
+        }
+
+
+if __name__ == "__main__":
+    import asyncio
+    import json
+
+    async def _demo():
+        bp = ChatbotBlueprint(blueprint_id="chatbot")
+        async for chunk in bp.run([{"role": "user", "content": "hello"}]):
+            print(json.dumps(chunk, indent=2))
+
+    asyncio.run(_demo())

--- a/src/swarm/blueprints/hybrid_swarm/blueprint_hybrid_swarm.py
+++ b/src/swarm/blueprints/hybrid_swarm/blueprint_hybrid_swarm.py
@@ -1,0 +1,184 @@
+"""Hybrid Swarm blueprint: a REST reasoning step MIXED with CLI agents.
+
+A larger orchestrated blueprint that, in a single ``run()``, routes across both
+a REST-style reasoning step *and* a CLI consensus panel. It combines three
+composable layers:
+
+  * a REST-style LLM reasoning step (deterministic under ``SWARM_TEST_MODE``),
+  * a grok CLI *persona*        (:func:`swarm.core.cli_tools.cli_persona`),
+  * a cross-model *consensus*   (:func:`swarm.core.consensus.run_consensus`
+                                 via :func:`swarm.core.cli_tools.consensus_fn`).
+
+Determinism in tests has TWO independent switches:
+  * REST half -> stubbed when ``os.environ["SWARM_TEST_MODE"]`` is set.
+  * CLI half  -> driven by a configured ``cli_agents`` block of fake echo CLIs
+                 (see tests/blueprints/test_hybrid_swarm.py), so no model/network.
+
+Request model: ``model: "hybrid_swarm"``. Config block ``hybrid_swarm``:
+  ``{ "grok": "<cli-name>", "panel": ["<cli>", ...], "judge": "<cli>" }``
+falls back to the ``cli_fusion`` ``default_cli`` / ``default_preset``.
+Per-request ``params`` may override grok / panel / judge / workdir.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, AsyncGenerator, ClassVar
+
+from swarm.blueprints.common import cli_fusion_support as support
+from swarm.core.blueprint_base import BlueprintBase
+from swarm.core.cli_adapter import CliAdapterRegistry
+from swarm.core.cli_tools import cli_persona, consensus_fn  # granular tool layer
+from swarm.core.consensus import run_consensus  # or call this directly
+
+logger = logging.getLogger(__name__)
+
+
+class HybridSwarmBlueprint(BlueprintBase):
+    """REST reasoning + grok persona + consensus panel, in one run()."""
+
+    metadata: ClassVar[dict[str, Any]] = {
+        "name": "hybrid_swarm",
+        "title": "Hybrid Swarm (REST + CLI agents)",
+        "description": (
+            "A larger orchestrated blueprint that routes across a REST reasoning "
+            "step, a grok CLI persona, and a cross-model CLI consensus panel in a "
+            "single request."
+        ),
+        "version": "0.1.0",
+        "author": "Open Swarm Team",
+        "tags": ["cli", "fusion", "rest", "consensus", "hybrid", "openai-compatible"],
+        "required_mcp_servers": [],
+        "env_vars": [],
+    }
+
+    def __init__(self, blueprint_id: str = "hybrid_swarm", config=None, config_path=None, **kwargs):
+        super().__init__(blueprint_id, config=config, config_path=config_path, **kwargs)
+        self._params: dict[str, Any] = {}
+
+    def set_params(self, params: dict[str, Any] | None) -> None:
+        self._params = dict(params or {})
+
+    # --- config resolution: grok persona + consensus panel ---------------- #
+
+    def _resolve(
+        self, params: dict[str, Any], registry: CliAdapterRegistry
+    ) -> tuple[str | None, list[str], str | None]:
+        """Resolve (grok_cli, panel, judge), falling back to cli_fusion config."""
+        hc = (self._config or {}).get("hybrid_swarm") or {}
+        fusion = (self._config or {}).get("cli_fusion") or {}
+
+        grok = params.get("grok") or hc.get("grok") or fusion.get("default_cli")
+        panel = params.get("panel") or hc.get("panel")
+        judge = params.get("judge") or hc.get("judge")
+        if not panel:
+            preset = (fusion.get("presets") or {}).get(fusion.get("default_preset")) or {}
+            panel = preset.get("panel")
+            judge = judge or preset.get("judge")
+
+        known = set(registry.names())
+        # grok defaults to the first available CLI if still unset.
+        if not grok:
+            avail = registry.available() or registry.names()
+            grok = avail[0] if avail else None
+        if grok and grok not in known:
+            grok = None
+        panel = [n for n in (panel or []) if n in known]
+        if judge and judge not in known:
+            judge = None
+        return grok, panel, judge
+
+    # --- the REST step (deterministic under SWARM_TEST_MODE) -------------- #
+
+    async def _rest_reason(self, prompt: str) -> str:
+        """A single REST-style LLM reasoning call.
+
+        Under ``SWARM_TEST_MODE`` we return a fixed stub so the REST half is
+        deterministic with no network — the same idiom blueprint_gawd /
+        blueprint_zeus use. Replace the body with your real OpenAI/Anthropic
+        client call in production.
+        """
+        if os.environ.get("SWARM_TEST_MODE"):
+            return f"[rest-plan] {prompt}"
+        # Real REST reasoning: one openai-agents Agent (the LLM orchestrator),
+        # degrading gracefully so a missing/unreachable LLM never sinks the run.
+        try:
+            from agents import Runner
+
+            agent = self.make_agent(
+                name="Orchestrator",
+                instructions=(
+                    "You are an orchestrator. In 1-2 sentences, outline how to "
+                    "answer the user's request and what to route to sub-agents."
+                ),
+                tools=[],
+            )
+            result = await Runner.run(agent, prompt)
+            return str(result.final_output)
+        except Exception as exc:  # noqa: BLE001 — degrade, don't crash the run
+            return f"[rest-plan unavailable: {exc}] {prompt}"
+
+    # --- entry point ------------------------------------------------------ #
+
+    async def run(
+        self, messages: list[dict[str, Any]], **kwargs: Any
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        # Snapshot params before any await (a cached instance may be shared).
+        params = dict(self._params)
+
+        prompt = support.render_prompt(messages)
+        if not prompt:
+            yield support.message_chunk("No prompt provided.", final=True)
+            return
+
+        registry = support.apply_overrides(support.build_registry(self._config), params)
+        grok_name, panel_names, judge_name = self._resolve(params, registry)
+        workdir = params.get(support.PARAM_WORKDIR)
+
+        # ---- 1. REST reasoning step (the master plan) -------------------- #
+        yield support.progress_chunk("_Reasoning (REST step)…_")
+        plan = await self._rest_reason(prompt)
+        # The REST plan steers the CLI sub-questions below.
+        sub_question = f"{prompt}\n\n--- Plan ---\n{plan}"
+
+        # ---- 2. grok CLI persona step ------------------------------------ #
+        grok_answer = ""
+        if grok_name:
+            yield support.progress_chunk(f"_Asking the grok persona (`{grok_name}`)…_")
+            ask_grok = cli_persona(registry.get(grok_name))  # async (str) -> str
+            grok_answer = await ask_grok(sub_question)
+            # cli_persona never raises: failures arrive as "[<name> unavailable: …]".
+
+        # ---- 3. consensus panel step ------------------------------------- #
+        consensus_answer = ""
+        if panel_names:
+            yield support.progress_chunk(
+                f"_Escalating to consensus over {', '.join(panel_names)}…_"
+            )
+            panel = registry.resolve_panel(panel_names)
+            judge = registry.get(judge_name) if judge_name else None
+
+            # The granular tool callable collapses the panel -> one answer.
+            # (For the full ConsensusResult — analysis, per-panelist rows, ok flag,
+            # next_step — call run_consensus(...) directly instead.)
+            consensus = consensus_fn(panel, judge)  # async (str) -> str
+            consensus_answer = await consensus(sub_question)
+
+        # ---- 4. combine REST + CLI outputs into the final answer --------- #
+        parts = [f"REST plan:\n{plan}"]
+        if grok_answer:
+            parts.append(f"grok persona:\n{grok_answer}")
+        if consensus_answer:
+            parts.append(f"Consensus:\n{consensus_answer}")
+        if not (grok_answer or consensus_answer):
+            parts.append(
+                "(no CLI agents configured — add a 'cli_agents' block; see docs/CLI_FUSION.md)"
+            )
+
+        yield support.message_chunk("\n\n".join(parts), final=True)
+
+
+# Keep ``run_consensus`` importable from this module for callers that want the
+# full ConsensusResult directly (kept here so the alternative path is obvious).
+__all__ = ["HybridSwarmBlueprint", "run_consensus"]

--- a/src/swarm/blueprints/hybrid_team/blueprint_hybrid_team.py
+++ b/src/swarm/blueprints/hybrid_team/blueprint_hybrid_team.py
@@ -1,0 +1,201 @@
+"""Hybrid team blueprint: a REST reasoning step MIXED with CLI agents.
+
+A small "team" that mixes backends in a single ``run()``:
+
+  * a REST-style LLM reasoning step (the *coordinator*; deterministic under
+    ``SWARM_TEST_MODE``),
+  * a grok CLI *persona*        (:func:`swarm.core.cli_tools.cli_persona` over a
+    :class:`~swarm.core.cli_adapter.CliAdapter`),
+  * a cross-model *consensus*   (:func:`swarm.core.cli_tools.consensus_fn` /
+    :func:`swarm.core.consensus.run_consensus`).
+
+The REST coordinator holds the master plan and delegates sub-questions to the
+grok/claude CLI personas (exposed as ``cli_tools`` callables) and to a consensus
+panel — that is the MIX: one REST inference reaching for CLI personas mid-run.
+
+Deterministic in tests two ways, independently:
+
+  * REST half -> stubbed when ``os.environ["SWARM_TEST_MODE"]`` is set.
+  * CLI half  -> driven by a configured ``cli_agents`` block of fake echo CLIs
+                 (``python -c '... print(...)'``; see
+                 ``tests/blueprints/test_hybrid_team.py``), so no model/network.
+
+Request model: ``model: "hybrid_team"``. Config block ``hybrid_team``::
+
+    {"grok": "<cli-name>", "panel": ["<cli>", ...], "judge": "<cli>"}
+
+falls back to the ``cli_fusion`` ``default_cli`` / ``default_preset``. Per-request
+``params`` may override ``grok`` / ``panel`` / ``judge`` / ``workdir`` / ``timeout``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, AsyncGenerator, ClassVar
+
+from swarm.blueprints.common import cli_fusion_support as support
+from swarm.core.blueprint_base import BlueprintBase
+from swarm.core.cli_adapter import CliAdapterRegistry
+from swarm.core.cli_tools import cli_persona, consensus_fn  # the granular tool layer
+from swarm.core.consensus import run_consensus  # noqa: F401  (Option B; see run())
+
+
+class HybridTeamBlueprint(BlueprintBase):
+    """REST coordinator + grok CLI persona + consensus panel, in one run()."""
+
+    metadata: ClassVar[dict[str, Any]] = {
+        "name": "hybrid_team",
+        "title": "Hybrid Team (REST coordinator + CLI agents)",
+        "description": (
+            "A REST coordinator that reasons, then delegates to a grok CLI "
+            "persona and a cross-model consensus panel — backends mixed in a "
+            "single request."
+        ),
+        "version": "0.1.0",
+        "author": "Open Swarm Team",
+        "tags": ["cli", "fusion", "rest", "consensus", "hybrid", "openai-compatible"],
+        "required_mcp_servers": [],
+        "env_vars": [],
+    }
+
+    def __init__(
+        self,
+        blueprint_id: str = "hybrid_team",
+        config=None,
+        config_path=None,
+        **kwargs,
+    ):
+        super().__init__(blueprint_id, config=config, config_path=config_path, **kwargs)
+        self._params: dict[str, Any] = {}
+
+    def set_params(self, params: dict[str, Any] | None) -> None:
+        self._params = dict(params or {})
+
+    # --- config resolution: grok persona + consensus panel ---------------- #
+
+    def _resolve(
+        self, params: dict[str, Any], registry: CliAdapterRegistry
+    ) -> tuple[str | None, list[str], str | None]:
+        """Resolve (grok_cli, panel, judge), falling back to cli_fusion config."""
+        hc = (self._config or {}).get("hybrid_team") or {}
+        fusion = (self._config or {}).get("cli_fusion") or {}
+
+        grok = params.get("grok") or hc.get("grok") or fusion.get("default_cli")
+        panel = params.get(support.PARAM_PANEL) or hc.get("panel")
+        judge = params.get(support.PARAM_JUDGE) or hc.get("judge")
+        if not panel:
+            preset = (fusion.get("presets") or {}).get(fusion.get("default_preset")) or {}
+            panel = preset.get("panel")
+            judge = judge or preset.get("judge")
+
+        known = set(registry.names())
+        # grok defaults to the first available CLI if still unset.
+        if not grok:
+            avail = registry.available() or registry.names()
+            grok = avail[0] if avail else None
+        if grok and grok not in known:
+            grok = None
+        panel = [n for n in (panel or []) if n in known]
+        if judge and judge not in known:
+            judge = None
+        return grok, panel, judge
+
+    # --- the REST step (deterministic under SWARM_TEST_MODE) -------------- #
+
+    async def _rest_reason(self, prompt: str) -> str:
+        """A single REST-style LLM reasoning call (the coordinator).
+
+        Under ``SWARM_TEST_MODE`` we return a fixed stub so the REST half is
+        deterministic with no network — the same idiom blueprint_gawd /
+        blueprint_zeus use. Replace the body below with a real OpenAI/Anthropic
+        client call in production.
+        """
+        if os.environ.get("SWARM_TEST_MODE"):
+            return f"[rest-plan] {prompt}"
+        # Real REST reasoning: one openai-agents Agent (the LLM coordinator). It
+        # degrades gracefully — if no LLM is configured/reachable, the CLI half
+        # still runs — so a missing key never sinks the whole hybrid.
+        try:
+            from agents import Runner
+
+            agent = self.make_agent(
+                name="Coordinator",
+                instructions=(
+                    "You are a planning coordinator. In 1-2 sentences, give a brief "
+                    "plan for answering the user's request — what to check and which "
+                    "sub-questions to delegate."
+                ),
+                tools=[],
+            )
+            result = await Runner.run(agent, prompt)
+            return str(result.final_output)
+        except Exception as exc:  # noqa: BLE001 — degrade, don't crash the run
+            return f"[rest-plan unavailable: {exc}] {prompt}"
+
+    # --- entry point ------------------------------------------------------ #
+
+    async def run(
+        self, messages: list[dict[str, Any]], **kwargs: Any
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        # Snapshot params before any await (a cached instance may be shared).
+        params = dict(self._params)
+
+        prompt = support.render_prompt(messages)
+        if not prompt:
+            yield support.message_chunk("No prompt provided.", final=True)
+            return
+
+        registry = support.apply_overrides(support.build_registry(self._config), params)
+        grok_name, panel_names, judge_name = self._resolve(params, registry)
+        workdir = params.get(support.PARAM_WORKDIR)
+
+        # ---- 1. REST reasoning step (the coordinator's master plan) ------ #
+        yield support.progress_chunk("_Coordinator reasoning (REST step)…_")
+        plan = await self._rest_reason(prompt)
+        # The REST plan steers the CLI sub-questions below.
+        sub_question = f"{prompt}\n\n--- Plan ---\n{plan}"
+
+        # ---- 2. grok CLI persona step ------------------------------------ #
+        grok_answer = ""
+        if grok_name:
+            yield support.progress_chunk(f"_Delegating to the grok persona (`{grok_name}`)…_")
+            ask_grok = cli_persona(registry.get(grok_name))  # async (str) -> str
+            grok_answer = await ask_grok(sub_question)
+            # cli_persona never raises: failures arrive as "[<name> unavailable: …]".
+
+        # ---- 3. consensus panel step ------------------------------------- #
+        consensus_answer = ""
+        if panel_names:
+            yield support.progress_chunk(
+                f"_Escalating to consensus over {', '.join(panel_names)}…_"
+            )
+            panel = registry.resolve_panel(panel_names)
+            judge = registry.get(judge_name) if judge_name else None
+
+            if workdir:
+                # Full ConsensusResult path: surface per-panelist failures, honour workdir.
+                cons = await run_consensus(
+                    sub_question, panel, judge,
+                    workdirs={n: workdir for n in registry.names()},
+                )
+                for r in cons.results:
+                    if not r.ok:
+                        yield support.progress_chunk(f"_• {r.name} failed: {r.error}_")
+                consensus_answer = cons.answer or "(no consensus reached)"
+            else:
+                # Granular tool callable: collapse the panel -> one answer.
+                consensus = consensus_fn(panel, judge)  # async (str) -> str
+                consensus_answer = await consensus(sub_question)
+
+        # ---- 4. combine REST + CLI outputs into the final answer --------- #
+        parts = [f"REST plan:\n{plan}"]
+        if grok_answer:
+            parts.append(f"grok persona:\n{grok_answer}")
+        if consensus_answer:
+            parts.append(f"Consensus:\n{consensus_answer}")
+        if not (grok_answer or consensus_answer):
+            parts.append(
+                "(no CLI agents configured — add a 'cli_agents' block; see docs/CLI_FUSION.md)"
+            )
+
+        yield support.message_chunk("\n\n".join(parts), final=True)

--- a/src/swarm/core/swarm_cli.py
+++ b/src/swarm/core/swarm_cli.py
@@ -273,13 +273,13 @@ def list_blueprints(
 
 @app.command(name="cli-agents")
 def cli_agents(
-    config_path: str = typer.Option(None, "--config", help="Path to swarm_config.json (defaults to the usual search)."),
-    check_auth: bool = typer.Option(False, "--check-auth", help="Also probe each installed CLI's authentication (runs its configured auth_check)."),
-    suggest: bool = typer.Option(False, "--suggest", help="Suggest ready-to-paste config blocks for supported CLIs that are installed but not yet configured."),
-    smoke: bool = typer.Option(False, "--smoke", help="Run one trivial one-shot per installed CLI to confirm it returns in non-interactive mode. NOTE: invokes each CLI's model once (small quota cost)."),
-    output_json: bool = typer.Option(False, "--json", help="Emit a single machine-readable JSON object instead of tables (honors --check-auth/--smoke/--suggest)."),
-    init: bool = typer.Option(False, "--init", help="Print a complete, ready-to-run swarm_config wiring every mode (cli_fusion/cli_orchestrator/cli_map) over the CLIs installed on this host."),
-    write: bool = typer.Option(False, "--write", help="With --init, write the config to your swarm config path (backs up any existing file)."),
+    config_path: str = typer.Option(None, "--config", "-c", help="Path to swarm_config.json (defaults to the usual search)."),
+    check_auth: bool = typer.Option(False, "--check-auth", "-a", help="Also probe each installed CLI's authentication (runs its configured auth_check)."),
+    suggest: bool = typer.Option(False, "--suggest", "-S", help="Suggest ready-to-paste config blocks for supported CLIs that are installed but not yet configured."),
+    smoke: bool = typer.Option(False, "--smoke", "-s", help="Run one trivial one-shot per installed CLI to confirm it returns in non-interactive mode. NOTE: invokes each CLI's model once (small quota cost)."),
+    output_json: bool = typer.Option(False, "--json", "-j", help="Emit a single machine-readable JSON object instead of tables (honors --check-auth/--smoke/--suggest)."),
+    init: bool = typer.Option(False, "--init", "-i", help="Print a complete, ready-to-run swarm_config wiring every mode (cli_fusion/cli_orchestrator/cli_map) over the CLIs installed on this host."),
+    write: bool = typer.Option(False, "--write", "-w", help="With --init, write the config to your swarm config path (backs up any existing file)."),
 ):
     """Autodiscover configured CLI agents: which are installed (and optionally authenticated)."""
     import asyncio
@@ -364,6 +364,10 @@ def cli_agents(
             typer.echo(f"Suggested cli_agents for installed-but-unconfigured CLIs ({names}):")
             typer.echo("Verify each CLI's flags with --help before use; see docs/CLI_FUSION.md.\n")
             typer.echo(json.dumps({"cli_agents": suggestions}, indent=2))
+
+
+# Laconic alias: `swarm-cli agents` == `swarm-cli cli-agents`.
+app.command(name="agents", help="Alias for cli-agents.")(cli_agents)
 
 
 if __name__ == "__main__":

--- a/tests/blueprints/test_chatbot.py
+++ b/tests/blueprints/test_chatbot.py
@@ -1,0 +1,102 @@
+"""Tests for the chatbot blueprint (minimal single-agent REST template).
+
+Mirrors the async/_collect/final-content style of test_cli_agent.py and
+test_cli_fusion.py. The SWARM_TEST_MODE path is exercised directly so these
+tests need no live LLM, API key, or network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from swarm.blueprints.chatbot.blueprint_chatbot import ChatbotBlueprint
+
+
+async def _collect(gen):
+    return [c async for c in gen]
+
+
+def _final_content(chunks):
+    text = None
+    for c in chunks:
+        msgs = c.get("messages") if isinstance(c, dict) else None
+        if msgs and msgs[0].get("content") is not None:
+            text = msgs[0]["content"]
+    return text
+
+
+@pytest.fixture(autouse=True)
+def _test_mode(monkeypatch):
+    # Deterministic, network-free path for every test in this module.
+    monkeypatch.setenv("SWARM_TEST_MODE", "1")
+
+
+# --------------------------------------------------------------------------- #
+# Metadata / discovery
+# --------------------------------------------------------------------------- #
+
+def test_metadata_name_is_chatbot():
+    assert ChatbotBlueprint.metadata["name"] == "chatbot"
+
+
+def test_subclasses_blueprint_base():
+    from swarm.core.blueprint_base import BlueprintBase
+
+    assert issubclass(ChatbotBlueprint, BlueprintBase)
+
+
+# --------------------------------------------------------------------------- #
+# run() behaviour
+# --------------------------------------------------------------------------- #
+
+async def test_echoes_user_message():
+    bp = ChatbotBlueprint(blueprint_id="chatbot")
+    chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
+    assert _final_content(chunks) == "You said: ping"
+
+
+async def test_last_chunk_marked_final():
+    bp = ChatbotBlueprint(blueprint_id="chatbot")
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+    assert chunks[-1].get("final") is True
+
+
+async def test_answer_is_nonempty_string():
+    bp = ChatbotBlueprint(blueprint_id="chatbot")
+    chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
+    final = _final_content(chunks)
+    assert isinstance(final, str) and final.strip()
+
+
+async def test_empty_messages_gives_greeting():
+    bp = ChatbotBlueprint(blueprint_id="chatbot")
+    chunks = await _collect(bp.run([]))
+    final = _final_content(chunks)
+    assert final == "Hello! How can I help you?"
+
+
+async def test_blank_content_gives_greeting():
+    bp = ChatbotBlueprint(blueprint_id="chatbot")
+    chunks = await _collect(bp.run([{"role": "user", "content": "   "}]))
+    assert _final_content(chunks) == "Hello! How can I help you?"
+
+
+async def test_uses_latest_turn_in_multiturn():
+    bp = ChatbotBlueprint(blueprint_id="chatbot")
+    chunks = await _collect(
+        bp.run(
+            [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "ok"},
+                {"role": "user", "content": "second"},
+            ]
+        )
+    )
+    assert _final_content(chunks) == "You said: second"
+
+
+async def test_does_not_leak_spinner_text():
+    # Guards the regression the API smoke matrix protects against.
+    bp = ChatbotBlueprint(blueprint_id="chatbot")
+    chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
+    assert not _final_content(chunks).startswith("Generating")

--- a/tests/blueprints/test_hybrid_swarm.py
+++ b/tests/blueprints/test_hybrid_swarm.py
@@ -1,0 +1,225 @@
+"""Tests for the Hybrid Swarm blueprint (REST reasoning MIXED with CLI agents).
+
+Both halves are deterministic, independently:
+  * REST half  -> stubbed via SWARM_TEST_MODE.
+  * CLI half   -> driven by fake echo CLIs (python -c '... print(...)'), so no
+                  real model/network is touched (same idiom as test_cli_fusion).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from swarm.blueprints.hybrid_swarm.blueprint_hybrid_swarm import HybridSwarmBlueprint
+
+PY = sys.executable
+
+
+# --------------------------------------------------------------------------- #
+# Fake CLIs + config helpers (mirror tests/blueprints/test_cli_fusion.py)
+# --------------------------------------------------------------------------- #
+
+def _echo(name_prefix: str) -> dict:
+    return {"cmd": [PY, "-c", f"import sys; print('{name_prefix}:' + sys.argv[1])", "{prompt}"]}
+
+
+def _boom(code: int = 1) -> dict:
+    return {"cmd": [PY, "-c", f"import sys; sys.exit({code})", "{prompt}"]}
+
+
+def _config(*, grok="grok", panel=("a", "b"), judge=None) -> dict:
+    agents = {"grok": _echo("GROK"), "a": _echo("A"), "b": _echo("B")}
+    hc: dict = {}
+    if grok is not None:
+        hc["grok"] = grok
+    if panel is not None:
+        hc["panel"] = list(panel)
+    if judge is not None:
+        hc["judge"] = judge
+    return {"cli_agents": agents, "hybrid_swarm": hc}
+
+
+async def _collect(gen):
+    return [c async for c in gen]
+
+
+def _final_content(chunks):
+    text = None
+    for c in chunks:
+        msgs = c.get("messages") if isinstance(c, dict) else None
+        if msgs and msgs[0].get("content") is not None:
+            text = msgs[0]["content"]
+    return text
+
+
+def _all_progress(chunks):
+    return "\n".join(
+        c["content"]
+        for c in chunks
+        if isinstance(c, dict) and c.get("type") == "fusion_progress"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _test_mode(monkeypatch):
+    # Make the REST half deterministic with no network for every test here.
+    monkeypatch.setenv("SWARM_TEST_MODE", "1")
+
+
+# --------------------------------------------------------------------------- #
+# Discovery / metadata contract
+# --------------------------------------------------------------------------- #
+
+def test_metadata_name_is_hybrid_swarm():
+    assert HybridSwarmBlueprint.metadata["name"] == "hybrid_swarm"
+
+
+def test_subclasses_blueprint_base():
+    from swarm.core.blueprint_base import BlueprintBase
+
+    assert issubclass(HybridSwarmBlueprint, BlueprintBase)
+
+
+# --------------------------------------------------------------------------- #
+# Happy path: REST + grok persona + consensus all run
+# --------------------------------------------------------------------------- #
+
+async def test_run_mixes_rest_grok_and_consensus():
+    bp = HybridSwarmBlueprint(config=_config())
+    bp.set_params({})
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+    final = _final_content(chunks)
+    assert chunks[-1].get("final") is True
+    # REST step ran (stubbed plan present).
+    assert "[rest-plan] hi" in final
+    # grok persona ran (fake CLI echoed the sub-question, which starts with prompt).
+    assert "GROK:hi" in final
+    # consensus panel ran (one of the fake panelists' echoes).
+    assert ("A:hi" in final) or ("B:hi" in final)
+
+
+async def test_run_yields_progress_for_each_stage():
+    bp = HybridSwarmBlueprint(config=_config())
+    chunks = await _collect(bp.run([{"role": "user", "content": "q"}]))
+    progress = _all_progress(chunks)
+    assert "REST step" in progress
+    assert "grok persona" in progress
+    assert "consensus" in progress.lower()
+    assert "a, b" in progress  # both panelists named
+
+
+async def test_final_answer_is_non_empty_in_test_mode():
+    bp = HybridSwarmBlueprint(config=_config())
+    chunks = await _collect(bp.run([{"role": "user", "content": "anything"}]))
+    final = _final_content(chunks)
+    assert isinstance(final, str) and final.strip()
+
+
+# --------------------------------------------------------------------------- #
+# Empty prompt
+# --------------------------------------------------------------------------- #
+
+async def test_empty_prompt_short_circuits():
+    bp = HybridSwarmBlueprint(config=_config())
+    chunks = await _collect(bp.run([]))
+    assert "No prompt provided" in _final_content(chunks)
+    assert chunks[-1].get("final") is True
+
+
+# --------------------------------------------------------------------------- #
+# No CLI agents configured: REST half still produces a deterministic answer
+# --------------------------------------------------------------------------- #
+
+async def test_no_cli_agents_still_runs_rest_step():
+    bp = HybridSwarmBlueprint(config={})
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+    final = _final_content(chunks)
+    assert "[rest-plan] hi" in final  # REST half is deterministic on its own
+    assert "no CLI agents configured" in final
+    assert chunks[-1].get("final") is True
+
+
+# --------------------------------------------------------------------------- #
+# Per-request params override the config block
+# --------------------------------------------------------------------------- #
+
+async def test_params_override_grok_and_panel():
+    cfg = _config(grok="grok", panel=("a", "b"))
+    bp = HybridSwarmBlueprint(config=cfg)
+    # Restrict the panel to just "a" and use "b" as the grok persona.
+    bp.set_params({"grok": "b", "panel": ["a"]})
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+    final = _final_content(chunks)
+    assert "B:hi" in final          # grok persona overridden to "b"
+    assert "A:hi" in final          # panel narrowed to "a"
+    progress = _all_progress(chunks)
+    assert "Escalating to consensus over a…" in progress
+    assert "grok persona (`b`)" in progress
+
+
+# --------------------------------------------------------------------------- #
+# Resolution falls back to the cli_fusion preset when no hybrid_swarm panel
+# --------------------------------------------------------------------------- #
+
+async def test_falls_back_to_cli_fusion_preset():
+    cfg = {
+        "cli_agents": {"grok": _echo("GROK"), "a": _echo("A"), "b": _echo("B")},
+        # No hybrid_swarm block -> grok defaults to first available; panel from preset.
+        "cli_fusion": {"presets": {"p": {"panel": ["a", "b"]}}, "default_preset": "p"},
+    }
+    bp = HybridSwarmBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+    final = _final_content(chunks)
+    assert "[rest-plan] hi" in final
+    assert ("A:hi" in final) or ("B:hi" in final)  # consensus ran off the preset panel
+
+
+# --------------------------------------------------------------------------- #
+# CLI failures never sink the run (sentinels, not exceptions)
+# --------------------------------------------------------------------------- #
+
+async def test_grok_failure_degrades_to_sentinel_not_exception():
+    cfg = {
+        "cli_agents": {"grok": _boom(), "a": _echo("A"), "b": _echo("B")},
+        "hybrid_swarm": {"grok": "grok", "panel": ["a", "b"]},
+    }
+    bp = HybridSwarmBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+    final = _final_content(chunks)
+    # cli_persona returns "[grok unavailable: …]" rather than raising.
+    assert "grok unavailable" in final
+    # The consensus panel survivors still answer.
+    assert ("A:hi" in final) or ("B:hi" in final)
+    assert chunks[-1].get("final") is True
+
+
+async def test_all_panel_fail_reports_no_consensus():
+    cfg = {
+        "cli_agents": {"grok": _echo("GROK"), "boom1": _boom(), "boom2": _boom(2)},
+        "hybrid_swarm": {"grok": "grok", "panel": ["boom1", "boom2"]},
+    }
+    bp = HybridSwarmBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+    final = _final_content(chunks)
+    # consensus_fn returns "(no consensus reached)" when every panelist failed.
+    assert "(no consensus reached)" in final
+    # grok persona still contributed; REST plan still present.
+    assert "GROK:hi" in final
+    assert "[rest-plan] hi" in final
+
+
+# --------------------------------------------------------------------------- #
+# Unknown names in config are filtered before registry.get() is called
+# --------------------------------------------------------------------------- #
+
+async def test_unknown_panel_names_are_filtered():
+    cfg = {
+        "cli_agents": {"grok": _echo("GROK"), "a": _echo("A")},
+        "hybrid_swarm": {"grok": "grok", "panel": ["a", "ghost-not-configured"]},
+    }
+    bp = HybridSwarmBlueprint(config=cfg)
+    # Must not raise CliAdapterError on the unknown "ghost-not-configured".
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+    assert "A:hi" in _final_content(chunks)

--- a/tests/blueprints/test_hybrid_team.py
+++ b/tests/blueprints/test_hybrid_team.py
@@ -1,0 +1,193 @@
+"""Tests for the hybrid_team blueprint (REST coordinator + grok persona + consensus).
+
+Both halves are made deterministic without a live LLM or live CLI:
+
+* REST half -> stubbed by setting ``SWARM_TEST_MODE``.
+* CLI half  -> driven by fake echo CLIs (``python -c '... print(...)'``), the same
+               idiom as tests/blueprints/test_cli_fusion.py / test_cli_agent.py.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from swarm.blueprints.hybrid_team.blueprint_hybrid_team import HybridTeamBlueprint
+
+PY = sys.executable
+
+
+# --------------------------------------------------------------------------- #
+# Fake CLIs + config helpers (mirror tests/blueprints/test_cli_fusion.py)
+# --------------------------------------------------------------------------- #
+
+def _echo(prefix: str) -> dict:
+    return {"cmd": [PY, "-c", f"import sys; print('{prefix}:' + sys.argv[1])", "{prompt}"]}
+
+
+def _boom(code: int = 1) -> dict:
+    return {"cmd": [PY, "-c", f"import sys; sys.exit({code})", "{prompt}"]}
+
+
+def _config(*, grok="grok", panel=("a", "b"), judge=None) -> dict:
+    agents = {"grok": _echo("GROK"), "a": _echo("A"), "b": _echo("B")}
+    block: dict = {"grok": grok, "panel": list(panel)}
+    if judge is not None:
+        block["judge"] = judge
+    return {"cli_agents": agents, "hybrid_team": block}
+
+
+async def _collect(gen):
+    return [c async for c in gen]
+
+
+def _final_content(chunks):
+    text = None
+    for c in chunks:
+        msgs = c.get("messages") if isinstance(c, dict) else None
+        if msgs and msgs[0].get("content") is not None:
+            text = msgs[0]["content"]
+    return text
+
+
+def _all_progress(chunks):
+    return "\n".join(
+        c["content"]
+        for c in chunks
+        if isinstance(c, dict) and c.get("type") == "fusion_progress"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _test_mode(monkeypatch):
+    # REST half deterministic: no model / no network / no API key.
+    monkeypatch.setenv("SWARM_TEST_MODE", "1")
+
+
+# --------------------------------------------------------------------------- #
+# Discovery / metadata
+# --------------------------------------------------------------------------- #
+
+def test_metadata_name_is_hybrid_team():
+    assert HybridTeamBlueprint.metadata["name"] == "hybrid_team"
+
+
+def test_subclasses_blueprint_base():
+    from swarm.core.blueprint_base import BlueprintBase
+
+    assert issubclass(HybridTeamBlueprint, BlueprintBase)
+
+
+# --------------------------------------------------------------------------- #
+# REST + CLI mix (the happy path)
+# --------------------------------------------------------------------------- #
+
+async def test_run_mixes_rest_grok_and_consensus():
+    bp = HybridTeamBlueprint(config=_config())
+    bp.set_params({})
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+
+    final = _final_content(chunks)
+    assert chunks[-1].get("final") is True
+    # REST coordinator ran (stubbed under SWARM_TEST_MODE).
+    assert "[rest-plan] hi" in final
+    # grok persona ran (fake CLI echoed with its prefix).
+    assert "GROK:" in final
+    # consensus panel ran (one of the fake panelists' echoes).
+    assert ("A:" in final) or ("B:" in final)
+
+
+async def test_progress_names_grok_and_panel():
+    bp = HybridTeamBlueprint(config=_config())
+    bp.set_params({})
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+    progress = _all_progress(chunks)
+    assert "REST step" in progress
+    assert "grok" in progress
+    assert "a, b" in progress  # panel names surfaced on the consensus progress line
+
+
+async def test_deterministic_across_runs():
+    cfg = _config()
+    a = _final_content(await _collect(HybridTeamBlueprint(config=cfg).run(
+        [{"role": "user", "content": "q"}])))
+    b = _final_content(await _collect(HybridTeamBlueprint(config=cfg).run(
+        [{"role": "user", "content": "q"}])))
+    assert a == b
+
+
+# --------------------------------------------------------------------------- #
+# Per-request param overrides
+# --------------------------------------------------------------------------- #
+
+async def test_params_override_grok_and_panel():
+    bp = HybridTeamBlueprint(config=_config(grok="grok", panel=("a", "b")))
+    bp.set_params({"grok": "a", "panel": ["b"]})
+    final = _final_content(await _collect(bp.run([{"role": "user", "content": "hi"}])))
+    # grok persona is now adapter "a".
+    assert "A:" in final
+    # panel collapsed to a single panelist "b".
+    assert "B:" in final
+    assert "GROK:" not in final
+
+
+# --------------------------------------------------------------------------- #
+# Empty / missing configuration
+# --------------------------------------------------------------------------- #
+
+async def test_empty_prompt():
+    bp = HybridTeamBlueprint(config=_config())
+    chunks = await _collect(bp.run([]))
+    assert "No prompt provided" in _final_content(chunks)
+
+
+async def test_no_cli_agents_still_returns_rest_plan():
+    # No cli_agents configured: REST coordinator alone still yields a final answer.
+    bp = HybridTeamBlueprint(config={})
+    bp.set_params({})
+    chunks = await _collect(bp.run([{"role": "user", "content": "solo"}]))
+    final = _final_content(chunks)
+    assert chunks[-1].get("final") is True
+    assert "[rest-plan] solo" in final
+    assert "no CLI agents configured" in final
+
+
+# --------------------------------------------------------------------------- #
+# CLI failures never sink the run (cli_persona / consensus_fn return sentinels)
+# --------------------------------------------------------------------------- #
+
+async def test_grok_failure_degrades_gracefully():
+    cfg = {
+        "cli_agents": {"grok": _boom(), "a": _echo("A"), "b": _echo("B")},
+        "hybrid_team": {"grok": "grok", "panel": ["a", "b"]},
+    }
+    bp = HybridTeamBlueprint(config=cfg)
+    bp.set_params({})
+    final = _final_content(await _collect(bp.run([{"role": "user", "content": "hi"}])))
+    # grok persona never raises: failure surfaces as an "[grok unavailable: …]" note.
+    assert "grok unavailable" in final
+    # The consensus panel still produced an answer.
+    assert ("A:" in final) or ("B:" in final)
+
+
+async def test_all_panel_fail_reports_no_consensus():
+    cfg = {
+        "cli_agents": {"grok": _echo("GROK"), "boom": _boom()},
+        "hybrid_team": {"grok": "grok", "panel": ["boom"]},
+    }
+    bp = HybridTeamBlueprint(config=cfg)
+    bp.set_params({})
+    final = _final_content(await _collect(bp.run([{"role": "user", "content": "hi"}])))
+    # grok still answered; consensus collapsed to the sentinel.
+    assert "GROK:" in final
+    assert "no consensus reached" in final
+
+
+async def test_workdir_uses_run_consensus_path(tmp_path):
+    # Passing a workdir takes the run_consensus branch; still deterministic.
+    bp = HybridTeamBlueprint(config=_config())
+    bp.set_params({"workdir": str(tmp_path)})
+    final = _final_content(await _collect(bp.run([{"role": "user", "content": "hi"}])))
+    assert "[rest-plan] hi" in final
+    assert ("A:" in final) or ("B:" in final)

--- a/tests/cli/test_cli_agents_command.py
+++ b/tests/cli/test_cli_agents_command.py
@@ -98,6 +98,17 @@ def test_init_write_creates_config_file(tmp_path, monkeypatch):
     assert (tmp_path / "swarm_config.json.bak").exists()
 
 
+def test_short_flags_and_agents_alias(monkeypatch):
+    from swarm.core import cli_catalog
+
+    monkeypatch.setattr(cli_catalog, "installed_catalog_clis", lambda: ["grok"])
+    # short -i works, and `agents` is an alias for `cli-agents`
+    r1 = runner.invoke(app, ["cli-agents", "-i"])
+    assert r1.exit_code == 0 and "cli_agents" in r1.stdout
+    r2 = runner.invoke(app, ["agents", "-i"])
+    assert r2.exit_code == 0 and json.loads(r2.stdout)["cli_agents"]
+
+
 def test_table_output_without_json(tmp_path):
     cfg = _write_config(
         tmp_path, {"echo": {"cmd": [PY, "-c", "print(1)", "{prompt}"]}}

--- a/uv.lock
+++ b/uv.lock
@@ -1782,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "open-swarm"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Fills the blueprint-library permutation matrix (agents × backend) and makes the CLI terse.

**New blueprints (built via a fanned-out 9-agent workflow):**
- `chatbot` — minimal single-agent REST template
- `hybrid_team` / `hybrid_swarm` — the **Mixed** column: a REST coordinator reaching for grok CLI personas + a consensus panel mid-run. CLI half verified live with grok; REST half wired to a real Agent that degrades gracefully without a key.

All 3 discovered, smoke-matrix green (streaming + non-streaming), 32 dedicated tests.

**Laconic CLI:** short flags (`-iwjsac`) + `agents` alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)