### PR TITLE
feat(api): real token usage in completions + responses

### DIFF
--- a/src/swarm/views/chat_views.py
+++ b/src/swarm/views/chat_views.py
@@ -33,11 +33,12 @@ from rest_framework.permissions import AllowAny
 from rest_framework.request import Request  # Import DRF Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from .openai_schema import chat_completions_schema
 
 # Import custom permission
 # Assuming serializers are in the same app
 from swarm.serializers import ChatCompletionRequestSerializer
+
+from .openai_schema import chat_completions_schema
 
 # Assuming utils are in the same app/directory level
 # Make sure these utils are async-safe or wrapped if they perform sync I/O
@@ -119,6 +120,20 @@ def _chunk_is_final(chunk: Any) -> bool:
 # API Views (DRF based)
 # ==============================================================================
 
+def usage_counts(messages: list[dict[str, Any]] | None, answer: Any, model: str) -> tuple[int, int, int]:
+    """Approximate (prompt, completion, total) token counts for a response.
+
+    Uses tiktoken via ``get_token_count`` (word-count fallback). Better than the
+    zeros we used to return, so OpenAI clients can do cost/usage tracking. It is
+    an estimate of the text in/out of the API, not the CLIs' own tokenisation.
+    """
+    from swarm.utils.context_utils import get_token_count
+
+    prompt = sum(get_token_count(m, model) for m in (messages or []))
+    completion = get_token_count(answer if answer is not None else "", model)
+    return prompt, completion, prompt + completion
+
+
 class HealthCheckView(APIView):
     """ Simple health check endpoint. """
     permission_classes = [AllowAny]
@@ -166,7 +181,8 @@ class ChatCompletionsView(APIView):
                  logger.error(f"[ReqID: {request_id}] Blueprint '{model_name}' did not yield any valid message chunk.")
                  raise APIException("Blueprint did not return valid data.", code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-            response_payload = { "id": f"chatcmpl-{request_id}", "object": "chat.completion", "created": int(time.time()), "model": model_name, "choices": [{"index": 0, "message": final_message, "logprobs": None, "finish_reason": "stop"}], "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}, "system_fingerprint": None }
+            p_tok, c_tok, t_tok = usage_counts(messages, final_message.get("content"), model_name)
+            response_payload = { "id": f"chatcmpl-{request_id}", "object": "chat.completion", "created": int(time.time()), "model": model_name, "choices": [{"index": 0, "message": final_message, "logprobs": None, "finish_reason": "stop"}], "usage": {"prompt_tokens": p_tok, "completion_tokens": c_tok, "total_tokens": t_tok}, "system_fingerprint": None }
             end_time = time.time()
             logger.info(f"[ReqID: {request_id}] Non-streaming request completed in {end_time - start_time:.2f}s.")
             return Response(response_payload, status=status.HTTP_200_OK)

--- a/src/swarm/views/responses_views.py
+++ b/src/swarm/views/responses_views.py
@@ -251,7 +251,7 @@ class ResponsesView(APIView):
             logger.error(f"[ReqID: {request_id}] Unexpected error during /v1/responses generation: {e}", exc_info=True)
             raise APIException(f"Internal server error during generation: {e}", code=status.HTTP_500_INTERNAL_SERVER_ERROR) from e
 
-        payload = _build_response_payload(request_id, model_name, answer, previous_response_id)
+        payload = _build_response_payload(request_id, model_name, answer, previous_response_id, messages)
         if store:
             await sync_to_async(_persist)(payload, messages, answer)
         return Response(payload, status=status.HTTP_200_OK)
@@ -281,7 +281,7 @@ class ResponsesView(APIView):
                     await asyncio.sleep(0.01)
 
                 final_text = "".join(full_text_parts)
-                payload = _build_response_payload(request_id, model_name, final_text, previous_response_id)
+                payload = _build_response_payload(request_id, model_name, final_text, previous_response_id, messages)
                 if store:
                     await sync_to_async(_persist)(payload, messages, final_text)
                 completed = {"type": "response.completed", "response": payload}
@@ -297,9 +297,16 @@ class ResponsesView(APIView):
 
 
 def _build_response_payload(
-    request_id: str, model_name: str, answer: str, previous_response_id: str | None = None
+    request_id: str,
+    model_name: str,
+    answer: str,
+    previous_response_id: str | None = None,
+    messages: list[dict[str, str]] | None = None,
 ) -> dict[str, Any]:
     """Shape an OpenAI Responses-style ``response`` object."""
+    from .chat_views import usage_counts
+
+    input_tok, output_tok, total_tok = usage_counts(messages, answer, model_name)
     return {
         "id": f"resp_{request_id}",
         "object": "response",
@@ -316,7 +323,7 @@ def _build_response_payload(
             }
         ],
         "output_text": answer,
-        "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        "usage": {"input_tokens": input_tok, "output_tokens": output_tok, "total_tokens": total_tok},
     }
 
 

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -181,3 +181,17 @@ class TestResponsesStateful:
         get_url = reverse("responses-detail", kwargs={"response_id": "resp_missing"})
         got = await async_client.get(get_url, SERVER_NAME="localhost")
         assert got.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_responses_reports_nonzero_token_usage(client):
+    resp = client.post(
+        "/v1/responses",
+        data='{"model": "cli_fusion", "input": "In one word, capital of France?"}',
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    usage = resp.json()["usage"]
+    assert usage["input_tokens"] > 0
+    assert usage["output_tokens"] > 0
+    assert usage["total_tokens"] == usage["input_tokens"] + usage["output_tokens"]


### PR DESCRIPTION
Both `/v1/chat/completions` and `/v1/responses` returned `usage: {0,0,0}`, which breaks OpenAI clients' cost/usage tracking. Now they report approximate `prompt`/`completion`/`total` token counts via the existing `get_token_count` (tiktoken, word-count fallback) over the input messages + the answer text. Shared `usage_counts()` helper; non-streaming + streaming-final payloads populated; regression test asserts non-zero, additive usage. `tests/api` green.

Note: it's an estimate of text in/out of the API (not the wrapped CLIs' own tokenisation), and matches how `ChatCompletionsView` already shapes its response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)