### PR TITLE
feat(responses): configurable fast-path sync vs queued (auto-escalation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - **Cancellation:** `POST /v1/responses/{id}/cancel` — cooperative cancel, `status → cancelled` (idempotent on finished tasks).
 - **Restart durability:** queued/in-progress tasks persist a spec and **resume** on server startup (at-least-once).
 - **No-auth opt-out:** `SWARM_ALLOW_NO_AUTH=true` lets the server boot in production without `API_AUTH_TOKEN` (for when an external OAuth/gateway layer gates access) — warns loudly instead of refusing.
+- **Fast-path sync vs queued (auto-escalation):** `max_wait_seconds` (per request) or `SWARM_RESPONSES_SYNC_TIMEOUT` (server default) make `/v1/responses` return the result inline if it beats the deadline, else a queued handle to poll — the task keeps running either way. No deadline = classic blocking sync.
 
 ### Added — Orchestration patterns (MAF-class, over CLIs)
 - Three new orchestration blueprints complete the field-standard pattern set over heterogeneous agentic CLIs: **`cli_pipeline`** (sequential — each stage refines the prior stage's output, draft → review → polish), **`cli_roundtable`** (group-chat — debaters react to each other in a shared transcript across bounded rounds, a moderator concludes and synthesizes), and **`cli_planner`** (Magentic-One — a planner keeps a task ledger, delegates to workers, and re-plans on stall until the goal is met). All follow the existing `BlueprintBase` + `cli_fusion_support` conventions, degrade gracefully on a dead backend, and are auto-discovered at `/v1/models`. 20 new tests.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -235,6 +235,7 @@ environment / `.env`, never in `swarm_config.json` (reference them with
 | `SWARM_CONFIG_PATH` | Explicit path to `swarm_config.json` (wins over discovery). | unset → XDG-first discovery (see [§1](#1-config-file-location-and-discovery)) |
 | `XDG_CONFIG_HOME` | Base for the config dir (`…/swarm/swarm_config.json`, `teams.json`). | `~/.config` |
 | `SWARM_RESPONSES_DIR` | Where `/v1/responses` stores records for `previous_response_id` chaining and `GET`/`DELETE`. | `$XDG_DATA_HOME/swarm/responses` (i.e. `~/.local/share/swarm/responses`) |
+| `SWARM_RESPONSES_SYNC_TIMEOUT` | Default seconds a `/v1/responses` request waits inline before auto-escalating to a queued handle (per-request override: `max_wait_seconds`). Unset = fully-blocking sync. | unset |
 | `XDG_DATA_HOME` | Base for state data (responses store). | `~/.local/share` |
 
 ### Server, security & auth

--- a/docs/ASYNC_RESPONSES.md
+++ b/docs/ASYNC_RESPONSES.md
@@ -42,6 +42,29 @@ Each queued/in-progress task persists a task spec, so if the server restarts
 mid-flight it **resumes** interrupted tasks on startup (re-runs from the stored
 input — at-least-once). Terminal tasks are left alone.
 
+## Fast-path sync vs queued (auto-escalation)
+
+You don't have to pre-decide sync vs async. Set a deadline and the server returns
+the result **inline** if the task beats it, or a **handle** to poll if it runs
+long:
+
+- `max_wait_seconds: N` on the request — wait up to N seconds, then escalate.
+- `SWARM_RESPONSES_SYNC_TIMEOUT=N` (env) — a server-wide default for every request.
+- `background: true` — don't wait at all (immediate handle).
+- Neither set — classic fully-blocking sync (returns whenever the task finishes).
+
+Same task either way; only the *return* differs:
+
+```
+POST /v1/responses {"model":"cli_fusion","input":"...","max_wait_seconds":10}
+  -> 200 {status:"completed", ...}   # finished within 10s — inline
+  -> 202 {status:"in_progress", id:"resp_…"}   # still running — poll the handle
+```
+
+The task keeps running in the background after a 202, so a long job is never
+lost just because the HTTP call returned. `execution_ms` is recorded for tuning
+the deadline to real task durations.
+
 ## How a client (e.g. Grok) uses it
 
 ```bash

--- a/src/swarm/views/responses_views.py
+++ b/src/swarm/views/responses_views.py
@@ -13,6 +13,7 @@ and emits ``response.output_text.delta`` events.
 import asyncio
 import json
 import logging
+import os
 import sys
 import threading
 import time
@@ -110,6 +111,29 @@ def _coerce_content(content: Any) -> str:
                 parts.append(part)
         return "".join(parts)
     return str(content)
+
+
+def _resolve_sync_wait(request_data: dict[str, Any], background: bool) -> float | None:
+    """How long to wait synchronously before returning a queued handle.
+
+    Precedence: ``background:true`` -> 0 (immediate handle) > per-request
+    ``max_wait_seconds`` > server default ``SWARM_RESPONSES_SYNC_TIMEOUT`` (env).
+    Returns None when nothing is configured — the classic fully-blocking sync path.
+    """
+    if background:
+        return 0.0
+    if "max_wait_seconds" in request_data:
+        try:
+            return max(0.0, float(request_data["max_wait_seconds"]))
+        except (TypeError, ValueError):
+            return None
+    env = os.environ.get("SWARM_RESPONSES_SYNC_TIMEOUT")
+    if env:
+        try:
+            return max(0.0, float(env))
+        except ValueError:
+            return None
+    return None
 
 
 async def _async_auth_dispatch(view: APIView, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
@@ -228,11 +252,16 @@ class ResponsesView(APIView):
             logger.warning(f"[ReqID: {request_id}] User '{request.user}' denied access to model '{model_name}'.")
             raise PermissionDenied(f"You do not have permission to access the model '{model_name}'.")
 
-        # Async fire-and-forget: persist a "queued" record, kick off a background
-        # worker, and return the handle immediately. Polled via GET. (Streaming and
-        # background are mutually exclusive; background wins.)
-        if background:
-            return await self._handle_background(request_id, model_name, messages, params, previous_response_id)
+        # Fast-path sync vs queued. The server runs the task on a background worker
+        # and waits up to `wait_seconds` for it to finish: returns the result inline
+        # (200) if it beats the deadline, else a handle (202, in_progress) the client
+        # polls. background:true => wait 0 (immediate handle). No wait configured =>
+        # the classic fully-blocking sync path. Streaming is always inline.
+        wait_seconds = _resolve_sync_wait(request_data, background)
+        if wait_seconds is not None and not stream:
+            return await self._handle_hybrid(
+                request_id, model_name, messages, params, previous_response_id, wait_seconds
+            )
 
         if hasattr(blueprint_instance, "set_params"):
             blueprint_instance.set_params(params)
@@ -240,8 +269,13 @@ class ResponsesView(APIView):
             return await self._handle_streaming(blueprint_instance, messages, request_id, model_name, store, previous_response_id)
         return await self._handle_non_streaming(blueprint_instance, messages, request_id, model_name, store, previous_response_id)
 
-    async def _handle_background(self, request_id, model_name, messages, params, previous_response_id) -> Response:
-        """Persist a queued record (with a resumable task spec), start a worker, return now."""
+    async def _handle_hybrid(self, request_id, model_name, messages, params, previous_response_id, wait_seconds) -> Response:
+        """Run on a background worker; wait up to ``wait_seconds`` for completion.
+
+        Returns the completed result inline (200) if it finishes within the window,
+        else the in-progress handle (202) to poll. ``wait_seconds == 0`` returns the
+        queued handle immediately (background mode).
+        """
         response_id = f"resp_{request_id}"
         payload = _build_response_payload(
             request_id, model_name, "", previous_response_id, None, None, status="queued"
@@ -254,8 +288,21 @@ class ResponsesView(APIView):
         # Daemon thread with its own event loop — decoupled from the request
         # lifecycle so it survives after we return the response.
         _spawn_worker(response_id, request_id, model_name, list(messages), params, previous_response_id)
-        logger.info(f"[ReqID: {request_id}] /v1/responses queued async task {response_id} (model '{model_name}').")
-        return Response(payload, status=status.HTTP_202_ACCEPTED)
+        logger.info(f"[ReqID: {request_id}] /v1/responses task {response_id} started (wait={wait_seconds}s, model '{model_name}').")
+
+        if wait_seconds <= 0:
+            return Response(payload, status=status.HTTP_202_ACCEPTED)
+
+        deadline = time.monotonic() + wait_seconds
+        while time.monotonic() < deadline:
+            await asyncio.sleep(0.15)
+            rec = await sync_to_async(responses_store.load)(response_id)
+            done = (rec or {}).get("response", {}).get("status") in ("completed", "failed", "cancelled")
+            if done:
+                return Response(rec["response"], status=status.HTTP_200_OK)  # beat the deadline
+        # Escalate to async: hand back the current (in_progress) handle to poll.
+        rec = await sync_to_async(responses_store.load)(response_id)
+        return Response((rec or {}).get("response") or payload, status=status.HTTP_202_ACCEPTED)
 
     async def _handle_non_streaming(self, blueprint_instance, messages, request_id, model_name, store=True, previous_response_id=None) -> Response:
         """Consume the blueprint generator, keep the last message, shape a response object."""

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -258,3 +258,37 @@ class TestResponsesAsync:
         body = json.loads(resp.content)
         assert body["status"] == "completed"
         assert "ping" in body["output_text"]
+
+    @pytest.mark.asyncio
+    async def test_max_wait_fast_task_returns_inline(self, async_client):
+        # A fast task that beats the deadline comes back inline (200, completed).
+        resp = await self._create(async_client, {"model": "chatbot", "input": "ping", "max_wait_seconds": 30})
+        assert resp.status_code == status.HTTP_200_OK
+        body = json.loads(resp.content)
+        assert body["status"] == "completed"
+        assert "ping" in body["output_text"]
+
+    @pytest.mark.asyncio
+    async def test_slow_task_escalates_to_handle_then_completes(self, async_client, monkeypatch):
+        # Worker slower than the wait window -> 202 handle; then it finishes and polls completed.
+        import swarm.views.responses_views as rv
+
+        async def _slow(bp, messages, cancel_check=None):
+            await asyncio.sleep(0.8)
+            return "You said: slow", None
+
+        monkeypatch.setattr(rv, "_consume_blueprint", _slow)
+        resp = await self._create(async_client, {"model": "chatbot", "input": "x", "max_wait_seconds": 0.2})
+        assert resp.status_code == status.HTTP_202_ACCEPTED
+        body = json.loads(resp.content)
+        assert body["status"] in ("queued", "in_progress")
+        final = await self._poll(async_client, body["id"])
+        assert final["status"] == "completed"
+        assert "slow" in final["output_text"]
+
+    @pytest.mark.asyncio
+    async def test_env_default_sync_timeout_applies(self, async_client, monkeypatch):
+        monkeypatch.setenv("SWARM_RESPONSES_SYNC_TIMEOUT", "30")
+        resp = await self._create(async_client, {"model": "chatbot", "input": "ping"})
+        assert resp.status_code == status.HTTP_200_OK  # hybrid kicked in via env default
+        assert json.loads(resp.content)["status"] == "completed"


### PR DESCRIPTION
The keystone for using `/v1/responses` as an orchestration backbone: clients stop pre-deciding sync vs async. Set a deadline; the server returns the result **inline** if the task beats it, else a **handle** to poll — and the task keeps running either way.

## Interface
- Per-request: `"max_wait_seconds": N`
- Server default: `SWARM_RESPONSES_SYNC_TIMEOUT=N` (env)
- `"background": true` → wait 0 (immediate handle)
- Neither → classic fully-blocking sync (unchanged)

Unifies the background path into `_handle_hybrid` (`background` == wait 0). `execution_ms` recorded for tuning the deadline to real durations.

## Verified live
- Fast: grok task, `max_wait_seconds:30` → **200 completed** inline, `execution_ms:8485`.
- Slow: cli_fusion essay, `max_wait_seconds:2` → **202 in_progress** handle (task keeps running, poll to completion).

## Tests
Fast task returns inline; a worker slower than the window escalates to a handle then completes on poll; env default applies. 17 passed in `tests/api/test_responses.py`.

## Docs
`docs/ASYNC_RESPONSES.md` fast-path section; `SWARM_RESPONSES_SYNC_TIMEOUT` in the env table; CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)