### PR TITLE
docs: config paths/XDG + env vars; dedup stale SWARM_CONFIG.md

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -15,9 +15,30 @@ Swarm supports both interactive and manual configuration. The recommended way to
 
 ## 1. Config File Location and Discovery
 
-- **Preferred:** `~/.config/swarm/swarm_config.json` (XDG Base Directory Spec)
-- **Fallbacks:** Current working directory, project root, blueprint directories
+**Recommended location:** `~/.config/swarm/swarm_config.json` (XDG Base Directory
+Spec — overridable with `XDG_CONFIG_HOME`).
+
+**Resolution differs slightly between the two entry points:**
+
+| Entry point | How `swarm_config.json` is found |
+|---|---|
+| `swarm-cli` (CLI tooling) | XDG path first, then an upward search from the working directory, then the current directory. |
+| `swarm-api` / `manage.py runserver` (the API server) | `SWARM_CONFIG_PATH` if set, otherwise `./swarm_config.json` in the server's working directory. |
+
+> **Tip:** set `SWARM_CONFIG_PATH=/abs/path/swarm_config.json` — it is honored by
+> both entry points and removes all ambiguity. Unifying the server to the same
+> XDG-first discovery as `swarm-cli` is planned (see [ROADMAP.md](./ROADMAP.md)).
+
 - **If missing:** Swarm generates a default config using `OPENAI_API_KEY` and the official OpenAI endpoint (with a warning).
+
+### Paths & environment variables
+
+| Variable / path | Purpose | Default |
+|---|---|---|
+| `SWARM_CONFIG_PATH` | Explicit path to `swarm_config.json` (both entry points). | unset → discovery above |
+| `~/.config/swarm/swarm_config.json` | Recommended config location. | `XDG_CONFIG_HOME`/swarm/… |
+| `SWARM_RESPONSES_DIR` | Where the stateful Responses API (`/v1/responses`) stores response records for `previous_response_id` chaining and `GET`/`DELETE`. | `XDG_DATA_HOME`/swarm/responses (i.e. `~/.local/share/swarm/responses`) |
+| `~/.config/swarm/teams.json` | Saved teams (web UI / CLI). | `XDG_CONFIG_HOME`/swarm/… |
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -46,9 +46,20 @@ planner** roles (in the `cli_fusion` / `cli_orchestrator` / `cli_map` blocks)
 point only at CLIs that showed as authenticated — `--init` prefers `grok` then
 `claude` by default; change them to match your host.
 
