### PR TITLE
feat(cli-fusion): gemini model selection + tool-calling proof

### DIFF
--- a/scripts/prove_gemini_toolcalling.py
+++ b/scripts/prove_gemini_toolcalling.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Prove a CLI agent does real tool calling through the cli_agent blueprint.
+
+Drives a write-mode CLI (default: gemini) on a task that REQUIRES its file and
+shell tools — create a script, run it — then verifies the on-disk result
+independently of what the model claims. This is the difference between
+one-shot Q&A and genuine agentic tool use.
+
+Run:  DJANGO_DEBUG=true python scripts/prove_gemini_toolcalling.py [cli] [model]
+e.g.  python scripts/prove_gemini_toolcalling.py gemini
+      python scripts/prove_gemini_toolcalling.py gemini gemini-3-pro-preview
+"""
+import asyncio
+import os
+import pathlib
+import subprocess
+import sys
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "swarm.settings")
+os.environ.setdefault("DJANGO_DEBUG", "true")
+import django  # noqa: E402
+
+django.setup()
+
+from swarm.core import cli_catalog  # noqa: E402
+from swarm.blueprints.cli_agent.blueprint_cli_agent import CliAgentBlueprint  # noqa: E402
+
+CLI = sys.argv[1] if len(sys.argv) > 1 else "gemini"
+MODEL = sys.argv[2] if len(sys.argv) > 2 else None
+WD = f"/tmp/prove_toolcall_{CLI}"
+
+TASK = (
+    "Using your file tools, do all of the following in the current directory: "
+    "1) create a file called fib.py that defines fib(n) returning the nth "
+    "Fibonacci number (0-indexed, fib(0)=0, fib(1)=1) and prints fib(10); "
+    "2) run it with python3 and report the exact stdout."
+)
+
+
+async def main() -> int:
+    pathlib.Path(WD).mkdir(parents=True, exist_ok=True)
+    fib = pathlib.Path(WD, "fib.py")
+    if fib.exists():
+        fib.unlink()  # start clean so existence proves the CLI created it
+
+    # Pro/heavy tiers think much longer than flash; give them room.
+    entry = (
+        cli_catalog.with_model(CLI, MODEL, timeout=600)
+        if MODEL
+        else {**cli_catalog.catalog_entry(CLI), "timeout": 240}
+    )
+    cfg = {"cli_agents": {CLI: entry}, "cli_fusion": {"default_cli": CLI}}
+
+    bp = CliAgentBlueprint(config=cfg)
+    bp.set_params({"cli": CLI, "failover": False, "workdir": WD})
+    out = None
+    async for chunk in bp.run([{"role": "user", "content": TASK}], stream=False):
+        msgs = chunk.get("messages") if isinstance(chunk, dict) else None
+        if msgs and msgs[0].get("content") is not None:
+            out = msgs[0]["content"]
+
+    print("=" * 80)
+    print(f"{CLI}{' ('+MODEL+')' if MODEL else ''} RESPONSE (verbatim):")
+    print("=" * 80)
+    print(out)
+    print("=" * 80)
+    print("INDEPENDENT ON-DISK VERIFICATION:")
+    print(f"  fib.py created by the CLI: {fib.exists()}")
+    if not fib.exists():
+        print("  TOOL-CALLING PROOF: FAIL (no file written)")
+        return 1
+    print("  --- fib.py ---\n  " + fib.read_text().replace("\n", "\n  "))
+    r = subprocess.run(["python3", str(fib)], capture_output=True, text=True, timeout=15)
+    ok = r.stdout.strip() == "55"
+    print(f"  python3 fib.py stdout: {r.stdout.strip()!r}  (expect '55')")
+    print(f"  TOOL-CALLING PROOF: {'PASS' if ok else 'FAIL'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/swarm/core/cli_catalog.py
+++ b/src/swarm/core/cli_catalog.py
@@ -19,6 +19,12 @@ Known per-CLI gotchas are encoded here so the defaults *just run* (verified live
 * **opencode** has no usable default model in ``run`` mode (its built-in default
   errors as "not supported"), so an explicit ``--model`` is required. The value
   below is account/version-specific — run ``opencode models`` to pick one.
+
+The gemini default uses the fast flash tier (no ``-m``). To select the pro tier
+use ``with_model("gemini", "gemini-3-pro-preview", timeout=600)`` — but note
+that on the free ``oauth-personal`` login the pro model is heavily throttled and
+can take minutes (or stall) even on a one-word prompt; it is far more usable on a
+paid ``GEMINI_API_KEY``. Flash answers in a few seconds.
 """
 
 from __future__ import annotations
@@ -105,6 +111,44 @@ def with_native_consensus(name: str, n: int = 2) -> dict[str, Any] | None:
     if entry is None or flags is None:
         return None
     entry["cmd"] = list(entry["cmd"]) + flags
