### PR TITLE
feat(cli): three MAF-class orchestration blueprints (pipeline, roundtable, planner)

### DIFF
--- a/src/swarm/blueprints/cli_pipeline/blueprint_cli_pipeline.py
+++ b/src/swarm/blueprints/cli_pipeline/blueprint_cli_pipeline.py
@@ -1,0 +1,152 @@
+"""CLI Pipeline blueprint — sequential refinement.
+
+The sequential complement to ``cli_fusion``. Where fusion sends the *same*
+prompt to a panel **in parallel** and finds consensus, pipeline chains CLIs **in
+order**: each stage refines the previous stage's output. Different backends play
+to their strengths in sequence — a fast model drafts, a strong model reviews, a
+third polishes.
+
+Request model: ``model: "cli_pipeline"``. Config block ``cli_pipeline``:
+``{ "stages": [<cli> | {"cli": <cli>, "instruction": <str>}, ...] }`` (falls back
+to a ``cli_fusion`` preset panel). Per-request ``params`` may set ``stages``
+(same shape) and ``workdir``.
+
+Each stage after the first sees the running output, not just the original
+prompt. A failed stage is skipped — the last good output carries forward — so a
+single flaky backend degrades the pipeline rather than breaking it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar
+
+from swarm.blueprints.common import cli_fusion_support as support
+from swarm.core.blueprint_base import BlueprintBase
+from swarm.core.cli_adapter import CliAdapterRegistry
+
+logger = logging.getLogger(__name__)
+
+MAX_STAGES = 8
+
+DEFAULT_INSTRUCTION = (
+    "Improve the draft below: fix errors, fill gaps, and tighten it. Return only "
+    "the improved version, not a commentary."
+)
+
+REFINE_TEMPLATE = """The original task was:
+<task>
+{prompt}
+</task>
+
+The current draft (produced by an earlier stage) is:
+<draft>
+{draft}
+</draft>
+
+{instruction}
+"""
+
+
+class CliPipelineBlueprint(BlueprintBase):
+    """Run a prompt through an ordered chain of CLIs, each refining the last."""
+
+    metadata: ClassVar[dict[str, Any]] = {
+        "name": "cli_pipeline",
+        "title": "CLI Pipeline (sequential refinement)",
+        "description": (
+            "Chain CLIs in order: each stage refines the previous stage's output "
+            "(draft then review then polish). The sequential complement to "
+            "cli_fusion's parallel panel."
+        ),
+        "version": "0.1.0",
+        "author": "Open Swarm Team",
+        "tags": ["cli", "sequential", "pipeline", "multi-agent", "openai-compatible"],
+        "required_mcp_servers": [],
+        "env_vars": [],
+    }
+
+    def __init__(self, blueprint_id: str = "cli_pipeline", config=None, config_path=None, **kwargs):
+        super().__init__(blueprint_id, config=config, config_path=config_path, **kwargs)
+        self._params: dict[str, Any] = {}
+
+    def set_params(self, params: dict[str, Any] | None) -> None:
+        self._params = dict(params or {})
+
+    def _resolve_stages(
+        self, params: dict[str, Any], registry: CliAdapterRegistry
+    ) -> list[tuple[str, str | None]]:
+        """Resolve the ordered stage list into (cli_name, instruction) pairs.
+
+        A stage may be a bare cli name or ``{"cli": name, "instruction": str}``.
+        Unknown CLIs are dropped. Falls back to a ``cli_fusion`` preset panel.
+        """
+        pc = (self._config or {}).get("cli_pipeline") or {}
+        fusion = (self._config or {}).get("cli_fusion") or {}
+
+        raw = params.get("stages") or pc.get("stages")
+        if not raw:
+            preset = (fusion.get("presets") or {}).get(fusion.get("default_preset")) or {}
+            raw = preset.get("panel") or registry.available() or registry.names()
+
+        known = set(registry.names())
+        stages: list[tuple[str, str | None]] = []
+        for item in raw or []:
+            if isinstance(item, dict):
+                name = item.get("cli") or item.get("name")
+                instruction = item.get("instruction") or item.get("role")
+            else:
+                name, instruction = item, None
+            if name and name in known:
+                stages.append((str(name), instruction))
+        return stages[:MAX_STAGES]
+
+    async def run(self, messages: list[dict[str, Any]], **kwargs) -> Any:
+        params = dict(self._params)
+
+        prompt = support.render_prompt(messages)
+        if not prompt:
+            yield support.message_chunk("No prompt provided.", final=True)
+            return
+
+        registry = support.apply_overrides(support.build_registry(self._config), params)
+        stages = self._resolve_stages(params, registry)
+        if not stages:
+            yield support.message_chunk(
+                "No pipeline stages are configured. Add a 'cli_pipeline' block (or a "
+                "'cli_fusion' preset) to your swarm config (see docs/CLI_FUSION.md).",
+                final=True,
+            )
+            return
+
+        workdir = params.get(support.PARAM_WORKDIR)
+        names = ", ".join(n for n, _ in stages)
+        yield support.progress_chunk(f"_Pipeline of {len(stages)} stage(s): {names}…_")
+
+        draft: str | None = None
+        for i, (name, instruction) in enumerate(stages):
+            adapter = registry.get(name)
+            if draft is None:
+                # First stage works the raw task (optionally with its instruction).
+                stage_prompt = f"{instruction}\n\n{prompt}" if instruction else prompt
+                label = f"stage {i + 1}/{len(stages)} `{name}` (draft)"
+            else:
+                stage_prompt = REFINE_TEMPLATE.format(
+                    prompt=prompt, draft=draft, instruction=instruction or DEFAULT_INSTRUCTION
+                )
+                label = f"stage {i + 1}/{len(stages)} `{name}` (refine)"
+            yield support.progress_chunk(f"_Running {label}…_")
+
+            res = await adapter.run(stage_prompt, workdir=workdir)
+            if res.ok and res.text.strip():
+                draft = res.text
+            else:
+                # Skip a failed stage; the last good draft carries forward.
+                yield support.progress_chunk(
+                    f"_• {name} failed ({res.error or 'empty output'}); carrying prior draft forward._"
+                )
+
+        if draft is None:
+            yield support.message_chunk("Every pipeline stage failed.", final=True)
+            return
+        yield support.message_chunk(draft, final=True)

--- a/src/swarm/blueprints/cli_planner/blueprint_cli_planner.py
+++ b/src/swarm/blueprints/cli_planner/blueprint_cli_planner.py
@@ -1,0 +1,214 @@
+"""CLI Planner blueprint — Magentic-One-style ledger.
+
+A planner CLI maintains a *task ledger*: it drafts an initial plan, delegates
+subtasks to specialist worker CLIs one at a time, inspects each result, and
+**re-plans on stall** — adding follow-up subtasks until the goal is met or a
+round budget is exhausted — then synthesizes the final answer.
+
+This is the iterative, reactive cousin of ``cli_map``: where map does one
+decompose → distribute → reduce pass, planner loops, letting the plan grow in
+response to what the workers actually produced.
+
+Request model: ``model: "cli_planner"``. Config block ``cli_planner``:
+``{ "planner": <cli>, "workers": [<cli>...] (or "worker": <cli>), "max_rounds": int }``
+(falls back to ``cli_map`` / ``cli_fusion`` config). Per-request ``params`` may set
+``planner``, ``workers``/``worker``, ``max_rounds``, ``workdir``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar
+
+from swarm.blueprints.common import cli_fusion_support as support
+from swarm.core.blueprint_base import BlueprintBase
+from swarm.core.cli_adapter import CliAdapterRegistry
+from swarm.core.consensus import safe_json
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_ROUNDS = 4
+MAX_ROUNDS_CEILING = 10
+MAX_SUBTASKS = 12
+
+PLAN_TEMPLATE = """PLAN THE GOAL below by drafting a task ledger: an ordered list of concrete
+subtasks a specialist agent can each carry out. Return ONLY a JSON object:
+{{"subtasks": ["<subtask 1>", "<subtask 2>", ...]}}
+Use as few subtasks as the goal needs.
+
+Goal:
+{goal}
+"""
+
+REPLAN_TEMPLATE = """PROGRESS REVIEW of work on this goal:
+<goal>
+{goal}
+</goal>
+
+Completed subtasks and their results so far:
+{completed}
+
+Decide whether the goal is met. Return ONLY a JSON object:
+{{"done": true or false, "new_subtasks": ["<follow-up subtask>", ...], "synthesis": "<best answer to the goal so far>"}}
+Add new_subtasks ONLY if something essential is still missing; otherwise return an empty list and set done to true.
+"""
+
+SYNTH_TEMPLATE = """The goal was:
+<goal>
+{goal}
+</goal>
+
+All completed subtasks and results:
+{completed}
+
+Write the final answer to the goal, integrating the results. Return only the answer.
+"""
+
+
+class CliPlannerBlueprint(BlueprintBase):
+    """Plan, delegate, review, re-plan on stall, then synthesize."""
+
+    metadata: ClassVar[dict[str, Any]] = {
+        "name": "cli_planner",
+        "title": "CLI Planner (Magentic-One-style ledger)",
+        "description": (
+            "A planner maintains a task ledger, delegates subtasks to worker CLIs, "
+            "reviews results, and re-plans on stall until the goal is met, then "
+            "synthesizes. The iterative cousin of cli_map."
+        ),
+        "version": "0.1.0",
+        "author": "Open Swarm Team",
+        "tags": ["cli", "planner", "magentic", "multi-agent", "openai-compatible"],
+        "required_mcp_servers": [],
+        "env_vars": [],
+    }
+
+    def __init__(self, blueprint_id: str = "cli_planner", config=None, config_path=None, **kwargs):
+        super().__init__(blueprint_id, config=config, config_path=config_path, **kwargs)
+        self._params: dict[str, Any] = {}
+
+    def set_params(self, params: dict[str, Any] | None) -> None:
+        self._params = dict(params or {})
+
+    def _resolve(
+        self, params: dict[str, Any], registry: CliAdapterRegistry
+    ) -> tuple[str | None, list[str]]:
+        """Resolve (planner, workers), falling back to cli_map / cli_fusion config."""
+        pc = (self._config or {}).get("cli_planner") or {}
+        mc = (self._config or {}).get("cli_map") or {}
+        fusion = (self._config or {}).get("cli_fusion") or {}
+        preset = (fusion.get("presets") or {}).get(fusion.get("default_preset")) or {}
+
+        planner = params.get("planner") or pc.get("planner") or mc.get("planner") or fusion.get("default_cli")
+        workers = params.get("workers") or pc.get("workers") or mc.get("workers")
+        if not workers:
+            single = params.get("worker") or pc.get("worker") or mc.get("worker")
+            workers = [single] if single else (preset.get("panel") or registry.available() or registry.names())
+
+        known = set(registry.names())
+        workers = [w for w in (workers or []) if w in known]
+        if planner and planner not in known:
+            planner = None
+        return planner, workers
+
+    def _max_rounds(self, params: dict[str, Any]) -> int:
+        raw = params.get("max_rounds", ((self._config or {}).get("cli_planner") or {}).get("max_rounds", DEFAULT_MAX_ROUNDS))
+        try:
+            return max(1, min(int(raw), MAX_ROUNDS_CEILING))
+        except (TypeError, ValueError):
+            return DEFAULT_MAX_ROUNDS
+
+    @staticmethod
+    def _completed_block(completed: list[tuple[str, str, str]]) -> str:
+        if not completed:
+            return "(nothing completed yet)"
+        return "\n\n".join(f"### {sub}\n_(by {w})_\n{text}" for sub, w, text in completed)
+
+    async def run(self, messages: list[dict[str, Any]], **kwargs) -> Any:
+        params = dict(self._params)
+
+        goal = support.render_prompt(messages)
+        if not goal:
+            yield support.message_chunk("No prompt provided.", final=True)
+            return
+
+        registry = support.apply_overrides(support.build_registry(self._config), params)
+        planner, workers = self._resolve(params, registry)
+        if not planner:
+            yield support.message_chunk(
+                "No planner CLI is configured for cli_planner. Add a 'cli_planner' "
+                "block (or a 'cli_map'/'cli_fusion' default) to your swarm config "
+                "(see docs/CLI_FUSION.md).",
+                final=True,
+            )
+            return
+        if not workers:
+            yield support.message_chunk("No worker CLIs are configured for cli_planner.", final=True)
+            return
+
+        workdir = params.get(support.PARAM_WORKDIR)
+        max_rounds = self._max_rounds(params)
+
+        # 1. Initial plan → the ledger of open subtasks.
+        yield support.progress_chunk(f"_Planning with `{planner}`…_")
+        pres = await registry.get(planner).run(PLAN_TEMPLATE.format(goal=goal), workdir=workdir)
+        plan = safe_json(pres.text) if pres.ok else None
+        open_q = [str(s) for s in (plan or {}).get("subtasks", []) if str(s).strip()][:MAX_SUBTASKS]
+        if not open_q:
+            yield support.message_chunk("Planner produced no subtasks.", final=True)
+            return
+        yield support.progress_chunk(f"_Ledger seeded with {len(open_q)} subtask(s)._")
+
+        completed: list[tuple[str, str, str]] = []
+        synthesis: str | None = None
+        added_total = 0
+
+        # 2. Work the ledger, re-planning after each subtask.
+        for round_i in range(max_rounds):
+            if not open_q:
+                break
+            subtask = open_q.pop(0)
+            worker = registry.get(workers[round_i % len(workers)])
+            yield support.progress_chunk(
+                f"_Round {round_i + 1}/{max_rounds}: `{worker.name}` on “{subtask[:60]}”…_"
+            )
+            res = await worker.run(subtask, workdir=workdir)
+            if res.ok and res.text.strip():
+                completed.append((subtask, worker.name, res.text))
+            else:
+                yield support.progress_chunk(f"_• {worker.name} failed on a subtask ({res.error or 'empty'})._")
+
+            # 3. Re-plan: is the goal met, or does the ledger need more?
+            rres = await registry.get(planner).run(
+                REPLAN_TEMPLATE.format(goal=goal, completed=self._completed_block(completed)),
+                workdir=workdir,
+            )
+            verdict = safe_json(rres.text) if rres.ok else None
+            if isinstance(verdict, dict):
+                if isinstance(verdict.get("synthesis"), str) and verdict["synthesis"].strip():
+                    synthesis = verdict["synthesis"].strip()
+                if bool(verdict.get("done")):
+                    yield support.progress_chunk(f"_Planner marked the goal met after round {round_i + 1}._")
+                    break
+                for ns in verdict.get("new_subtasks", []) or []:
+                    if str(ns).strip() and added_total < MAX_SUBTASKS:
+                        open_q.append(str(ns))
+                        added_total += 1
+                        yield support.progress_chunk(f"_Re-planned: added subtask “{str(ns)[:60]}”._")
+
+        if not completed:
+            yield support.message_chunk("Every worker subtask failed.", final=True)
+            return
+
+        # 4. Synthesize — prefer the planner's last synthesis, else a final synth call.
+        if synthesis:
+            yield support.message_chunk(synthesis, final=True)
+            return
+        yield support.progress_chunk(f"_Synthesizing final answer with `{planner}`…_")
+        sres = await registry.get(planner).run(
+            SYNTH_TEMPLATE.format(goal=goal, completed=self._completed_block(completed)), workdir=workdir
+        )
+        if sres.ok and sres.text.strip():
+            yield support.message_chunk(sres.text, final=True)
+            return
+        yield support.message_chunk(self._completed_block(completed), final=True)