+> **Point the server at the config explicitly.** `swarm-cli` finds the XDG file
+> automatically, but the **server** resolves config from `SWARM_CONFIG_PATH` (or
+> its working directory) — it does *not* search the XDG path. Export it so the
+> server loads what you just generated:
+> ```bash
+> export SWARM_CONFIG_PATH="$HOME/.config/swarm/swarm_config.json"
+> ```
+> See [CONFIGURATION.md §1](../CONFIGURATION.md#1-config-file-location-and-discovery)
+> for the full resolution rules.
+
 ## 3. Run
 
 ```bash
+export SWARM_CONFIG_PATH="$HOME/.config/swarm/swarm_config.json"  # see note above
 swarm-api                 # ASGI server on :8000 (also powers websocket chat)
 # or:
 docker compose up -d
@@ -56,6 +67,12 @@ docker compose up -d
 
 Point any OpenAI client at `http://<host>:8000/v1` with
 `Authorization: Bearer $API_AUTH_TOKEN`.
+
+> **Persist Responses state.** `/v1/responses` is stateful: stored responses (for
+> `previous_response_id` chaining and `GET`/`DELETE`) live under
+> `SWARM_RESPONSES_DIR` (default `~/.local/share/swarm/responses`). In Docker,
+> mount a volume there — or set `SWARM_RESPONSES_DIR` to a mounted path — or
+> chained responses won't survive a container restart.
 
 ## 4. Prove it works
 

--- a/docs/SWARM_CONFIG.md
+++ b/docs/SWARM_CONFIG.md
@@ -1,42 +1,18 @@
-# swarm_config.json Documentation
+# `swarm_config.json`
 
-## Purpose
-`swarm_config.json` is the primary configuration file for the Open Swarm framework. It defines global settings, agent/blueprint registration, model defaults, environment variables, and other core options that control Swarm’s behavior.
+> **This page has moved.** The configuration reference now lives in one place to
+> avoid drift:
+>
+> ### → [CONFIGURATION.md](../CONFIGURATION.md)
 
-## Typical Fields
-- **agents**: List of agent/blueprint definitions, each with a unique ID, type, and configuration.
-- **models**: Default LLM or model configuration (e.g., model name, provider, API key reference).
-- **env**: Environment variables to be set for subprocesses or agent runs.
-- **logging**: Logging level, output file, and format options.
-- **blueprints**: (optional) Blueprint-specific overrides or registration.
-- **other**: Any additional fields required for custom extensions or plugins.
+That canonical guide covers everything `swarm_config.json`:
 
-## Example
-```json
-{
-  "agents": [
-    {"id": "jeeves", "type": "butler", "config": {"home_assistant_url": "http://..."}},
-    {"id": "codey", "type": "coder", "config": {"model": "gpt-4"}}
-  ],
-  "models": {
-    "default": "gpt-4",
-    "providers": ["openai", "local"]
-  },
-  "env": {
-    "OPENAI_API_KEY": "..."
-  },
-  "logging": {
-    "level": "info",
-    "file": "swarm.log"
-  }
-}
-```
+- **File location, discovery precedence, and environment variables** (XDG path,
+  `SWARM_CONFIG_PATH`, `SWARM_RESPONSES_DIR`) — [§1](../CONFIGURATION.md#1-config-file-location-and-discovery)
+- **The real config schema** — `llm` profiles, `settings`, `blueprints`,
+  `mcpServers` — with a full example ([§2](../CONFIGURATION.md#2-example-config-structure))
+- Env-var substitution, per-blueprint model overrides, memory, security/redaction,
+  and troubleshooting.
 
-## Best Practices
-- Always validate your config with `swarm-cli` before running agents.
-- Use environment variable references for secrets (never hardcode API keys).
-- Document custom fields with comments in a separate `.md` file, as JSON does not support comments.
-
----
-
-**Reference this file for all questions about configuring Open Swarm via `swarm_config.json`.**
+For wrapping agentic CLIs (`cli_agents` / `cli_fusion` blocks) see
+[CLI_FUSION.md](./CLI_FUSION.md).


### PR DESCRIPTION
Standing habit: keep the md docs current, DRY, and complete. This pass adds the missing config-path/env-var info (surfaced while wiring the live curl demo) and kills a stale duplicate.

## Added missing info
- **`CONFIGURATION.md` §1** — the *real* config resolution: `swarm-cli` is XDG-first; the **server** uses `SWARM_CONFIG_PATH` or its cwd and does **not** search XDG. New **Paths & environment** table: `SWARM_CONFIG_PATH`, the XDG config path, **`SWARM_RESPONSES_DIR`** (the stateful-Responses store, default `~/.local/share/swarm/responses` — previously undocumented), and `teams.json`.
- **`docs/DEPLOYMENT.md`** — the `SWARM_CONFIG_PATH` export step (so the server actually loads the config `swarm-cli --init` wrote to `~/.config/swarm/`), plus a note to persist `SWARM_RESPONSES_DIR` via a Docker volume so `previous_response_id` chaining survives restarts.

## Eliminated DRY
- **`docs/SWARM_CONFIG.md`** was a stale duplicate of `CONFIGURATION.md` with the **wrong schema** (`agents`/`models`/`env` vs the real `llm`/`settings`/`blueprints`/`mcpServers`). Replaced its body with a canonical pointer to `CONFIGURATION.md`, preserving its 3 inbound links (DEVELOPER_GUIDE, QUICKSTART ×2).

These document current behavior honestly; unifying the server to XDG-first discovery is noted as planned (the `system_fingerprint` + XDG-loader refactor I flagged separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)