### PR TITLE
fix(webui): best-practice a11y (landmarks, h1, heading-order) + CLI permutation proof — 0.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project will be documented in this file.
 
 (nothing yet)
 
+## [0.4.11] - 2026-06-17
+
+### Fixed — accessibility best-practice (web UI)
+- A deeper axe pass with the **full** ruleset (not just WCAG2 A/AA) surfaced best-practice violations the scoped run missed, now all fixed:
+  - `landmark-one-main` / `region`: page content is wrapped in a single `<main>` so every region sits inside a landmark.
+  - `page-has-heading-one`: the Dashboard had no `<h1>` — added one.
+  - `heading-order`: Blueprints/Teams card titles jumped from `<h1>` to `<h3>`; demoted to `<h2>`.
+- Adds reusable `webui/frontend/scripts/a11y-audit.mjs` (full ruleset, 7 routes × light/dark × desktop/mobile). **0 violations across all 28 combinations.**
+
+### Added — CLI permutation proof
+- `scripts/prove_cli_permutations.py` exercises every installed CLI through every framework mode (cli_agent, cli_fusion panel, cli_orchestrator, cli_map, self-consensus ×2, native best-of-n). Verified live: **12/12 permutations PASS** across claude + gemini + grok + opencode.
+
 ## [0.4.10] - 2026-06-17
 
 ### Changed — Builder visual polish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-swarm"
-version = "0.4.10"
+version = "0.4.11"
 description = "Open Swarm: Orchestrating AI Agent Swarms with Django"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/prove_cli_permutations.py