--- a/src/swarm/blueprints/cli_roundtable/blueprint_cli_roundtable.py
+++ b/src/swarm/blueprints/cli_roundtable/blueprint_cli_roundtable.py
@@ -1,0 +1,195 @@
+"""CLI Roundtable blueprint — group-chat debate.
+
+Several CLIs debate in a *shared transcript* across bounded rounds. Each round
+every debater sees the others' latest positions, so they react to each other —
+unlike ``cli_fusion``, where the panel answers once in isolation and a judge
+reconciles. A moderator decides after each round whether the table has converged
+(conclude) or should keep going, and produces the final synthesis.
+
+Request model: ``model: "cli_roundtable"``. Config block ``cli_roundtable``:
+``{ "debaters": [<cli>...], "moderator": <cli>, "rounds": int }`` (falls back to
+a ``cli_fusion`` preset panel + judge). Per-request ``params`` may set
+``debaters``, ``moderator``, ``rounds``, ``workdir``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, ClassVar
+
+from swarm.blueprints.common import cli_fusion_support as support
+from swarm.core.blueprint_base import BlueprintBase
+from swarm.core.cli_adapter import CliAdapterRegistry
+from swarm.core.consensus import safe_json
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ROUNDS = 2
+MAX_ROUNDS = 4
+MAX_CONCURRENCY = 8
+
+DEBATER_TEMPLATE = """You are participant "{name}" in a panel debate on this question:
+<question>
+{question}
+</question>
+
+Discussion so far:
+{transcript}
+
+Give your position in 2-4 sentences. If you disagree with another participant, say
+why specifically. Do not repeat points already settled. Be concise.
+"""
+
+MODERATOR_TEMPLATE = """You are the moderator of a panel debate on this question:
+<question>
+{question}
+</question>
+
+The latest round of positions:
+{positions}
+
+Decide whether the panel has converged enough to conclude. Return ONLY a JSON object:
+{{"done": true or false, "synthesis": "<the best combined answer so far>", "next_prompt": "<if not done, the specific point the panel should resolve next>"}}
+"""
+
+
+class CliRoundtableBlueprint(BlueprintBase):
+    """Run a bounded multi-CLI debate moderated to a synthesized conclusion."""
+
+    metadata: ClassVar[dict[str, Any]] = {
+        "name": "cli_roundtable",
+        "title": "CLI Roundtable (group-chat debate)",
+        "description": (
+            "Several CLIs debate in a shared transcript across bounded rounds, "
+            "reacting to each other; a moderator decides when to conclude and "
+            "synthesizes the result. Group chat over heterogeneous CLIs."
+        ),
+        "version": "0.1.0",
+        "author": "Open Swarm Team",
+        "tags": ["cli", "group-chat", "debate", "multi-agent", "openai-compatible"],
+        "required_mcp_servers": [],
+        "env_vars": [],
+    }
+
+    def __init__(self, blueprint_id: str = "cli_roundtable", config=None, config_path=None, **kwargs):
+        super().__init__(blueprint_id, config=config, config_path=config_path, **kwargs)
+        self._params: dict[str, Any] = {}
+
+    def set_params(self, params: dict[str, Any] | None) -> None:
+        self._params = dict(params or {})
+
+    def _resolve(
+        self, params: dict[str, Any], registry: CliAdapterRegistry
+    ) -> tuple[list[str], str | None]:
+        """Resolve (debaters, moderator), falling back to a cli_fusion preset."""
+        rc = (self._config or {}).get("cli_roundtable") or {}
+        fusion = (self._config or {}).get("cli_fusion") or {}
+        preset = (fusion.get("presets") or {}).get(fusion.get("default_preset")) or {}
+
+        debaters = params.get("debaters") or rc.get("debaters") or preset.get("panel")
+        if not debaters:
+            debaters = registry.available() or registry.names()
+        moderator = (
+            params.get("moderator")
+            or rc.get("moderator")
+            or preset.get("judge")
+            or fusion.get("default_cli")
+        )
+
+        known = set(registry.names())
+        debaters = [d for d in (debaters or []) if d in known]
+        if moderator and moderator not in known:
+            moderator = None
+        return debaters, moderator
+
+    def _rounds(self, params: dict[str, Any]) -> int:
+        raw = params.get("rounds", ((self._config or {}).get("cli_roundtable") or {}).get("rounds", DEFAULT_ROUNDS))
+        try:
+            return max(1, min(int(raw), MAX_ROUNDS))
+        except (TypeError, ValueError):
+            return DEFAULT_ROUNDS
+
+    async def run(self, messages: list[dict[str, Any]], **kwargs) -> Any:
+        params = dict(self._params)
+
+        question = support.render_prompt(messages)
+        if not question:
+            yield support.message_chunk("No prompt provided.", final=True)
+            return
+
+        registry = support.apply_overrides(support.build_registry(self._config), params)
+        debaters, moderator = self._resolve(params, registry)
+        if not debaters:
+            yield support.message_chunk(
+                "No debater CLIs are configured for the roundtable. Add a "
+                "'cli_roundtable' block (or a 'cli_fusion' preset) to your swarm "
+                "config (see docs/CLI_FUSION.md).",
+                final=True,
+            )
+            return
+
+        workdir = params.get(support.PARAM_WORKDIR)
+        rounds = self._rounds(params)
+        sem = asyncio.Semaphore(MAX_CONCURRENCY)
+        yield support.progress_chunk(
+            f"_Roundtable: {len(debaters)} debater(s) over up to {rounds} round(s)…_"
+        )
+
+        transcript = "(no prior discussion)"
+        last_positions: list[tuple[str, str]] = []
+        synthesis: str | None = None
+
+        for round_i in range(rounds):
+            yield support.progress_chunk(f"_Round {round_i + 1}/{rounds}: debaters responding…_")
+
+            async def _one(name: str, transcript=transcript):
+                adapter = registry.get(name)
+                async with sem:
+                    res = await adapter.run(
+                        DEBATER_TEMPLATE.format(name=name, question=question, transcript=transcript),
+                        workdir=workdir,
+                    )
+                return name, res
+
+            results = await asyncio.gather(*(_one(d) for d in debaters))
+            positions = [(name, res.text) for name, res in results if res.ok and res.text.strip()]
+            for name, res in results:
+                if not (res.ok and res.text.strip()):
+                    yield support.progress_chunk(f"_• {name} did not respond ({res.error or 'empty'})._")
+            if not positions:
+                yield support.progress_chunk("_No debater responded this round._")
+                break
+            last_positions = positions
+
+            # Grow the shared transcript with this round's positions.
+            block = "\n".join(f"[{name}] {text}" for name, text in positions)
+            transcript = f"{transcript}\n\n--- Round {round_i + 1} ---\n{block}".lstrip()
+
+            if not moderator:
+                continue  # no moderator: keep debating to the round bound, then concatenate
+
+            yield support.progress_chunk(f"_Moderator `{moderator}` reviewing round {round_i + 1}…_")
+            mres = await registry.get(moderator).run(
+                MODERATOR_TEMPLATE.format(question=question, positions=block), workdir=workdir
+            )
+            verdict = safe_json(mres.text) if mres.ok else None
+            if isinstance(verdict, dict):
+                if isinstance(verdict.get("synthesis"), str) and verdict["synthesis"].strip():
+                    synthesis = verdict["synthesis"].strip()
+                if bool(verdict.get("done")):
+                    yield support.progress_chunk(f"_Moderator concluded after round {round_i + 1}._")
+                    break
+                nxt = verdict.get("next_prompt")
+                if isinstance(nxt, str) and nxt.strip():
+                    transcript = f"{transcript}\n\n[moderator] Focus next on: {nxt.strip()}"
+
+        if synthesis:
+            yield support.message_chunk(synthesis, final=True)
+            return
+        # No moderator synthesis — return the final round's positions, labeled.
+        if last_positions:
+            block = "\n\n".join(f"### {name}\n{text}" for name, text in last_positions)
+            yield support.message_chunk(block, final=True)
+            return
+        yield support.message_chunk("The roundtable produced no positions.", final=True)

--- a/tests/blueprints/test_cli_pipeline.py
+++ b/tests/blueprints/test_cli_pipeline.py
@@ -1,0 +1,112 @@
+"""Tests for the cli_pipeline blueprint (sequential refinement)."""
+
+from __future__ import annotations
+
+import sys
+
+from swarm.blueprints.cli_pipeline.blueprint_cli_pipeline import CliPipelineBlueprint
+
+PY = sys.executable
+
+# A stage CLI that appends "+<tag>" to the running draft. It extracts the prior
+# draft from the <draft>…</draft> block when present (refine stages), else treats
+# the whole prompt as the base (the first stage). This makes the sequential
+# chain visible in the final output: hello -> hello+A -> hello+A+B.
+_STAGE_CODE = (
+    "import sys,re\n"
+    "s=sys.argv[1]\n"
+    "m=re.search(r'<draft>\\n(.*)\\n</draft>', s, re.S)\n"
+    "b=m.group(1) if m else s\n"
+    "print(b + '+{tag}')"
+)
+
+
+def _stage(tag: str) -> dict:
+    return {"cmd": [PY, "-c", _STAGE_CODE.format(tag=tag), "{prompt}"], "parse": "text"}
+
+
+def _boom() -> dict:
+    return {"cmd": [PY, "-c", "import sys; sys.exit(1)", "{prompt}"]}
+
+
+async def _collect(gen):
+    return [c async for c in gen]
+
+
+def _final(chunks):
+    text = None
+    for c in chunks:
+        msgs = c.get("messages") if isinstance(c, dict) else None
+        if msgs and msgs[0].get("content") is not None:
+            text = msgs[0]["content"]
+    return text
+
+
+def _progress(chunks):
+    return "\n".join(c["content"] for c in chunks if isinstance(c, dict) and c.get("type") == "fusion_progress")
+
+
+async def test_stages_chain_in_order():
+    cfg = {
+        "cli_agents": {"a": _stage("A"), "b": _stage("B"), "c": _stage("C")},
+        "cli_pipeline": {"stages": ["a", "b", "c"]},
+    }
+    bp = CliPipelineBlueprint(config=cfg)
+    final = _final(await _collect(bp.run([{"role": "user", "content": "hello"}])))
+    # Each stage saw the previous draft and appended its tag, in order.
+    assert final == "hello+A+B+C"
+
+
+async def test_failed_stage_carries_prior_draft_forward():
+    cfg = {
+        "cli_agents": {"a": _stage("A"), "boom": _boom(), "c": _stage("C")},
+        "cli_pipeline": {"stages": ["a", "boom", "c"]},
+    }
+    bp = CliPipelineBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "hello"}]))
+    # boom is skipped; c refines a's draft, not nothing.
+    assert _final(chunks) == "hello+A+C"
+    assert "boom failed" in _progress(chunks)
+
+
+async def test_dict_stage_with_instruction_runs():
+    cfg = {
+        "cli_agents": {"a": _stage("A")},
+        "cli_pipeline": {"stages": [{"cli": "a", "instruction": "DRAFT IT"}]},
+    }
+    bp = CliPipelineBlueprint(config=cfg)
+    final = _final(await _collect(bp.run([{"role": "user", "content": "hello"}])))
+    assert final.endswith("+A")
+
+
+async def test_unknown_stage_cli_is_dropped():
+    cfg = {
+        "cli_agents": {"a": _stage("A")},
+        "cli_pipeline": {"stages": ["a", "nonexistent"]},
+    }
+    bp = CliPipelineBlueprint(config=cfg)
+    final = _final(await _collect(bp.run([{"role": "user", "content": "hello"}])))
+    assert final == "hello+A"  # only the known stage ran
+
+
+async def test_no_stages_configured():
+    bp = CliPipelineBlueprint(config={})
+    final = _final(await _collect(bp.run([{"role": "user", "content": "t"}])))
+    assert "No pipeline stages are configured" in final
+
+
+async def test_all_stages_fail():
+    cfg = {"cli_agents": {"boom": _boom()}, "cli_pipeline": {"stages": ["boom"]}}
+    bp = CliPipelineBlueprint(config=cfg)
+    final = _final(await _collect(bp.run([{"role": "user", "content": "t"}])))
+    assert "Every pipeline stage failed" in final
+
+
+async def test_falls_back_to_fusion_preset_panel():
+    cfg = {
+        "cli_agents": {"a": _stage("A"), "b": _stage("B")},
+        "cli_fusion": {"presets": {"p": {"panel": ["a", "b"]}}, "default_preset": "p"},
+    }
+    bp = CliPipelineBlueprint(config=cfg)
+    final = _final(await _collect(bp.run([{"role": "user", "content": "hello"}])))
+    assert final == "hello+A+B"

--- a/tests/blueprints/test_cli_planner.py
+++ b/tests/blueprints/test_cli_planner.py
@@ -1,0 +1,150 @@
+"""Tests for the cli_planner blueprint (Magentic-One-style ledger)."""
+
+from __future__ import annotations
+
+import sys
+
+from swarm.blueprints.cli_planner.blueprint_cli_planner import CliPlannerBlueprint
+
+PY = sys.executable
+
+
+def _planner(code: str) -> dict:
+    return {"cmd": [PY, "-c", code, "{prompt}"], "parse": "text"}
+
+
+def _worker(tag: str = "W") -> dict:
+    # Echoes "<tag>:<subtask>" so the executed subtask is visible in results.
+    return {"cmd": [PY, "-c", f"import sys; print('{tag}:' + sys.argv[1])", "{prompt}"], "parse": "text"}
+
+
+def _boom() -> dict:
+    return {"cmd": [PY, "-c", "import sys; sys.exit(1)", "{prompt}"]}
+
+
+async def _collect(gen):
+    return [c async for c in gen]
+
+
+def _final(chunks):
+    text = None
+    for c in chunks:
+        msgs = c.get("messages") if isinstance(c, dict) else None
+        if msgs and msgs[0].get("content") is not None:
+            text = msgs[0]["content"]
+    return text
+
+
+def _progress(chunks):
+    return "\n".join(c["content"] for c in chunks if isinstance(c, dict) and c.get("type") == "fusion_progress")
+
+
+# A planner that, on review, adds one follow-up subtask the first time, then
+# concludes once that follow-up's result ("extra-task") shows up as completed.
+_REPLANNING_PLANNER = (
+    "import sys\n"
+    "p = sys.argv[1]\n"
+    "if 'PROGRESS REVIEW' in p:\n"
+    "    if 'extra-task' in p:\n"
+    "        print('{\"done\": true, \"synthesis\": \"FINAL\"}')\n"
+    "    else:\n"
+    "        print('{\"done\": false, \"new_subtasks\": [\"extra-task\"], \"synthesis\": \"interim\"}')\n"
+    "elif 'PLAN THE GOAL' in p:\n"
+    "    print('{\"subtasks\": [\"s1\"]}')\n"
+    "else:\n"
+    "    print('SYNTH')\n"
+)
+
+
+async def test_replans_on_stall_then_concludes():
+    cfg = {
+        "cli_agents": {"p": _planner(_REPLANNING_PLANNER), "w": _worker("W")},
+        "cli_planner": {"planner": "p", "worker": "w", "max_rounds": 5},
+    }
+    bp = CliPlannerBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "achieve the goal"}]))
+    assert _final(chunks) == "FINAL"
+    prog = _progress(chunks)
+    assert "added subtask" in prog  # the ledger grew in response to progress
+    assert "goal met" in prog
+
+
+async def test_concludes_immediately_with_synthesis():
+    code = (
+        "import sys\n"
+        "p = sys.argv[1]\n"
+        "if 'PROGRESS REVIEW' in p:\n"
+        "    print('{\"done\": true, \"synthesis\": \"QUICK\"}')\n"
+        "elif 'PLAN THE GOAL' in p:\n"
+        "    print('{\"subtasks\": [\"only\"]}')\n"
+        "else:\n"
+        "    print('SYNTH')\n"
+    )
+    cfg = {
+        "cli_agents": {"p": _planner(code), "w": _worker("W")},
+        "cli_planner": {"planner": "p", "worker": "w"},
+    }
+    bp = CliPlannerBlueprint(config=cfg)
+    assert _final(await _collect(bp.run([{"role": "user", "content": "g"}]))) == "QUICK"
+
+
+async def test_synthesis_fallback_calls_planner_synth():
+    # done=true but no synthesis text -> blueprint makes a final SYNTH call.
+    code = (
+        "import sys\n"
+        "p = sys.argv[1]\n"
+        "if 'PROGRESS REVIEW' in p:\n"
+        "    print('{\"done\": true, \"synthesis\": \"\"}')\n"
+        "elif 'PLAN THE GOAL' in p:\n"
+        "    print('{\"subtasks\": [\"only\"]}')\n"
+        "else:\n"
+        "    print('FINAL-SYNTH')\n"
+    )
+    cfg = {
+        "cli_agents": {"p": _planner(code), "w": _worker("W")},
+        "cli_planner": {"planner": "p", "worker": "w"},
+    }
+    bp = CliPlannerBlueprint(config=cfg)
+    assert _final(await _collect(bp.run([{"role": "user", "content": "g"}]))) == "FINAL-SYNTH"
+
+
+async def test_no_planner_configured():
+    cfg = {"cli_agents": {"w": _worker("W")}}
+    bp = CliPlannerBlueprint(config=cfg)
+    assert "No planner CLI is configured" in _final(await _collect(bp.run([{"role": "user", "content": "g"}])))
+
+
+async def test_planner_no_subtasks():
+    code = (
+        "import sys\n"
+        "p = sys.argv[1]\n"
+        "if 'PLAN THE GOAL' in p:\n"
+        "    print('{\"subtasks\": []}')\n"
+        "else:\n"
+        "    print('{}')\n"
+    )
+    cfg = {
+        "cli_agents": {"p": _planner(code), "w": _worker("W")},
+        "cli_planner": {"planner": "p", "worker": "w"},
+    }
+    bp = CliPlannerBlueprint(config=cfg)
+    assert "no subtasks" in _final(await _collect(bp.run([{"role": "user", "content": "g"}]))).lower()
+
+
+async def test_all_worker_subtasks_fail():
+    code = (
+        "import sys\n"
+        "p = sys.argv[1]\n"
+        "if 'PROGRESS REVIEW' in p:\n"
+        "    print('{\"done\": false, \"new_subtasks\": []}')\n"
+        "elif 'PLAN THE GOAL' in p:\n"
+        "    print('{\"subtasks\": [\"s1\"]}')\n"
+        "else:\n"
+        "    print('X')\n"
+    )
+    cfg = {
+        "cli_agents": {"p": _planner(code), "boom": _boom()},
+        "cli_planner": {"planner": "p", "worker": "boom", "max_rounds": 2},
+    }
+    bp = CliPlannerBlueprint(config=cfg)
+    assert "Every worker subtask failed" in _final(await _collect(bp.run([{"role": "user", "content": "g"}])))

--- a/tests/blueprints/test_cli_roundtable.py
+++ b/tests/blueprints/test_cli_roundtable.py
@@ -1,0 +1,112 @@
+"""Tests for the cli_roundtable blueprint (group-chat debate)."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from swarm.blueprints.cli_roundtable.blueprint_cli_roundtable import (
+    CliRoundtableBlueprint,
+)
+
+PY = sys.executable
+
+
+def _debater(tag: str) -> dict:
+    # Prints a fixed tag so its participation is visible in the transcript.
+    return {"cmd": [PY, "-c", f"print({tag!r})", "{prompt}"], "parse": "text"}
+
+
+def _moderator(done: bool, synthesis: str = "AGREED", next_prompt: str = "dig deeper") -> dict:
+    payload = json.dumps({"done": done, "synthesis": synthesis, "next_prompt": next_prompt})
+    return {"cmd": [PY, "-c", "import sys; print(sys.argv[2])", "{prompt}", payload], "parse": "text"}
+
+
+def _boom() -> dict:
+    return {"cmd": [PY, "-c", "import sys; sys.exit(1)", "{prompt}"]}
+
+
+async def _collect(gen):
+    return [c async for c in gen]
+
+
+def _final(chunks):
+    text = None
+    for c in chunks:
+        msgs = c.get("messages") if isinstance(c, dict) else None
+        if msgs and msgs[0].get("content") is not None:
+            text = msgs[0]["content"]
+    return text
+
+
+def _progress(chunks):
+    return "\n".join(c["content"] for c in chunks if isinstance(c, dict) and c.get("type") == "fusion_progress")
+
+
+async def test_moderator_concludes_early():
+    cfg = {
+        "cli_agents": {"a": _debater("A"), "b": _debater("B"), "m": _moderator(True, "AGREED")},
+        "cli_roundtable": {"debaters": ["a", "b"], "moderator": "m", "rounds": 3},
+    }
+    bp = CliRoundtableBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "debate this"}]))
+    assert _final(chunks) == "AGREED"
+    assert "concluded after round 1" in _progress(chunks)
+
+
+async def test_runs_all_rounds_when_never_done():
+    cfg = {
+        "cli_agents": {"a": _debater("A"), "b": _debater("B"), "m": _moderator(False, "PARTIAL")},
+        "cli_roundtable": {"debaters": ["a", "b"], "moderator": "m", "rounds": 2},
+    }
+    bp = CliRoundtableBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "debate this"}]))
+    assert _final(chunks) == "PARTIAL"  # last synthesis carried forward
+    assert "Round 2/2" in _progress(chunks)
+
+
+async def test_no_moderator_concatenates_last_positions():
+    cfg = {
+        "cli_agents": {"a": _debater("ALPHA"), "b": _debater("BETA")},
+        "cli_roundtable": {"debaters": ["a", "b"], "rounds": 1},
+    }
+    bp = CliRoundtableBlueprint(config=cfg)
+    final = _final(await _collect(bp.run([{"role": "user", "content": "q"}])))
+    assert "ALPHA" in final and "BETA" in final
+
+
+async def test_failed_debater_noted_others_continue():
+    cfg = {
+        "cli_agents": {"a": _debater("ALPHA"), "boom": _boom()},
+        "cli_roundtable": {"debaters": ["a", "boom"], "rounds": 1},
+    }
+    bp = CliRoundtableBlueprint(config=cfg)
+    chunks = await _collect(bp.run([{"role": "user", "content": "q"}]))
+    assert "ALPHA" in _final(chunks)
+    assert "boom did not respond" in _progress(chunks)
+
+
+async def test_all_debaters_fail():
+    cfg = {
+        "cli_agents": {"boom": _boom()},
+        "cli_roundtable": {"debaters": ["boom"], "rounds": 1},
+    }
+    bp = CliRoundtableBlueprint(config=cfg)
+    final = _final(await _collect(bp.run([{"role": "user", "content": "q"}])))
+    assert "no positions" in final.lower()
+
+
+async def test_no_debaters_configured():
+    bp = CliRoundtableBlueprint(config={})
+    final = _final(await _collect(bp.run([{"role": "user", "content": "q"}])))
+    assert "No debater CLIs are configured" in final
+
+
+async def test_falls_back_to_fusion_preset():
+    cfg = {
+        "cli_agents": {"a": _debater("A"), "b": _debater("B"), "m": _moderator(True, "DONE")},
+        "cli_fusion": {"presets": {"p": {"panel": ["a", "b"], "judge": "m"}}, "default_preset": "p"},
+    }
+    bp = CliRoundtableBlueprint(config=cfg)
+    final = _final(await _collect(bp.run([{"role": "user", "content": "q"}])))
+    assert final == "DONE"


