### PR TITLE
fix(api): document POST /v1/teams request body (unblocks MCP team registration)

### DIFF
--- a/src/swarm/views/teams_api.py
+++ b/src/swarm/views/teams_api.py
@@ -21,7 +21,9 @@ deployments.
 import logging
 
 from django.conf import settings as dj_settings
-from rest_framework import status
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiExample, extend_schema, inline_serializer
+from rest_framework import serializers, status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -75,6 +77,42 @@ class TeamsAPIView(APIView):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
+    @extend_schema(
+        operation_id="v1_teams_create",
+        summary="Register a dynamic team",
+        description=(
+            "Register a named dynamic team (a saved alias over an `llm_profile`). "
+            "`name` is **required**; it is slugified into the team id."
+        ),
+        request=inline_serializer(
+            name="TeamCreateRequest",
+            fields={
+                "name": serializers.CharField(
+                    help_text="Team name (required). Slugified into the team id."
+                ),
+                "description": serializers.CharField(
+                    required=False, allow_blank=True, help_text="Optional human description."
+                ),
+                "llm_profile": serializers.CharField(
+                    required=False,
+                    allow_blank=True,
+                    help_text="LLM profile name to use (defaults to 'default').",
+                ),
+            },
+        ),
+        examples=[
+            OpenApiExample(
+                "Minimal",
+                value={"name": "research-squad", "llm_profile": "default"},
+                request_only=True,
+            )
+        ],
+        responses={
+            201: OpenApiTypes.OBJECT,
+            400: OpenApiTypes.OBJECT,
+            409: OpenApiTypes.OBJECT,
+        },
+    )
     def post(self, request, *_args, **_kwargs):
         try:
             body = request.data or {}


### PR DESCRIPTION
## Bug (reported by an MCP client)
A client calling `mcp_openswarm_post_v1_teams` got **400 "Team name is required."** even though it tried to register a team. Root cause: `POST /v1/teams` was in the OpenAPI spec but had **no `requestBody`** — so the MCP tool generated from the spec had **no parameters**, the client couldn't know `name` was required, and the call always 400'd.

## Fix
`@extend_schema` with an inline request serializer documents the body: **`name` (required)**, `description`, `llm_profile` (optional), plus a minimal example. MCP/codegen tools built from `/api/schema/` now surface these parameters.

## Verified
- `requestBody.required == ['name']` in the spec
- `POST {"name":"research-squad","llm_profile":"default"}` → **201**
- `POST {"description":"no name"}` → **400** (validation intact)
- 24 teams tests pass

**Client note:** mcp-openapi-proxy generates its tools from the spec **at startup** — restart/refresh it so it re-reads `/api/schema/` and regenerates `mcp_openswarm_post_v1_teams` with the new `name` parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)