### PR TITLE
feat(api): OpenAPI spec endpoint + /v1/responses (OpenAI Responses API)

### DIFF
--- a/src/swarm/settings.py
+++ b/src/swarm/settings.py
@@ -202,7 +202,7 @@ REST_FRAMEWORK = {
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Open Swarm API',
     'DESCRIPTION': 'API for managing autonomous agent swarms',
-    'VERSION': '0.2.0',
+    'VERSION': '0.4.11',
     'SERVE_INCLUDE_SCHEMA': False,
 }
 

--- a/src/swarm/urls.py
+++ b/src/swarm/urls.py
@@ -5,6 +5,12 @@ from django.http import HttpResponse, FileResponse
 from django.views.static import serve
 from pathlib import Path
 
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
+
 from swarm.views.agent_creator_pro import agent_creator_pro_page
 from swarm.views.agent_creator_views import (
     agent_creator_page,
@@ -37,6 +43,7 @@ from swarm.views.blueprint_library_views import (
     remove_blueprint_from_library,
 )
 from swarm.views.chat_views import ChatCompletionsView
+from swarm.views.responses_views import ResponsesView
 from swarm.views.library_api import LibraryAPIView, LibraryDetailAPIView
 from swarm.views.settings_views import (
     environment_variables,
@@ -79,6 +86,21 @@ urlpatterns = [
     path("marketplace/github/blueprints/", MarketplaceGitHubBlueprintsView.as_view(), name="marketplace-github-blueprints"),
     path("marketplace/github/mcp-configs/", MarketplaceGitHubMCPConfigsView.as_view(), name="marketplace-github-mcp-configs"),
     path("v1/chat/completions", ChatCompletionsView.as_view(), name="chat_completions"),
+    # OpenAI Responses API (MVP) — normalizes `input`/`instructions` to messages
+    # and reuses the same blueprint-resolution + run path as chat completions.
+    path("v1/responses", ResponsesView.as_view(), name="responses"),
+    # OpenAPI schema + interactive docs (drf-spectacular).
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "api/schema/swagger-ui/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
+    path(
+        "api/schema/redoc/",
+        SpectacularRedocView.as_view(url_name="schema"),
+        name="redoc",
+    ),
     # JSON Teams API (REST counterpart to the server-rendered /teams/ page)
     path("v1/teams", TeamsAPIView.as_view(), name="teams-api-no-slash"),
     path("v1/teams/", TeamsAPIView.as_view(), name="teams-api"),

--- a/src/swarm/views/responses_views.py
+++ b/src/swarm/views/responses_views.py
@@ -1,0 +1,298 @@
+"""OpenAI Responses API (`/v1/responses`) — MVP implementation.
+
+This view accepts an OpenAI Responses-style request, normalizes its ``input``
+(string OR array of input items / messages) plus optional ``instructions`` into
+a standard chat ``messages`` list, then runs it through the SAME
+blueprint-resolution + run machinery that
+:class:`swarm.views.chat_views.ChatCompletionsView` uses.
+
+The response is shaped like an OpenAI ``response`` object (``output`` items +
+flattened ``output_text``). Streaming is supported via the existing SSE machinery
+and emits ``response.output_text.delta`` events.
+"""
+import asyncio
+import json
+import logging
+import sys
+import time
+import uuid
+from typing import Any
+
+from asgiref.sync import sync_to_async
+from django.conf import settings
+from django.http import (
+    HttpRequest,
+    HttpResponseBase,
+    StreamingHttpResponse,
+)
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import status
+from rest_framework.exceptions import (
+    APIException,
+    NotFound,
+    ParseError,
+    PermissionDenied,
+)
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .chat_views import _chunk_is_final, _extract_message_from_chunk
+from .utils import get_blueprint_instance, validate_model_access
+
+logger = logging.getLogger(__name__)
+print_logger = logging.getLogger('print_debug')
+
+# Bridge module aliasing between 'swarm' and 'src.swarm' so test patches hit the
+# correct module (mirrors chat_views.py).
+try:
+    if __name__ == 'swarm.views.responses_views':
+        sys.modules.setdefault('src.swarm.views.responses_views', sys.modules[__name__])
+    elif __name__ == 'src.swarm.views.responses_views':
+        sys.modules.setdefault('swarm.views.responses_views', sys.modules[__name__])
+except Exception:
+    pass
+
+
+def _normalize_input_to_messages(
+    input_value: Any,
+    instructions: str | None = None,
+) -> list[dict[str, str]]:
+    """Normalize a Responses-style ``input`` into a chat ``messages`` list.
+
+    - ``input`` as a string -> a single ``user`` message.
+    - ``input`` as an array of ``{role, content}`` items -> passthrough, with
+      content coerced to a string (Responses items may carry content as a list
+      of parts such as ``[{"type": "input_text", "text": "..."}]``).
+    - ``instructions`` (if given) is prepended as a ``system`` message.
+    """
+    messages: list[dict[str, str]] = []
+    if instructions:
+        messages.append({"role": "system", "content": str(instructions)})
+
+    if isinstance(input_value, str):
+        messages.append({"role": "user", "content": input_value})
+        return messages
+
+    if isinstance(input_value, list):
+        for item in input_value:
+            if not isinstance(item, dict):
+                # Bare string entries are treated as user content.
+                messages.append({"role": "user", "content": str(item)})
+                continue
+            role = item.get("role") or "user"
+            content = item.get("content")
+            messages.append({"role": role, "content": _coerce_content(content)})
+        return messages
+
+    raise ParseError("'input' must be a string or an array of input items.")
+
+
+def _coerce_content(content: Any) -> str:
+    """Coerce Responses content (string, or list of content parts) to a string."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+            elif isinstance(part, str):
+                parts.append(part)
+        return "".join(parts)
+    return str(content)
+
+
+class ResponsesView(APIView):
+    """Handles OpenAI Responses API requests (``/v1/responses``).
+
+    Reuses ``ChatCompletionsView``'s blueprint-resolution + run path. Auth /
+    permission behavior matches ``ChatCompletionsView`` (same custom ``dispatch``
+    wrapping ``perform_authentication`` and enforcing ``ENABLE_API_AUTH``).
+    """
+
+    # --- Auth dispatch (mirrors ChatCompletionsView) ---
+    @method_decorator(csrf_exempt)
+    async def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
+        self.args = args
+        self.kwargs = kwargs
+        drf_request: Request = self.initialize_request(request, *args, **kwargs)
+        self.request = drf_request
+        self.headers = self.default_response_headers
+
+        response = None
+        try:
+            await sync_to_async(self.perform_authentication)(drf_request)
+
+            if bool(getattr(settings, 'ENABLE_API_AUTH', False)):
+                has_token = getattr(drf_request, 'auth', None) is not None
+                user_obj = getattr(drf_request, 'user', None)
+                is_authenticated = bool(user_obj and getattr(user_obj, 'is_authenticated', False))
+                if not (has_token or is_authenticated):
+                    raise PermissionDenied('Authentication credentials were not provided')
+
+            self.check_permissions(drf_request)
+            self.check_throttles(drf_request)
+
+            if drf_request.method.lower() in self.http_method_names:
+                handler = getattr(self, drf_request.method.lower(), self.http_method_not_allowed)
+            else:
+                handler = self.http_method_not_allowed
+
+            if asyncio.iscoroutinefunction(handler):
+                response = await handler(drf_request, *args, **kwargs)
+            else:
+                response = await sync_to_async(handler)(drf_request, *args, **kwargs)
+        except Exception as exc:
+            response = self.handle_exception(exc)
+
+        self.response = self.finalize_response(drf_request, response, *args, **kwargs)
+        return self.response
+
+    async def post(self, request: Request, *_args: Any, **_kwargs: Any) -> HttpResponseBase:
+        request_id = str(uuid.uuid4())
+        logger.info(f"[ReqID: {request_id}] Processing /v1/responses POST request.")
+
+        # --- Request body parsing ---
+        try:
+            request_data = request.data
+        except ParseError as e:
+            logger.error(f"[ReqID: {request_id}] Invalid request body format: {e.detail}")
+            raise
+        except json.JSONDecodeError as e:
+            logger.error(f"[ReqID: {request_id}] JSON Decode Error: {e}")
+            raise ParseError(f"Invalid JSON body: {e}") from e
+
+        if not isinstance(request_data, dict):
+            raise ParseError("Request body must be a JSON object.")
+
+        model_name = request_data.get('model')
+        if not model_name or not isinstance(model_name, str):
+            raise ParseError("Field 'model' is required and must be a string.")
+
+        if 'input' not in request_data:
+            raise ParseError("Field 'input' is required.")
+
+        stream = bool(request_data.get('stream', False))
+        instructions = request_data.get('instructions')
+
+        messages = _normalize_input_to_messages(request_data.get('input'), instructions)
+        if not messages:
+            raise ParseError("'input' did not yield any messages.")
+
+        # --- Model access validation (same helper as ChatCompletionsView) ---
+        try:
+            access_granted = await sync_to_async(validate_model_access)(request.user, model_name)
+        except Exception as e:
+            logger.error(f"[ReqID: {request_id}] Error during model access validation for '{model_name}': {e}", exc_info=True)
+            raise APIException("Error checking model permissions.", code=status.HTTP_500_INTERNAL_SERVER_ERROR) from e
+
+        # --- Get blueprint instance (existence determines 404) ---
+        try:
+            blueprint_instance = await get_blueprint_instance(model_name, params=None)
+        except Exception as e:
+            logger.error(f"[ReqID: {request_id}] Error getting blueprint instance for '{model_name}': {e}", exc_info=True)
+            raise APIException(f"Failed to load model '{model_name}': {e}", code=status.HTTP_500_INTERNAL_SERVER_ERROR) from e
+
+        if blueprint_instance is None:
+            logger.error(f"[ReqID: {request_id}] Blueprint '{model_name}' not found or failed to initialize.")
+            raise NotFound(f"The requested model (blueprint) '{model_name}' was not found or could not be initialized.")
+
+        if not access_granted:
+            logger.warning(f"[ReqID: {request_id}] User '{request.user}' denied access to model '{model_name}'.")
+            raise PermissionDenied(f"You do not have permission to access the model '{model_name}'.")
+
+        if stream:
+            return await self._handle_streaming(blueprint_instance, messages, request_id, model_name)
+        return await self._handle_non_streaming(blueprint_instance, messages, request_id, model_name)
+
+    async def _handle_non_streaming(self, blueprint_instance, messages, request_id, model_name) -> Response:
+        """Consume the blueprint generator, keep the last message, shape a response object."""
+        final_message = None
+        try:
+            async_generator = blueprint_instance.run(messages, stream=False)
+            async for chunk in async_generator:
+                message = _extract_message_from_chunk(chunk)
+                if message is None:
+                    continue
+                final_message = message
+                if _chunk_is_final(chunk):
+                    break
+
+            if not isinstance(final_message, dict) or final_message.get('content') is None:
+                logger.error(f"[ReqID: {request_id}] Blueprint '{model_name}' did not yield any valid message chunk.")
+                raise APIException("Blueprint did not return valid data.", code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+            answer = final_message['content']
+        except APIException:
+            raise
+        except Exception as e:
+            logger.error(f"[ReqID: {request_id}] Unexpected error during /v1/responses generation: {e}", exc_info=True)
+            raise APIException(f"Internal server error during generation: {e}", code=status.HTTP_500_INTERNAL_SERVER_ERROR) from e
+
+        return Response(_build_response_payload(request_id, model_name, answer), status=status.HTTP_200_OK)
+
+    async def _handle_streaming(self, blueprint_instance, messages, request_id, model_name) -> StreamingHttpResponse:
+        """Stream ``response.output_text.delta`` SSE events, then a final completed response."""
+        response_id = f"resp_{request_id}"
+
+        async def event_stream():
+            full_text_parts: list[str] = []
+            try:
+                async_generator = blueprint_instance.run(messages, stream=True)
+                async for chunk in async_generator:
+                    message = _extract_message_from_chunk(chunk)
+                    if message is None:
+                        continue
+                    delta = message.get("content")
+                    if not delta:
+                        continue
+                    full_text_parts.append(delta)
+                    event = {
+                        "type": "response.output_text.delta",
+                        "response_id": response_id,
+                        "delta": delta,
+                    }
+                    yield f"data: {json.dumps(event)}\n\n"
+                    await asyncio.sleep(0.01)
+
+                final_text = "".join(full_text_parts)
+                completed = {
+                    "type": "response.completed",
+                    "response": _build_response_payload(request_id, model_name, final_text),
+                }
+                yield f"data: {json.dumps(completed)}\n\n"
+                yield "data: [DONE]\n\n"
+            except Exception as e:
+                logger.error(f"[ReqID: {request_id}] Error during /v1/responses streaming: {e}", exc_info=True)
+                error_event = {"type": "error", "error": {"message": str(e)}}
+                yield f"data: {json.dumps(error_event)}\n\n"
+                yield "data: [DONE]\n\n"
+
+        return StreamingHttpResponse(event_stream(), content_type="text/event-stream")
+
+
+def _build_response_payload(request_id: str, model_name: str, answer: str) -> dict[str, Any]:
+    """Shape an OpenAI Responses-style ``response`` object."""
+    return {
+        "id": f"resp_{request_id}",
+        "object": "response",
+        "created_at": int(time.time()),
+        "model": model_name,
+        "status": "completed",
+        "output": [
+            {
+                "type": "message",
+                "id": f"msg_{request_id}",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": answer}],
+            }
+        ],
+        "output_text": answer,
+        "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+    }

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -1,0 +1,86 @@
+"""Tests for the OpenAI Responses API endpoint (`/v1/responses`).
+
+The ``chatbot`` blueprint returns deterministic, network-free output under
+``SWARM_TEST_MODE`` (``"You said: <text>"``), so these tests need no model /
+API key. ``validate_model_access`` is patched to True (it normally requires the
+blueprint to appear in discovery, which it does, but patching keeps the test
+isolated from discovery state).
+"""
+import json
+import os
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+# Ensure deterministic blueprint output regardless of how the suite is launched.
+os.environ.setdefault("SWARM_TEST_MODE", "1")
+
+
+@pytest.mark.django_db(transaction=True)
+class TestResponsesAPI:
+
+    @pytest.fixture(autouse=True)
+    def _enable_test_mode(self, monkeypatch):
+        monkeypatch.setenv("SWARM_TEST_MODE", "1")
+        # Keep the test independent of blueprint-discovery state.
+        monkeypatch.setattr("swarm.views.responses_views.validate_model_access", lambda *a, **k: True)
+
+    @pytest.mark.asyncio
+    async def test_responses_string_input(self, async_client):
+        url = reverse("responses")
+        data = {"model": "chatbot", "input": "ping"}
+        response = await async_client.post(
+            url, data=json.dumps(data), content_type="application/json", SERVER_NAME="localhost"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        body = json.loads(response.content)
+        assert body["object"] == "response"
+        assert body["status"] == "completed"
+        assert body["model"] == "chatbot"
+        assert body["output_text"]
+        assert "ping" in body["output_text"]
+        # Output item structure.
+        assert body["output"][0]["type"] == "message"
+        assert body["output"][0]["content"][0]["type"] == "output_text"
+        assert body["output"][0]["content"][0]["text"] == body["output_text"]
+
+    @pytest.mark.asyncio
+    async def test_responses_array_input_with_instructions(self, async_client):
+        url = reverse("responses")
+        data = {
+            "model": "chatbot",
+            "instructions": "Be terse.",
+            "input": [{"role": "user", "content": "hello there"}],
+        }
+        response = await async_client.post(
+            url, data=json.dumps(data), content_type="application/json", SERVER_NAME="localhost"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        body = json.loads(response.content)
+        assert body["object"] == "response"
+        assert "hello there" in body["output_text"]
+
+    @pytest.mark.asyncio
+    async def test_responses_missing_input_is_400(self, async_client):
+        url = reverse("responses")
+        data = {"model": "chatbot"}
+        response = await async_client.post(
+            url, data=json.dumps(data), content_type="application/json", SERVER_NAME="localhost"
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.asyncio
+    async def test_responses_unknown_model_is_404(self, async_client, monkeypatch):
+        # For unknown-model behavior, don't short-circuit access validation.
+        monkeypatch.setattr(
+            "swarm.views.responses_views.validate_model_access", lambda *a, **k: False
+        )
+        url = reverse("responses")
+        data = {"model": "does-not-exist", "input": "ping"}
+        response = await async_client.post(
+            url, data=json.dumps(data), content_type="application/json", SERVER_NAME="localhost"
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
Adds two OpenAI-compatibility surfaces so Open Swarm can be plugged into any OpenAI client.

### OpenAPI spec endpoint (drf-spectacular was installed but unrouted)
- `GET /api/schema/` — OpenAPI 3 spec (`application/vnd.oai.openapi`)
- `GET /api/schema/swagger-ui/` and `/api/schema/redoc/` — interactive docs
- `manage.py spectacular` generates a valid spec; `/v1/responses` appears in it.

### `/v1/responses` — OpenAI Responses API (MVP, streaming + non-streaming)
- `ResponsesView` reuses `ChatCompletionsView`'s exact machinery (model→blueprint resolution, run path, auth/permission behavior).
- Accepts `{model, input (string or message array), instructions?, stream?}`; normalizes `input` to messages (string→user msg; array passthrough; `instructions`→system msg).
- Returns a Responses-shaped object (`object:"response"`, `output[]`, `output_text`); `stream:true` emits `response.output_text.delta` + `response.completed` SSE.
- 4 api tests; `tests/api` green (80 passed). Streaming verified.

**Limitation:** `usage` token counts are stubbed (same as chat/completions — the run path doesn't surface usage yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)