### PR TITLE
docs: deploy-readiness — CLI auth env vars + new endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,16 @@ OPENAI_API_KEY="your-openai-api-key"
 # LITELLM_MODEL=""
 # LITELLM_BASE_URL=""
 
+# --- CLI Agent Fusion (cli_agent / cli_fusion / cli_map / cli_orchestrator) ---
+# These blueprints shell out to your installed agentic CLIs, so each CLI must be
+# installed AND authenticated on the host/container. Auth varies by CLI:
+#   gemini  — GEMINI_API_KEY or GOOGLE_API_KEY (or `gemini` oauth login)
+#   claude  — ANTHROPIC_API_KEY (above) or `claude` login
+#   grok    — file-based login via the `grok`/`agent` CLI (no single env var)
+#   codex   — OPENAI_API_KEY (above)
+# GEMINI_API_KEY="your-gemini-api-key"
+# GOOGLE_API_KEY="your-google-api-key"
+
 # Default LLM profile when none is specified for an agent (e.g., "default")
 DEFAULT_LLM="default"
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **Open Swarm** is a Python framework for building, running, and deploying multi-agent AI workflows. Agent teams are defined as **Blueprints** — self-contained, discoverable Python modules — and can be used two ways:
 
 1. **As a CLI tool (`swarm-cli`):** run blueprints locally, interactively or one-shot, and optionally compile them into standalone executables.
-2. **As an API service (`swarm-api`):** serve blueprints over an **OpenAI-compatible REST API** (`/v1/models`, `/v1/chat/completions`), so any OpenAI client — SDKs, chat UIs, integrations — can talk to your agents.
+2. **As an API service (`swarm-api`):** serve blueprints over an **OpenAI-compatible REST API** (`/v1/models`, `/v1/chat/completions`, `/v1/responses`), so any OpenAI client — SDKs, chat UIs, integrations — can talk to your agents. The OpenAPI spec is served at `/api/schema/` (with Swagger UI at `/api/schema/swagger-ui/`).
 
 Built on the [openai-agents SDK](https://github.com/openai/openai-agents-python). Derivative of OpenAI's experimental [Swarm](https://github.com/openai/swarm) (see [Attribution](#acknowledgements--attribution)).
 
@@ -61,9 +61,15 @@ curl -sf http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${API_AUTH_TOKEN}" \
   -d '{"model": "suggestion", "messages": [{"role":"user","content":"ping"}]}' | jq .
+
+# OpenAI Responses API (input as a string or a message array):
+curl -sf http://localhost:8000/v1/responses \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${API_AUTH_TOKEN}" \
+  -d '{"model": "suggestion", "input": "ping"}' | jq .
 ```
 
-The `model` field selects which blueprint handles the request. Streaming is supported. A Django web UI (teams, blueprint library, agent creator, settings, websocket chat) is served at `/` — built with server-rendered templates + HTMx; it is the supported UI.
+The `model` field selects which blueprint handles the request. Streaming is supported. **Wrapping your CLIs:** install + authenticate your agentic CLIs, run `swarm-cli cli-agents --init --write` to generate the `cli_agents` config, then call with `model: "cli_fusion"` (one agent, consensus across your CLIs) or `model: "cli_map"` (many agents, each one CLI). See [docs/CLI_FUSION.md](docs/CLI_FUSION.md). A Django web UI (teams, blueprint library, agent creator, settings, websocket chat) is served at `/` — built with server-rendered templates + HTMx; it is the supported UI.
 
 ---
 


### PR DESCRIPTION
Hardens the cloud-deploy path while a CLI-wrapping completions server is being stood up.

- **.env.example**: adds a CLI Agent Fusion auth section (gemini `GEMINI_API_KEY`/`GOOGLE_API_KEY`, claude/codex notes, grok file-based login) so an agent's credential check finds the right knobs.
- **README**: lists `/v1/responses` + `/api/schema/` (Swagger UI) in the API surface and quickstart; adds a 'wrapping your CLIs' note (`cli-agents --init` → `cli_fusion`/`cli_map`).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)