### PR TITLE
v0.4.8 — pedantic a11y pass (0 axe WCAG2 A/AA violations, light + dark)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 (nothing yet)
 
+## [0.4.8] - 2026-06-17
+
+### Fixed — accessibility (web UI)
+- Pedantic a11y pass (axe-core, WCAG 2 A/AA): **0 violations across all pages in both light and dark mode** (was several "serious"). Fixes: CodeMirror editor/scroller given an accessible name + keyboard focus (read-only, not editable=false); the config `<pre>` made focusable + labeled; the Settings icon-link labeled; `aria-current` on active list items; replaced fixed `text-gray-*`/low-opacity text with theme-adaptive `text-base-content` tokens (fixed dark-mode contrast); fixed a low-contrast stat color and the CodeMirror dark gutter.
+
 ## [0.4.7] - 2026-06-17
 
 ### Changed — Blueprint Builder polish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-swarm"
-version = "0.4.7"
+version = "0.4.8"
 description = "Open Swarm: Orchestrating AI Agent Swarms with Django"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1782,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "open-swarm"
-version = "0.4.7"
+version = "0.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/webui/frontend/package-lock.json
+++ b/webui/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "@types/react": "^18.3.28",
         "@types/react-dom": "^18.3.7",
         "@vitejs/plugin-react": "^6.0.2",
+        "axe-core": "^4.12.1",
         "eslint": "^8.53.0",
         "eslint-config-react-app": "^7.0.1",
         "eslint-plugin-react-hooks": "^4.6.0",

--- a/webui/frontend/package.json
+++ b/webui/frontend/package.json
@@ -61,6 +61,7 @@
     "@types/react": "^18.3.28",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react": "^6.0.2",
+    "axe-core": "^4.12.1",
     "eslint": "^8.53.0",
     "eslint-config-react-app": "^7.0.1",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/webui/frontend/src/App.tsx
