### PR TITLE
fix(blueprints): real FunctionTool instead of PatchedFunctionTool stub (jeeves/poets/rue_code)

### DIFF
--- a/src/swarm/blueprints/jeeves/blueprint_jeeves.py
+++ b/src/swarm/blueprints/jeeves/blueprint_jeeves.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 import pytz
-from agents import Runner
+from agents import Runner, function_tool
 
 from swarm.blueprints.common.operation_box_utils import display_operation_box
 from swarm.core.output_utils import get_spinner_state
@@ -121,12 +121,8 @@ gutenberg_instructions = (
 )
 
 # --- FileOps Tool Logic Definitions ---
-class PatchedFunctionTool:
-    def __init__(self, func, name):
-        self.func = func
-        self.name = name
-
 def read_file(path: str) -> str:
+    """Read a text file and return its contents."""
     try:
         with open(path) as f:
             return f.read()
@@ -134,6 +130,7 @@ def read_file(path: str) -> str:
         return f"ERROR: {e}"
 
 def write_file(path: str, content: str) -> str:
+    """Write content to a text file, overwriting any existing file."""
     try:
         with open(path, 'w') as f:
             f.write(content)
@@ -142,12 +139,14 @@ def write_file(path: str, content: str) -> str:
         return f"ERROR: {e}"
 
 def list_files(directory: str = '.') -> str:
+    """List the entries in a directory (defaults to the current directory)."""
     try:
         return '\n'.join(os.listdir(directory))
     except Exception as e:
         return f"ERROR: {e}"
 
 def execute_shell_command(command: str) -> str:
+    """Run a shell command and return its combined stdout and stderr."""
     import subprocess
     try:
         result = subprocess.run(shlex.split(command), shell=False, capture_output=True, text=True)
@@ -155,10 +154,12 @@ def execute_shell_command(command: str) -> str:
     except Exception as e:
         return f"ERROR: {e}"
 
-read_file_tool = PatchedFunctionTool(read_file, 'read_file')
-write_file_tool = PatchedFunctionTool(write_file, 'write_file')
-list_files_tool = PatchedFunctionTool(list_files, 'list_files')
-execute_shell_command_tool = PatchedFunctionTool(execute_shell_command, 'execute_shell_command')
+# Wrap as real openai-agents FunctionTools (the old PatchedFunctionTool stub was
+# not a FunctionTool, so the ChatCompletions path mis-flagged it as a hosted tool).
+read_file_tool = function_tool(read_file)
+write_file_tool = function_tool(write_file)
+list_files_tool = function_tool(list_files)
+execute_shell_command_tool = function_tool(execute_shell_command)
 
 # --- Unified Operation/Result Box for UX ---
 class JeevesBlueprint(BlueprintBase):

