### PR TITLE
feat(responses): cancel endpoint + restart-durable async workers (+ no-auth opt-out)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added — Async tasking (`/v1/responses` background mode)
 - Fire-and-forget for long-running agent work: `POST /v1/responses` with `"background": true` returns **202** immediately with a `resp_<id>` and `status: "queued"`; the blueprint runs in a daemon worker that updates the file-backed store `queued → in_progress → completed/failed` with `execution_ms`/`started_at`. Poll via `GET /v1/responses/{id}`; completed results carry `output_text`/`system_fingerprint`/`usage` and are chainable via `previous_response_id`. Sync behavior unchanged when `background` is absent. Also wired per-request `params` into `/v1/responses`. See **[docs/ASYNC_RESPONSES.md](docs/ASYNC_RESPONSES.md)**.
+- **Cancellation:** `POST /v1/responses/{id}/cancel` — cooperative cancel, `status → cancelled` (idempotent on finished tasks).
+- **Restart durability:** queued/in-progress tasks persist a spec and **resume** on server startup (at-least-once).
+- **No-auth opt-out:** `SWARM_ALLOW_NO_AUTH=true` lets the server boot in production without `API_AUTH_TOKEN` (for when an external OAuth/gateway layer gates access) — warns loudly instead of refusing.
 
 ### Added — Orchestration patterns (MAF-class, over CLIs)
 - Three new orchestration blueprints complete the field-standard pattern set over heterogeneous agentic CLIs: **`cli_pipeline`** (sequential — each stage refines the prior stage's output, draft → review → polish), **`cli_roundtable`** (group-chat — debaters react to each other in a shared transcript across bounded rounds, a moderator concludes and synthesizes), and **`cli_planner`** (Magentic-One — a planner keeps a task ledger, delegates to workers, and re-plans on stall until the goal is met). All follow the existing `BlueprintBase` + `cli_fusion_support` conventions, degrade gracefully on a dead backend, and are auto-discovered at `/v1/models`. 20 new tests.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -246,7 +246,8 @@ environment / `.env`, never in `swarm_config.json` (reference them with
 | `DJANGO_ALLOWED_HOSTS` | Comma-separated allowed hosts. **Required in production.** | dev: localhost |
 | `DJANGO_CSRF_TRUSTED_ORIGINS` | Comma-separated trusted origins for CSRF on mutating routes. | none |
 | `API_AUTH_TOKEN` | Bearer token OpenAI clients present to the API. | none |
-| `ENABLE_API_AUTH` | Require auth on `/v1/*`. Forced on in production. | prod: on |
+| `ENABLE_API_AUTH` | Require auth on `/v1/*`. Auto-on when `API_AUTH_TOKEN` is set. | prod: on |
+| `SWARM_ALLOW_NO_AUTH` | Allow booting in production **without** a token (warns) — for when an external OAuth proxy / API gateway already gates access. | `false` |
 | `ALLOW_TESTUSER_AUTOLOGIN` | Dev-only auto-login (debug only, random password). | `false` |
 | `HOST` / `PORT` | Bind address/port for the server. | `0.0.0.0` / `8000` |
 

--- a/docs/ASYNC_RESPONSES.md
+++ b/docs/ASYNC_RESPONSES.md
@@ -23,6 +23,25 @@ GET  /v1/responses/{id}  ->  status: "queued" -> "in_progress" -> "completed" | 
 - Sync behavior is unchanged: omit `background` and the call blocks and returns
   the completed response as before.
 
+## Cancelling a task
+
+```bash
+curl -s -X POST http://10.0.0.36:8000/v1/responses/resp_abc…/cancel
+# -> {"status": "cancelled", ...}
+```
+
+Cooperative: the worker stops at its next chunk boundary and the record becomes
+`cancelled`. A single in-flight CLI call still finishes (or hits its own
+timeout) — for multi-step blueprints (fusion/pipeline/planner) cancellation
+lands between CLI calls. Idempotent: cancelling a finished task is a no-op that
+returns its current status.
+
+## Restart durability
+
+Each queued/in-progress task persists a task spec, so if the server restarts
+mid-flight it **resumes** interrupted tasks on startup (re-runs from the stored
+input — at-least-once). Terminal tasks are left alone.
+
 ## How a client (e.g. Grok) uses it
 
 ```bash
@@ -55,15 +74,21 @@ heavy multi-CLI fusion or coding task can be longer).
 **Now possible**
 - Fire-and-forget tasking with a durable handle and `queued → in_progress →
   completed/failed` polling.
+- **Cancellation** — `POST /v1/responses/{id}/cancel`.
+- **Restart durability** — interrupted tasks resume on startup.
 - Per-task observability (`execution_ms`, `started_at`).
 - Stateful chaining across async tasks (`previous_response_id`).
 - Per-request `params` on `/v1/responses` (e.g. `preset`, `cli`).
 
+**Auth:** none by default (warns). Set `API_AUTH_TOKEN` to require a Bearer
+token; or, when an external layer (cloud OAuth proxy / API gateway) already gates
+access, set `SWARM_ALLOW_NO_AUTH=true` to run unauthenticated in production
+(DEBUG=false) with a warning instead of a hard refusal.
+
 **Still missing (next)**
-- **Auth** — currently none (LAN/DEBUG). Add an API token before exposing beyond a trusted network.
-- **TLS** — plain HTTP today.
-- **Cancellation** — no `POST /v1/responses/{id}/cancel` yet (DELETE removes the record but doesn't stop a running worker).
+- **TLS** — plain HTTP today (front with a reverse proxy for HTTPS).
+- **Hard cancel** — cancellation is cooperative; a single long in-flight CLI call isn't killed mid-call.
 - **Cloud** — the CLIs are host-bound (OAuth/file-login); a cloud instance must re-auth them on its host.
-- **Worker durability** — in-process daemon threads; a server restart mid-task drops the in-progress run (the record stays at `in_progress`). A persistent queue would survive restarts.
+- **Durable queue** — resume re-runs from stored input (at-least-once); not an exactly-once persistent job queue.
 
 See [VISION.md](./VISION.md) and [ORCHESTRATION_PATTERNS.md](./ORCHESTRATION_PATTERNS.md) for the blueprints you can task this way.

--- a/src/swarm/apps.py
+++ b/src/swarm/apps.py
@@ -68,7 +68,34 @@ class SwarmConfig(AppConfig):
         # behavior is unchanged, we only *add* XDG.
         self.config = self._load_swarm_config()
 
+        # Resume async /v1/responses tasks left in-flight by a restart — server
+        # processes only (not migrate/test), guarded against the runserver
+        # reloader's parent process to avoid double-resume.
+        self._maybe_resume_async_tasks()
+
         logger.info("Swarm app initialization checks completed.")
+
+    @staticmethod
+    def _maybe_resume_async_tasks() -> None:
+        import sys
+
+        if os.environ.get("SWARM_TEST_MODE"):
+            return
+        argv = " ".join(sys.argv)
+        if "runserver" in argv:
+            serving = ("--noreload" in argv) or os.environ.get("RUN_MAIN") == "true"
+        else:
+            serving = any(s in argv for s in ("swarm-api", "daphne", "uvicorn", "gunicorn"))
+        if not serving:
+            return
+        try:
+            import threading
+
+            from swarm.views.responses_views import resume_pending_responses
+
+            threading.Thread(target=resume_pending_responses, daemon=True).start()
+        except Exception as e:  # never let resume break startup
+            logger.warning("Could not schedule async-task resume: %s", e)
 
     @staticmethod
     def _load_swarm_config() -> dict:

--- a/src/swarm/urls.py
+++ b/src/swarm/urls.py
@@ -43,7 +43,7 @@ from swarm.views.blueprint_library_views import (
     remove_blueprint_from_library,
 )
 from swarm.views.chat_views import ChatCompletionsView
-from swarm.views.responses_views import ResponsesView, ResponsesDetailView
+from swarm.views.responses_views import ResponsesCancelView, ResponsesDetailView, ResponsesView
 from swarm.views.library_api import LibraryAPIView, LibraryDetailAPIView
 from swarm.views.settings_views import (
     environment_variables,
@@ -89,6 +89,7 @@ urlpatterns = [
     # OpenAI Responses API (MVP) — normalizes `input`/`instructions` to messages
     # and reuses the same blueprint-resolution + run path as chat completions.
     path("v1/responses", ResponsesView.as_view(), name="responses"),
+    path("v1/responses/<str:response_id>/cancel", ResponsesCancelView.as_view(), name="responses-cancel"),
     path("v1/responses/<str:response_id>", ResponsesDetailView.as_view(), name="responses-detail"),
     # OpenAPI schema + interactive docs (drf-spectacular).
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),

--- a/src/swarm/utils/env_utils.py
+++ b/src/swarm/utils/env_utils.py
@@ -151,22 +151,30 @@ def get_enforced_api_auth_token() -> str | None:
     token = get_api_auth_token()
     if token:
         return token
-    if is_django_debug():
+    # Permissive (no-auth) is allowed without a token when EITHER debug is on OR
+    # the operator explicitly opts out via SWARM_ALLOW_NO_AUTH — e.g. when an
+    # external layer (a cloud OAuth proxy / API gateway) already gates access.
+    # Either way we log a clear one-time warning rather than silently disabling.
+    allow_no_auth = os.getenv('SWARM_ALLOW_NO_AUTH', 'false').lower() in ('true', '1', 't', 'yes', 'y')
+    if is_django_debug() or allow_no_auth:
         global _api_auth_disabled_warning_emitted
         if not _api_auth_disabled_warning_emitted:
             _api_auth_disabled_warning_emitted = True
+            reason = "DJANGO_DEBUG=true" if is_django_debug() else "SWARM_ALLOW_NO_AUTH is set"
             _logger.warning(
-                "API authentication is DISABLED because API_AUTH_TOKEN is not set. "
-                "This permissive default is allowed only because DJANGO_DEBUG=true. "
-                "Set API_AUTH_TOKEN to require authentication."
+                "API authentication is DISABLED because API_AUTH_TOKEN is not set "
+                "(%s). Anyone who can reach this server can call it — make sure an "
+                "external layer (OAuth proxy / firewall) gates access, or set "
+                "API_AUTH_TOKEN to require a bearer token.",
+                reason,
             )
         return None
     from django.core.exceptions import ImproperlyConfigured
     raise ImproperlyConfigured(
         "API_AUTH_TOKEN (or SWARM_API_KEY) environment variable is required "
-        "when DJANGO_DEBUG is not enabled (production). Refusing to start "
-        "with API authentication disabled. Set API_AUTH_TOKEN, or set "
-        "DJANGO_DEBUG=true for local development."
+        "when DJANGO_DEBUG is not enabled (production). Refusing to start with "
+        "API authentication disabled. Set API_AUTH_TOKEN, or set "
+        "SWARM_ALLOW_NO_AUTH=true if an external layer already gates access."
     )
 
 

--- a/src/swarm/views/responses_views.py
+++ b/src/swarm/views/responses_views.py
@@ -241,21 +241,19 @@ class ResponsesView(APIView):
         return await self._handle_non_streaming(blueprint_instance, messages, request_id, model_name, store, previous_response_id)
 
     async def _handle_background(self, request_id, model_name, messages, params, previous_response_id) -> Response:
-        """Persist a queued record, start a worker thread, return the handle now."""
+        """Persist a queued record (with a resumable task spec), start a worker, return now."""
         response_id = f"resp_{request_id}"
         payload = _build_response_payload(
             request_id, model_name, "", previous_response_id, None, None, status="queued"
         )
-        await sync_to_async(responses_store.save)(
-            {"id": response_id, "object": "response", "response": payload, "messages": None}
-        )
+        # The _task spec lets a server restart resume this (see resume_pending_responses).
+        await sync_to_async(responses_store.save)({
+            "id": response_id, "object": "response", "response": payload, "messages": None,
+            "_task": _task_spec(request_id, model_name, list(messages), params, previous_response_id),
+        })
         # Daemon thread with its own event loop — decoupled from the request
         # lifecycle so it survives after we return the response.
-        threading.Thread(
-            target=_run_background_response,
-            args=(response_id, request_id, model_name, list(messages), params, previous_response_id),
-            daemon=True,
-        ).start()
+        _spawn_worker(response_id, request_id, model_name, list(messages), params, previous_response_id)
         logger.info(f"[ReqID: {request_id}] /v1/responses queued async task {response_id} (model '{model_name}').")
         return Response(payload, status=status.HTTP_202_ACCEPTED)
 
@@ -388,14 +386,49 @@ def _persist(payload: dict[str, Any], messages: list[dict[str, Any]], answer: st
     responses_store.save(record)
 
 
-async def _consume_blueprint(blueprint_instance: Any, messages: list[dict[str, Any]]) -> tuple[str, dict | None]:
+# --- Cancellation registry -------------------------------------------------- #
+# Cooperative cancel: a cancel request adds the id here; the worker checks it
+# between blueprint chunks and stops. A single in-flight CLI call still runs to
+# completion (or its own timeout) — cancellation takes effect at the next chunk
+# boundary, which for multi-step blueprints (fusion/pipeline/planner) is between
+# CLI calls.
+_CANCELLED: set[str] = set()
+_CANCELLED_LOCK = threading.Lock()
+
+
+def _request_cancel(response_id: str) -> None:
+    with _CANCELLED_LOCK:
+        _CANCELLED.add(response_id)
+
+
+def _is_cancel_requested(response_id: str) -> bool:
+    with _CANCELLED_LOCK:
+        return response_id in _CANCELLED
+
+
+def _clear_cancel(response_id: str) -> None:
+    with _CANCELLED_LOCK:
+        _CANCELLED.discard(response_id)
+
+
+class _Cancelled(Exception):
+    """Raised inside the worker when a cancel was requested mid-run."""
+
+
+async def _consume_blueprint(
+    blueprint_instance: Any, messages: list[dict[str, Any]], cancel_check: Any = None
+) -> tuple[str, dict | None]:
     """Drive a blueprint to its final answer. Returns (answer, backend_meta).
 
-    Shared by the synchronous handler and the async worker.
+    Shared by the synchronous handler and the async worker. ``cancel_check`` (a
+    zero-arg callable) is polled between chunks; if it returns True we raise
+    :class:`_Cancelled`.
     """
     final_message = None
     backend_meta = None
     async for chunk in blueprint_instance.run(messages, stream=False):
+        if cancel_check is not None and cancel_check():
+            raise _Cancelled()
         if isinstance(chunk, dict) and chunk.get("meta"):
             backend_meta = chunk["meta"]
         message = _extract_message_from_chunk(chunk)
@@ -409,6 +442,26 @@ async def _consume_blueprint(blueprint_instance: Any, messages: list[dict[str, A
     return final_message["content"], backend_meta
 
 
+def _task_spec(request_id, model_name, messages, params, previous_response_id) -> dict[str, Any]:
+    """The minimal spec needed to (re)run an async task — persisted for resume."""
+    return {
+        "request_id": request_id,
+        "model": model_name,
+        "messages": messages,
+        "params": params,
+        "previous_response_id": previous_response_id,
+    }
+
+
+def _spawn_worker(response_id, request_id, model_name, messages, params, previous_response_id) -> None:
+    """Start a daemon worker thread (own event loop) for an async response task."""
+    threading.Thread(
+        target=_run_background_response,
+        args=(response_id, request_id, model_name, list(messages), params, previous_response_id),
+        daemon=True,
+    ).start()
+
+
 def _run_background_response(
     response_id: str,
     request_id: str,
@@ -418,42 +471,101 @@ def _run_background_response(
     previous_response_id: str | None,
 ) -> None:
     """Worker (own thread + event loop): run the blueprint, update the stored record
-    queued -> in_progress -> completed/failed, with execution timing for observability."""
+    queued -> in_progress -> completed/failed/cancelled, with execution timing.
+
+    The record keeps a ``_task`` spec while queued/in_progress so a server restart
+    can resume it; the spec is dropped once the task reaches a terminal state.
+    """
     started = time.time()
+    spec = _task_spec(request_id, model_name, messages, params, previous_response_id)
 
-    def _save(payload: dict[str, Any], transcript: list[dict[str, Any]] | None) -> None:
+    def _save(payload, transcript, *, keep_task=False):
         payload["execution_ms"] = int((time.time() - started) * 1000)
-        responses_store.save(
-            {"id": response_id, "object": "response", "response": payload, "messages": transcript}
-        )
+        record = {"id": response_id, "object": "response", "response": payload, "messages": transcript}
+        if keep_task:
+            record["_task"] = spec
+        responses_store.save(record)
 
-    # Mark in_progress so a poller sees movement.
+    def _terminal(status_str, *, answer="", backend_meta=None, transcript=None, error=None):
+        payload = _build_response_payload(
+            request_id, model_name, answer, previous_response_id, messages if answer else None,
+            backend_meta, status=status_str,
+        )
+        payload["started_at"] = int(started)
+        if error is not None:
+            payload["error"] = {"message": str(error)}
+        _save(payload, transcript)  # no _task: terminal states aren't resumed
+
+    # Mark in_progress (keep the task spec for restart-resume).
     in_prog = _build_response_payload(request_id, model_name, "", previous_response_id, None, None, status="in_progress")
     in_prog["started_at"] = int(started)
-    _save(in_prog, None)
+    _save(in_prog, None, keep_task=True)
 
     try:
+        if _is_cancel_requested(response_id):
+            raise _Cancelled()
+
         async def _go():
             bp = await get_blueprint_instance(model_name, params=params)
             if bp is None:
                 raise RuntimeError(f"Model '{model_name}' could not be initialized.")
             if hasattr(bp, "set_params"):
                 bp.set_params(params)
-            return await _consume_blueprint(bp, messages)
+            return await _consume_blueprint(bp, messages, cancel_check=lambda: _is_cancel_requested(response_id))
 
         answer, backend_meta = asyncio.run(_go())
-        payload = _build_response_payload(
-            request_id, model_name, answer, previous_response_id, messages, backend_meta, status="completed"
-        )
-        payload["started_at"] = int(started)
-        _save(payload, list(messages) + [{"role": "assistant", "content": answer}])
-        logger.info(f"[ReqID: {request_id}] async task {response_id} completed in {payload['execution_ms']}ms.")
+        # A cancel may have landed between the last chunk and here.
+        if _is_cancel_requested(response_id):
+            _terminal("cancelled")
+            logger.info(f"[ReqID: {request_id}] async task {response_id} cancelled.")
+        else:
+            _terminal(
+                "completed", answer=answer, backend_meta=backend_meta,
+                transcript=list(messages) + [{"role": "assistant", "content": answer}],
+            )
+            logger.info(f"[ReqID: {request_id}] async task {response_id} completed.")
+    except _Cancelled:
+        _terminal("cancelled")
+        logger.info(f"[ReqID: {request_id}] async task {response_id} cancelled mid-run.")
     except Exception as e:
         logger.error(f"[ReqID: {request_id}] async task {response_id} failed: {e}", exc_info=True)
-        payload = _build_response_payload(request_id, model_name, "", previous_response_id, None, None, status="failed")
-        payload["started_at"] = int(started)
-        payload["error"] = {"message": str(e)}
-        _save(payload, None)
+        _terminal("failed", error=e)
+    finally:
+        _clear_cancel(response_id)
+
+
+def resume_pending_responses() -> int:
+    """On server startup, resume async tasks left queued/in_progress by a restart.
+
+    Returns the number resumed. Safe to call once at boot; terminal tasks are
+    ignored. Re-runs from the persisted ``_task`` spec (at-least-once semantics).
+    """
+    import glob
+    import os
+
+    base = responses_store._store_dir()
+    if not base.is_dir():
+        return 0
+    resumed = 0
+    for path in glob.glob(os.path.join(str(base), "resp_*.json")):
+        try:
+            with open(path) as f:
+                record = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        status_str = (record.get("response") or {}).get("status")
+        spec = record.get("_task")
+        if status_str not in ("queued", "in_progress") or not isinstance(spec, dict):
+            continue
+        logger.warning("Resuming interrupted async task %s (was %s).", record.get("id"), status_str)
+        _spawn_worker(
+            record["id"], spec.get("request_id"), spec.get("model"),
+            spec.get("messages") or [], spec.get("params"), spec.get("previous_response_id"),
+        )
+        resumed += 1
+    if resumed:
+        logger.info("Resumed %d interrupted async response task(s).", resumed)
+    return resumed
 
 
 class ResponsesDetailView(APIView):
@@ -474,3 +586,29 @@ class ResponsesDetailView(APIView):
         if not deleted:
             raise NotFound(f"Response '{response_id}' not found.")
         return Response({"id": response_id, "object": "response.deleted", "deleted": True}, status=status.HTTP_200_OK)
+
+
+class ResponsesCancelView(APIView):
+    """Cancel an in-flight async response (``POST /v1/responses/<id>/cancel``)."""
+
+    @method_decorator(csrf_exempt)
+    async def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
+        return await _async_auth_dispatch(self, request, *args, **kwargs)
+
+    async def post(self, _request: Request, response_id: str, *_a: Any, **_k: Any) -> Response:
+        record = await sync_to_async(responses_store.load)(response_id)
+        if record is None:
+            raise NotFound(f"Response '{response_id}' not found.")
+        payload = record.get("response") or {}
+        current = payload.get("status")
+        # No-op on already-finished tasks (idempotent) — return the current state.
+        if current in ("completed", "failed", "cancelled"):
+            return Response(payload, status=status.HTTP_200_OK)
+        # Request cooperative cancel and reflect it immediately so a poller sees it
+        # even before the worker reaches its next checkpoint.
+        _request_cancel(response_id)
+        payload["status"] = "cancelled"
+        await sync_to_async(responses_store.save)(
+            {"id": response_id, "object": "response", "response": payload, "messages": record.get("messages")}
+        )
+        return Response(payload, status=status.HTTP_200_OK)

--- a/tests/api/test_responses_async_control.py
+++ b/tests/api/test_responses_async_control.py
@@ -1,0 +1,126 @@
+"""Async control-plane tests: cancellation, restart-resume, and the no-auth opt-out."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from swarm.core import responses_store
+from swarm.views import responses_views as rv
+
+
+@pytest.fixture(autouse=True)
+def _isolated(monkeypatch, tmp_path):
+    monkeypatch.setenv("SWARM_TEST_MODE", "1")
+    monkeypatch.setenv("SWARM_RESPONSES_DIR", str(tmp_path))
+    monkeypatch.setattr("swarm.views.responses_views.validate_model_access", lambda *a, **k: True)
+
+
+def _save_state(rid, status_str, *, with_task=True):
+    rec = {
+        "id": rid,
+        "object": "response",
+        "response": {"id": rid, "object": "response", "status": status_str, "output": [], "output_text": ""},
+        "messages": None,
+    }
+    if with_task:
+        rec["_task"] = {"request_id": rid.removeprefix("resp_"), "model": "chatbot",
+                        "messages": [{"role": "user", "content": "ping"}], "params": None,
+                        "previous_response_id": None}
+    responses_store.save(rec)
+
+
+# --- cancellation endpoint -------------------------------------------------- #
+
+@pytest.mark.django_db(transaction=True)
+class TestCancel:
+    @pytest.mark.asyncio
+    async def test_cancel_unknown_is_404(self, async_client):
+        url = reverse("responses-cancel", kwargs={"response_id": "resp_nope"})
+        resp = await async_client.post(url, SERVER_NAME="localhost")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_cancel_in_progress_marks_cancelled(self, async_client):
+        rid = "resp_inflight1"
+        _save_state(rid, "in_progress")
+        url = reverse("responses-cancel", kwargs={"response_id": rid})
+        resp = await async_client.post(url, SERVER_NAME="localhost")
+        assert resp.status_code == status.HTTP_200_OK
+        assert json.loads(resp.content)["status"] == "cancelled"
+        # And the stored record reflects it for a poller.
+        got = await async_client.get(reverse("responses-detail", kwargs={"response_id": rid}), SERVER_NAME="localhost")
+        assert json.loads(got.content)["status"] == "cancelled"
+        rv._clear_cancel(rid)
+
+    @pytest.mark.asyncio
+    async def test_cancel_completed_is_noop(self, async_client):
+        rid = "resp_done1"
+        _save_state(rid, "completed", with_task=False)
+        url = reverse("responses-cancel", kwargs={"response_id": rid})
+        resp = await async_client.post(url, SERVER_NAME="localhost")
+        assert resp.status_code == status.HTTP_200_OK
+        assert json.loads(resp.content)["status"] == "completed"  # unchanged
+
+
+# --- worker honors a pre-requested cancel ----------------------------------- #
+
+@pytest.mark.django_db(transaction=True)
+def test_worker_honors_precancel():
+    rid = "resp_precancel"
+    rv._request_cancel(rid)
+    try:
+        rv._run_background_response(rid, "precancel", "chatbot", [{"role": "user", "content": "x"}], None, None)
+        rec = responses_store.load(rid)
+        assert rec["response"]["status"] == "cancelled"
+    finally:
+        rv._clear_cancel(rid)
+
+
+# --- restart resume --------------------------------------------------------- #
+
+@pytest.mark.django_db(transaction=True)
+def test_resume_pending_reruns_interrupted_task():
+    rid = "resp_resume1"
+    _save_state(rid, "in_progress")  # as if a restart left it mid-flight
+    resumed = rv.resume_pending_responses()
+    assert resumed == 1
+    # The resumed worker runs chatbot and reaches a terminal state.
+    for _ in range(50):
+        rec = responses_store.load(rid)
+        if rec and rec["response"]["status"] in ("completed", "failed", "cancelled"):
+            break
+        time.sleep(0.1)
+    assert responses_store.load(rid)["response"]["status"] == "completed"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_resume_ignores_terminal_tasks():
+    _save_state("resp_term1", "completed", with_task=False)
+    assert rv.resume_pending_responses() == 0
+
+
+# --- no-auth opt-out -------------------------------------------------------- #
+
+def test_no_auth_opt_out(monkeypatch):
+    from swarm.utils import env_utils
+
+    monkeypatch.setattr(env_utils, "_api_auth_disabled_warning_emitted", False)
+    monkeypatch.delenv("API_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("SWARM_API_KEY", raising=False)
+    monkeypatch.setenv("DJANGO_DEBUG", "false")
+
+    # Production + no token + no opt-out -> refuses (ImproperlyConfigured).
+    from django.core.exceptions import ImproperlyConfigured
+    monkeypatch.delenv("SWARM_ALLOW_NO_AUTH", raising=False)
+    with pytest.raises(ImproperlyConfigured):
+        env_utils.get_enforced_api_auth_token()
+
+    # Production + no token + explicit opt-out -> permitted (None), warns.
+    monkeypatch.setattr(env_utils, "_api_auth_disabled_warning_emitted", False)
+    monkeypatch.setenv("SWARM_ALLOW_NO_AUTH", "true")
+    assert env_utils.get_enforced_api_auth_token() is None


### PR DESCRIPTION
Follow-up to async (#154), per priorities: **cancellation** + **restart-durable workers**. Plus the small **no-auth opt-out** so a cloud-OAuth-fronted instance can run without a swarm token.

## Cancellation — `POST /v1/responses/{id}/cancel`
Cooperative: a registry flags the id; the worker checks it between blueprint chunks and stops → `status: cancelled`. Idempotent no-op on finished tasks; 404 on unknown. A single in-flight CLI call still finishes/timeouts — cancel lands at the next chunk boundary (between CLIs for fusion/pipeline/planner). **Live-verified:** `cli_fusion` task `queued → cancelled`.

## Restart durability
Queued/in-progress records persist a `_task` spec; on server startup (server processes only — guarded against the runserver reloader parent and test mode) `resume_pending_responses()` re-runs interrupted tasks from that spec (at-least-once). Terminal tasks ignored.

## No-auth opt-out
`SWARM_ALLOW_NO_AUTH=true` lets the server boot in production (`DEBUG=false`) **without** `API_AUTH_TOKEN` — for when an external layer (cloud OAuth proxy / API gateway) already gates access. Logs a loud one-time warning; default still refuses to silently run unauthenticated.

## Tests
Cancel (404 / in-progress→cancelled / completed no-op), worker honors a pre-requested cancel, resume re-runs interrupted + ignores terminal, no-auth opt-out. 21 passed in the responses suites.

## Docs
`docs/ASYNC_RESPONSES.md` cancel + durability sections; CHANGELOG; `SWARM_ALLOW_NO_AUTH` in the canonical env table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)