### PR TITLE
feat(api): system_fingerprint names which CLI(s) answered

### DIFF
--- a/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
+++ b/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
@@ -141,7 +141,9 @@ class CliAgentBlueprint(BlueprintBase):
                 if not r.ok:
                     yield support.progress_chunk(f"_• {r.name} failed: {r.error}_")
             yield support.message_chunk(
-                cons.answer or "All consensus panelists failed.", final=True
+                cons.answer or "All consensus panelists failed.",
+                final=True,
+                meta=support.backend_meta([r.name for r in cons.ok_results], judge_name),
             )
             return
 
@@ -180,7 +182,7 @@ class CliAgentBlueprint(BlueprintBase):
             if result.ok:
                 if result.parse_error:
                     logger.warning("CLI %s parse issue: %s", name, result.parse_error)
-                yield support.message_chunk(result.text, final=True)
+                yield support.message_chunk(result.text, final=True, meta=support.backend_meta([name]))
                 return
             last = (name, result.error or "unknown error")
             yield support.progress_chunk(f"_`{name}` failed: {last[1]} — failing over…_")

--- a/src/swarm/blueprints/cli_fusion/blueprint_cli_fusion.py
+++ b/src/swarm/blueprints/cli_fusion/blueprint_cli_fusion.py
@@ -282,6 +282,7 @@ class CliFusionBlueprint(BlueprintBase):
                 yield support.message_chunk(
                     self._format_final(params, answer, analysis, ok_results, rounds=round_i + 1),
                     final=True,
+                    meta=support.backend_meta([r.name for r in ok_results], judge_name),
                 )
                 return
 

--- a/src/swarm/blueprints/cli_map/blueprint_cli_map.py
+++ b/src/swarm/blueprints/cli_map/blueprint_cli_map.py
@@ -175,13 +175,16 @@ class CliMapBlueprint(BlueprintBase):
 
         # 3. Reduce — a reducer CLI combines, else labeled concatenation.
         block = "\n\n".join(f"### Subtask: {s}\n_(by {w})_\n{r.text}" for s, w, r in ok)
+        worker_names = list(dict.fromkeys(w for _s, w, _r in ok))  # unique, order-preserving
         if reducer:
             yield support.progress_chunk(f"_Reducing {len(ok)} result(s) with `{reducer}`…_")
             rres = await registry.get(reducer).run(
                 REDUCE_TEMPLATE.format(prompt=prompt, results=block), workdir=workdir
             )
             if rres.ok and rres.text.strip():
-                yield support.message_chunk(rres.text, final=True)
+                yield support.message_chunk(
+                    rres.text, final=True, meta=support.backend_meta(worker_names, judge=reducer)
+                )
                 return
             yield support.progress_chunk(f"_Reducer failed ({rres.error}); returning subtask results._")
-        yield support.message_chunk(block, final=True)
+        yield support.message_chunk(block, final=True, meta=support.backend_meta(worker_names))

--- a/src/swarm/blueprints/cli_orchestrator/blueprint_cli_orchestrator.py
+++ b/src/swarm/blueprints/cli_orchestrator/blueprint_cli_orchestrator.py
@@ -120,7 +120,7 @@ class CliOrchestratorBlueprint(BlueprintBase):
         # 2. Resolve directly unless the router escalated (and a panel exists).
         if rres.ok and not escalate:
             yield support.progress_chunk(f"_Resolved directly — no consensus needed ({reason or 'low-stakes'})._")
