### PR TITLE
feat(responses): stateful Responses API — store, chain, GET/DELETE

### DIFF
--- a/src/swarm/core/responses_store.py
+++ b/src/swarm/core/responses_store.py
@@ -1,0 +1,83 @@
+"""File-backed store for the OpenAI Responses API statefulness.
+
+The Responses API is *stateful*: a response is persisted (unless ``store: false``)
+and a later request can pass ``previous_response_id`` to continue the
+conversation. We persist each response as one JSON file on disk — no DB
+migration, and the store dir is configurable (``SWARM_RESPONSES_DIR``).
+
+Each record holds the public ``response`` payload (for ``GET /v1/responses/{id}``)
+plus the full ``messages`` transcript that produced it (input + the assistant
+reply) so a follow-up ``previous_response_id`` can replay the conversation.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+
+# resp ids we mint look like ``resp_<uuid>``; restrict to a safe charset so a
+# caller-supplied id can never traverse out of the store dir.
+_ID_RE = re.compile(r"^resp_[A-Za-z0-9_-]{1,128}$")
+
+
+def _store_dir() -> Path:
+    """Where response records live: ``$SWARM_RESPONSES_DIR`` or an XDG default."""
+    env = os.environ.get("SWARM_RESPONSES_DIR")
+    if env:
+        return Path(env)
+    base = os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local" / "share")
+    return Path(base) / "swarm" / "responses"
+
+
+def _path_for(response_id: str, base_dir: Path | None) -> Path | None:
+    if not _ID_RE.match(response_id or ""):
+        return None
+    return (base_dir or _store_dir()) / f"{response_id}.json"
+
+
+def save(record: dict[str, Any], *, base_dir: Path | None = None) -> None:
+    """Persist a record (must have a valid ``id``). Atomic write; best-effort."""
+    rid = record.get("id", "")
+    path = _path_for(rid, base_dir)
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # write to a temp file in the same dir, then atomic rename.
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(record, f, default=str)
+        os.replace(tmp, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+def load(response_id: str, *, base_dir: Path | None = None) -> dict[str, Any] | None:
+    """Return the stored record for ``response_id``, or None if absent/invalid."""
+    path = _path_for(response_id, base_dir)
+    if path is None or not path.is_file():
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def delete(response_id: str, *, base_dir: Path | None = None) -> bool:
+    """Delete the stored record; True if one was removed."""
+    path = _path_for(response_id, base_dir)
+    if path is None or not path.is_file():
+        return False
+    try:
+        path.unlink()
+        return True
+    except OSError:
+        return False

--- a/src/swarm/urls.py
+++ b/src/swarm/urls.py
@@ -43,7 +43,7 @@ from swarm.views.blueprint_library_views import (
     remove_blueprint_from_library,
 )
 from swarm.views.chat_views import ChatCompletionsView
-from swarm.views.responses_views import ResponsesView
+from swarm.views.responses_views import ResponsesView, ResponsesDetailView
 from swarm.views.library_api import LibraryAPIView, LibraryDetailAPIView
 from swarm.views.settings_views import (
     environment_variables,
@@ -89,6 +89,7 @@ urlpatterns = [
     # OpenAI Responses API (MVP) — normalizes `input`/`instructions` to messages
     # and reuses the same blueprint-resolution + run path as chat completions.
     path("v1/responses", ResponsesView.as_view(), name="responses"),
+    path("v1/responses/<str:response_id>", ResponsesDetailView.as_view(), name="responses-detail"),
     # OpenAPI schema + interactive docs (drf-spectacular).
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path(

--- a/src/swarm/views/responses_views.py
+++ b/src/swarm/views/responses_views.py
@@ -37,9 +37,11 @@ from rest_framework.exceptions import (
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from .openai_schema import responses_schema
+
+from swarm.core import responses_store
 
 from .chat_views import _chunk_is_final, _extract_message_from_chunk
+from .openai_schema import responses_schema
 from .utils import get_blueprint_instance, validate_model_access
 
 logger = logging.getLogger(__name__)
@@ -109,51 +111,54 @@ def _coerce_content(content: Any) -> str:
     return str(content)
 
 
+async def _async_auth_dispatch(view: APIView, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
+    """Shared async dispatch (mirrors ChatCompletionsView): authenticate, enforce
+    ``ENABLE_API_AUTH``, run the (async or sync) handler, finalize."""
+    view.args = args
+    view.kwargs = kwargs
+    drf_request: Request = view.initialize_request(request, *args, **kwargs)
+    view.request = drf_request
+    view.headers = view.default_response_headers
+
+    response = None
+    try:
+        await sync_to_async(view.perform_authentication)(drf_request)
+
+        if bool(getattr(settings, 'ENABLE_API_AUTH', False)):
+            has_token = getattr(drf_request, 'auth', None) is not None
+            user_obj = getattr(drf_request, 'user', None)
+            is_authenticated = bool(user_obj and getattr(user_obj, 'is_authenticated', False))
+            if not (has_token or is_authenticated):
+                raise PermissionDenied('Authentication credentials were not provided')
+
+        view.check_permissions(drf_request)
+        view.check_throttles(drf_request)
+
+        method = drf_request.method.lower()
+        handler = getattr(view, method, view.http_method_not_allowed) if method in view.http_method_names else view.http_method_not_allowed
+
+        if asyncio.iscoroutinefunction(handler):
+            response = await handler(drf_request, *args, **kwargs)
+        else:
+            response = await sync_to_async(handler)(drf_request, *args, **kwargs)
+    except Exception as exc:
+        response = view.handle_exception(exc)
+
+    view.response = view.finalize_response(drf_request, response, *args, **kwargs)
+    return view.response
+
+
 class ResponsesView(APIView):
     """Handles OpenAI Responses API requests (``/v1/responses``).
 
