### PR TITLE
docs: Oracle deploy runbook (systemd + nginx/TLS + bearer auth)

### DIFF
--- a/deploy/oracle/nginx-open-swarm.conf
+++ b/deploy/oracle/nginx-open-swarm.conf
@@ -1,0 +1,39 @@
+# nginx reverse proxy for Open Swarm Oracle — TLS termination + bearer-auth passthrough.
+# Place at /etc/nginx/sites-available/open-swarm and symlink into sites-enabled,
+# then run certbot (see docs/ORACLE_DEPLOY.md) to fill in the TLS lines.
+
+server {
+    listen 80;
+    server_name oracle.example.com;
+    # certbot adds the HTTP->HTTPS redirect here automatically.
+    location / { return 301 https://$host$request_uri; }
+}
+
+server {
+    listen 443 ssl;
+    server_name oracle.example.com;
+
+    # Filled in by `certbot --nginx` (Let's Encrypt):
+    # ssl_certificate     /etc/letsencrypt/live/oracle.example.com/fullchain.pem;
+    # ssl_certificate_key /etc/letsencrypt/live/oracle.example.com/privkey.pem;
+
+    # Long-running async tasks: keep upstream reads generous (CLI agents can take minutes).
+    proxy_read_timeout 600s;
+    proxy_send_timeout 600s;
+    client_max_body_size 25m;
+
+    location / {
+        proxy_pass http://127.0.0.1:8001;     # the open-swarm-oracle service
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # The Authorization: Bearer <token> header is forwarded as-is; the app
+        # enforces it (API_AUTH_TOKEN). nginx does not strip it.
+
+        # SSE / streaming responses:
+        proxy_buffering off;
+        proxy_set_header Connection "";
+        proxy_http_version 1.1;
+    }
+}

--- a/deploy/oracle/open-swarm-oracle.service
+++ b/deploy/oracle/open-swarm-oracle.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Open Swarm ORACLE — authenticated OpenAI-compatible gateway
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/YOURUSER/open-swarm
+# The wrapped CLIs are host tools (gemini in nvm, claude/grok in ~/.local/bin).
+# PATH MUST include them or the adapters can't exec the CLIs. Adjust the node
+# version path to match `which gemini` on the host.
+Environment=PATH=/home/YOURUSER/.nvm/versions/node/v22.22.3/bin:/home/YOURUSER/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=DJANGO_DEBUG=true
+# Add your public hostname here once TLS/nginx is in front:
+Environment=DJANGO_ALLOWED_HOSTS=127.0.0.1,localhost,oracle.example.com
+Environment=SWARM_CONFIG_PATH=/home/YOURUSER/.config/swarm/swarm_config.json
+Environment=SWARM_RESPONSES_DIR=/home/YOURUSER/.local/share/swarm/responses
+# REQUIRE a bearer token. Generate: python -c "import secrets; print(secrets.token_urlsafe(32))"
+Environment=API_AUTH_TOKEN=CHANGE_ME_GENERATE_A_TOKEN
+# Bind localhost-only; nginx terminates TLS and proxies to it. (Use 0.0.0.0:8001
+# only if you intend to expose it directly without a TLS proxy — not recommended.)
+ExecStart=/home/YOURUSER/open-swarm/.venv/bin/python manage.py runserver 127.0.0.1:8001 --noreload
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=default.target

--- a/docs/ORACLE_DEPLOY.md
+++ b/docs/ORACLE_DEPLOY.md
@@ -1,0 +1,102 @@
+# Open Swarm Oracle — authenticated, durable, public-HTTPS deployment
+
+A runbook to stand up an Open Swarm gateway that an external client (e.g. Grok
+via mcp-gateway) can reach over **public HTTPS with a bearer token**, durable
+across reboots.
+
+> **The one hard constraint — read first.** Open Swarm's CLI blueprints
+> (`cli_agent`, `cli_fusion`, `cli_*`) **shell out to host-installed CLIs**
+> (`gemini`, `claude`, `grok`, `opencode`), each with its **own** auth (gemini
+> OAuth, grok file-login, claude key/login). Those don't containerize or
+> transfer cleanly — **the gateway must run on a host where the CLIs are
+> installed and authenticated.** So "cloud" here means *a VM you control and can
+> log into to authenticate the CLIs*, not a stateless container image. Non-CLI
+> blueprints (chatbot, etc.) just need an `llm` profile and have no such
+> constraint.
+
+Artifacts referenced below live in [`deploy/oracle/`](../deploy/oracle/):
+`open-swarm-oracle.service`, `nginx-open-swarm.conf`.
+
+## 0. Prerequisites (on the cloud host)
+- A VM you can SSH into, plus a **domain** (`oracle.example.com`) pointed at its IP.
+- Python 3.11+, `uv`, `node` (for gemini), and the CLIs you want
+  (`claude`, `gemini`, `grok`, …) **installed and authenticated** as the run user.
+- nginx + certbot for TLS.
+
+## 1. App + config
+```bash
+git clone https://github.com/matthewhand/open-swarm.git ~/open-swarm
+cd ~/open-swarm && uv sync --all-extras
+# Bring your CLI-agent config (or generate it):
+mkdir -p ~/.config/swarm
+swarm-cli cli-agents --init --write     # autodiscovers installed+authed CLIs
+# (or copy an existing ~/.config/swarm/swarm_config.json over)
+```
+
+## 2. Auth token
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(32))"   # save this
+```
+
+## 3. systemd service (durable, bound to localhost)
+```bash
+mkdir -p ~/.config/systemd/user
+cp ~/open-swarm/deploy/oracle/open-swarm-oracle.service ~/.config/systemd/user/
+# edit it: set YOURUSER, the node path (match `which gemini`), DJANGO_ALLOWED_HOSTS
+# (include your domain), and API_AUTH_TOKEN=<the token from step 2>.
+systemctl --user daemon-reload
+systemctl --user enable --now open-swarm-oracle.service
+loginctl enable-linger "$USER"          # survive logout/reboot
+curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8001/v1/models   # 200
+```
+The unit binds **127.0.0.1:8001** — only nginx (next step) faces the internet.
+
+## 4. Public HTTPS (nginx + Let's Encrypt)
+```bash
+sudo cp ~/open-swarm/deploy/oracle/nginx-open-swarm.conf /etc/nginx/sites-available/open-swarm
+# edit server_name -> your domain
+sudo ln -s /etc/nginx/sites-available/open-swarm /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+sudo certbot --nginx -d oracle.example.com     # fills in the ssl_* lines, adds HTTP->HTTPS
+```
+
+## 5. Verify (with auth)
+```bash
+T=<your token>
+B=https://oracle.example.com/v1
+curl -s -o /dev/null -w "no-auth: %{http_code}\n"  -X POST $B/v1/chat/completions \
+  -H "Content-Type: application/json" -d '{"model":"cli_agent","messages":[{"role":"user","content":"hi"}]}'   # 403
+curl -s -o /dev/null -w "authed: %{http_code}\n"   -X POST $B/v1/chat/completions \
+  -H "Authorization: Bearer $T" -H "Content-Type: application/json" \
+  -d '{"model":"cli_agent","messages":[{"role":"user","content":"hi"}],"params":{"cli":"grok"}}'              # 200
+```
+
+## 6. Async tasking (what Grok uses)
+```bash
+# fire
+curl -s https://oracle.example.com/v1/responses -H "Authorization: Bearer $T" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"cli_fusion","input":"<long task>","background":true,"params":{"preset":"tri"}}'
+# -> {"id":"resp_...","status":"queued"}
+# poll
+curl -s https://oracle.example.com/v1/responses/resp_... -H "Authorization: Bearer $T"
+# -> {"status":"completed","output_text":"...","execution_ms":...,"system_fingerprint":"..."}
+```
+`chat/completions` also supports `"background": true` (returns a `poll_url`).
+
+## 7. Wire into mcp-gateway
+Add Open Swarm as a backend pointing at the OpenAPI spec, with the bearer token:
+`https://oracle.example.com/api/schema/` (spec) and base URL
+`https://oracle.example.com/v1`, header `Authorization: Bearer <token>`.
+After the proxy reloads the spec, the generated tools expose `params`, `name`,
+etc. (every write endpoint's body is documented).
+
+## Notes
+- Keep `DJANGO_DEBUG=true` only if you accept verbose error pages on the LAN side;
+  for stricter prod, set `DJANGO_DEBUG=false` and also set `DJANGO_SECRET_KEY` +
+  `DJANGO_ALLOWED_HOSTS` (the server refuses to boot without them in prod), and
+  use `--insecure`-free serving via `swarm-api`/daphne if you serve the web UI.
+- Persist `SWARM_RESPONSES_DIR` (async task state) on durable storage so queued
+  tasks survive restarts (the worker resumes in-progress tasks on boot).
+- For an internal layer that already gates access (e.g. cloud OAuth proxy), you
+  may run without a token by setting `SWARM_ALLOW_NO_AUTH=true` instead.


### PR DESCRIPTION
Turn-key runbook + artifacts to lift the authenticated gateway to a real cloud host with public HTTPS — the one part that needs a host + domain (and re-authing the host-bound CLIs).

- **docs/ORACLE_DEPLOY.md** — prerequisites → app/config → token → systemd (localhost-bound + linger) → nginx + certbot TLS → auth & async-tasking verification → mcp-gateway wiring. Leads with the host-bound-CLI constraint.
- **deploy/oracle/open-swarm-oracle.service** — systemd unit template (token placeholder, binds `127.0.0.1:8001` behind nginx).
- **deploy/oracle/nginx-open-swarm.conf** — TLS reverse proxy, long read timeouts for async tasks, SSE passthrough, forwards `Authorization` as-is.

No secrets committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)