-            yield support.message_chunk(quick, final=True)
+            yield support.message_chunk(quick, final=True, meta=support.backend_meta([router]))
             return
         if not panel_names:
             yield support.message_chunk(
@@ -143,4 +143,6 @@ class CliOrchestratorBlueprint(BlueprintBase):
         if not cons.ok:
             yield support.message_chunk(quick or "All consensus panelists failed.", final=True)
             return
-        yield support.message_chunk(cons.answer, final=True)
+        yield support.message_chunk(
+            cons.answer, final=True, meta=support.backend_meta([r.name for r in cons.ok_results], judge_name)
+        )

--- a/src/swarm/blueprints/cli_pipeline/blueprint_cli_pipeline.py
+++ b/src/swarm/blueprints/cli_pipeline/blueprint_cli_pipeline.py
@@ -124,6 +124,7 @@ class CliPipelineBlueprint(BlueprintBase):
         yield support.progress_chunk(f"_Pipeline of {len(stages)} stage(s): {names}…_")
 
         draft: str | None = None
+        contributed: list[str] = []  # stages that actually shaped the output
         for i, (name, instruction) in enumerate(stages):
             adapter = registry.get(name)
             if draft is None:
@@ -140,6 +141,7 @@ class CliPipelineBlueprint(BlueprintBase):
             res = await adapter.run(stage_prompt, workdir=workdir)
             if res.ok and res.text.strip():
                 draft = res.text
+                contributed.append(name)
             else:
                 # Skip a failed stage; the last good draft carries forward.
                 yield support.progress_chunk(
@@ -149,4 +151,4 @@ class CliPipelineBlueprint(BlueprintBase):
         if draft is None:
             yield support.message_chunk("Every pipeline stage failed.", final=True)
             return
-        yield support.message_chunk(draft, final=True)
+        yield support.message_chunk(draft, final=True, meta=support.backend_meta(contributed))

--- a/src/swarm/blueprints/cli_planner/blueprint_cli_planner.py
+++ b/src/swarm/blueprints/cli_planner/blueprint_cli_planner.py
@@ -201,14 +201,16 @@ class CliPlannerBlueprint(BlueprintBase):
             return
 
         # 4. Synthesize — prefer the planner's last synthesis, else a final synth call.
+        worker_names = list(dict.fromkeys(w for _s, w, _r in completed))  # unique, order-preserving
+        meta = support.backend_meta(worker_names, judge=planner)
         if synthesis:
-            yield support.message_chunk(synthesis, final=True)
+            yield support.message_chunk(synthesis, final=True, meta=meta)
             return
         yield support.progress_chunk(f"_Synthesizing final answer with `{planner}`…_")
         sres = await registry.get(planner).run(
             SYNTH_TEMPLATE.format(goal=goal, completed=self._completed_block(completed)), workdir=workdir
         )
         if sres.ok and sres.text.strip():
-            yield support.message_chunk(sres.text, final=True)
+            yield support.message_chunk(sres.text, final=True, meta=meta)
             return
-        yield support.message_chunk(self._completed_block(completed), final=True)
+        yield support.message_chunk(self._completed_block(completed), final=True, meta=meta)

--- a/src/swarm/blueprints/cli_roundtable/blueprint_cli_roundtable.py
+++ b/src/swarm/blueprints/cli_roundtable/blueprint_cli_roundtable.py
@@ -184,12 +184,15 @@ class CliRoundtableBlueprint(BlueprintBase):
                 if isinstance(nxt, str) and nxt.strip():
                     transcript = f"{transcript}\n\n[moderator] Focus next on: {nxt.strip()}"
 
+        debater_names = [name for name, _ in last_positions]
         if synthesis:
-            yield support.message_chunk(synthesis, final=True)
+            yield support.message_chunk(
+                synthesis, final=True, meta=support.backend_meta(debater_names, judge=moderator)
+            )
             return
         # No moderator synthesis — return the final round's positions, labeled.
         if last_positions:
             block = "\n\n".join(f"### {name}\n{text}" for name, text in last_positions)
-            yield support.message_chunk(block, final=True)
+            yield support.message_chunk(block, final=True, meta=support.backend_meta(debater_names))
             return
         yield support.message_chunk("The roundtable produced no positions.", final=True)

--- a/src/swarm/blueprints/common/cli_fusion_support.py
+++ b/src/swarm/blueprints/common/cli_fusion_support.py
@@ -323,12 +323,29 @@ def apply_overrides(
 
 # --- Chunk helpers (match what swarm.views.chat_views expects to consume) --- #
 
-def message_chunk(content: str, *, final: bool = False, role: str = "assistant") -> dict:
-    """A content-bearing chunk. ``final=True`` lets the API short-circuit."""
+def message_chunk(
+    content: str, *, final: bool = False, role: str = "assistant", meta: dict[str, Any] | None = None
+) -> dict:
+    """A content-bearing chunk. ``final=True`` lets the API short-circuit.
+
+    ``meta`` (e.g. ``{"backends": ["gemini", "claude"], "judge": "claude"}``) is a
+    side-channel the API view reads to populate ``system_fingerprint`` — which
+    CLI(s) actually answered. It is not part of the message content.
+    """
     chunk: dict[str, Any] = {"messages": [{"role": role, "content": content}]}
     if final:
         chunk["final"] = True
+    if meta:
+        chunk["meta"] = meta
     return chunk
+
+
+def backend_meta(backends: list[str], judge: str | None = None) -> dict[str, Any]:
+    """Build the ``meta`` payload naming the resolved CLI backends (+ optional judge)."""
+    meta: dict[str, Any] = {"backends": [b for b in backends if b]}
+    if judge:
+        meta["judge"] = judge
+    return meta
 
 
 #: Chunk ``type`` for fusion progress side-channel events.

--- a/src/swarm/views/chat_views.py
+++ b/src/swarm/views/chat_views.py
@@ -134,6 +134,27 @@ def usage_counts(messages: list[dict[str, Any]] | None, answer: Any, model: str)
     return prompt, completion, prompt + completion
 
 
+def backend_fingerprint(model_name: str, meta: dict[str, Any] | None) -> str:
+    """Build ``system_fingerprint`` naming the resolved CLI backends + judge.
+
+    A blueprint may yield a ``meta`` side-channel (see
+    ``cli_fusion_support.backend_meta``) on its final chunk. We render it as e.g.
+    ``cli_fusion:gemini+claude+grok|judge=claude`` so any OpenAI client can read
+    ``resp.system_fingerprint`` to see which CLI(s) actually answered. Falls back
+    to the blueprint id when a blueprint emits no backend meta.
+    """
+    if not isinstance(meta, dict):
+        return model_name
+    fp = model_name
+    backends = [str(b) for b in (meta.get("backends") or []) if b]
+    if backends:
+        fp += ":" + "+".join(backends)
+    judge = meta.get("judge")
+    if judge:
+        fp += f"|judge={judge}"
+    return fp
+
+
 class HealthCheckView(APIView):
     """ Simple health check endpoint. """
     permission_classes = [AllowAny]
@@ -158,6 +179,7 @@ class ChatCompletionsView(APIView):
         """ Handles non-streaming requests. """
         logger.info(f"[ReqID: {request_id}] Processing non-streaming request for model '{model_name}'.")
         final_message = None
+        backend_meta = None
         start_time = time.time()
         try:
             # The blueprint's run method should be an async generator. Blueprints
@@ -168,6 +190,8 @@ class ChatCompletionsView(APIView):
             # short-circuit the scan.
             async_generator = blueprint_instance.run(messages, stream=False)
             async for chunk in async_generator:
+                if isinstance(chunk, dict) and chunk.get("meta"):
+                    backend_meta = chunk["meta"]  # which CLI(s) answered (system_fingerprint)
                 message = _extract_message_from_chunk(chunk)
                 if message is None:
                     logger.debug(f"[ReqID: {request_id}] Skipping non-message chunk during non-streaming run: {chunk}")
@@ -182,7 +206,7 @@ class ChatCompletionsView(APIView):
                  raise APIException("Blueprint did not return valid data.", code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
             p_tok, c_tok, t_tok = usage_counts(messages, final_message.get("content"), model_name)
-            response_payload = { "id": f"chatcmpl-{request_id}", "object": "chat.completion", "created": int(time.time()), "model": model_name, "choices": [{"index": 0, "message": final_message, "logprobs": None, "finish_reason": "stop"}], "usage": {"prompt_tokens": p_tok, "completion_tokens": c_tok, "total_tokens": t_tok}, "system_fingerprint": None }
+            response_payload = { "id": f"chatcmpl-{request_id}", "object": "chat.completion", "created": int(time.time()), "model": model_name, "choices": [{"index": 0, "message": final_message, "logprobs": None, "finish_reason": "stop"}], "usage": {"prompt_tokens": p_tok, "completion_tokens": c_tok, "total_tokens": t_tok}, "system_fingerprint": backend_fingerprint(model_name, backend_meta) }
             end_time = time.time()
             logger.info(f"[ReqID: {request_id}] Non-streaming request completed in {end_time - start_time:.2f}s.")
             return Response(response_payload, status=status.HTTP_200_OK)
@@ -198,18 +222,21 @@ class ChatCompletionsView(APIView):
         async def event_stream():
             start_time = time.time()
             chunk_index = 0
+            backend_meta = None
             try:
                 logger.debug(f"[ReqID: {request_id}] Getting async generator from blueprint.run()...")
                 async_generator = blueprint_instance.run(messages, stream=True)
                 logger.debug(f"[ReqID: {request_id}] Got async generator. Starting iteration...")
                 async for chunk in async_generator:
                     logger.debug(f"[ReqID: {request_id}] Received stream chunk {chunk_index}: {chunk}")
+                    if isinstance(chunk, dict) and chunk.get("meta"):
+                        backend_meta = chunk["meta"]  # which CLI(s) answered
                     message = _extract_message_from_chunk(chunk)
                     if message is None:
                         logger.warning(f"[ReqID: {request_id}] Skipping invalid chunk format: {chunk}")
                         continue
                     delta = {"role": "assistant", "content": message["content"]}
-                    response_chunk = { "id": f"chatcmpl-{request_id}", "object": "chat.completion.chunk", "created": int(time.time()), "model": model_name, "choices": [{"index": 0, "delta": delta, "logprobs": None, "finish_reason": None}] }
+                    response_chunk = { "id": f"chatcmpl-{request_id}", "object": "chat.completion.chunk", "created": int(time.time()), "model": model_name, "choices": [{"index": 0, "delta": delta, "logprobs": None, "finish_reason": None}], "system_fingerprint": backend_fingerprint(model_name, backend_meta) }
                     logger.debug(f"[ReqID: {request_id}] Sending SSE chunk {chunk_index}")
                     yield f"data: {json.dumps(response_chunk)}\n\n"
                     chunk_index += 1

--- a/src/swarm/views/responses_views.py
+++ b/src/swarm/views/responses_views.py
@@ -230,9 +230,12 @@ class ResponsesView(APIView):
     async def _handle_non_streaming(self, blueprint_instance, messages, request_id, model_name, store=True, previous_response_id=None) -> Response:
         """Consume the blueprint generator, keep the last message, shape a response object."""
         final_message = None
+        backend_meta = None
         try:
             async_generator = blueprint_instance.run(messages, stream=False)
             async for chunk in async_generator:
+                if isinstance(chunk, dict) and chunk.get("meta"):
+                    backend_meta = chunk["meta"]  # which CLI(s) answered (system_fingerprint)
                 message = _extract_message_from_chunk(chunk)
                 if message is None:
                     continue
@@ -251,7 +254,7 @@ class ResponsesView(APIView):
             logger.error(f"[ReqID: {request_id}] Unexpected error during /v1/responses generation: {e}", exc_info=True)
             raise APIException(f"Internal server error during generation: {e}", code=status.HTTP_500_INTERNAL_SERVER_ERROR) from e
 
-        payload = _build_response_payload(request_id, model_name, answer, previous_response_id, messages)
+        payload = _build_response_payload(request_id, model_name, answer, previous_response_id, messages, backend_meta)
         if store:
             await sync_to_async(_persist)(payload, messages, answer)
         return Response(payload, status=status.HTTP_200_OK)
@@ -262,9 +265,12 @@ class ResponsesView(APIView):
 
         async def event_stream():
             full_text_parts: list[str] = []
+            backend_meta = None
             try:
                 async_generator = blueprint_instance.run(messages, stream=True)
                 async for chunk in async_generator:
+                    if isinstance(chunk, dict) and chunk.get("meta"):
+                        backend_meta = chunk["meta"]
                     message = _extract_message_from_chunk(chunk)
                     if message is None:
                         continue
@@ -281,7 +287,7 @@ class ResponsesView(APIView):
                     await asyncio.sleep(0.01)
 
                 final_text = "".join(full_text_parts)
-                payload = _build_response_payload(request_id, model_name, final_text, previous_response_id, messages)
+                payload = _build_response_payload(request_id, model_name, final_text, previous_response_id, messages, backend_meta)
                 if store:
                     await sync_to_async(_persist)(payload, messages, final_text)
                 completed = {"type": "response.completed", "response": payload}
@@ -302,9 +308,10 @@ def _build_response_payload(
     answer: str,
     previous_response_id: str | None = None,
     messages: list[dict[str, str]] | None = None,
+    backend_meta: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Shape an OpenAI Responses-style ``response`` object."""
-    from .chat_views import usage_counts
+    from .chat_views import backend_fingerprint, usage_counts
 
     input_tok, output_tok, total_tok = usage_counts(messages, answer, model_name)
     return {
@@ -314,6 +321,8 @@ def _build_response_payload(
         "model": model_name,
         "status": "completed",
         "previous_response_id": previous_response_id,
+        # Which CLI(s) answered — mirrors chat.completion's system_fingerprint.
+        "system_fingerprint": backend_fingerprint(model_name, backend_meta),
         "output": [
             {
                 "type": "message",

--- a/tests/api/test_cli_fusion_api.py
+++ b/tests/api/test_cli_fusion_api.py
@@ -79,6 +79,25 @@ def test_cli_fusion_uses_default_preset_without_params(client, fake_cli_config):
 
 
 @pytest.mark.django_db
+def test_system_fingerprint_names_resolved_backends(client, fake_cli_config):
+    # The response's system_fingerprint reports which CLI(s) actually answered,
+    # not just the blueprint id — so an OpenAI client can attribute the answer.
+    resp = _post(client, "cli_fusion", "hello", params={"panel": ["a", "b"], "judge": "a"})
+    assert resp.status_code == 200, resp.content[:300]
+    fp = resp.json().get("system_fingerprint") or ""
+    assert fp.startswith("cli_fusion:")
+    assert "a" in fp and "b" in fp
+    assert "judge=a" in fp
+
+
+@pytest.mark.django_db
+def test_system_fingerprint_single_cli_agent(client, fake_cli_config):
+    resp = _post(client, "cli_agent", "hello", params={"cli": "b"})
+    assert resp.status_code == 200, resp.content[:300]
+    assert resp.json().get("system_fingerprint") == "cli_agent:b"
+
+
+@pytest.mark.django_db
 def test_cli_agent_respects_cli_param_over_api(client, fake_cli_config):
     # The single-CLI blueprint should run exactly the adapter named in params.
     resp = _post(client, "cli_agent", "pick", params={"cli": "b"})

--- a/tests/views/test_system_fingerprint.py
+++ b/tests/views/test_system_fingerprint.py
@@ -1,0 +1,75 @@
+"""Tests for system_fingerprint — naming which CLI(s) actually answered.
+
+A blueprint yields a ``meta`` side-channel on its final chunk; the API views
+render it into ``system_fingerprint`` (chat.completions + responses) so any
+OpenAI client can read which backends + judge produced the answer.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from swarm.blueprints.common import cli_fusion_support as support
+from swarm.views.chat_views import backend_fingerprint
+
+PY = sys.executable
+
+
+# --- the pure helper -------------------------------------------------------
+
+def test_fingerprint_falls_back_to_blueprint_id_without_meta():
+    assert backend_fingerprint("cli_fusion", None) == "cli_fusion"
+    assert backend_fingerprint("cli_agent", {}) == "cli_agent"
+
+
+def test_fingerprint_renders_backends_and_judge():
+    meta = support.backend_meta(["gemini", "claude", "grok"], judge="claude")
+    assert backend_fingerprint("cli_fusion", meta) == "cli_fusion:gemini+claude+grok|judge=claude"
+
+
+def test_fingerprint_backends_only_when_no_judge():
+    meta = support.backend_meta(["grok"])
+    assert backend_fingerprint("cli_agent", meta) == "cli_agent:grok"
+
+
+def test_backend_meta_drops_empty_names():
+    assert support.backend_meta(["grok", "", None], judge=None) == {"backends": ["grok"]}
+
+
+# --- end-to-end through a blueprint ----------------------------------------
+
+def _echo(tag: str) -> dict:
+    return {"cmd": [PY, "-c", f"print({tag!r})", "{prompt}"], "parse": "text"}
+
+
+async def test_cli_agent_emits_backend_meta_on_final_chunk():
+    from swarm.blueprints.cli_agent.blueprint_cli_agent import CliAgentBlueprint
+
+    cfg = {"cli_agents": {"grok": _echo("HI")}, "cli_fusion": {"default_cli": "grok"}}
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    bp.set_params({"cli": "grok"})
+    final = None
+    async for chunk in bp.run([{"role": "user", "content": "x"}]):
+        if isinstance(chunk, dict) and chunk.get("final"):
+            final = chunk
+    assert final is not None
+    assert final.get("meta") == {"backends": ["grok"]}
+    # And the view helper renders it as expected.
+    assert backend_fingerprint("cli_agent", final["meta"]) == "cli_agent:grok"
+
+
+async def test_cli_fusion_emits_panel_and_judge_meta():
+    from swarm.blueprints.cli_fusion.blueprint_cli_fusion import CliFusionBlueprint
+
+    cfg = {
+        "cli_agents": {"a": _echo("A"), "b": _echo("B")},
+        "cli_fusion": {"presets": {"p": {"panel": ["a", "b"], "judge": "a"}}, "default_preset": "p"},
+    }
+    bp = CliFusionBlueprint(config=cfg)
+    meta = None
+    async for chunk in bp.run([{"role": "user", "content": "x"}]):
+        if isinstance(chunk, dict) and chunk.get("meta"):
+            meta = chunk["meta"]
+    assert meta is not None
+    assert set(meta["backends"]) == {"a", "b"}
+    assert meta["judge"] == "a"


### PR DESCRIPTION
## What

Closes the "which agent responded?" gap. The response `model` field is the **blueprint** id (`cli_fusion`); there was no way for a client to see which underlying CLI produced or judged the answer. This populates the OpenAI-standard **`system_fingerprint`** with the resolved backends.

Example: `"system_fingerprint": "cli_fusion:gemini+claude+grok|judge=claude"`

## How

- **`cli_fusion_support`**: `message_chunk` gains an optional `meta` side-channel; `backend_meta(backends, judge)` builds it.
- **All seven CLI blueprints** emit `meta` on their success final chunk — panel + judge (fusion/orchestrator/roundtable), workers + reducer/planner (map/planner), the stage chain (pipeline), the single CLI (cli_agent).
- **`chat_views` + `responses_views`** capture `meta` and render it via `backend_fingerprint()` into `system_fingerprint` across non-streaming, streaming, and the Responses payload. Falls back to the blueprint id when a blueprint emits no meta — never null for a real answer.

## Client consumption

```python
resp = client.chat.completions.create(model="cli_fusion", messages=[...])
print(resp.system_fingerprint)   # cli_fusion:gemini+claude+grok|judge=claude
```

OpenAI clients already expose `.system_fingerprint` — no schema break, no SDK change. Raw HTTP reads top-level `.system_fingerprint`.

## Tests

Helper unit tests, per-blueprint meta-emission tests, and end-to-end API assertions (`/v1/chat/completions`). **410 passed** across blueprints/api/views.

This delivers AC1 of the tracked "XDG + system_fingerprint" work; XDG unification follows in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)