### PR TITLE
docs: DEPLOYMENT.md runbook (CLI-wrapping OpenAI server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ ruff check .                          # lint
 Documentation map:
 
 * [USERGUIDE.md](./USERGUIDE.md) — task-oriented `swarm-cli` reference.
+* [docs/DEPLOYMENT.md](./docs/DEPLOYMENT.md) — runbook for deploying a CLI-wrapping OpenAI-compatible server (pull → configure → prove).
 * [docs/USER_JOURNEY.md](./docs/USER_JOURNEY.md) — screenshot-illustrated end-to-end story (install → CLI → web UI → API) with real transcripts.
 * [docs/GUIDED_TOUR.md](./docs/GUIDED_TOUR.md) — visual page-by-page tour of the web UI (React SPA + Django templates).
 * [docs/SKILLS_AND_CONSENSUS_WALKTHROUGH.md](./docs/SKILLS_AND_CONSENSUS_WALKTHROUGH.md) — illustrated end-to-end walkthrough of skills + 3-CLI consensus, with real terminal captures.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,108 @@
+# Deploying a CLI-wrapping OpenAI-compatible server
+
+A runbook for standing up Open Swarm so it exposes an **OpenAI-compatible API**
+(`/v1/chat/completions`, `/v1/responses`, `/v1/models`, OpenAPI at `/api/schema/`)
+that wraps your installed agentic CLIs (grok, claude, gemini, codex, opencode).
+
+## 0. Prerequisites — the CLIs must be installed *where the server runs*
+
+The fusion blueprints shell out to the CLIs as subprocesses, so each CLI you
+want to use must be **installed and authenticated on the same host/container as
+the server** (not just on your laptop). In Docker, that means baking the CLIs
+into the image (or mounting them) and providing their auth.
+
+Auth, per CLI:
+
+| CLI | Auth |
+|---|---|
+| `gemini` | `GEMINI_API_KEY` / `GOOGLE_API_KEY`, or `gemini` oauth login |
+| `claude` | `ANTHROPIC_API_KEY`, or `claude` login |
+| `grok` (a.k.a. `agent`) | file-based login via the `grok` CLI (no single env var) |
+| `codex` | `OPENAI_API_KEY` |
+| `opencode` | per its own config (`opencode models`) |
+
+## 1. Update
+
+```bash
+git checkout main && git pull --ff-only
+```
+
+## 2. Configure
+
+```bash
+cp .env.example .env   # set DJANGO_SECRET_KEY, DJANGO_ALLOWED_HOSTS, API_AUTH_TOKEN
+                       # (production refuses to start without all three)
+
+# which CLIs are installed AND authenticated on this host?
+swarm-cli cli-agents --check-auth
+
+# generate a swarm_config.json wiring cli_agent/cli_fusion/cli_map/cli_orchestrator
+# over the installed CLIs (writes to ~/.config/swarm/swarm_config.json):
+swarm-cli cli-agents --init --write
+```
+
+Then open the written `swarm_config.json` and confirm the **judge / router /
+planner** roles (in the `cli_fusion` / `cli_orchestrator` / `cli_map` blocks)
+point only at CLIs that showed as authenticated — `--init` prefers `grok` then
+`claude` by default; change them to match your host.
+
+## 3. Run
+
+```bash
+swarm-api                 # ASGI server on :8000 (also powers websocket chat)
+# or:
+docker compose up -d
+```
+
+Point any OpenAI client at `http://<host>:8000/v1` with
+`Authorization: Bearer $API_AUTH_TOKEN`.
+
+## 4. Prove it works
+
+```bash
+H="-H 'Authorization: Bearer $API_AUTH_TOKEN' -H 'Content-Type: application/json'"
+
+curl -sf http://localhost:8000/v1/models | jq .          # lists cli_fusion, cli_map, …
+curl -sf http://localhost:8000/api/schema/ | head        # OpenAPI spec (200)
+
+# one agent, consensus across your CLIs:
+curl -sf http://localhost:8000/v1/chat/completions -H "Authorization: Bearer $API_AUTH_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"cli_fusion","messages":[{"role":"user","content":"In one word, capital of France?"}]}' | jq .
+
+# many agents, each one CLI:
+curl -sf http://localhost:8000/v1/chat/completions -H "Authorization: Bearer $API_AUTH_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"cli_map","messages":[{"role":"user","content":"In one word, capital of France?"}]}' | jq .
+
+# Responses API:
+curl -sf http://localhost:8000/v1/responses -H "Authorization: Bearer $API_AUTH_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"cli_fusion","input":"In one word, capital of France?"}' | jq .
+```
+
+PASS = HTTP 200 and a non-empty answer naming Paris.
+
+## Which blueprint?
+
+| You want | `model:` |
+|---|---|
+| One agent, consensus across many CLIs | `cli_fusion` |
+| Many agents, each using one CLI | `cli_map` |
+| Cheap router that escalates hard questions to a panel | `cli_orchestrator` |
+| A single named CLI, no consensus | `cli_agent` |
+
+See [CLI_FUSION.md](CLI_FUSION.md) for the full config reference (panels, judges,
+presets, per-request `params`, failover, workdir isolation, native best-of-N).
+
+## Common gotchas
+
+- **`All CLI panelists failed` / empty answers** → the CLI isn't installed or not
+  authenticated *in the server's environment*. Re-run `swarm-cli cli-agents
+  --check-auth` on the host.
+- **Server refuses to start** → in production (`DJANGO_DEBUG` not true) you must
+  set `DJANGO_SECRET_KEY`, `DJANGO_ALLOWED_HOSTS`, and `API_AUTH_TOKEN`.
+- **401/403** → missing/wrong `Authorization: Bearer $API_AUTH_TOKEN`.
+- **gemini slow / stalls** → the free `oauth-personal` tier throttles the pro
+  model heavily; the flash default answers in seconds. Use a paid `GEMINI_API_KEY`
+  for the pro tier.


### PR DESCRIPTION
A single end-to-end runbook for the deployment path that's currently scattered across README/CLI_FUSION/env: prerequisites (the CLIs must be installed + authenticated **where the server runs**), update → configure (`cli-agents --check-auth` / `--init --write`) → run (`swarm-api` / docker) → **prove it** (curls for `cli_fusion`/`cli_map`/`responses`/`schema`). Includes a blueprint-picker table and a common-gotchas section. Docs-only; linked from the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)