### PR TITLE
fix(config): explicit --config path beats the XDG default

### DIFF
--- a/src/swarm/core/config_loader.py
+++ b/src/swarm/core/config_loader.py
@@ -42,20 +42,14 @@ def find_config_file(
 ) -> Path | None:
     """
     Locate swarm_config.json using precedence:
-      1) XDG (~/.config/swarm/swarm_config.json)
-      2) User-specified path
+      1) User-specified path (explicit ``--config`` always wins)
+      2) XDG (~/.config/swarm/swarm_config.json)
       3) Upwards search from start_dir
       4) default_dir/swarm_config.json
       5) CWD/swarm_config.json
     Logs actionable hints on common mistakes.
     """
-    # 1. XDG config path
-    xdg_config = _xdg_config_path()
-    if xdg_config.is_file():
-        logger.debug(f"Found config XDG: {xdg_config}")
-        return xdg_config.resolve()
-
-    # 2. User-specified path
+    # 1. User-specified path — an explicit choice must win over the XDG default.
     if specific_path:
         p = Path(specific_path)
         if p.is_file():
@@ -66,6 +60,12 @@ def find_config_file(
                     f"{specific_path}")
         )
         # Fall through
+
+    # 2. XDG config path
+    xdg_config = _xdg_config_path()
+    if xdg_config.is_file():
+        logger.debug(f"Found config XDG: {xdg_config}")
+        return xdg_config.resolve()
 
     # 3. Upwards from start_dir
     if start_dir:

--- a/tests/core/test_find_config_precedence.py
+++ b/tests/core/test_find_config_precedence.py
@@ -1,0 +1,43 @@
+"""find_config_file precedence — an explicit path must beat the XDG default.
+
+Regression: previously XDG was checked before the user-specified path, so
+`swarm-cli --config /some/file` was silently overridden whenever an
+`~/.config/swarm/swarm_config.json` existed.
+"""
+
+from __future__ import annotations
+
+import json
+
+from swarm.core.config_loader import find_config_file
+
+
+def _write(path, data=None):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data or {"settings": {}}))
+    return path
+
+
+def test_explicit_path_beats_xdg(monkeypatch, tmp_path):
+    xdg = _write(tmp_path / "cfg" / "swarm" / "swarm_config.json", {"src": "xdg"})
+    explicit = _write(tmp_path / "explicit.json", {"src": "explicit"})
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+
+    found = find_config_file(specific_path=str(explicit))
+    assert found == explicit.resolve()
+    assert found != xdg.resolve()
+
+
+def test_falls_back_to_xdg_when_no_explicit(monkeypatch, tmp_path):
+    xdg = _write(tmp_path / "cfg" / "swarm" / "swarm_config.json", {"src": "xdg"})
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+
+    assert find_config_file() == xdg.resolve()
+
+
+def test_nonexistent_explicit_falls_through_to_xdg(monkeypatch, tmp_path):
+    xdg = _write(tmp_path / "cfg" / "swarm" / "swarm_config.json", {"src": "xdg"})
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+
+    # A bad --config path should warn and fall through, not crash, landing on XDG.
+    assert find_config_file(specific_path=str(tmp_path / "nope.json")) == xdg.resolve()


### PR DESCRIPTION
## What

`find_config_file` checked the **XDG path before the user-specified path**, so `swarm-cli --config /some/file` was silently overridden whenever `~/.config/swarm/swarm_config.json` existed — backwards from the universal "explicit wins over implicit" convention. (Found while testing the XDG work in #150: a local `~/.config/swarm/swarm_config.json` was shadowing `--config` tmpfiles in `tests/cli/test_cli_agents_command.py`.)

Swap the order: an explicit path is honored first; XDG is used only when no explicit path is given. A non-existent explicit path warns and falls through, as before.

## Tests

`tests/core/test_find_config_precedence.py` — explicit beats XDG, XDG fallback without an explicit path, bad explicit path falls through. The `cli_agents` command tests now pass even with an XDG config present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)