### PR TITLE
v0.4.10 — Builder file-browser polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 (nothing yet)
 
+## [0.4.10] - 2026-06-17
+
+### Changed — Builder visual polish
+- The source file-browser is shown only when a blueprint has more than one file; single-file blueprints get a full-width editor instead of a lonely 1-item list. Verified: tap targets all >=24px across pages; axe stays at 0 (mobile+desktop, light+dark).
+
 ## [0.4.9] - 2026-06-17
 
 ### Fixed — responsive / mobile (web UI)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-swarm"
-version = "0.4.9"
+version = "0.4.10"
 description = "Open Swarm: Orchestrating AI Agent Swarms with Django"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1782,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "open-swarm"
-version = "0.4.9"
+version = "0.4.10"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/webui/frontend/src/pages/BuilderPage.tsx
+++ b/webui/frontend/src/pages/BuilderPage.tsx
@@ -234,21 +234,25 @@ export default function BuilderPage() {
               {source.isPending && <LoadingSpinner size="sm" />}
               {source.isError && <Alert type="warning">Source unavailable for this blueprint.</Alert>}
               {source.data && (
-                <div className="grid gap-3 md:grid-cols-[180px_1fr]">
-                  <ul className="menu menu-xs rounded-box bg-base-200 px-1">
-                    {source.data.files.map((f) => (
-                      <li key={f.path}>
-                        <button
-                          className={f.name === source.data!.selected ? 'active' : ''}
-                          aria-current={f.name === source.data!.selected ? 'true' : undefined}
-                          onClick={() => setOpenFile(f.name)}
-                        >
-                          <FileText className="h-3.5 w-3.5" />
-                          {f.name}
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
+                // Show the file browser only when there's more than one file;
+                // otherwise the editor takes the full width (no lonely 1-item list).
+                <div className={source.data.files.length > 1 ? 'grid gap-3 md:grid-cols-[180px_1fr]' : ''}>
+                  {source.data.files.length > 1 && (
+                    <ul className="menu menu-xs rounded-box bg-base-200 px-1" aria-label="Blueprint files">
+                      {source.data.files.map((f) => (
+                        <li key={f.path}>
+                          <button
+                            className={f.name === source.data!.selected ? 'active' : ''}
+                            aria-current={f.name === source.data!.selected ? 'true' : undefined}
+                            onClick={() => setOpenFile(f.name)}
+                          >
+                            <FileText className="h-3.5 w-3.5" />
+                            {f.name}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
                   <div className="overflow-hidden rounded-lg border border-base-300">
                     <Suspense fallback={<div className="p-4"><LoadingSpinner size="sm" /></div>}>
                       <CodeViewer value={source.data.content} />


### PR DESCRIPTION
Source file-browser shown only when >1 file (full-width editor otherwise). Tap targets all >=24px; axe 0 across mobile+desktop, light+dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)