### PR TITLE
v0.4.5 — self-consensus, call-time flag, native (built-in) consensus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 (nothing yet)
 
+## [0.4.5] - 2026-06-17
+
+### Added — more consensus modes
+- **Self-consensus:** `consensus: N` (int) runs the **same persona N times** and synthesizes — self-consistency sampling. Verified live (grok ×3 → "operational/distributed complexity… no material disagreement on substance").
+- **Call-time consensus flag:** a per-request `params.consensus` (bool/int/list/dict) overrides the agent's config designation; falsy forces a single call.
+- **Native (built-in) consensus catalog:** `cli_catalog.NATIVE_CONSENSUS` records CLIs whose *own* flag fans out (grok `--best-of-n N`, verified live), with `has_native_consensus()` / `native_consensus_flags()` / `with_native_consensus()`. `swarm-cli cli-agents --json` now emits a `native_consensus` map so a UI can offer a "use this CLI's built-in consensus" toggle only where available. Framework and native consensus compose (N framework samples × M native candidates).
+
 ## [0.4.4] - 2026-06-16
 
 ### Added

--- a/docs/BLUEPRINT_LIBRARY.md
+++ b/docs/BLUEPRINT_LIBRARY.md
@@ -67,10 +67,17 @@ named `coder` can be invoked many ways, and each is a blueprint permutation:
 | Mode | How you call it | What happens | Status |
 |---|---|---|---|
 | **Single** | `coder` | one inference | ✅ `cli_agent` |
-| **Agent-designated consensus** | `coder` (config `consensus: true` / `["grok","claude"]` / `{panel,judge}`) | calling the agent runs a heterogeneous **panel of CLIs** and synthesizes; preferred whitelist falls back to all-available | ✅ shipped (0.4.4) |
-| **Self-consensus (homogeneous)** | `coder` + `consensus: N` | run the **same persona N times** (sampling variance) and vote/synthesize — "many inferences, one persona" | 📋 planned (small: panel = `[coder] × N`) |
-| **Call-time flag** | `coder` + `params.consensus` | consensus chosen **per request**, not baked into config | 📋 planned (param override of the designation) |
+| **Agent-designated consensus** | `coder` (config `consensus: true` / `["grok","claude"]` / `{panel,judge}`) | calling the agent runs a heterogeneous **panel of CLIs** and synthesizes; preferred whitelist falls back to all-available | ✅ (0.4.4) |
+| **Self-consensus (homogeneous)** | `coder` + `consensus: N` | run the **same persona N times** (sampling variance) and synthesize — "many inferences, one persona" | ✅ (0.4.5) |
+| **Call-time flag** | `coder` + `params.consensus` | consensus chosen **per request** (overrides config; falsy forces single) | ✅ (0.4.5) |
+| **Native (built-in) consensus** | a CLI whose own flag fans out (grok `--best-of-n N`, `--check`) | the **CLI itself** runs N candidates internally and picks the best — one call | ✅ catalog-aware (0.4.5) |
 | **Orchestrated multi-persona** | `coder` + `architect` (+ …) | an **orchestrator** agent runs each *distinct* persona and does the consensus/synthesis across them | 🟢 `cli_fusion` / `cli_orchestrator` already panel distinct agents; formalize "named personas" |
