### PR TITLE
feat(webui): Responses API snippet in the connect-any-client panel

### DIFF
--- a/webui/frontend/src/components/ApiAccessPanel.tsx
+++ b/webui/frontend/src/components/ApiAccessPanel.tsx
@@ -11,6 +11,7 @@ export interface ApiAccessPanelProps {
 
 export interface Snippets {
   curl: string
+  responses: string
   python: string
   openWebUI: string
 }
@@ -24,6 +25,12 @@ export function buildSnippets(baseUrl: string, token: string | null, model: stri
       `  -H "Authorization: Bearer ${key}" \\`,
       `  -H "Content-Type: application/json" \\`,
       `  -d '{"model":"${model}","messages":[{"role":"user","content":"ping"}]}'`,
+    ].join('\n'),
+    responses: [
+      `curl -sf ${baseUrl}/responses \\`,
+      `  -H "Authorization: Bearer ${key}" \\`,
+      `  -H "Content-Type: application/json" \\`,
+      `  -d '{"model":"${model}","input":"ping"}'`,
     ].join('\n'),
     python: [
       'from openai import OpenAI',
@@ -121,6 +128,7 @@ export function ApiAccessPanel({ baseUrl, token, models }: ApiAccessPanelProps) 
       )}
 
       <CopyBlock label="curl" code={snippets.curl} />
+      <CopyBlock label="curl (Responses API)" code={snippets.responses} />
       <CopyBlock label="OpenAI Python SDK" code={snippets.python} />
       <CopyBlock label="Open WebUI" code={snippets.openWebUI} />
     </div>

--- a/webui/frontend/src/components/__tests__/ApiAccessPanel.test.tsx
+++ b/webui/frontend/src/components/__tests__/ApiAccessPanel.test.tsx
@@ -11,6 +11,8 @@ describe('buildSnippets', () => {
     expect(s.python).toContain('base_url="http://host:8000/v1"')
     expect(s.python).toContain('model="cli_fusion"')
     expect(s.openWebUI).toContain('Base URL: http://host:8000/v1')
+    expect(s.responses).toContain('http://host:8000/v1/responses')
+    expect(s.responses).toContain('"input":"ping"')
   })
 
   it('uses a placeholder key when auth is disabled (no token)', () => {
@@ -32,7 +34,7 @@ describe('ApiAccessPanel', () => {
     expect(screen.getByText('http://localhost:8000/v1')).toBeInTheDocument()
     expect(screen.getByText(/any key works/i)).toBeInTheDocument()
     expect(screen.getByRole('option', { name: 'cli_fusion' })).toBeInTheDocument()
-    expect(screen.getAllByText('Copy').length).toBe(3)
+    expect(screen.getAllByText('Copy').length).toBe(4)
   })
 
   it('shows the token suffix when a token is set', () => {


### PR DESCRIPTION
The 'connect any OpenAI client' panel only showed a `/v1/chat/completions` curl; adds a `/v1/responses` curl snippet (input-as-string) so it covers both endpoints. `buildSnippets` gains a `responses` field; test updated. vitest green, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)