### PR TITLE
feat(blueprints): external/community blueprint discovery (foundation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Community blueprints (discovery foundation)
+- Blueprint discovery now scans **external roots** in addition to the bundled set: the user data dir `$XDG_DATA_HOME/swarm/blueprints` (where community packs install) plus any paths in `SWARM_BLUEPRINT_PATHS`. External roots load under a synthetic module namespace so they can't shadow or collide with `swarm.blueprints`; the bundled set always wins on name collisions. New `merge_community_blueprints()` / `discover_all_blueprints()` in `swarm.core.blueprint_discovery`. This is the foundation for installing community blueprint packs from GitHub (explicit opt-in; running third-party blueprint code is a code-execution trust decision).
+
 ## [0.5.0] — 2026-06-19
 
 ### Removed — Dead code cleanup (pre-release)

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -237,6 +237,7 @@ environment / `.env`, never in `swarm_config.json` (reference them with
 | `SWARM_RESPONSES_DIR` | Where `/v1/responses` stores records for `previous_response_id` chaining and `GET`/`DELETE`. | `$XDG_DATA_HOME/swarm/responses` (i.e. `~/.local/share/swarm/responses`) |
 | `SWARM_RESPONSES_SYNC_TIMEOUT` | Default seconds a `/v1/responses` request waits inline before auto-escalating to a queued handle (per-request override: `max_wait_seconds`). Unset = fully-blocking sync. | unset |
 | `XDG_DATA_HOME` | Base for state data (responses store). | `~/.local/share` |
+| `SWARM_BLUEPRINT_PATHS` | Extra blueprint roots scanned **in addition** to the bundled set (os.pathsep-separated). The user data blueprints dir (`$XDG_DATA_HOME/swarm/blueprints`) is always scanned too. Bundled blueprints win on name collision. | unset |
 
 ### Server, security & auth
 

--- a/src/swarm/core/blueprint_discovery.py
+++ b/src/swarm/core/blueprint_discovery.py
@@ -49,7 +49,9 @@ class BlueprintLoadError(Exception):
 #         return dir_name[len(prefix):]
 #     return dir_name
 
-def discover_blueprints(blueprint_dir: str) -> dict[str, DiscoveredBlueprintInfo]:
+def discover_blueprints(
+    blueprint_dir: str, namespace: str | None = None
+) -> dict[str, DiscoveredBlueprintInfo]:
     """
     Discovers blueprints by looking for Python files within subdirectories
     of the given blueprint directory. Extracts metadata including name, version,
@@ -57,6 +59,12 @@ def discover_blueprints(blueprint_dir: str) -> dict[str, DiscoveredBlueprintInfo
 
     Args:
         blueprint_dir: The path to the directory containing blueprint subdirectories.
+        namespace: When set, modules are loaded under
+            ``<namespace>.<dir>.<file>`` instead of being derived from the
+            on-disk folder structure, and the directory tree is NOT added to
+            ``sys.path``. Use this for *external* (community) blueprint roots so
+            they cannot collide with or shadow the bundled ``swarm.blueprints``
+            package. Leave ``None`` for the bundled root (legacy behavior).
 
     Returns:
         A dictionary mapping blueprint directory names (as keys) to
@@ -101,7 +109,11 @@ def discover_blueprints(blueprint_dir: str) -> dict[str, DiscoveredBlueprintInfo
         # This assumes 'swarm.blueprints' is a package containing subdirectories for each blueprint.
         # The base_dir is typically .../swarm/blueprints/
         # So, subdir.name would be 'codey', py_file_path.stem would be 'codey'
-        module_import_path = f"{base_dir.parent.name}.{base_dir.name}.{subdir.name}.{py_file_path.stem}"
+        if namespace:
+            # External/community root: synthetic, collision-proof module name.
+            module_import_path = f"{namespace}.{subdir.name}.{py_file_path.stem}"
+        else:
+            module_import_path = f"{base_dir.parent.name}.{base_dir.name}.{subdir.name}.{py_file_path.stem}"
         # A more robust way if base_dir is not always '.../swarm/blueprints':
         # Find the 'swarm' package root relative to py_file_path and build from there.
         # For now, assuming a fixed structure like 'swarm.blueprints.blueprint_name.module_name'
@@ -112,10 +124,16 @@ def discover_blueprints(blueprint_dir: str) -> dict[str, DiscoveredBlueprintInfo
             # Ensure the parent of 'swarm' (e.g., 'src') is in sys.path if not already.
             # This helps Python find the 'swarm' package.
             # If blueprint_dir is 'src/swarm/blueprints', then base_dir.parent.parent is 'src'.
-            project_src_dir = str(base_dir.parent.parent)
-            if project_src_dir not in sys.path:
-                logger.debug(f"Adding '{project_src_dir}' to sys.path for module import.")
-                sys.path.insert(0, project_src_dir)
+            # Only the bundled root is added to sys.path (so 'swarm.blueprints.*'
+            # resolves). External roots are loaded purely by file path under a
+            # synthetic namespace and must NOT inject their tree onto sys.path —
+            # a community dir named '.../swarm/blueprints' would otherwise shadow
+            # the installed package.
+            if not namespace:
+                project_src_dir = str(base_dir.parent.parent)
+                if project_src_dir not in sys.path:
+                    logger.debug(f"Adding '{project_src_dir}' to sys.path for module import.")
+                    sys.path.insert(0, project_src_dir)
 
             module_spec = importlib.util.spec_from_file_location(module_import_path, py_file_path)
 
@@ -198,6 +216,51 @@ def discover_blueprints(blueprint_dir: str) -> dict[str, DiscoveredBlueprintInfo
 
     logger.info(f"Blueprint discovery complete. Found {len(blueprints)} blueprints: {list(blueprints.keys())}")
     return blueprints
+
+
+def merge_community_blueprints(
+    base: dict[str, DiscoveredBlueprintInfo],
+    extra_dirs: "list[str] | None" = None,
+) -> dict[str, DiscoveredBlueprintInfo]:
+    """Merge external/community blueprint roots into an already-discovered dict.
+
+    ``base`` (the bundled blueprints) is authoritative: a community blueprint
+    whose key collides with one already present is ignored (and logged), never
+    allowed to shadow it. Each external root is loaded under its own synthetic
+    namespace so module names cannot clash. Missing/!dir roots are skipped
+    silently — the common case is that the community dir doesn't exist yet.
+
+    Kept separate from :func:`discover_blueprints` so call sites can still patch
+    the bundled discovery in tests while this no-ops over empty community roots.
+    """
+    merged = dict(base)
+    for index, directory in enumerate(extra_dirs or []):
+        if not directory or not Path(directory).is_dir():
+            continue
+        namespace = f"swarm_community_{index}"
+        try:
+            found = discover_blueprints(directory, namespace=namespace)
+        except Exception:
+            logger.exception("Failed discovering community blueprints in %s", directory)
+            continue
+        for name, info in found.items():
+            if name in merged:
+                logger.warning(
+                    "Community blueprint %r in %s collides with a bundled blueprint; ignoring it.",
+                    name, directory,
+                )
+                continue
+            merged[name] = info
+    return merged
+
+
+def discover_all_blueprints(
+    bundled_dir: str,
+    extra_dirs: "list[str] | None" = None,
+) -> dict[str, DiscoveredBlueprintInfo]:
+    """Convenience: discover the bundled root, then merge community roots."""
+    return merge_community_blueprints(discover_blueprints(bundled_dir), extra_dirs)
+
 
 if __name__ == '__main__':
     # Example Usage (assuming you have a 'blueprints' directory structured correctly)

--- a/src/swarm/mcp/provider.py
+++ b/src/swarm/mcp/provider.py
@@ -17,10 +17,13 @@ import subprocess
 import time
 from typing import Any
 
-from swarm.core.blueprint_discovery import discover_blueprints
+from swarm.core.blueprint_discovery import (
+    discover_blueprints,
+    merge_community_blueprints,
+)
 from swarm.core.mcp_server_config import MCPServerConfig
 from swarm.core.requirements import load_active_config
-from swarm.settings import BLUEPRINT_DIRECTORY
+from swarm.settings import BLUEPRINT_DIRECTORY, BLUEPRINT_EXTRA_DIRS
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +52,9 @@ class BlueprintMCPProvider:
 
     def refresh(self) -> None:
         """Re-discover blueprints and rebuild the internal index."""
-        discovered = discover_blueprints(self._blueprint_dir)
+        discovered = merge_community_blueprints(
+            discover_blueprints(self._blueprint_dir), BLUEPRINT_EXTRA_DIRS
+        )
         index: dict[str, dict[str, Any]] = {}
         for key, info in discovered.items():
             meta = info.get("metadata", {}) if isinstance(info, dict) else {}

--- a/src/swarm/settings.py
+++ b/src/swarm/settings.py
@@ -49,6 +49,27 @@ if ENABLE_API_AUTH:
 SWARM_CONFIG_PATH = get_swarm_config_path()
 BLUEPRINT_DIRECTORY = get_blueprint_directory()
 
+
+def _blueprint_extra_dirs() -> list[str]:
+    """External/community blueprint roots, scanned in addition to the bundled dir.
+
+    Order: the user data 'blueprints' dir (where community packs are installed),
+    then any paths in ``SWARM_BLUEPRINT_PATHS`` (os.pathsep-separated). The bundled
+    dir always wins on name collisions (see ``discover_all_blueprints``).
+    """
+    dirs: list[str] = []
+    try:
+        from swarm.core.paths import get_user_blueprints_dir
+        dirs.append(str(get_user_blueprints_dir()))
+    except Exception:
+        pass
+    extra = os.getenv("SWARM_BLUEPRINT_PATHS", "")
+    dirs.extend(p for p in extra.split(os.pathsep) if p.strip())
+    return dirs
+
+
+BLUEPRINT_EXTRA_DIRS = _blueprint_extra_dirs()
+
 # Web UI Configuration
 ENABLE_WEBUI = os.getenv('ENABLE_WEBUI', 'true').lower() in ('true', '1', 'yes')
 WEBUI_STATIC_DIR = BASE_DIR.parent / 'staticfiles' / 'webui'

--- a/src/swarm/views/library_api.py
+++ b/src/swarm/views/library_api.py
@@ -28,9 +28,12 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from swarm.core.blueprint_discovery import discover_blueprints
+from swarm.core.blueprint_discovery import (
+    discover_blueprints,
+    merge_community_blueprints,
+)
 from swarm.permissions import HasValidTokenOrSession
-from swarm.settings import BLUEPRINT_DIRECTORY, ENABLE_API_AUTH
+from swarm.settings import BLUEPRINT_DIRECTORY, BLUEPRINT_EXTRA_DIRS, ENABLE_API_AUTH
 from swarm.views.blueprint_library_views import (
     BLUEPRINT_METADATA,
     get_user_blueprint_library,
@@ -98,7 +101,9 @@ class LibraryAPIView(APIView):
                 )
 
             # Verify the blueprint exists, mirroring add_blueprint_to_library.
-            discovered = discover_blueprints(BLUEPRINT_DIRECTORY)
+            discovered = merge_community_blueprints(
+                discover_blueprints(BLUEPRINT_DIRECTORY), BLUEPRINT_EXTRA_DIRS
+            )
             if name not in discovered:
                 return Response(
                     {"error": f"Blueprint '{name}' not found."},

--- a/src/swarm/views/utils.py
+++ b/src/swarm/views/utils.py
@@ -7,7 +7,10 @@ from django.conf import settings
 from swarm.blueprints.dynamic_team.blueprint_dynamic_team import DynamicTeamBlueprint
 
 # Assuming the discovery functions are correctly located now
-from swarm.core.blueprint_discovery import discover_blueprints
+from swarm.core.blueprint_discovery import (
+    discover_blueprints,
+    merge_community_blueprints,
+)
 from swarm.core.paths import (
     ensure_swarm_directories_exist,
     get_user_config_dir_for_swarm,
@@ -102,6 +105,9 @@ def _load_all_blueprint_metadata_sync():
     global _blueprint_meta_cache
     logger.info("Discovering blueprint classes (sync)...")
     blueprint_classes = discover_blueprints(settings.BLUEPRINT_DIRECTORY)
+    blueprint_classes = merge_community_blueprints(
+        blueprint_classes, getattr(settings, "BLUEPRINT_EXTRA_DIRS", None)
+    )
 
     # Merge dynamic teams as blueprints
     dyn = load_dynamic_registry()

--- a/tests/core/test_community_blueprint_discovery.py
+++ b/tests/core/test_community_blueprint_discovery.py
@@ -1,0 +1,72 @@
+"""External/community blueprint discovery (discover_all_blueprints).
+
+Community blueprints live outside the bundled tree and are loaded under a
+synthetic namespace so they cannot shadow or collide with swarm.blueprints.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from swarm.core.blueprint_discovery import (
+    discover_all_blueprints,
+    discover_blueprints,
+)
+
+# A minimal, self-contained community blueprint that subclasses the real base.
+_COMMUNITY_BP = textwrap.dedent(
+    '''
+    from collections.abc import AsyncGenerator
+    from typing import Any
+
+    from swarm.core.blueprint_base import BlueprintBase
+
+
+    class AcmeBlueprint(BlueprintBase):
+        metadata = {"name": "acme", "description": "community demo"}
+
+        async def run(self, messages, **kwargs) -> "AsyncGenerator[dict[str, Any], None]":
+            yield {"messages": [{"role": "assistant", "content": "acme"}]}
+    '''
+)
+
+
+def _write_community_pack(root: Path, name: str = "acme") -> Path:
+    bp_dir = root / name
+    bp_dir.mkdir(parents=True)
+    (bp_dir / f"blueprint_{name}.py").write_text(_COMMUNITY_BP)
+    return root
+
+
+def test_external_root_is_discovered_under_namespace(tmp_path):
+    community = _write_community_pack(tmp_path / "community")
+    found = discover_blueprints(str(community), namespace="swarm_community_test")
+    assert "acme" in found
+    cls = found["acme"]["class_type"]
+    # Loaded under the synthetic namespace, NOT swarm.blueprints.*
+    assert cls.__module__.startswith("swarm_community_test.")
+
+
+def test_discover_all_merges_bundled_and_community(tmp_path):
+    community = _write_community_pack(tmp_path / "community")
+    bundled = Path("src/swarm/blueprints").resolve()
+    merged = discover_all_blueprints(str(bundled), [str(community)])
+    # A known bundled blueprint and the community one both present.
+    assert "cli_fusion" in merged
+    assert "acme" in merged
+
+
+def test_missing_extra_dirs_are_skipped(tmp_path):
+    bundled = Path("src/swarm/blueprints").resolve()
+    merged = discover_all_blueprints(str(bundled), [str(tmp_path / "does-not-exist")])
+    assert "cli_fusion" in merged  # bundled still works; missing root ignored
+
+
+def test_community_cannot_shadow_bundled(tmp_path):
+    # A community pack whose key collides with a bundled blueprint is ignored.
+    community = _write_community_pack(tmp_path / "community", name="cli_fusion")
+    bundled = Path("src/swarm/blueprints").resolve()
+    merged = discover_all_blueprints(str(bundled), [str(community)])
+    # The bundled cli_fusion wins — its description is not the community stub.
+    assert merged["cli_fusion"]["metadata"].get("description") != "community demo"


### PR DESCRIPTION
**Phase 1** of the community-blueprints plan: let the app load blueprints from outside the bundled tree. Nothing moves or is removed yet — this is purely additive foundation.

## What changes
- Discovery scans extra roots in addition to the bundled set:
  - `$XDG_DATA_HOME/swarm/blueprints` (where community packs will install)
  - any `os.pathsep` paths in **`SWARM_BLUEPRINT_PATHS`**
- External roots load under a synthetic namespace (`swarm_community_N.*`) and are **not** added to `sys.path`, so a dir named `.../swarm/blueprints` can't shadow the installed package.
- **Bundled wins**: a community blueprint whose key collides with a bundled one is ignored + logged.
- New `merge_community_blueprints()` / `discover_all_blueprints()`; `discover_blueprints()` keeps its signature (gains optional `namespace`).

## Why this shape
Call sites keep calling the patchable `discover_blueprints()` for the bundled dir, then a separate merge step folds in community roots — so every existing test patch is untouched and community roots no-op when absent.

## Verification
- New `tests/core/test_community_blueprint_discovery.py` (namespace isolation, merge, missing-dir skip, no-shadow).
- Full suite: **1291 passed, 7 skipped**, 0 fail.

## Next (not in this PR)
Phase 2: private repo holding the 14 themed/legacy blueprints as a pack. Phase 3: GitHub **topic** auto-discovery (`open-swarm-blueprint`) + **explicit opt-in install** (`swarm-cli blueprint add`). Phase 4: remove the 14 from this repo. `dynamic_team` stays public (it's the engine behind user-created teams).

🤖 Generated with [Claude Code](https://claude.com/claude-code)