### PR TITLE
fix(api): document request bodies for ALL write endpoints (unblocks MCP clients)

### DIFF
--- a/src/swarm/views/api_views.py
+++ b/src/swarm/views/api_views.py
@@ -3,10 +3,28 @@ import time
 
 # *** Import async_to_sync ***
 from asgiref.sync import async_to_sync
-from rest_framework import status
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import serializers, status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+# Shared request body for creating/updating a custom blueprint (documents the
+# OpenAPI requestBody so MCP/codegen clients know what fields to send).
+_custom_blueprint_request = inline_serializer(
+    name="CustomBlueprintRequest",
+    fields={
+        "id": serializers.CharField(required=False, help_text="Blueprint id (or provide name)."),
+        "name": serializers.CharField(required=False, help_text="Display name (id or name is required)."),
+        "description": serializers.CharField(required=False, allow_blank=True),
+        "category": serializers.CharField(required=False, help_text="Default: ai_assistants."),
+        "tags": serializers.ListField(child=serializers.CharField(), required=False),
+        "requirements": serializers.CharField(required=False, allow_blank=True),
+        "code": serializers.CharField(required=False, allow_blank=True, help_text="Blueprint source."),
+        "required_mcp_servers": serializers.ListField(child=serializers.CharField(), required=False),
+        "env_vars": serializers.ListField(child=serializers.CharField(), required=False),
+    },
+)
 
 from swarm.services import github_topics_service as gh_service
 from swarm.settings import (
@@ -164,6 +182,7 @@ class CustomBlueprintsView(APIView):
         filtered = [i for i in items if match(i)]
         return Response({"object": "list", "data": filtered}, status=status.HTTP_200_OK)
 
+    @extend_schema(summary="Create a custom blueprint", request=_custom_blueprint_request)
     def post(self, request, *_args, **_kwargs):
         try:
             body = request.data or {}
@@ -241,6 +260,7 @@ class CustomBlueprintDetailView(APIView):
             return Response({"error": "failed to persist"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
+    @extend_schema(summary="Update a custom blueprint", request=_custom_blueprint_request)
     def patch(self, request, blueprint_id: str, *_args, **_kwargs):
         try:
             lib, items, item = self._load(blueprint_id)

--- a/src/swarm/views/library_api.py
+++ b/src/swarm/views/library_api.py
@@ -22,7 +22,8 @@ HasValidTokenOrSession is required; otherwise AllowAny.
 
 import logging
 
-from rest_framework import status
+from drf_spectacular.utils import OpenApiExample, extend_schema, inline_serializer
+from rest_framework import serializers, status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -74,6 +75,18 @@ class LibraryAPIView(APIView):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
+    @extend_schema(
+        summary="Add a blueprint to the library",
+        request=inline_serializer(
+            name="LibraryAddRequest",
+            fields={
+                "name": serializers.CharField(
+                    help_text="Blueprint id to install (must be a discovered blueprint). Required."
+                ),
+            },
+        ),
+        examples=[OpenApiExample("Install", value={"name": "cli_fusion"}, request_only=True)],
+    )
     def post(self, request, *_args, **_kwargs):
         try:
             body = request.data or {}

--- a/src/swarm/views/openai_schema.py
+++ b/src/swarm/views/openai_schema.py
@@ -14,6 +14,17 @@ _MESSAGES = serializers.ListField(
     help_text='OpenAI-style messages, e.g. [{"role": "user", "content": "..."}].',
 )
 
+_PARAMS = serializers.DictField(
+    required=False,
+    help_text=(
+        "Per-request blueprint options (free-form object). Drives the CLI-fusion "
+        "blueprints. Common keys: preset, cli, panel, judge, router, planner, "
+        "workers, reducer, stages, debaters, moderator, rounds, max_rounds, "
+        "workdir, show_analysis. Most blueprints also work with config defaults "
+        "if omitted."
+    ),
+)
+
 chat_completions_schema = extend_schema(
     tags=["OpenAI"],
     summary="Create a chat completion",
@@ -28,6 +39,7 @@ chat_completions_schema = extend_schema(
             "model": serializers.CharField(help_text="Blueprint id, e.g. cli_fusion."),
             "messages": _MESSAGES,
             "stream": serializers.BooleanField(required=False, default=False),
+            "params": _PARAMS,
         },
     ),
     responses={
@@ -69,6 +81,20 @@ responses_schema = extend_schema(
             "input": serializers.JSONField(help_text="A string, or an array of message objects."),
             "instructions": serializers.CharField(required=False, help_text="Optional system instructions."),
             "stream": serializers.BooleanField(required=False, default=False),
+            "params": _PARAMS,
+            "previous_response_id": serializers.CharField(
+                required=False, help_text="Chain from a prior response id (stateful multi-turn)."
+            ),
+            "store": serializers.BooleanField(
+                required=False, default=True, help_text="Persist the response (default true)."
+            ),
+            "background": serializers.BooleanField(
+                required=False, help_text="Async: return a queued resp_id immediately; poll GET /v1/responses/{id}."
+            ),
+            "max_wait_seconds": serializers.FloatField(
+                required=False,
+                help_text="Wait inline up to N seconds, then return a handle to poll (auto-escalation).",
+            ),
         },
     ),
     responses={

--- a/src/swarm/views/responses_views.py
+++ b/src/swarm/views/responses_views.py
@@ -29,6 +29,7 @@ from django.http import (
 )
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.exceptions import (
     APIException,
@@ -642,6 +643,11 @@ class ResponsesCancelView(APIView):
     async def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
         return await _async_auth_dispatch(self, request, *args, **kwargs)
 
+    @extend_schema(
+        summary="Cancel an async response",
+        description="Cooperatively cancel an in-flight async task. No request body. Idempotent on finished tasks.",
+        request=None,
+    )
     async def post(self, _request: Request, response_id: str, *_a: Any, **_k: Any) -> Response:
         record = await sync_to_async(responses_store.load)(response_id)
         if record is None:


### PR DESCRIPTION
Generalizes the teams fix (#158): a client got 400s because the OpenAPI spec didn't document what to send. Swept every write endpoint and fixed all of them.

## Before → after
| Endpoint | Before | After |
|---|---|---|
| `chat/completions` | model/messages/stream | **+ `params`** |
| `responses` | model/input/instructions/stream | **+ `params`, background, max_wait_seconds, previous_response_id, store** |
| `POST/PUT/PATCH /v1/blueprints/custom/` | **no body** | CustomBlueprintRequest |
| `POST /v1/library` | **no body** | name (required) |
| `POST /v1/responses/{id}/cancel` | **no body** | `request=None` (documented as bodyless) |
| `teams` | (fixed in #158) | name/description/llm_profile |

**Sweep now reports 0 undocumented write endpoints.**

## Why this fixes the client
The big one is **`params`** on chat/completions — that's how a client drives `cli_fusion`/`cli_map`/`cli_orchestrator`/`cli_pipeline`/`cli_roundtable`/`cli_planner` (preset, cli, panel, judge, router, planner, workers, stages, …). Without it documented, MCP-generated tools couldn't pass those, so multi-CLI blueprints fell back/failed. Now they're discoverable.

## Also (runtime config, not in this PR)
Added default config blocks for cli_orchestrator/map/pipeline/roundtable/planner so they work with a **bare `{model, messages}`** call (no params needed) — verified live: all return 200 (e.g. cli_pipeline → "Tokyo", `fp: cli_pipeline:grok+claude`).

34 tests pass; `manage.py spectacular` generates cleanly.

**Client note:** restart/refresh mcp-openapi-proxy so it re-reads `/api/schema/` and regenerates tools with the new parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)