+++ b/webui/frontend/src/App.tsx
@@ -70,7 +70,7 @@ function App() {
                       <Sun className="swap-on h-5 w-5" />
                       <Moon className="swap-off h-5 w-5" />
                     </label>
-                    <Link to="/settings" className="btn btn-ghost btn-sm">
+                    <Link to="/settings" className="btn btn-ghost btn-sm" aria-label="Settings">
                       <Settings className="h-5 w-5" />
                     </Link>
                   </div>
@@ -207,7 +207,7 @@ function Dashboard() {
         <Card compact bordered>
           <div className="stat">
             <div className="stat-title">Models</div>
-            <div className="stat-value text-accent">
+            <div className="stat-value text-primary">
               <StatValue
                 isPending={modelsQuery.isPending}
                 isError={modelsQuery.isError}

--- a/webui/frontend/src/components/ApiAccessPanel.tsx
+++ b/webui/frontend/src/components/ApiAccessPanel.tsx
@@ -56,7 +56,7 @@ function CopyBlock({ label, code }: { label: string; code: string }) {
   return (
     <div className="mt-3">
       <div className="flex items-center justify-between mb-1">
-        <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">{label}</span>
+        <span className="text-xs font-semibold uppercase tracking-wide text-base-content/70">{label}</span>
         <button type="button" className="btn btn-xs" onClick={onCopy} aria-label={`Copy ${label} snippet`}>
           {copied ? 'Copied' : 'Copy'}
         </button>
@@ -81,7 +81,7 @@ export function ApiAccessPanel({ baseUrl, token, models }: ApiAccessPanelProps) 
 
   return (
     <div>
-      <p className="text-sm text-gray-500">
+      <p className="text-sm text-base-content/70">
         Point any OpenAI-compatible client at this server. The <code>model</code> field selects the
         blueprint (e.g. <code>cli_fusion</code>).{' '}
         {token ? 'Use your API token as the key.' : 'Auth is disabled — any key works.'}

--- a/webui/frontend/src/components/CodeViewer.tsx
+++ b/webui/frontend/src/components/CodeViewer.tsx
@@ -1,5 +1,16 @@
 import CodeMirror from '@uiw/react-codemirror'
 import { python } from '@codemirror/lang-python'
+import { EditorView } from '@codemirror/view'
+
+// Give CodeMirror's editable region (.cm-content, role=textbox) an accessible
+// name so screen readers announce it (axe: aria-input-field-name).
+const a11yLabel = EditorView.contentAttributes.of({
+  'aria-label': 'Blueprint source code (read-only)',
+})
+
+// The @uiw dark theme's gutter line numbers (#7d8799 on #282c34 = 3.86:1) fail
+// WCAG AA; lift them to a passing contrast in dark mode only.
+const darkGutterContrast = EditorView.theme({ '.cm-gutterElement': { color: '#aeb6c2' } })
 
 /** Match the app's DaisyUI theme (App sets data-theme on a wrapper div). */
 function isDark(): boolean {
@@ -10,14 +21,21 @@ function isDark(): boolean {
 /** Read-only, syntax-highlighted code view. Lazy-loaded to keep CodeMirror out
  * of the main bundle. */
 export default function CodeViewer({ value, height = '420px' }: { value: string; height?: string }) {
+  const dark = isDark()
   return (
     <CodeMirror
       value={value}
       height={height}
-      theme={isDark() ? 'dark' : 'light'}
-      extensions={[python()]}
-      editable={false}
-      basicSetup={{ lineNumbers: true, foldGutter: true, highlightActiveLine: false }}
+      theme={dark ? 'dark' : 'light'}
+      extensions={dark ? [python(), a11yLabel, darkGutterContrast] : [python(), a11yLabel]}
+      readOnly
+      onCreateEditor={(view) => {
+        // Make the scroll container keyboard-reachable + named
+        // (axe: scrollable-region-focusable).
+        view.scrollDOM.setAttribute('tabindex', '0')
+        view.scrollDOM.setAttribute('role', 'region')
+        view.scrollDOM.setAttribute('aria-label', 'Blueprint source code (read-only)')
+      }}
     />
   )
 }

--- a/webui/frontend/src/components/DaisyUI/Pagination.tsx
+++ b/webui/frontend/src/components/DaisyUI/Pagination.tsx
@@ -195,13 +195,13 @@ export const AdvancedPagination = ({
 
   return (
     <div className={`flex flex-col sm:flex-row items-center justify-between gap-4 ${className}`}>
-      <div className="text-sm text-gray-500">
+      <div className="text-sm text-base-content/70">
         Showing {(currentPage - 1) * itemsPerPage + 1} to 
         {Math.min(currentPage * itemsPerPage, totalItems)} of {totalItems} items
       </div>
 
       <div className="flex items-center gap-2">
-        <span className="text-sm text-gray-500">Items per page:</span>
+        <span className="text-sm text-base-content/70">Items per page:</span>
         <select
           className="select select-bordered select-sm"
           value={itemsPerPage}

--- a/webui/frontend/src/components/DaisyUI/Tabs.tsx
+++ b/webui/frontend/src/components/DaisyUI/Tabs.tsx
@@ -288,7 +288,7 @@ export const Stepper = ({
           </button>
         ))}
       </div>
-      <div className="text-sm text-gray-500">
+      <div className="text-sm text-base-content/70">
         Step {activeStep + 1} of {steps.length}
       </div>
     </div>

--- a/webui/frontend/src/pages/AgentCreatorPage.tsx
+++ b/webui/frontend/src/pages/AgentCreatorPage.tsx
@@ -178,7 +178,7 @@ const AgentCreatorPageContent = () => {
           <Wand2 className="h-8 w-8" />
           Agent Creator
         </h1>
-        <p className="text-gray-500 mt-1">
+        <p className="text-base-content/70 mt-1">
           Generate a blueprint from a persona spec, validate the Python code
           server-side, and save it to the custom blueprint library
           (/v1/blueprints/custom/).
@@ -256,7 +256,7 @@ const AgentCreatorPageContent = () => {
             <ShieldCheck className="h-5 w-5" />
             Blueprint code
           </h2>
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-base-content/70">
             Generated code lands here; you can also paste or edit code by hand
             before validating and saving.
           </p>
@@ -384,9 +384,9 @@ const AgentCreatorPageContent = () => {
 
         {!customQuery.isPending && !customQuery.isError && customBlueprints.length === 0 && (
           <Card bordered className="text-center py-10">
-            <Bot className="h-14 w-14 mx-auto text-gray-400 mb-3" />
+            <Bot className="h-14 w-14 mx-auto text-base-content/60 mb-3" />
             <h3 className="text-lg font-semibold mb-1">No custom blueprints yet</h3>
-            <p className="text-gray-500 text-sm">
+            <p className="text-base-content/70 text-sm">
               Agents saved from this page appear here (stored in the server's
               blueprint library).
             </p>
@@ -404,7 +404,7 @@ const AgentCreatorPageContent = () => {
                       {blueprint.category}
                     </Badge>
                   </div>
-                  <p className="text-sm text-gray-500 mb-2">
+                  <p className="text-sm text-base-content/70 mb-2">
                     {blueprint.description || 'No description provided.'}
                   </p>
                   {blueprint.tags.length > 0 && (

--- a/webui/frontend/src/pages/BlueprintsPage.tsx
+++ b/webui/frontend/src/pages/BlueprintsPage.tsx
@@ -184,7 +184,7 @@ const BlueprintsPageContent = () => {
                     </span>
                   </div>
 
-                  <p className="text-xs text-base-content/50 font-mono">{blueprint.id}</p>
+                  <p className="text-xs text-base-content/70 font-mono">{blueprint.id}</p>
                   <p
                     className="text-sm text-base-content/70 line-clamp-3"
                     title={blueprint.description}
@@ -260,7 +260,7 @@ const BlueprintsPageContent = () => {
       {!isPending && !isError && filteredBlueprints.length === 0 && (
         <Card bordered className="text-center py-12">
           <div className="mb-4">
-            <Book className="h-16 w-16 mx-auto text-base-content/40" />
+            <Book className="h-16 w-16 mx-auto text-base-content/70" />
           </div>
           <h3 className="text-xl font-semibold mb-2">No blueprints found</h3>
           <p className="text-base-content/70 mb-4">

--- a/webui/frontend/src/pages/BuilderPage.tsx
+++ b/webui/frontend/src/pages/BuilderPage.tsx
@@ -116,7 +116,7 @@ function AgentConfigBuilder({ info }: { info: CliAgentsInfo | undefined }) {
 
       <div className="mt-3">
         <div className="mb-1 flex items-center justify-between">
-          <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">cli_agents config</span>
+          <span className="text-xs font-semibold uppercase tracking-wide text-base-content/70">cli_agents config</span>
           <div className="flex gap-1">
             <button type="button" className="btn btn-xs gap-1" onClick={download} aria-label="Download config">
               <Download className="h-3.5 w-3.5" /> Download
@@ -127,7 +127,12 @@ function AgentConfigBuilder({ info }: { info: CliAgentsInfo | undefined }) {
             </button>
           </div>
         </div>
-        <pre className="max-h-64 overflow-auto rounded-lg bg-base-300 p-3 text-xs"><code>{json}</code></pre>
+        <pre
+          tabIndex={0}
+          role="region"
+          aria-label="Generated cli_agents config JSON"
+          className="max-h-64 overflow-auto rounded-lg bg-base-300 p-3 text-xs focus:outline focus:outline-2 focus:outline-primary"
+        ><code>{json}</code></pre>
       </div>
     </Card>
   )
@@ -153,7 +158,7 @@ export default function BuilderPage() {
       <h1 className="mb-1 flex items-center gap-2 text-3xl font-bold">
         <Wrench className="h-7 w-7" /> Blueprint Builder
       </h1>
-      <p className="mb-6 text-sm text-gray-500">
+      <p className="mb-6 text-sm text-base-content/70">
         Configure and edit any blueprint — its agents, model setup, and files.
       </p>
 
@@ -169,6 +174,7 @@ export default function BuilderPage() {
                 <li key={b.id}>
                   <button
                     className={b.id === selected?.id ? 'active' : ''}
+                    aria-current={b.id === selected?.id ? 'true' : undefined}
                     onClick={() => {
                       setSelectedId(b.id)
                       setOpenFile(null)
@@ -186,7 +192,7 @@ export default function BuilderPage() {
               <h2 className="card-title flex items-center gap-2 text-base">
                 {selected?.id ?? '—'}
               </h2>
-              <p className="text-sm text-gray-500">{selected?.description || 'No description.'}</p>
+              <p className="text-sm text-base-content/70">{selected?.description || 'No description.'}</p>
               <div className="mt-2 flex flex-wrap gap-1">
                 {(selected?.tags ?? []).map((t) => (
                   <Badge key={t}>{t}</Badge>
@@ -200,7 +206,7 @@ export default function BuilderPage() {
               <h2 className="card-title flex items-center gap-2 text-base">
                 <FileCode className="h-5 w-5" /> Source
                 {source.data?.selected && (
-                  <code className="text-xs font-normal text-gray-500">{source.data.selected}</code>
+                  <code className="text-xs font-normal text-base-content/70">{source.data.selected}</code>
                 )}
               </h2>
               {source.isPending && <LoadingSpinner size="sm" />}
@@ -212,6 +218,7 @@ export default function BuilderPage() {
                       <li key={f.path}>
                         <button
                           className={f.name === source.data!.selected ? 'active' : ''}
+                          aria-current={f.name === source.data!.selected ? 'true' : undefined}
                           onClick={() => setOpenFile(f.name)}
                         >
                           <FileText className="h-3.5 w-3.5" />

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -276,7 +276,7 @@ const ChatPage = () => {
                       ? 'Connecting to the chat websocket…'
                       : 'Websocket not connected'}
                 </p>
-                <p className="text-sm text-base-content/50">
+                <p className="text-sm text-base-content/70">
                   {status === 'open'
                     ? 'Send a message below to start the conversation.'
                     : status === 'connecting'

--- a/webui/frontend/src/pages/SettingsPage.tsx
+++ b/webui/frontend/src/pages/SettingsPage.tsx
@@ -82,7 +82,7 @@ const SettingsPage = () => {
             <KeyRound className="h-5 w-5" />
             API Authentication
           </h2>
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-base-content/70">
             The backend uses a static bearer token (its{' '}
             <code>API_AUTH_TOKEN</code> setting). The token is stored locally
             in your browser and sent as an <code>Authorization: Bearer</code>{' '}
@@ -193,14 +193,14 @@ function SettingsGroupTable({ group }: { group: ServerSettingsGroup }) {
     <details className="collapse collapse-arrow bg-base-200">
       <summary className="collapse-title font-medium">
         {group.icon} {group.title}{' '}
-        <span className="text-sm font-normal text-gray-500">
+        <span className="text-sm font-normal text-base-content/70">
           ({entries.length} {entries.length === 1 ? 'setting' : 'settings'})
         </span>
       </summary>
       <div className="collapse-content overflow-x-auto">
-        <p className="text-sm text-gray-500 mb-2">{group.description}</p>
+        <p className="text-sm text-base-content/70 mb-2">{group.description}</p>
         {entries.length === 0 ? (
-          <p className="text-sm text-gray-400">No settings reported in this group.</p>
+          <p className="text-sm text-base-content/60">No settings reported in this group.</p>
         ) : (
           <table className="table table-sm">
             <thead>
@@ -215,7 +215,7 @@ function SettingsGroupTable({ group }: { group: ServerSettingsGroup }) {
                 <tr key={settingName}>
                   <td>
                     <div className="font-mono text-xs">{settingName}</div>
-                    <div className="text-xs text-gray-500">{entry.description}</div>
+                    <div className="text-xs text-base-content/70">{entry.description}</div>
                   </td>
                   <td className="font-mono text-xs break-all">
                     {formatSettingValue(settingName, entry.value)}
@@ -245,7 +245,7 @@ function ServerSettingsCard() {
         <ServerCog className="h-5 w-5" />
         Server Settings
       </h2>
-      <p className="text-sm text-gray-500">
+      <p className="text-sm text-base-content/70">
         Read-only view of the server configuration reported by{' '}
         <code>/settings/api/</code>. Sensitive values are masked by the server;
         anything secret-looking is additionally reduced to its last 4
@@ -254,7 +254,7 @@ function ServerSettingsCard() {
 
       <div className="mt-3">
         {isPending && (
-          <div className="flex items-center gap-2 text-sm text-gray-500">
+          <div className="flex items-center gap-2 text-sm text-base-content/70">
             <LoadingSpinner size="sm" /> Loading server settings…
           </div>
         )}
@@ -266,7 +266,7 @@ function ServerSettingsCard() {
           />
         )}
         {!isPending && !isError && groups.length === 0 && (
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-base-content/60">
             The server reported no settings groups.
           </p>
         )}
@@ -296,7 +296,7 @@ function EnvironmentVariablesCard() {
         <TerminalSquare className="h-5 w-5" />
         Environment Variables
       </h2>
-      <p className="text-sm text-gray-500">
+      <p className="text-sm text-base-content/70">
         Swarm-related environment variables on the server, from{' '}
         <code>/settings/environment/</code>. The server replaces values of
         key/token/secret/password variables with <code>***SET***</code>; the
@@ -305,7 +305,7 @@ function EnvironmentVariablesCard() {
 
       <div className="mt-3">
         {isPending && (
-          <div className="flex items-center gap-2 text-sm text-gray-500">
+          <div className="flex items-center gap-2 text-sm text-base-content/70">
             <LoadingSpinner size="sm" /> Loading environment variables…
           </div>
         )}
@@ -317,7 +317,7 @@ function EnvironmentVariablesCard() {
           />
         )}
         {!isPending && !isError && variables.length === 0 && (
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-base-content/60">
             No swarm-related environment variables are set on the server.
           </p>
         )}

--- a/webui/frontend/src/pages/TeamsPage.tsx
+++ b/webui/frontend/src/pages/TeamsPage.tsx
@@ -100,7 +100,7 @@ const TeamsPageContent = () => {
             <Users className="h-8 w-8" />
             Team Management
           </h1>
-          <p className="text-gray-500 mt-1">
+          <p className="text-base-content/70 mt-1">
             Create and manage dynamic AI teams (served by /v1/teams/)
           </p>
         </div>
@@ -150,7 +150,7 @@ const TeamsPageContent = () => {
                     {team.llm_profile}
                   </Badge>
                 </div>
-                <p className="text-sm text-gray-500 mb-4 whitespace-pre-line">
+                <p className="text-sm text-base-content/70 mb-4 whitespace-pre-line">
                   {team.description || 'No description provided.'}
                 </p>
                 <div className="card-actions justify-end">
@@ -185,10 +185,10 @@ const TeamsPageContent = () => {
       {!isPending && !isError && teams.length === 0 && (
         <Card bordered className="text-center py-12">
           <div className="mb-4">
-            <Users className="h-16 w-16 mx-auto text-gray-400" />
+            <Users className="h-16 w-16 mx-auto text-base-content/60" />
           </div>
           <h3 className="text-xl font-semibold mb-2">No teams yet</h3>
-          <p className="text-gray-500 mb-4">
+          <p className="text-base-content/70 mb-4">
             No dynamic teams are registered on this server.
           </p>
           <div>
@@ -227,7 +227,7 @@ const TeamsPageContent = () => {
             value={llmProfile}
             onChange={(e) => setLlmProfile(e.target.value)}
           />
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-base-content/60">
             The name is slugified server-side (lowercase letters, numbers and
             dashes) and exposed as a model id via /v1/models.
           </p>


### PR DESCRIPTION
Ran axe-core across all 7 pages in light and dark mode and fixed every serious violation: CodeMirror accessible name + keyboard focus, focusable/labeled config block, labeled Settings icon-link, aria-current on active items, theme-adaptive text tokens (fixes dark-mode contrast), low-contrast stat color + CodeMirror dark gutter. **Result: 0 violations in both themes.** 19 vitest, tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)