### PR TITLE
test(smoke): isolate app.config so blueprint smoke tests stay hermetic

### DIFF
--- a/tests/api/test_blueprint_api_smoke.py
+++ b/tests/api/test_blueprint_api_smoke.py
@@ -44,6 +44,14 @@ def _test_mode(monkeypatch):
     # Keyless CI: some blueprints construct an OpenAI client even on the
     # test-mode path; a dummy key keeps the matrix deterministic everywhere.
     monkeypatch.setenv("OPENAI_API_KEY", "sk-dummy-test-mode")
+    # Hermetic config: the AppConfig loads ~/.config/swarm/swarm_config.json at
+    # startup (XDG). A dev box with a real LLM backend configured there would make
+    # LLM-backed blueprints (e.g. dynamic_team) attempt a live call instead of the
+    # test-mode canned path — failing only locally. Force an empty config so the
+    # smoke matrix behaves identically everywhere (matches CI).
+    from django.apps import apps
+
+    monkeypatch.setattr(apps.get_app_config("swarm"), "config", {}, raising=False)
 
 
 def _post_completion(client: Client, model: str, stream: bool):


### PR DESCRIPTION
After XDG config loading (#150), the AppConfig loads `~/.config/swarm/swarm_config.json` at startup. On a **dev box with a real LLM backend** configured there (e.g. a local LiteLLM as `default`), LLM-backed blueprints like `dynamic_team` make a **live** call during the streaming smoke test instead of the `SWARM_TEST_MODE` canned path — so `test_streaming_emits_done[dynamic_team]` fails **locally** (emits `[DONE]` with no content) while passing in CI (no `~/.config` there).

Fix: force `app.config = {}` in the autouse fixture so the matrix behaves identically everywhere. Same hermetic-isolation class as #153.

Verified: the failing test now passes (3s canned path, was a 10s live call); full smoke file **48/48**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)