-    Reuses ``ChatCompletionsView``'s blueprint-resolution + run path. Auth /
-    permission behavior matches ``ChatCompletionsView`` (same custom ``dispatch``
-    wrapping ``perform_authentication`` and enforcing ``ENABLE_API_AUTH``).
+    Reuses ``ChatCompletionsView``'s blueprint-resolution + run path. Stateful:
+    a response is persisted (unless ``store: false``) and ``previous_response_id``
+    continues a prior conversation. See :mod:`swarm.core.responses_store`.
     """
 
-    # --- Auth dispatch (mirrors ChatCompletionsView) ---
     @method_decorator(csrf_exempt)
     async def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
-        self.args = args
-        self.kwargs = kwargs
-        drf_request: Request = self.initialize_request(request, *args, **kwargs)
-        self.request = drf_request
-        self.headers = self.default_response_headers
-
-        response = None
-        try:
-            await sync_to_async(self.perform_authentication)(drf_request)
-
-            if bool(getattr(settings, 'ENABLE_API_AUTH', False)):
-                has_token = getattr(drf_request, 'auth', None) is not None
-                user_obj = getattr(drf_request, 'user', None)
-                is_authenticated = bool(user_obj and getattr(user_obj, 'is_authenticated', False))
-                if not (has_token or is_authenticated):
-                    raise PermissionDenied('Authentication credentials were not provided')
-
-            self.check_permissions(drf_request)
-            self.check_throttles(drf_request)
-
-            if drf_request.method.lower() in self.http_method_names:
-                handler = getattr(self, drf_request.method.lower(), self.http_method_not_allowed)
-            else:
-                handler = self.http_method_not_allowed
-
-            if asyncio.iscoroutinefunction(handler):
-                response = await handler(drf_request, *args, **kwargs)
-            else:
-                response = await sync_to_async(handler)(drf_request, *args, **kwargs)
-        except Exception as exc:
-            response = self.handle_exception(exc)
-
-        self.response = self.finalize_response(drf_request, response, *args, **kwargs)
-        return self.response
+        return await _async_auth_dispatch(self, request, *args, **kwargs)
 
     @responses_schema
     async def post(self, request: Request, *_args: Any, **_kwargs: Any) -> HttpResponseBase:
@@ -182,10 +187,19 @@ class ResponsesView(APIView):
 
         stream = bool(request_data.get('stream', False))
         instructions = request_data.get('instructions')
+        previous_response_id = request_data.get('previous_response_id')
+        store = request_data.get('store', True) is not False  # persist unless store:false
 
         messages = _normalize_input_to_messages(request_data.get('input'), instructions)
         if not messages:
             raise ParseError("'input' did not yield any messages.")
+
+        # --- Statefulness: continue a prior conversation by id ---
+        if previous_response_id:
+            prior = await sync_to_async(responses_store.load)(str(previous_response_id))
+            if prior is None:
+                raise NotFound(f"Previous response '{previous_response_id}' not found.")
+            messages = list(prior.get("messages") or []) + messages
 
         # --- Model access validation (same helper as ChatCompletionsView) ---
         try:
@@ -210,10 +224,10 @@ class ResponsesView(APIView):
             raise PermissionDenied(f"You do not have permission to access the model '{model_name}'.")
 
         if stream:
-            return await self._handle_streaming(blueprint_instance, messages, request_id, model_name)
-        return await self._handle_non_streaming(blueprint_instance, messages, request_id, model_name)
+            return await self._handle_streaming(blueprint_instance, messages, request_id, model_name, store, previous_response_id)
+        return await self._handle_non_streaming(blueprint_instance, messages, request_id, model_name, store, previous_response_id)
 
-    async def _handle_non_streaming(self, blueprint_instance, messages, request_id, model_name) -> Response:
+    async def _handle_non_streaming(self, blueprint_instance, messages, request_id, model_name, store=True, previous_response_id=None) -> Response:
         """Consume the blueprint generator, keep the last message, shape a response object."""
         final_message = None
         try:
@@ -237,9 +251,12 @@ class ResponsesView(APIView):
             logger.error(f"[ReqID: {request_id}] Unexpected error during /v1/responses generation: {e}", exc_info=True)
             raise APIException(f"Internal server error during generation: {e}", code=status.HTTP_500_INTERNAL_SERVER_ERROR) from e
 
-        return Response(_build_response_payload(request_id, model_name, answer), status=status.HTTP_200_OK)
+        payload = _build_response_payload(request_id, model_name, answer, previous_response_id)
+        if store:
+            await sync_to_async(_persist)(payload, messages, answer)
+        return Response(payload, status=status.HTTP_200_OK)
 
-    async def _handle_streaming(self, blueprint_instance, messages, request_id, model_name) -> StreamingHttpResponse:
+    async def _handle_streaming(self, blueprint_instance, messages, request_id, model_name, store=True, previous_response_id=None) -> StreamingHttpResponse:
         """Stream ``response.output_text.delta`` SSE events, then a final completed response."""
         response_id = f"resp_{request_id}"
 
@@ -264,10 +281,10 @@ class ResponsesView(APIView):
                     await asyncio.sleep(0.01)
 
                 final_text = "".join(full_text_parts)
-                completed = {
-                    "type": "response.completed",
-                    "response": _build_response_payload(request_id, model_name, final_text),
-                }
+                payload = _build_response_payload(request_id, model_name, final_text, previous_response_id)
+                if store:
+                    await sync_to_async(_persist)(payload, messages, final_text)
+                completed = {"type": "response.completed", "response": payload}
                 yield f"data: {json.dumps(completed)}\n\n"
                 yield "data: [DONE]\n\n"
             except Exception as e:
@@ -279,7 +296,9 @@ class ResponsesView(APIView):
         return StreamingHttpResponse(event_stream(), content_type="text/event-stream")
 
 
-def _build_response_payload(request_id: str, model_name: str, answer: str) -> dict[str, Any]:
+def _build_response_payload(
+    request_id: str, model_name: str, answer: str, previous_response_id: str | None = None
+) -> dict[str, Any]:
     """Shape an OpenAI Responses-style ``response`` object."""
     return {
         "id": f"resp_{request_id}",
@@ -287,6 +306,7 @@ def _build_response_payload(request_id: str, model_name: str, answer: str) -> di
         "created_at": int(time.time()),
         "model": model_name,
         "status": "completed",
+        "previous_response_id": previous_response_id,
         "output": [
             {
                 "type": "message",
@@ -298,3 +318,35 @@ def _build_response_payload(request_id: str, model_name: str, answer: str) -> di
         "output_text": answer,
         "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
     }
+
+
+def _persist(payload: dict[str, Any], messages: list[dict[str, Any]], answer: str) -> None:
+    """Save a response record so it can be retrieved and chained from later."""
+    record = {
+        "id": payload["id"],
+        "object": "response",
+        "response": payload,
+        # Full transcript incl. the assistant reply, so previous_response_id replays it.
+        "messages": list(messages) + [{"role": "assistant", "content": answer}],
+    }
+    responses_store.save(record)
+
+
+class ResponsesDetailView(APIView):
+    """Retrieve or delete a stored response (``/v1/responses/<id>``)."""
+
+    @method_decorator(csrf_exempt)
+    async def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
+        return await _async_auth_dispatch(self, request, *args, **kwargs)
+
+    async def get(self, _request: Request, response_id: str, *_a: Any, **_k: Any) -> Response:
+        record = await sync_to_async(responses_store.load)(response_id)
+        if record is None:
+            raise NotFound(f"Response '{response_id}' not found.")
+        return Response(record.get("response") or record, status=status.HTTP_200_OK)
+
+    async def delete(self, _request: Request, response_id: str, *_a: Any, **_k: Any) -> Response:
+        deleted = await sync_to_async(responses_store.delete)(response_id)
+        if not deleted:
+            raise NotFound(f"Response '{response_id}' not found.")
+        return Response({"id": response_id, "object": "response.deleted", "deleted": True}, status=status.HTTP_200_OK)

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -84,3 +84,100 @@ class TestResponsesAPI:
             url, data=json.dumps(data), content_type="application/json", SERVER_NAME="localhost"
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db(transaction=True)
+class TestResponsesStateful:
+    """Statefulness: store, retrieve, chain via previous_response_id, delete."""
+
+    @pytest.fixture(autouse=True)
+    def _enable_test_mode(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("SWARM_TEST_MODE", "1")
+        # Isolate the on-disk response store to a per-test tmp dir.
+        monkeypatch.setenv("SWARM_RESPONSES_DIR", str(tmp_path))
+        monkeypatch.setattr("swarm.views.responses_views.validate_model_access", lambda *a, **k: True)
+
+    async def _create(self, async_client, data):
+        url = reverse("responses")
+        return await async_client.post(
+            url, data=json.dumps(data), content_type="application/json", SERVER_NAME="localhost"
+        )
+
+    @pytest.mark.asyncio
+    async def test_response_is_stored_and_retrievable(self, async_client):
+        resp = await self._create(async_client, {"model": "chatbot", "input": "ping"})
+        assert resp.status_code == status.HTTP_200_OK
+        rid = json.loads(resp.content)["id"]
+
+        get_url = reverse("responses-detail", kwargs={"response_id": rid})
+        got = await async_client.get(get_url, SERVER_NAME="localhost")
+        assert got.status_code == status.HTTP_200_OK
+        body = json.loads(got.content)
+        assert body["id"] == rid
+        assert body["object"] == "response"
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_chains_context(self, async_client):
+        first = await self._create(async_client, {"model": "chatbot", "input": "my name is Ada"})
+        first_id = json.loads(first.content)["id"]
+
+        second = await self._create(
+            async_client,
+            {"model": "chatbot", "input": "again", "previous_response_id": first_id},
+        )
+        assert second.status_code == status.HTTP_200_OK
+        body = json.loads(second.content)
+        assert body["previous_response_id"] == first_id
+        assert body["id"] != first_id
+
+        # The chained request must replay the prior transcript: the stored record
+        # for the second response contains the first turn's user + assistant
+        # messages ahead of the new turn.
+        from swarm.core import responses_store
+
+        record = responses_store.load(body["id"])
+        assert record is not None
+        contents = [m.get("content") for m in record["messages"]]
+        assert "my name is Ada" in contents  # replayed prior user message
+        assert "again" in contents           # the new turn
+
+    @pytest.mark.asyncio
+    async def test_unknown_previous_response_id_is_404(self, async_client):
+        resp = await self._create(
+            async_client,
+            {"model": "chatbot", "input": "hi", "previous_response_id": "resp_doesnotexist"},
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_store_false_is_not_persisted(self, async_client):
+        resp = await self._create(async_client, {"model": "chatbot", "input": "ping", "store": False})
+        assert resp.status_code == status.HTTP_200_OK
+        rid = json.loads(resp.content)["id"]
+
+        get_url = reverse("responses-detail", kwargs={"response_id": rid})
+        got = await async_client.get(get_url, SERVER_NAME="localhost")
+        assert got.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_delete_response(self, async_client):
+        resp = await self._create(async_client, {"model": "chatbot", "input": "ping"})
+        rid = json.loads(resp.content)["id"]
+        detail_url = reverse("responses-detail", kwargs={"response_id": rid})
+
+        deleted = await async_client.delete(detail_url, SERVER_NAME="localhost")
+        assert deleted.status_code == status.HTTP_200_OK
+        body = json.loads(deleted.content)
+        assert body["id"] == rid
+        assert body["object"] == "response.deleted"
+        assert body["deleted"] is True
+
+        # Gone afterwards.
+        got = await async_client.get(detail_url, SERVER_NAME="localhost")
+        assert got.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_get_unknown_response_is_404(self, async_client):
+        get_url = reverse("responses-detail", kwargs={"response_id": "resp_missing"})
+        got = await async_client.get(get_url, SERVER_NAME="localhost")
+        assert got.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/core/test_responses_store.py
+++ b/tests/core/test_responses_store.py
@@ -1,0 +1,51 @@
+"""Unit tests for the file-backed Responses store (``swarm.core.responses_store``).
+
+These exercise the persistence layer directly (no HTTP), including the
+path-traversal guard on caller-supplied ids.
+"""
+from pathlib import Path
+
+from swarm.core import responses_store
+
+
+def test_save_load_roundtrip(tmp_path):
+    record = {"id": "resp_abc123", "object": "response", "messages": [{"role": "user", "content": "hi"}]}
+    responses_store.save(record, base_dir=tmp_path)
+    loaded = responses_store.load("resp_abc123", base_dir=tmp_path)
+    assert loaded == record
+
+
+def test_load_missing_returns_none(tmp_path):
+    assert responses_store.load("resp_nope", base_dir=tmp_path) is None
+
+
+def test_delete_removes_record(tmp_path):
+    responses_store.save({"id": "resp_del1"}, base_dir=tmp_path)
+    assert responses_store.delete("resp_del1", base_dir=tmp_path) is True
+    assert responses_store.load("resp_del1", base_dir=tmp_path) is None
+    # Second delete is a no-op.
+    assert responses_store.delete("resp_del1", base_dir=tmp_path) is False
+
+
+def test_save_invalid_id_is_noop(tmp_path):
+    # Ids that don't match the resp_ pattern are silently dropped (never written).
+    responses_store.save({"id": "../escape"}, base_dir=tmp_path)
+    responses_store.save({"id": ""}, base_dir=tmp_path)
+    assert list(tmp_path.glob("*")) == []
+
+
+def test_load_rejects_traversal_ids(tmp_path):
+    # A planted file outside the safe charset must never be reachable.
+    evil = tmp_path / "secret.json"
+    evil.write_text('{"id": "secret"}')
+    assert responses_store.load("../secret", base_dir=tmp_path) is None
+    assert responses_store.load("resp_../secret", base_dir=tmp_path) is None
+    assert responses_store.delete("../secret", base_dir=tmp_path) is False
+
+
+def test_store_dir_honors_env(monkeypatch, tmp_path):
+    target = tmp_path / "custom"
+    monkeypatch.setenv("SWARM_RESPONSES_DIR", str(target))
+    responses_store.save({"id": "resp_envcfg"}, base_dir=None)
+    assert (target / "resp_envcfg.json").is_file()
+    assert isinstance(responses_store._store_dir(), Path)


### PR DESCRIPTION
## What

Makes `/v1/responses` **stateful** — the defining feature of the OpenAI Responses API — using a file-backed store (no DB migration required).

- **`swarm.core.responses_store`** — one JSON file per response. `save`/`load`/`delete`, atomic writes, store dir configurable via `SWARM_RESPONSES_DIR` (XDG default otherwise). A `resp_`-prefixed charset guard blocks path traversal on caller-supplied ids.
- **`ResponsesView.post`** — persists each response unless `store: false`. Honors `previous_response_id` by replaying the prior transcript; returns **404** on an unknown id.
- **`ResponsesDetailView`** — `GET /v1/responses/{id}` returns the stored response payload; `DELETE` returns `response.deleted` and removes it.

## Tests

- Store unit tests: roundtrip, delete, invalid/traversal ids are no-ops, env-dir honored.
- API integration: persist + retrieve, chaining replays prior context (verified against the stored record), `store:false` not persisted, unknown `previous_response_id` → 404, delete then GET → 404.

437 passed across `tests/api` + `tests/core`; ruff clean.

## Notes

- `_build_response_payload` now carries `previous_response_id`. This overlaps with #141 (which adds a `messages` param for real token-usage counts) — once #141 merges, the two changes reconcile so the payload builder takes both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)