--- a/src/swarm/blueprints/poets/blueprint_poets.py
+++ b/src/swarm/blueprints/poets/blueprint_poets.py
@@ -131,10 +131,8 @@ AGENT_BASE_INSTRUCTIONS = {
 
 # --- FileOps Tool Logic Definitions ---
 # Patch: Expose underlying fileops functions for direct testing
-class PatchedFunctionTool:
-    def __init__(self, func, name):
-        self.func = func
-        self.name = name
+from agents import function_tool
+
 
 def read_file(path: str) -> str:
     try:
@@ -177,10 +175,10 @@ def execute_shell_command(command: str) -> str:
     except Exception as e:
         logger.error(f"Error executing command '{command}': {e}", exc_info=True)
         return f"Error executing command: {e}"
-read_file_tool = PatchedFunctionTool(read_file, 'read_file')
-write_file_tool = PatchedFunctionTool(write_file, 'write_file')
-list_files_tool = PatchedFunctionTool(list_files, 'list_files')
-execute_shell_command_tool = PatchedFunctionTool(execute_shell_command, 'execute_shell_command')
+read_file_tool = function_tool(read_file)
+write_file_tool = function_tool(write_file)
+list_files_tool = function_tool(list_files)
+execute_shell_command_tool = function_tool(execute_shell_command)
 
 # --- Spinner and ANSI/emoji operation box for unified UX ---
 import threading

--- a/src/swarm/blueprints/rue_code/blueprint_rue_code.py
+++ b/src/swarm/blueprints/rue_code/blueprint_rue_code.py
@@ -21,10 +21,8 @@ logger = logging.getLogger(__name__)
 
 # Last swarm update: {{ datetime.now(pytz.utc).strftime('%Y-%m-%dT%H:%M:%SZ') }}
 # Patch: Expose underlying fileops functions for direct testing
-class PatchedFunctionTool:
-    def __init__(self, func, name):
-        self.func = func
-        self.name = name
+from agents import function_tool
+
 
 def read_file(path: str) -> str:
     try:
@@ -75,10 +73,10 @@ def execute_shell_command(command: str) -> str:
     except Exception as e:
         logger.error(f"Error executing command '{command}': {e}", exc_info=True)
         return f"Error executing command: {e}"
-read_file_tool = PatchedFunctionTool(read_file, 'read_file')
-write_file_tool = PatchedFunctionTool(write_file, 'write_file')
-list_files_tool = PatchedFunctionTool(list_files, 'list_files')
-execute_shell_command_tool = PatchedFunctionTool(execute_shell_command, 'execute_shell_command')
+read_file_tool = function_tool(read_file)
+write_file_tool = function_tool(write_file)
+list_files_tool = function_tool(list_files)
+execute_shell_command_tool = function_tool(execute_shell_command)
 
 # Attempt to import BlueprintBase, handle potential ImportError during early setup/testing
 try:
@@ -246,7 +244,7 @@ def llm_cost_tool(model: str, prompt_tokens: int, completion_tokens: int = 0, co
     except Exception as e:
         return f"Error: {e}"
 
-llm_cost_tool_fn = PatchedFunctionTool(llm_cost_tool, 'llm_cost')
+llm_cost_tool_fn = function_tool(llm_cost_tool, strict_mode=False)  # config:dict param needs relaxed schema
 
 # --- RueCodeBlueprint Definition ---
 # === OpenAI GPT-4.1 Prompt Engineering Guide ===

--- a/tests/blueprints/test_function_tool_not_hosted.py
+++ b/tests/blueprints/test_function_tool_not_hosted.py
@@ -1,0 +1,31 @@
+"""Regression guard: blueprint file/shell tools must be real SDK FunctionTools.
+
+These blueprints previously wrapped their tools in a local ``PatchedFunctionTool``
+stub that the openai-agents SDK did not recognize, so the ChatCompletions path
+mis-flagged them as *hosted* tools and raised "Hosted tools are not supported
+with the ChatCompletions API" — breaking jeeves/poets/rue_code on any non-OpenAI
+backend. They must be `agents.FunctionTool` instances.
+"""
+
+from __future__ import annotations
+
+from agents import FunctionTool
+
+from swarm.blueprints.jeeves import blueprint_jeeves as jeeves
+from swarm.blueprints.poets import blueprint_poets as poets
+from swarm.blueprints.rue_code import blueprint_rue_code as rue
+
+
+def test_jeeves_tools_are_function_tools():
+    for t in (jeeves.read_file_tool, jeeves.write_file_tool, jeeves.list_files_tool, jeeves.execute_shell_command_tool):
+        assert isinstance(t, FunctionTool)
+
+
+def test_poets_tools_are_function_tools():
+    for t in (poets.read_file_tool, poets.write_file_tool, poets.list_files_tool, poets.execute_shell_command_tool):
+        assert isinstance(t, FunctionTool)
+
+
+def test_rue_code_tools_are_function_tools():
+    for t in (rue.read_file_tool, rue.write_file_tool, rue.list_files_tool, rue.execute_shell_command_tool, rue.llm_cost_tool_fn):
+        assert isinstance(t, FunctionTool)


### PR DESCRIPTION
## Bug
jeeves/poets/rue_code wrapped their file/shell tools in a local `PatchedFunctionTool` stub (it just held `func` + `name`). The openai-agents SDK doesn't recognize it as a `FunctionTool`, so the **ChatCompletions path mis-flags it as a hosted tool** and raises `Hosted tools are not supported with the ChatCompletions API` — breaking these blueprints on **any non-OpenAI backend** (surfaced when the gateway's `default` profile moved to a local LiteLLM).

## Fix
Replace the stub with the SDK's `function_tool()`:
- the four file/shell tools (default strict schema),
- rue_code's `llm_cost` tool with `strict_mode=False` (its `config: dict` param can't satisfy strict JSON schema).
- Added docstrings on the jeeves tools for proper tool descriptions.

## Verified
Live against the local LiteLLM/`qwen3.5` backend: **jeeves / poets / rue_code all return HTTP 200, zero hosted-tools errors** (poets returns a real poem). New regression test asserts every tool is `agents.FunctionTool`; existing spinner tests still pass.

Note: jeeves with a *local* model may emit a tool call as text (LM Studio's tool-call format vs OpenAI's) — that's a separate local-model function-calling nuance, not this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)