+++ b/scripts/prove_cli_permutations.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Prove every available CLI works across every framework permutation.
+
+Discovers the installed catalog CLIs and exercises them LIVE through each
+blueprint/consensus mode, printing a PASS/FAIL matrix with verbatim output.
+
+Run:  DJANGO_DEBUG=true python scripts/prove_cli_permutations.py
+"""
+import asyncio
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "swarm.settings")
+os.environ.setdefault("DJANGO_DEBUG", "true")
+import django  # noqa: E402
+
+django.setup()
+
+from swarm.core import cli_catalog  # noqa: E402
+from swarm.blueprints.cli_agent.blueprint_cli_agent import CliAgentBlueprint  # noqa: E402
+from swarm.blueprints.cli_fusion.blueprint_cli_fusion import CliFusionBlueprint  # noqa: E402
+from swarm.blueprints.cli_orchestrator.blueprint_cli_orchestrator import CliOrchestratorBlueprint  # noqa: E402
+from swarm.blueprints.cli_map.blueprint_cli_map import CliMapBlueprint  # noqa: E402
+
+WD = "/tmp/prove_perms"
+os.makedirs(WD, exist_ok=True)
+Q = "In one word, what is the capital of France?"
+
+INSTALLED = cli_catalog.installed_catalog_clis()
+AGENTS = {n: {**cli_catalog.catalog_entry(n), "timeout": 90} for n in INSTALLED}
+PRIMARY = "grok" if "grok" in INSTALLED else (INSTALLED[0] if INSTALLED else None)
+
+results = []  # (permutation, status, verbatim)
+
+
+def record(name, ans):
+    text = (ans or "").strip()
+    low = text.lower()
+    ok = bool(text) and "all cli" not in low and "unavailable" not in low and "no cli agents" not in low
+    results.append((name, "PASS" if ok else "FAIL", text.replace("\n", " ")[:90]))
+
+
+async def drive(bp, params):
+    bp.set_params({**params, "workdir": WD})
+    out = None
+    async for c in bp.run([{"role": "user", "content": Q}], stream=False):
+        m = c.get("messages") if isinstance(c, dict) else None
+        if m and m[0].get("content") is not None:
+            out = m[0]["content"]
+    return out
+
+
+async def main():
+    print(f"Installed CLIs: {INSTALLED}\n")
+
+    # 1. cli_agent — each CLI as a single agent
+    for cli in INSTALLED:
+        cfg = {"cli_agents": AGENTS, "cli_fusion": {"default_cli": cli}}
+        try:
+            record(f"cli_agent[{cli}]", await drive(CliAgentBlueprint(config=cfg), {"cli": cli, "failover": False}))
+        except Exception as e:  # noqa: BLE001
+            results.append((f"cli_agent[{cli}]", "ERR", str(e)[:90]))
+
+    panel = list(INSTALLED)
+    fcfg = {"cli_agents": AGENTS,
+            "cli_fusion": {"default_cli": PRIMARY, "default_preset": "all",
+                           "presets": {"all": {"panel": panel, "judge": PRIMARY}}}}
+
+    # 2. cli_fusion — consensus over the whole panel
+    try:
+        record("cli_fusion[all]", await drive(CliFusionBlueprint(config=fcfg), {"preset": "all"}))
+    except Exception as e:  # noqa: BLE001
+        results.append(("cli_fusion[all]", "ERR", str(e)[:90]))
+
+    # 3. cli_orchestrator — router + (forced) escalation
+    ocfg = {"cli_agents": AGENTS, "cli_orchestrator": {"router": PRIMARY, "panel": panel, "judge": PRIMARY}}
+    try:
+        record("cli_orchestrator", await drive(CliOrchestratorBlueprint(config=ocfg),
+               {"router": PRIMARY, "panel": panel}))
+    except Exception as e:  # noqa: BLE001
+        results.append(("cli_orchestrator", "ERR", str(e)[:90]))
+
+    # 4. cli_map — decompose / distribute / reduce
+    mcfg = {"cli_agents": AGENTS, "cli_map": {"planner": PRIMARY, "workers": panel, "reducer": PRIMARY}}
+    try:
+        record("cli_map", await drive(CliMapBlueprint(config=mcfg), {}))
+    except Exception as e:  # noqa: BLE001
+        results.append(("cli_map", "ERR", str(e)[:90]))
+
+    # 5. self-consensus — same persona x2 (one per CLI)
+    for cli in INSTALLED:
+        cfg = {"cli_agents": AGENTS, "cli_fusion": {"default_cli": cli}}
+        try:
+            record(f"self-consensus[{cli}x2]",
+                   await drive(CliAgentBlueprint(config=cfg), {"cli": cli, "consensus": 2}))
+        except Exception as e:  # noqa: BLE001
+            results.append((f"self-consensus[{cli}x2]", "ERR", str(e)[:90]))
+
+    # 6. native best-of-n — for each CLI that has a built-in mode
+    for cli in INSTALLED:
+        if not cli_catalog.has_native_consensus(cli):
+            continue
+        entry = {**cli_catalog.with_native_consensus(cli, 2), "timeout": 120}
+        cfg = {"cli_agents": {**AGENTS, cli: entry}, "cli_fusion": {"default_cli": cli}}
+        try:
+            record(f"native-best-of-n[{cli}]",
+                   await drive(CliAgentBlueprint(config=cfg), {"cli": cli, "failover": False}))
+        except Exception as e:  # noqa: BLE001
+            results.append((f"native-best-of-n[{cli}]", "ERR", str(e)[:90]))
+
+    # --- matrix ---
+    print("=" * 100)
+    print(f"  {'PERMUTATION':32} {'STATUS':6} VERBATIM")
+    print("=" * 100)
+    npass = 0
+    for name, status, text in results:
+        if status == "PASS":
+            npass += 1
+        print(f"  {name:32} {status:6} {text}")
+    print("=" * 100)
+    print(f"  {npass}/{len(results)} permutations PASS")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/uv.lock
+++ b/uv.lock
@@ -1782,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "open-swarm"
-version = "0.4.10"
+version = "0.4.11"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/webui/frontend/scripts/a11y-audit.mjs
+++ b/webui/frontend/scripts/a11y-audit.mjs
@@ -1,0 +1,72 @@
+// Full-ruleset accessibility audit (WCAG2 A/AA + best-practice).
+// Walks every route in both light and dark themes, injects axe-core into the
+// live page, runs the COMPLETE ruleset (no runOnly filter), and prints every
+// violation verbatim. Exit 1 if any violation is found.
+//
+// Run:  node scripts/a11y-audit.mjs [baseUrl]
+import { chromium } from 'playwright'
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const axePath = require.resolve('axe-core/axe.min.js')
+const axeSource = readFileSync(axePath, 'utf8')
+
+const BASE = process.argv[2] || 'http://127.0.0.1:8011'
+const ROUTES = ['/', '/chat', '/teams', '/blueprints', '/builder', '/agent-creator', '/settings']
+const THEMES = ['light', 'dark']
+const VIEWPORTS = [
+  { name: 'desktop', width: 1280, height: 900 },
+  { name: 'mobile', width: 390, height: 844 },
+]
+
+const consoleErrors = []
+let totalViolations = 0
+
+const browser = await chromium.launch()
+for (const vp of VIEWPORTS) {
+  const ctx = await browser.newContext({ viewport: { width: vp.width, height: vp.height } })
+  const page = await ctx.newPage()
+  page.on('console', (m) => {
+    if (m.type() === 'error') consoleErrors.push(`[${vp.name}] ${m.text()}`)
+  })
+  page.on('pageerror', (e) => consoleErrors.push(`[${vp.name}] pageerror: ${e.message}`))
+
+  for (const theme of THEMES) {
+    for (const route of ROUTES) {
+      const url = `${BASE}${route}`
+      await page.goto(url, { waitUntil: 'networkidle' }).catch(() => {})
+      // App stores theme on a data-theme attr toggled by a checkbox; force it.
+      await page.evaluate((t) => {
+        localStorage.setItem('swarm_theme', t)
+        document.querySelectorAll('[data-theme]').forEach((el) => el.setAttribute('data-theme', t))
+      }, theme)
+      await page.waitForTimeout(150)
+      await page.addScriptTag({ content: axeSource })
+      const result = await page.evaluate(async () => await window.axe.run(document))
+      const tag = `${vp.name}/${theme}${route}`
+      if (result.violations.length === 0) {
+        console.log(`  PASS  ${tag}`)
+      } else {
+        totalViolations += result.violations.length
+        console.log(`  FAIL  ${tag}  (${result.violations.length})`)
+        for (const v of result.violations) {
+          console.log(`        • [${v.impact}] ${v.id}: ${v.help}`)
+          for (const n of v.nodes.slice(0, 3)) {
+            console.log(`            ${n.target.join(' ')}`)
+          }
+        }
+      }
+    }
+  }
+  await ctx.close()
+}
+await browser.close()
+
+console.log('\n' + '='.repeat(70))
+console.log(`Total axe violations: ${totalViolations}`)
+const uniqErrors = [...new Set(consoleErrors)]
+console.log(`Console errors: ${uniqErrors.length}`)
+for (const e of uniqErrors) console.log(`  • ${e}`)
+console.log('='.repeat(70))
+process.exit(totalViolations === 0 ? 0 : 1)

--- a/webui/frontend/scripts/shots.mjs
+++ b/webui/frontend/scripts/shots.mjs
@@ -1,0 +1,27 @@
+// Capture full-page screenshots of key routes in light + dark for visual review.
+import { chromium } from 'playwright'
+import { mkdirSync } from 'node:fs'
+
+const BASE = process.argv[2] || 'http://127.0.0.1:8011'
+const OUT = process.argv[3] || '/tmp/swarm_shots'
+mkdirSync(OUT, { recursive: true })
+const ROUTES = [['/', 'dashboard'], ['/blueprints', 'blueprints'], ['/builder', 'builder'], ['/chat', 'chat']]
+const THEMES = ['light', 'dark']
+
+const browser = await chromium.launch()
+const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 } })
+const page = await ctx.newPage()
+for (const theme of THEMES) {
+  for (const [route, name] of ROUTES) {
+    await page.goto(`${BASE}${route}`, { waitUntil: 'networkidle' }).catch(() => {})
+    await page.evaluate((t) => {
+      localStorage.setItem('swarm_theme', t)
+      document.querySelectorAll('[data-theme]').forEach((el) => el.setAttribute('data-theme', t))
+    }, theme)
+    await page.waitForTimeout(250)
+    const file = `${OUT}/${name}-${theme}.png`
+    await page.screenshot({ path: file, fullPage: true })
+    console.log(file)
+  }
+}
+await browser.close()

--- a/webui/frontend/src/App.tsx
+++ b/webui/frontend/src/App.tsx
@@ -78,11 +78,10 @@ function App() {
               </div>
             </nav>
 
-            {/* Auth failure banner (only shown after a real 401/403) */}
-            <AuthErrorBanner />
-
             {/* Main Content (pb-24 clears the fixed mobile dock below lg) */}
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8 pb-24 lg:pb-8">
+            <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8 pb-24 lg:pb-8">
+              {/* Auth failure banner (only shown after a real 401/403) */}
+              <AuthErrorBanner />
               <Routes>
                 <Route path="/" element={<Dashboard />} />
                 <Route path="/chat" element={<ChatPage />} />
@@ -92,7 +91,7 @@ function App() {
                 <Route path="/agent-creator" element={<AgentCreatorPage />} />
                 <Route path="/settings" element={<SettingsPage />} />
               </Routes>
-            </div>
+            </main>
 
             {/* Bottom Navigation (Mobile) — DaisyUI 5 "dock" (btm-nav was
                 removed in v5); fixed to the viewport bottom below lg. */}
@@ -182,6 +181,10 @@ function Dashboard() {
 
   return (
     <div className="space-y-6">
+      <h1 className="text-3xl font-bold flex items-center gap-2">
+        <Home className="h-7 w-7" /> Dashboard
+      </h1>
+
       {/* Welcome Alert */}
       <Alert type="info" icon={<Home className="h-5 w-5" />}>
         <span className="font-medium">Welcome to Open Swarm!&nbsp;</span>

--- a/webui/frontend/src/pages/BlueprintsPage.tsx
+++ b/webui/frontend/src/pages/BlueprintsPage.tsx
@@ -178,7 +178,7 @@ const BlueprintsPageContent = () => {
                       WhiskeyTangoFoxtrotBlueprint) must not push the badge
                       outside the card / widen the page on small screens. */}
                   <div className="flex flex-wrap justify-between items-start gap-2">
-                    <h3 className="card-title text-base leading-snug min-w-0 break-words">{blueprint.name}</h3>
+                    <h2 className="card-title text-base leading-snug min-w-0 break-words">{blueprint.name}</h2>
                     <span className="badge badge-neutral badge-sm font-mono shrink-0">
                       {blueprint.abbreviation || blueprint.id}
                     </span>
@@ -262,7 +262,7 @@ const BlueprintsPageContent = () => {
           <div className="mb-4">
             <Book className="h-16 w-16 mx-auto text-base-content/70" />
           </div>
-          <h3 className="text-xl font-semibold mb-2">No blueprints found</h3>
+          <h2 className="text-xl font-semibold mb-2">No blueprints found</h2>
           <p className="text-base-content/70 mb-4">
             {searchTerm || libraryOnly
               ? 'No blueprints match your search criteria'

--- a/webui/frontend/src/pages/TeamsPage.tsx
+++ b/webui/frontend/src/pages/TeamsPage.tsx
@@ -145,7 +145,7 @@ const TeamsPageContent = () => {
             <Card key={team.id} bordered className="hover:shadow-lg transition-shadow">
               <div className="card-body">
                 <div className="flex justify-between items-start gap-2 mb-2">
-                  <h3 className="card-title font-mono text-lg">{team.id}</h3>
+                  <h2 className="card-title font-mono text-lg">{team.id}</h2>
                   <Badge type="info" size="sm">
                     {team.llm_profile}
                   </Badge>
@@ -187,7 +187,7 @@ const TeamsPageContent = () => {
           <div className="mb-4">
             <Users className="h-16 w-16 mx-auto text-base-content/60" />
           </div>
-          <h3 className="text-xl font-semibold mb-2">No teams yet</h3>
+          <h2 className="text-xl font-semibold mb-2">No teams yet</h2>
           <p className="text-base-content/70 mb-4">
             No dynamic teams are registered on this server.
           </p>


### PR DESCRIPTION
## Summary
Pedantic a11y pass + a live proof that every CLI works across every framework mode.

### Best-practice accessibility (web UI)
A deeper axe run with the **full** ruleset (not just \`wcag2a\`/\`wcag2aa\`) surfaced best-practice violations the scoped run missed:

| Violation | Where | Fix |
|---|---|---|
| \`landmark-one-main\` / \`region\` | every page | content wrapped in a single \`<main>\` |
| \`page-has-heading-one\` | Dashboard \`/\` | added an \`<h1>\` |
| \`heading-order\` (h1→h3 skip) | Blueprints, Teams | card titles demoted to \`<h2>\` |

New reusable `webui/frontend/scripts/a11y-audit.mjs` runs the full ruleset over 7 routes × light/dark × desktop/mobile → **0 violations across all 28 combinations**. Typecheck clean, 19/19 unit tests pass, build succeeds.

The remaining `/ws/ai-demo/ 403` console line is expected: `DjangoChatConsumer` rejects unauthenticated scopes by design and ChatPage already renders a graceful fallback; an authenticated session won't see it.

### CLI permutation proof
`scripts/prove_cli_permutations.py` exercises every installed CLI through every mode. Verified live — **12/12 PASS** across claude + gemini + grok + opencode:

\`\`\`
cli_agent[claude|gemini|grok|opencode]   PASS
cli_fusion[all]                          PASS  (unanimous across all four)
cli_orchestrator                         PASS
cli_map                                  PASS
self-consensus[*x2] (all four)           PASS
native-best-of-n[grok]                   PASS
12/12 permutations PASS
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)