+    return entry
+
+
+# Flag each CLI uses to pin a specific model, so callers can request a
+# particular tier (e.g. gemini's pro vs. flash). Only flags verified against the
+# installed CLI version belong here; omit a CLI rather than guess.
+MODEL_FLAG: dict[str, str] = {
+    "gemini": "-m",        # verified live (gemini 0.45): -m gemini-3-pro-preview
+    "claude": "--model",   # claude -p --model <name>
+    "opencode": "--model", # opencode run --model <name>
+}
+
+
+def with_model(name: str, model: str, *, timeout: int | None = None) -> dict[str, Any] | None:
+    """A catalog entry for ``name`` pinned to a specific ``model``.
+
+    Pro/heavy tiers (notably ``gemini-3-pro-preview``) think for much longer than
+    the flash default, so pass a larger ``timeout`` when selecting one. Returns
+    None for an unknown CLI; returns the entry unchanged if the catalog has no
+    known model flag for it.
+    """
+    entry = catalog_entry(name)
+    if entry is None:
+        return None
+    flag = MODEL_FLAG.get(name)
+    if flag is not None:
+        cmd = list(entry["cmd"])
+        if flag in cmd:  # replace any model already pinned (e.g. opencode's default)
+            i = cmd.index(flag)
+            if i + 1 < len(cmd):
+                cmd[i + 1] = model
+            else:
+                cmd.append(model)
+        else:
+            cmd += [flag, model]
+        entry["cmd"] = cmd
+    if timeout is not None:
+        entry["timeout"] = timeout
     return entry
 
 

--- a/tests/core/test_cli_catalog.py
+++ b/tests/core/test_cli_catalog.py
@@ -148,3 +148,32 @@ def test_with_native_consensus_appends_flag():
 def test_with_native_consensus_does_not_mutate_catalog():
     cli_catalog.with_native_consensus("grok", 2)
     assert "--best-of-n" not in cli_catalog.CATALOG["grok"]["cmd"]
+
+
+def test_with_model_appends_flag_for_gemini():
+    entry = cli_catalog.with_model("gemini", "gemini-3-pro-preview", timeout=600)
+    assert entry["cmd"][-2:] == ["-m", "gemini-3-pro-preview"]
+    assert entry["timeout"] == 600
+    assert entry["parse"] == "json:.response"  # base entry preserved
+
+
+def test_with_model_replaces_existing_model_for_opencode():
+    # opencode pins a default --model; with_model must replace, not duplicate it.
+    entry = cli_catalog.with_model("opencode", "opencode/other")
+    assert entry["cmd"].count("--model") == 1
+    assert entry["cmd"][entry["cmd"].index("--model") + 1] == "opencode/other"
+
+
+def test_with_model_unknown_cli_is_none():
+    assert cli_catalog.with_model("nope", "x") is None
+
+
+def test_with_model_no_flag_known_returns_entry_unchanged():
+    # grok has no MODEL_FLAG entry: return the base entry, don't guess a flag.
+    base = cli_catalog.catalog_entry("grok")
+    assert cli_catalog.with_model("grok", "whatever")["cmd"] == base["cmd"]
+
+
+def test_with_model_does_not_mutate_catalog():
+    cli_catalog.with_model("gemini", "gemini-3-pro-preview")
+    assert "-m" not in cli_catalog.CATALOG["gemini"]["cmd"]


### PR DESCRIPTION
## Summary
Sharpens the **gemini** integration ahead of the free-tier window closing: model selection (so the pro tier is reachable), a durable tool-calling proof, and an honest note on pro's throttling.

### Changes
- **`cli_catalog.with_model(name, model, timeout=)`** — pin a CLI to a specific model, mirroring `with_native_consensus`. A `MODEL_FLAG` map carries the verified per-CLI flag (`gemini -m`, `claude`/`opencode --model`); it *replaces* an already-pinned model instead of duplicating it, and returns the entry unchanged for CLIs with no known flag (no guessing).
- **Pro-tier gotcha documented** — on the free `oauth-personal` login, `gemini-3-pro-preview` is heavily throttled and stalled past 300s even on a one-word prompt; flash answers in ~4s. Pro is practical on a paid `GEMINI_API_KEY`.
- **`scripts/prove_gemini_toolcalling.py`** — drives a write-mode CLI through `cli_agent` on a task that *requires* its file + shell tools (write `fib.py`, run it), then verifies the on-disk result independently of the model's claims.
- 5 new unit tests for `with_model`.

### Verified live
- **Tool calling: PASS** — gemini created `fib.py` from a clean dir, executed it with `python3`, on-disk check confirms correct code and stdout `55`.
- `with_model('gemini', 'gemini-3-pro-preview', timeout=600)` → `[... '-m', 'gemini-3-pro-preview']`, timeout 600.
- 26/26 catalog tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)