### PR TITLE
test(config): make no-config-files test hermetic vs a real XDG config

### DIFF
--- a/tests/core/test_blueprint_base.py
+++ b/tests/core/test_blueprint_base.py
@@ -62,11 +62,17 @@ class TestBlueprintBase(TestCase):
     @patch.dict(os.environ, {}, clear=True)
     def test_config_loading_no_config_files(self, mock_home, mock_cwd):
         """Test config loading when no config files exist"""
+        from django.apps import apps
+
         mock_cwd.return_value = Path('/fake/cwd')
         mock_home.return_value = Path('/fake/home')
 
-        # Mock paths to not exist
-        with patch.object(Path, 'exists', return_value=False):
+        # Force the AppConfig.config (loaded once at startup, XDG-aware) empty so
+        # this test is hermetic — it must not depend on whether the dev's machine
+        # happens to have a ~/.config/swarm/swarm_config.json.
+        # Mock paths to not exist.
+        with patch.object(apps.get_app_config('swarm'), 'config', {}), \
+             patch.object(Path, 'exists', return_value=False):
             blueprint = ConcreteBlueprint(self.blueprint_id)
             assert blueprint._config == {}
 


### PR DESCRIPTION
After #150 the AppConfig loads config XDG-aware once at startup. `test_config_loading_no_config_files` asserts an empty `_config` when no config files exist — but on a dev machine that has a real `~/.config/swarm/swarm_config.json`, that file's contents leaked into `app.config` and the test failed. CI passes (no such file in the runner), so this never blocked CI, but it's a real isolation weakness surfaced by a local full-suite run.

Fix: force `app.config = {}` for the duration of the test so it exercises the no-files fallback regardless of the dev's home directory. Verified it now passes with a real `~/.config/swarm/swarm_config.json` present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)