### PR TITLE
v0.4.9 — responsive/mobile UI polish + mobile a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 (nothing yet)
 
+## [0.4.9] - 2026-06-17
+
+### Fixed — responsive / mobile (web UI)
+- Builder: the blueprint list (a desktop sidebar) buried the config + editor on mobile; below `lg` it's now a compact blueprint **dropdown**, so the agent/model config and source editor are immediately reachable.
+- Mobile a11y: the API Access snippet `<pre>` blocks and the chat message list became scrollable-region-focusable violations at narrow widths — made keyboard-focusable + labeled. **0 axe WCAG2 A/AA violations across mobile (light+dark) and desktop.**
+
 ## [0.4.8] - 2026-06-17
 
 ### Fixed — accessibility (web UI)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-swarm"
-version = "0.4.8"
+version = "0.4.9"
 description = "Open Swarm: Orchestrating AI Agent Swarms with Django"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1782,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "open-swarm"
-version = "0.4.8"
+version = "0.4.9"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/webui/frontend/src/components/ApiAccessPanel.tsx
+++ b/webui/frontend/src/components/ApiAccessPanel.tsx
@@ -61,7 +61,12 @@ function CopyBlock({ label, code }: { label: string; code: string }) {
           {copied ? 'Copied' : 'Copy'}
         </button>
       </div>
-      <pre className="bg-base-300 rounded p-3 text-xs overflow-x-auto">
+      <pre
+        tabIndex={0}
+        role="region"
+        aria-label={`${label} snippet`}
+        className="bg-base-300 rounded p-3 text-xs overflow-x-auto focus:outline focus:outline-2 focus:outline-primary"
+      >
         <code>{code}</code>
       </pre>
     </div>

--- a/webui/frontend/src/pages/BuilderPage.tsx
+++ b/webui/frontend/src/pages/BuilderPage.tsx
@@ -167,7 +167,9 @@ export default function BuilderPage() {
 
       {!isPending && !isError && (
         <div className="grid gap-4 lg:grid-cols-[240px_1fr]">
-          <Card bordered>
+          {/* Sidebar list on desktop; a compact dropdown on mobile so the config
+              and editor aren't buried below a 21-item list. */}
+          <Card bordered className="hidden lg:block">
             <h2 className="card-title text-base">Blueprints ({blueprints.length})</h2>
             <ul className="menu menu-sm px-0">
               {blueprints.map((b) => (
@@ -188,6 +190,26 @@ export default function BuilderPage() {
           </Card>
 
           <div className="space-y-4">
+            {/* Mobile blueprint picker (the desktop sidebar is hidden < lg). */}
+            <label className="form-control lg:hidden">
+              <span className="label-text text-xs">Blueprint ({blueprints.length})</span>
+              <select
+                className="select select-bordered select-sm font-mono"
+                aria-label="Select blueprint"
+                value={selected?.id ?? ''}
+                onChange={(e) => {
+                  setSelectedId(e.target.value)
+                  setOpenFile(null)
+                }}
+              >
+                {blueprints.map((b) => (
+                  <option key={b.id} value={b.id}>
+                    {b.id}
+                  </option>
+                ))}
+              </select>
+            </label>
+
             <Card bordered>
               <h2 className="card-title flex items-center gap-2 text-base">
                 {selected?.id ?? '—'}

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -262,8 +262,11 @@ const ChatPage = () => {
       {/* Conversation: scrollable message list + composer pinned at bottom */}
       <div className="card flex min-h-0 flex-1 flex-col overflow-hidden border border-base-300 bg-base-100">
         <div
-          className="min-h-0 flex-1 space-y-1 overflow-y-auto p-4"
+          className="min-h-0 flex-1 space-y-1 overflow-y-auto p-4 focus:outline focus:outline-2 focus:outline-primary"
           aria-live="polite"
+          role="log"
+          aria-label="Conversation"
+          tabIndex={0}
         >
           {messages.length === 0 ? (
             <div className="flex h-full flex-col items-center justify-center gap-3 text-center">


### PR DESCRIPTION
Mobile Builder: blueprint dropdown instead of a buried 21-item list. Fixed mobile-only scrollable-region-focusable a11y on the API Access snippets + chat list. 0 axe violations across mobile (light+dark) + desktop. 19 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)