### PR TITLE
feat(api): async background mode on /v1/chat/completions (fire + poll)

### DIFF
--- a/src/swarm/views/chat_views.py
+++ b/src/swarm/views/chat_views.py
@@ -383,11 +383,45 @@ class ChatCompletionsView(APIView):
             logger.warning(f"[ReqID: {request_id}] User '{request.user}' denied access to model '{model_name}'.")
             raise PermissionDenied(f"You do not have permission to access the model '{model_name}'.")
 
+        # --- Async fire-and-forget: return a queued handle immediately, run in a
+        #     background worker, poll via GET /v1/responses/{id}. Reuses the
+        #     Responses async machinery. (Streaming is always inline.) ---
+        background = bool(request_data.get('background', False)) if isinstance(request_data, dict) else False
+        if background and not stream:
+            return await self._handle_background_chat(request_id, model_name, messages, blueprint_params)
+
         # --- Handle Streaming or Non-Streaming Response ---
         if stream:
             return await self._handle_streaming(blueprint_instance, messages, request_id, model_name)
         else:
             return await self._handle_non_streaming(blueprint_instance, messages, request_id, model_name)
+
+    async def _handle_background_chat(self, request_id: str, model_name: str, messages, params) -> Response:
+        """Queue a chat-completions task on the shared Responses worker; return a
+        chat.completion-shaped handle to poll at GET /v1/responses/{id}."""
+        # Lazy import to avoid the chat_views <-> responses_views import cycle.
+        from swarm.core import responses_store
+
+        from .responses_views import _build_response_payload, _spawn_worker, _task_spec
+
+        response_id = f"resp_{request_id}"
+        rpayload = _build_response_payload(request_id, model_name, "", None, None, None, status="queued")
+        await sync_to_async(responses_store.save)({
+            "id": response_id, "object": "response", "response": rpayload, "messages": None,
+            "_task": _task_spec(request_id, model_name, list(messages), params, None),
+        })
+        _spawn_worker(response_id, request_id, model_name, list(messages), params, None)
+        logger.info(f"[ReqID: {request_id}] /v1/chat/completions queued async task {response_id} (model '{model_name}').")
+        ack = {
+            "id": response_id,
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": model_name,
+            "status": "queued",
+            "choices": [],
+            "poll_url": f"/v1/responses/{response_id}",
+        }
+        return Response(ack, status=status.HTTP_202_ACCEPTED)
 
 
 # ==============================================================================

--- a/tests/api/test_cli_fusion_api.py
+++ b/tests/api/test_cli_fusion_api.py
@@ -146,3 +146,37 @@ def test_cli_agent_streams_incremental_deltas_over_api(client, streaming_cli_con
 
     deltas = "".join(re.findall(r'"content":\s*"([^"]*)"', sse))
     assert "alpha" in deltas and "beta" in deltas
+
+
+@pytest.mark.django_db(transaction=True)
+def test_chat_completions_background_then_poll(client, fake_cli_config, monkeypatch, tmp_path):
+    """Async on /v1/chat/completions: background -> 202 queued handle, poll via responses."""
+    import time
+
+    monkeypatch.setenv("SWARM_RESPONSES_DIR", str(tmp_path))
+    resp = client.post(
+        "/v1/chat/completions",
+        data=json.dumps({
+            "model": "cli_agent",
+            "messages": [{"role": "user", "content": "hi"}],
+            "params": {"cli": "a"},
+            "background": True,
+        }),
+        content_type="application/json",
+    )
+    assert resp.status_code == 202, resp.content[:300]
+    ack = resp.json()
+    assert ack["status"] == "queued"
+    assert ack["id"].startswith("resp_")
+    assert ack["poll_url"] == f"/v1/responses/{ack['id']}"
+
+    final = None
+    for _ in range(80):
+        d = client.get(f"/v1/responses/{ack['id']}").json()
+        if d.get("status") in ("completed", "failed"):
+            final = d
+            break
+        time.sleep(0.1)
+    assert final is not None and final["status"] == "completed"
+    assert "A:hi" in final["output_text"]
+    assert isinstance(final.get("execution_ms"), int)


### PR DESCRIPTION
Completes the async pattern: `/v1/responses` already had background+poll (#154–#156); this extends it to **`/v1/chat/completions`** so MCP clients can fire-and-poll through the familiar OpenAI chat endpoint.

- `POST /v1/chat/completions {"background": true}` → **202** `{id: resp_<uuid>, object: "chat.completion", status: "queued", poll_url: "/v1/responses/{id}"}`
- Runs on the shared Responses worker (background thread); poll `GET /v1/responses/{id}` → `queued → in_progress → completed/failed`, with `output_text` + `execution_ms`.
- Sync unchanged when `background` absent; streaming always inline.

Verified live: `cli_agent` (grok) fired → polled → "Madrid", `execution_ms: 11082`, `fp: cli_agent:grok`. Test covers fire→poll→completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)