### PR TITLE
docs: mark pipeline/roundtable/planner as built + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Orchestration patterns (MAF-class, over CLIs)
+- Three new orchestration blueprints complete the field-standard pattern set over heterogeneous agentic CLIs: **`cli_pipeline`** (sequential — each stage refines the prior stage's output, draft → review → polish), **`cli_roundtable`** (group-chat — debaters react to each other in a shared transcript across bounded rounds, a moderator concludes and synthesizes), and **`cli_planner`** (Magentic-One — a planner keeps a task ledger, delegates to workers, and re-plans on stall until the goal is met). All follow the existing `BlueprintBase` + `cli_fusion_support` conventions, degrade gracefully on a dead backend, and are auto-discovered at `/v1/models`. 20 new tests.
+- New docs: **[docs/VISION.md](docs/VISION.md)** (front-and-centre vision + honest built-vs-remaining) and **[docs/ORCHESTRATION_PATTERNS.md](docs/ORCHESTRATION_PATTERNS.md)** (GitHub Mermaid sequence diagrams for all seven patterns). Live cross-CLI transcripts (consensus, routing, tool calling) under `docs/proofs/`.
+
 ### Added — Skills
 - Reusable **skills**: `SKILL.md` directories (Anthropic [Agent Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) open standard) discoverable via `swarm-cli skills` (`--show`/`--json`) and applied to any CLI with the `cli_agent` `skill=<name>` param. Applying a skill prepends its instructions and stages any bundled assets into the workdir so a write-mode CLI can execute them.
 - Bundled skills: `conventional-commit`, `reviewing-code`, `writing-changelog`, and `counting-lines` (ships an executable `count.py`).

--- a/docs/ORCHESTRATION_PATTERNS.md
+++ b/docs/ORCHESTRATION_PATTERNS.md
@@ -15,9 +15,9 @@ All diagrams are GitHub-rendered Mermaid. Backends shown (`gemini`, `claude`,
 | [`cli_fusion`](#cli_fusion--concurrent-panel--judge) | concurrent | ✅ built |
 | [`cli_orchestrator`](#cli_orchestrator--handoff--escalation) | handoff / escalation | ✅ built |
 | [`cli_map`](#cli_map--map-reduce) | map-reduce | ✅ built |
-| [`cli_pipeline`](#cli_pipeline--sequential-refinement) | sequential | ⏳ planned |
-| [`cli_roundtable`](#cli_roundtable--group-chat-debate) | group chat | ⏳ planned |
-| [`cli_planner`](#cli_planner--magentic-one-ledger) | Magentic-One | ⏳ planned |
+| [`cli_pipeline`](#cli_pipeline--sequential-refinement) | sequential | ✅ built |
+| [`cli_roundtable`](#cli_roundtable--group-chat-debate) | group chat | ✅ built |
+| [`cli_planner`](#cli_planner--magentic-one-ledger) | Magentic-One | ✅ built |
 
 ---
 
@@ -136,7 +136,7 @@ sequenceDiagram
 
 ---
 
-## `cli_pipeline` — sequential refinement ⏳ planned
+## `cli_pipeline` — sequential refinement ✅
 
 A staged chain where each CLI refines the previous stage's output. Different
 backends play to their strengths in order — for example a fast model drafts, a
@@ -163,7 +163,7 @@ sequenceDiagram
 
 ---
 
-## `cli_roundtable` — group-chat debate ⏳ planned
+## `cli_roundtable` — group-chat debate ✅
 
 Several CLIs **debate in a shared transcript** across bounded rounds. Each round
 every debater sees the others' latest positions; a moderator decides whether to
@@ -197,7 +197,7 @@ sequenceDiagram
 
 ---
 
-## `cli_planner` — Magentic-One ledger ⏳ planned
+## `cli_planner` — Magentic-One ledger ✅
 
 A planner maintains a **task ledger**, delegates subtasks to specialist CLIs,
 inspects results, and **re-plans on stall** up to a bound before synthesizing.
@@ -241,9 +241,9 @@ sequenceDiagram
 | The best single answer from several models | `cli_fusion` |
 | Cheap by default, rigorous only when it matters | `cli_orchestrator` |
 | To split a big task across workers and merge | `cli_map` |
-| Staged refinement, draft then review then polish | `cli_pipeline` ⏳ |
-| Models to argue toward a conclusion | `cli_roundtable` ⏳ |
-| A planner to drive specialists toward a goal | `cli_planner` ⏳ |
+| Staged refinement, draft then review then polish | `cli_pipeline` |
+| Models to argue toward a conclusion | `cli_roundtable` |
+| A planner to drive specialists toward a goal | `cli_planner` |
 
 See [VISION.md](./VISION.md) for how these fit the larger picture, and
 [CLI_FUSION.md](./CLI_FUSION.md) for configuration of the built blueprints.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -96,6 +96,11 @@ under [`docs/proofs/`](./proofs/).
 - **Tool calling** — `gemini` and `claude` each *read a real file*
   (`pyproject.toml`) via their own tools and returned the exact version string.
   See [`docs/proofs/tool_calling_run.txt`](./proofs/tool_calling_run.txt).
+- **Sequential / group-chat / planner** — `cli_pipeline` (gemini draft → claude
+  review), `cli_roundtable` (gemini + grok debate, claude moderator concludes),
+  and `cli_planner` (claude plans a ledger, a worker executes, planner concludes
+  with a 12-point checklist). See the `pipeline_run`, `roundtable_run`, and
+  `planner_run` transcripts in [`docs/proofs/`](./proofs/).
 - **Full permutation matrix** — every installed CLI through every framework mode,
   12/12 passing: `scripts/prove_cli_permutations.py`.
 
@@ -109,11 +114,11 @@ The standard pattern set is now built end to end: concurrent (`cli_fusion`),
 handoff/escalation (`cli_orchestrator`), map-reduce (`cli_map`), sequential
 (`cli_pipeline`), group-chat (`cli_roundtable`), and Magentic-One
 (`cli_planner`). Each has a sequence diagram in
-[ORCHESTRATION_PATTERNS.md](./ORCHESTRATION_PATTERNS.md) and tests under
-`tests/blueprints/`. Remaining work here is depth, not coverage: streaming
-progress for the multi-round patterns, and live multi-CLI proof transcripts for
-pipeline / roundtable / planner alongside the consensus and routing ones in
-[`docs/proofs/`](./proofs/).
+[ORCHESTRATION_PATTERNS.md](./ORCHESTRATION_PATTERNS.md), tests under
+`tests/blueprints/`, and a live cross-CLI transcript in
+[`docs/proofs/`](./proofs/). Remaining work here is depth, not coverage:
+richer streaming progress for the multi-round patterns, and per-stage usage
+accounting.
 
 ### Other known gaps (unchanged from the roadmap)
 

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -70,6 +70,9 @@ This is verified, shipped, and covered by an 1100+ test suite. Status marks:
 | **`cli_fusion`** — panel → judge → synthesize, bounded master-plan loop | ✅ | `blueprints/cli_fusion/` |
 | **`cli_orchestrator`** — cheap router, escalate to a panel only when high-stakes | ✅ | `blueprints/cli_orchestrator/` |
 | **`cli_map`** — decompose → distribute → reduce (divide-and-conquer) | ✅ | `blueprints/cli_map/` |
+| **`cli_pipeline`** — sequential refinement (draft → review → polish) | ✅ | `blueprints/cli_pipeline/` |
+| **`cli_roundtable`** — group-chat debate, moderated to a conclusion | ✅ | `blueprints/cli_roundtable/` |
+| **`cli_planner`** — Magentic-One-style task ledger, re-plans on stall | ✅ | `blueprints/cli_planner/` |
 | CLI autodiscovery + auth probe (`swarm-cli cli-agents --init/--check-auth`) | ✅ | `swarm/core/cli_adapter.py`, `cli_catalog.py` |
 | Per-panelist **git-worktree isolation** for write-mode CLIs | ✅ | `cli_fusion` |
 | **Inference profiles** — pick a backend by traits (intelligence/speed/cost), not brand | ✅ | `docs/examples/inference-profile-routing.md` |
@@ -100,21 +103,17 @@ under [`docs/proofs/`](./proofs/).
 
 ## What remains (honest)
 
-### Orchestration patterns not yet built
+### Orchestration patterns — complete ✅
 
-We have concurrent (`cli_fusion`), handoff/escalation (`cli_orchestrator`), and
-map-reduce (`cli_map`). To reach parity with the field's standard pattern set,
-three remain. These are the active build targets:
-
-| Planned blueprint | Pattern it mirrors | What it adds over what we have |
-|---|---|---|
-| **`cli_pipeline`** | Sequential | Output of CLI A becomes input to CLI B to C — staged refinement (draft → review → polish), distinct from `cli_fusion`'s parallel panel. |
-| **`cli_roundtable`** | Group chat | CLIs *debate in a shared thread* across bounded rounds; a moderator decides continue-vs-conclude. Distinct from `cli_fusion`'s single-shot panel + one judge pass. |
-| **`cli_planner`** | Magentic-One | A planner maintains a **task ledger**, delegates subtasks to specialist CLIs, tracks progress, and **re-plans on stall**. Distinct from `cli_map`'s single decompose→reduce. |
-
-Their sequence diagrams are already drawn in
-[ORCHESTRATION_PATTERNS.md](./ORCHESTRATION_PATTERNS.md) (marked *planned*) so the
-contract is fixed before the code lands.
+The standard pattern set is now built end to end: concurrent (`cli_fusion`),
+handoff/escalation (`cli_orchestrator`), map-reduce (`cli_map`), sequential
+(`cli_pipeline`), group-chat (`cli_roundtable`), and Magentic-One
+(`cli_planner`). Each has a sequence diagram in
+[ORCHESTRATION_PATTERNS.md](./ORCHESTRATION_PATTERNS.md) and tests under
+`tests/blueprints/`. Remaining work here is depth, not coverage: streaming
+progress for the multi-round patterns, and live multi-CLI proof transcripts for
+pipeline / roundtable / planner alongside the consensus and routing ones in
+[`docs/proofs/`](./proofs/).
 
 ### Other known gaps (unchanged from the roadmap)
 
@@ -138,13 +137,16 @@ flowchart LR
     BP -->|concurrent| F[cli_fusion]
     BP -->|handoff| O[cli_orchestrator]
     BP -->|map reduce| M[cli_map]
-    BP -.planned.-> P[cli_pipeline]
-    BP -.planned.-> R[cli_roundtable]
-    BP -.planned.-> PL[cli_planner]
+    BP -->|sequential| P[cli_pipeline]
+    BP -->|group chat| R[cli_roundtable]
+    BP -->|planner| PL[cli_planner]
     A --> REG[CLI adapter registry]
     F --> REG
     O --> REG
     M --> REG
+    P --> REG
+    R --> REG
+    PL --> REG
     REG --> g[gemini]
     REG --> c[claude]
     REG --> k[grok]

--- a/docs/proofs/README.md
+++ b/docs/proofs/README.md
@@ -8,6 +8,9 @@ heterogeneous agentic CLIs (not mocks). Captured 2026-06-17 against
 |---|---|---|
 | [tri_cli_fusion_run.txt](./tri_cli_fusion_run.txt) | `cli_fusion` (concurrent) | One prompt fanned to gemini + claude + grok in parallel; a claude judge synthesizes; analysis surfaces consensus, contradictions, gaps, and per-model unique insights. ~27 s. |
 | [orchestrator_escalation_run.txt](./orchestrator_escalation_run.txt) | `cli_orchestrator` (handoff) | A gemini router answers directly and states whether to escalate, reserving the panel for contested questions. |
+| [pipeline_run.txt](./pipeline_run.txt) | `cli_pipeline` (sequential) | gemini drafts, claude reviews and tightens — the refined paragraph is the output of the chain. ~18 s. |
+| [roundtable_run.txt](./roundtable_run.txt) | `cli_roundtable` (group chat) | gemini + grok debate trunk-based vs feature branches; a claude moderator concludes after one round and synthesizes a sided answer. ~22 s. |
+| [planner_run.txt](./planner_run.txt) | `cli_planner` (Magentic-One) | claude plans a ledger, a worker executes, the planner reviews and concludes — yielding a 12-point production-safety checklist. ~35 s. |
 | [tool_calling_run.txt](./tool_calling_run.txt) | tool use | gemini and claude each read a real file (`pyproject.toml`) via their own tools and return the exact version string. |
 
 ## Re-running

--- a/docs/proofs/pipeline_run.txt
+++ b/docs/proofs/pipeline_run.txt
@@ -1,0 +1,9 @@
+## TASK
+Explain why git worktrees help when running multiple coding agents on one repo.
+
+[progress] _Pipeline of 2 stage(s): gemini, claude…_
+[progress] _Running stage 1/2 `gemini` (draft)…_
+[progress] _Running stage 2/2 `claude` (refine)…_
+
+## FINAL (after gemini draft -> claude review)  [17.8s]
+Git worktrees are well suited to running multiple coding agents on one repository because they let you check out several branches at once into separate working directories that all share the same underlying `.git` data. Each agent gets an isolated directory, so their file edits, build artifacts, and working states can't collide, enabling safe parallel work on independent tasks (say, a feature in one tree and an urgent hotfix in another) without the disk cost and sync overhead of maintaining multiple full clones.

--- a/docs/proofs/planner_run.txt
+++ b/docs/proofs/planner_run.txt
@@ -1,0 +1,34 @@
+## GOAL
+From your own knowledge (do not search any files), produce a concise numbered checklist for safely deleting an unused database column in production.
+
+[progress] _Planning with `claude`…_
+[progress] _Ledger seeded with 1 subtask(s)._
+[progress] _Round 1/3: `grok` on “From internal knowledge, write a concise numbered checklist ”…_
+[progress] _Planner marked the goal met after round 1._
+
+## FINAL (planner claude, workers grok+claude)  [34.9s]
+## Safe production column deletion checklist
+
+1. **Confirm the column is unused** — Search the repo, ORM models, raw SQL, reports, ETL, BI tools, cron jobs, and external integrations; check DB logs/audit trails for reads/writes on that column.
+
+2. **Document intent and get sign-off** — Record why it's safe to drop, who owns the data, blast radius, and rollback plan; get approval from engineering, DBA/platform, and any data/compliance stakeholders.
+
+3. **Back up column data** — Export or snapshot the column (and key identifiers) before any schema change; store backups with a defined retention period.
+
+4. **Stop application dependency first (deploy before drop)** — Remove reads/writes, API fields, serializers, and any code that references it; deploy and confirm no code path still touches the column. On databases that scan or rewrite on drop, consider first renaming or marking the column deprecated.
+
+5. **Observe in production** — Run for at least one normal traffic cycle (or agreed soak period); watch errors, query plans, and metrics to confirm zero dependency.
+
+6. **Schedule the drop in a low-traffic window** — Pick a maintenance window with on-call coverage and a clear go/no-go owner.
+
+7. **Use a reversible migration** — Prefer `DROP COLUMN` paired with a down-migration that can re-add the column (and restore data from backup if needed); avoid irreversible steps until verification is complete. Check for dependent objects (indexes, views, constraints, triggers) first.
+
+8. **Drop the column** — Apply the migration; keep the transaction/window short and avoid coupling unrelated schema changes.
+
+9. **Verify immediately** — Confirm the schema change applied, app health checks pass, critical flows work, and no new errors reference the old column.
+
+10. **Monitor post-change** — Watch error rates, latency, replication lag, and job failures for 24–72 hours (or your team's standard soak period).
+
+11. **Keep rollback ready until soak completes** — Rollback = re-add column + restore data from backup + redeploy previous app version if code was already decoupled.
+
+12. **Close out** — Update schema docs/runbooks, remove dead backup artifacts per retention policy, and mark the deprecation complete.

--- a/docs/proofs/roundtable_run.txt
+++ b/docs/proofs/roundtable_run.txt
@@ -1,0 +1,10 @@
+## QUESTION
+Should a small team adopt trunk-based development or long-lived feature branches? Take a clear side.
+
+[progress] _Roundtable: 2 debater(s) over up to 1 round(s)…_
+[progress] _Round 1/1: debaters responding…_
+[progress] _Moderator `claude` reviewing round 1…_
+[progress] _Moderator concluded after round 1._
+
+## MODERATED CONCLUSION (debaters gemini+grok, moderator claude)  [22.1s]
+A small team should adopt trunk-based development. Both panelists agree: long-lived feature branches only appear safer—they defer integration to a costly 'merge day' of conflicts, duplicated work, and 'works on my branch' surprises, while also delaying code review. Trunk-based development keeps changes small, frequently reviewed, and continuously integrated, producing the tight feedback loops a small team benefits from most. Incomplete work is kept off the critical path with feature flags rather than isolated on divergent branches. The coordination overhead that branches supposedly solve is smaller, for a team of a few people, than the integration debt they accrue. Practical guardrails: short-lived branches (hours to a day) that merge to trunk quickly are an acceptable variant, paired with CI on every commit, feature flags for incomplete work, and a fast review cadence so the trunk stays releasable.


### PR DESCRIPTION
Follow-up to #145 (docs) and #146 (blueprints). Now that the three MAF-class patterns are on `main`, flip their status from ⏳ planned to ✅ built:

- `docs/VISION.md` — add `cli_pipeline`/`cli_roundtable`/`cli_planner` to the built-capabilities table; rewrite the "orchestration patterns" remaining-work section (the set is complete; remaining work is depth, not coverage); solid edges in the architecture flowchart.
- `docs/ORCHESTRATION_PATTERNS.md` — status table + section headings + selection table flipped to built.
- `CHANGELOG.md` — `[Unreleased]` entry for the three blueprints and the new docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)