+
+**Framework vs native, and they compose.** Framework consensus (rows 2–4) is the
+framework orchestrating multiple calls and synthesizing — works for any CLI.
+Native consensus is the CLI's *own* internal fan-out via a flag — only for CLIs
+that have one. They stack: a `consensus: 3` agent whose CLI also carries
+`--best-of-n 2` runs 3 framework samples × 2 native candidates each.
 
 The shared engine for every mode is `swarm.core.consensus.run_consensus()`; the
 modes differ only in how the *panel* is assembled (one CLI, N copies of one CLI,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-swarm"
-version = "0.4.4"
+version = "0.4.5"
 description = "Open Swarm: Orchestrating AI Agent Swarms with Django"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
+++ b/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
@@ -72,10 +72,12 @@ class CliAgentBlueprint(BlueprintBase):
         workdir = params.get(support.PARAM_WORKDIR)
 
         # Consensus agents: if the selected agent is designated as a consensus
-        # agent, calling it runs a PANEL (default = all available CLIs, or a
-        # preferred whitelist that falls back to default), not a single call.
+        # agent (or the request asks for consensus), calling it runs a PANEL
+        # instead of a single call. A per-request `consensus` param overrides the
+        # agent's config designation (set it falsy to force a single call).
         selected = registry.get(chain[0])
-        panel_spec = support.resolve_agent_consensus(selected.config, registry)
+        spec = params[support.PARAM_CONSENSUS] if support.PARAM_CONSENSUS in params else selected.config.consensus
+        panel_spec = support.resolve_consensus_spec(spec, selected.name, registry)
         if panel_spec is not None:
             panel_names, judge_name = panel_spec
             yield support.progress_chunk(

--- a/src/swarm/blueprints/common/cli_fusion_support.py
+++ b/src/swarm/blueprints/common/cli_fusion_support.py
@@ -24,6 +24,7 @@ PARAM_WORKDIR = "workdir"    # working directory for the CLI(s)
 PARAM_ISOLATE = "isolate"    # fusion: per-panelist workdir isolation (bool)
 PARAM_FALLBACK = "fallback"  # single-CLI: explicit ordered failover list
 PARAM_FAILOVER = "failover"  # single-CLI: enable auto-failover (default True)
+PARAM_CONSENSUS = "consensus"  # single-CLI: per-request consensus override (bool/int/list/dict)
 
 
 def render_prompt(messages: list[dict[str, Any]]) -> str:
@@ -152,21 +153,21 @@ def resolve_failover_chain(
     return out
 
 
-def resolve_agent_consensus(
-    cfg, registry: CliAdapterRegistry
+def resolve_consensus_spec(
+    spec: Any, name: str | None, registry: CliAdapterRegistry
 ) -> tuple[list[str], str | None] | None:
-    """If this agent is consensus-designated, resolve (panel_names, judge_name).
+    """Resolve a consensus ``spec`` into (panel_names, judge_name), or None.
 
-    ``cfg.consensus`` may be:
-    * ``True`` — panel of every **available** CLI (the default set);
-    * a list — a **preferred whitelist**; the available members are used, and if
-      *none* of them are available it falls back to the default (all available);
+    ``spec`` may be:
+    * ``True`` — panel of every available CLI (real CLIs, not other designations);
+    * an ``int`` N≥2 — **self-consensus**: the same persona (``name``) run N times;
+    * a list — a preferred **whitelist** that falls back to the default if it
+      matches nothing;
     * a dict ``{"panel": [...], "judge": "<cli>"}`` — explicit (same fallback).
 
-    Returns None when the agent is not consensus-designated. The judge defaults
-    to the agent itself when it is in the panel, else the first panelist.
+    Anything falsy (``None``/``False``/``0``/``[]``) returns None (single call).
+    The judge defaults to the persona when it's in the panel, else the first.
     """
-    spec = getattr(cfg, "consensus", None)
     if not spec:
         return None
 
@@ -185,6 +186,10 @@ def resolve_agent_consensus(
 
     if spec is True:
         panel = list(default_panel)
+    elif isinstance(spec, int) and not isinstance(spec, bool):
+        if spec < 2 or not name:
+            return None  # <2 is just a single call
+        panel = [name] * min(int(spec), 16)  # self-consensus: same persona, N times
     elif isinstance(spec, list):
         preferred = [n for n in spec if n in available_set]
         panel = preferred or list(default_panel)  # whitelist matched nothing -> default
@@ -197,8 +202,15 @@ def resolve_agent_consensus(
         return None
 
     if judge is None:
-        judge = cfg.name if cfg.name in panel else (panel[0] if panel else None)
+        judge = name if name in panel else (panel[0] if panel else None)
     return panel, judge
+
+
+def resolve_agent_consensus(
+    cfg, registry: CliAdapterRegistry
+) -> tuple[list[str], str | None] | None:
+    """Resolve the consensus panel for a configured agent (its ``cfg.consensus``)."""
+    return resolve_consensus_spec(getattr(cfg, "consensus", None), getattr(cfg, "name", None), registry)
 
 
 def apply_overrides(

--- a/src/swarm/core/cli_catalog.py
+++ b/src/swarm/core/cli_catalog.py
@@ -72,6 +72,42 @@ CATALOG: dict[str, dict[str, Any]] = {
 }
 
 
+# CLIs with a BUILT-IN "run N candidates and pick the best" mode (native
+# consensus) — the CLI fans out internally in one call, distinct from the
+# framework running it N times. Maps cli name -> argv to APPEND, with "{n}"
+# substituted for the candidate count.
+NATIVE_CONSENSUS: dict[str, list[str]] = {
+    "grok": ["--best-of-n", "{n}"],  # verified live: grok runs an N-candidate tournament
+}
+
+
+def has_native_consensus(name: str) -> bool:
+    """True when this CLI has a built-in consensus/heavy mode the catalog knows."""
+    return name in NATIVE_CONSENSUS
+
+
+def native_consensus_flags(name: str, n: int = 2) -> list[str] | None:
+    """argv to append to enable ``name``'s built-in consensus for N candidates, or None."""
+    tmpl = NATIVE_CONSENSUS.get(name)
+    if not tmpl:
+        return None
+    count = str(max(2, int(n)))
+    return [count if part == "{n}" else part for part in tmpl]
+
+
+def with_native_consensus(name: str, n: int = 2) -> dict[str, Any] | None:
+    """A catalog entry for ``name`` with its built-in consensus mode enabled.
+
+    Returns None if the CLI is unknown or has no native consensus flag.
+    """
+    entry = catalog_entry(name)
+    flags = native_consensus_flags(name, n)
+    if entry is None or flags is None:
+        return None
+    entry["cmd"] = list(entry["cmd"]) + flags
+    return entry
+
+
 def catalog_names() -> list[str]:
     """Names of every CLI the catalog knows about (sorted)."""
     return sorted(CATALOG)

--- a/src/swarm/core/swarm_cli.py
+++ b/src/swarm/core/swarm_cli.py
@@ -316,6 +316,13 @@ def cli_agents(
 
     if output_json:
         payload: dict = {"agents": [d.as_dict() for d in rows]}
+        # Native (built-in) consensus capability per configured CLI, so a UI can
+        # offer a "use this CLI's own consensus mode" toggle only where available.
+        payload["native_consensus"] = {
+            d.name: cli_catalog.NATIVE_CONSENSUS[d.name]
+            for d in rows
+            if cli_catalog.has_native_consensus(d.name)
+        }
         if smoke:
             smoke_names = [d.name for d in rows if d.installed]
             payload["smoke"] = [

--- a/tests/blueprints/test_cli_agent.py
+++ b/tests/blueprints/test_cli_agent.py
@@ -337,3 +337,36 @@ async def test_non_consensus_agent_is_still_single_call():
     chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
     assert _final_content(chunks) == "SOLO:ping"
     assert "consensus agent" not in _progress_text(chunks)
+
+
+def test_resolve_consensus_int_is_self_consensus():
+    reg = CliAdapterRegistry.from_config({"cli_agents": {"coder": _ag("C")}})
+    panel, judge = support.resolve_consensus_spec(3, "coder", reg)
+    assert panel == ["coder", "coder", "coder"]  # same persona x3
+    assert judge == "coder"
+
+
+def test_resolve_consensus_int_below_two_is_single():
+    reg = CliAdapterRegistry.from_config({"cli_agents": {"coder": _ag("C")}})
+    assert support.resolve_consensus_spec(1, "coder", reg) is None
+
+
+async def test_param_consensus_self_consensus_runs_n():
+    cfg = {"cli_agents": {"coder": _ag("SOLO")}, "cli_fusion": {"default_cli": "coder"}}
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    bp.set_params({"consensus": 3})
+    chunks = await _collect(bp.run([{"role": "user", "content": "q"}]))
+    assert _final_content(chunks) == "SOLO:q"  # 3 identical samples -> that answer
+    assert "consensus agent" in _progress_text(chunks)
+
+
+async def test_param_consensus_overrides_config_to_single():
+    cfg = {
+        "cli_agents": {"coder": _ag("SOLO", consensus=True), "b": _ag("B")},
+        "cli_fusion": {"default_cli": "coder"},
+    }
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    bp.set_params({"cli": "coder", "consensus": False})  # force single despite config
+    chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
+    assert _final_content(chunks) == "SOLO:ping"
+    assert "consensus agent" not in _progress_text(chunks)

--- a/tests/cli/test_cli_agents_command.py
+++ b/tests/cli/test_cli_agents_command.py
@@ -44,7 +44,9 @@ def test_json_empty_config_emits_empty_agents(tmp_path):
     cfg = _write_config(tmp_path, {})
     result = runner.invoke(app, ["cli-agents", "--json", "--config", cfg])
     assert result.exit_code == 0
-    assert json.loads(result.stdout) == {"agents": []}
+    payload = json.loads(result.stdout)
+    assert payload["agents"] == []
+    assert payload["native_consensus"] == {}  # no configured agents -> none
 
 
 def test_json_lists_configured_agents(tmp_path):

--- a/tests/core/test_cli_catalog.py
+++ b/tests/core/test_cli_catalog.py
@@ -125,3 +125,26 @@ def test_suggest_returns_deep_copies(monkeypatch):
     s = cli_catalog.suggest_unconfigured([], installed_only=True)
     s["claude"]["cmd"].append("--mutated")
     assert "--mutated" not in cli_catalog.CATALOG["claude"]["cmd"]
+
+
+def test_grok_has_native_consensus():
+    assert cli_catalog.has_native_consensus("grok") is True
+    assert cli_catalog.has_native_consensus("claude") is False
+
+
+def test_native_consensus_flags_substitutes_n():
+    assert cli_catalog.native_consensus_flags("grok", 3) == ["--best-of-n", "3"]
+    assert cli_catalog.native_consensus_flags("grok", 1) == ["--best-of-n", "2"]  # clamped >=2
+    assert cli_catalog.native_consensus_flags("claude", 3) is None
+
+
+def test_with_native_consensus_appends_flag():
+    entry = cli_catalog.with_native_consensus("grok", 4)
+    assert entry["cmd"][-2:] == ["--best-of-n", "4"]
+    assert entry["parse"] == "json:.text"  # base entry preserved
+    assert cli_catalog.with_native_consensus("claude", 2) is None  # no native mode
+
+
+def test_with_native_consensus_does_not_mutate_catalog():
+    cli_catalog.with_native_consensus("grok", 2)
+    assert "--best-of-n" not in cli_catalog.CATALOG["grok"]["cmd"]

--- a/uv.lock
+++ b/uv.lock
@@ -1782,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "open-swarm"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Three more consensus modes:
- **Self-consensus** `consensus: N` — run the same persona N times, synthesize (verified live grok x3).
- **Call-time flag** `params.consensus` — per-request override.
- **Native consensus** — catalog records CLIs with a built-in fan-out flag (grok `--best-of-n`, verified live); `cli-agents --json` emits a `native_consensus` map for the UI. Framework + native consensus compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)