### PR DESCRIPTION
## What

Implements the three orchestration patterns marked **planned** in #145, completing CLI-fusion's parity with the field-standard pattern set (sequential / concurrent / handoff / group-chat / Magentic-One). Each is a discoverable blueprint — a `model` id.

| Blueprint | Pattern | Distinct from |
|---|---|---|
| **`cli_pipeline`** | sequential | `cli_fusion` — stages are sequential and dependent (draft → review → polish), not a parallel panel. A failed stage carries the last good draft forward. |
| **`cli_roundtable`** | group chat | `cli_fusion` — debaters react to each other in a shared transcript across bounded rounds; a moderator decides continue-vs-conclude and synthesizes. |
| **`cli_planner`** | Magentic-One | `cli_map` — a planner keeps a task ledger, delegates to workers, reviews each result, and **re-plans on stall** until the goal is met, then synthesizes. |

## Conventions

All three follow the existing blueprint contract: `BlueprintBase`, `cli_fusion_support` helpers, the progress + final chunk protocol, backend resolution via the shared CLI adapter registry, graceful degradation on a dead backend, and fallback to `cli_fusion`/`cli_map` config. Auto-discovered at `/v1/models`.

## Tests

20 new tests using fake Python-process CLIs (mirroring `tests/blueprints` conventions), covering: sequential chaining (each stage provably sees the prior draft), early-conclude vs run-all-rounds, re-plan-on-stall growing the ledger, graceful degradation, and the no-config / all-fail paths. Full `tests/blueprints` suite: **142 passed**.

## Docs

Sequence diagrams and selection guidance already in [docs/ORCHESTRATION_PATTERNS.md](https://github.com/matthewhand/open-swarm/blob/docs/vision-and-orchestration/docs/ORCHESTRATION_PATTERNS.md) (#145), where these are drawn. Once #145 and this merge, their status flips from ⏳ planned to ✅ built (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)