### PR TITLE
feat(docker): API-only base compose + opt-in CLI mapping override

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -1,11 +1,67 @@
-version: '3.8'
+# Open Swarm — CLI mapping override (EXAMPLE).
+#
+# The base docker-compose.yml serves the REST API only. To use any agentic-CLI
+# blueprint inside the container you must map that CLI into it yourself: its
+# executable, its runtime (e.g. node for gemini), AND its host-bound auth/state
+# folder. There is no maintained "all CLIs" image — paths, runtimes and login
+# state vary per host/version, so you wire in only what you have.
+#
+# HOW TO USE
+#   cp docker-compose.override.example.yml docker-compose.override.yml
+#   # uncomment the block(s) for the CLI(s) you have; fix the host paths/versions
+#   docker compose up --build         # compose auto-merges this override
+#   # verify inside the container:
+#   docker compose exec swarm sh -lc 'which claude gemini grok && claude -p hi'
+#
+# CAVEATS (why this is opt-in, not baked in)
+#   • Bind-mounting host binaries couples the container to your exact paths,
+#     runtime versions and glibc — it works on the machine that built it, it is
+#     NOT portable. The alternative is to install the CLI in a custom Dockerfile.
+#   • The auth folder must be writable if the CLI refreshes tokens (most do) —
+#     mount it read/write (no `:ro`).
+#   • `PATH` below must list every dir holding a CLI you enabled, plus the system
+#     defaults. Trim it to match.
+#   • Paths use ${HOME} so source and target match the host; the container HOME
+#     is set to the same value in the base file. Versions (e.g. node v22.x) are
+#     examples — set yours.
 
 services:
   swarm:
+    environment:
+      # Make the host CLI dirs discoverable. Keep the system defaults at the end.
+      # Trim to only the dirs for CLIs you actually enable below.
+      PATH: "${HOME}/.nvm/versions/node/v22.22.3/bin:${HOME}/.local/bin:${HOME}/.opencode/bin:/usr/local/bin:/usr/bin:/bin"
+
+      # Per-CLI env keys (only if you use API-key auth instead of device login):
+      # ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"   # claude
+      # GEMINI_API_KEY:    "${GEMINI_API_KEY}"      # gemini (or GOOGLE_API_KEY)
+      # OPENAI_API_KEY:    "${OPENAI_API_KEY}"      # codex
+
     volumes:
-      # Map the Roo-Cline MCP settings file into the container.
-      - ${HOME}/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json:/home/chatgpt/.vscode-server/data/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json:ro
-      
-      # If running on Windows, uncomment the following line to map the Claude Desktop MCP settings.
-      # The host path uses the APPDATA environment variable; adjust if necessary.
-      # - "%APPDATA%\Claude\claude_desktop_config.json:/home/chatgpt/Claude/claude_desktop_config.json:ro"
+      # ── claude (Claude Code) ──────────────────────────────────────────────
+      # Launcher in ~/.local/bin, login/state in ~/.claude.
+      # - "${HOME}/.local/bin:${HOME}/.local/bin:ro"
+      # - "${HOME}/.claude:${HOME}/.claude"
+
+      # ── grok (xAI) ────────────────────────────────────────────────────────
+      # Binary in ~/.local/bin (mount shared with claude above), login in ~/.grok.
+      # - "${HOME}/.local/bin:${HOME}/.local/bin:ro"
+      # - "${HOME}/.grok:${HOME}/.grok"
+
+      # ── gemini (Google) ───────────────────────────────────────────────────
+      # npm global under nvm: mount the WHOLE node version dir so both the
+      # `gemini` symlink target (lib/node_modules) and `node` resolve. OAuth in
+      # ~/.gemini. Match your node version (run: node -v).
+      # - "${HOME}/.nvm/versions/node/v22.22.3:${HOME}/.nvm/versions/node/v22.22.3:ro"
+      # - "${HOME}/.gemini:${HOME}/.gemini"
+
+      # ── codex (OpenAI) ────────────────────────────────────────────────────
+      # Binary wherever you installed it (add its dir to PATH above); state in ~/.codex.
+      # - "${HOME}/.local/bin:${HOME}/.local/bin:ro"
+      # - "${HOME}/.codex:${HOME}/.codex"
+
+      # ── opencode ──────────────────────────────────────────────────────────
+      # Binary + state under ~/.opencode (writable: it caches there); extra
+      # config in ~/.config/opencode.
+      # - "${HOME}/.opencode:${HOME}/.opencode"
+      # - "${HOME}/.config/opencode:${HOME}/.config/opencode"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+# Open Swarm — containerized gateway.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# WHAT THIS GIVES YOU BY DEFAULT: the OpenAI-compatible API only.
+# ─────────────────────────────────────────────────────────────────────────────
+# Out of the box this container serves /v1/chat/completions, /v1/responses and
+# /v1/models backed by your REST / LLM profiles (the `llm` block in
+# swarm_config.json). That covers the pure-REST blueprints (chatbot, the REST
+# half of hybrid_team, anything that talks to an OpenAI-compatible HTTP backend).
+#
+# It does NOT include the agentic CLIs (claude, grok, gemini, codex, opencode).
+# Those carry their OWN host-bound auth (OAuth / device login living in your home
+# dir) and cannot be baked into a portable image. So the CLI-driven blueprints
+# (cli_agent, cli_fusion, cli_orchestrator, cli_map, persona_council, the cli_*
+# orchestrators, the CLI half of the hybrids) will NOT work until you map each
+# CLI in yourself.
+#
+# ── The trade-off of running in a container ──
+# To use any CLI blueprint you must map that CLI's binary, runtime and auth
+# folder into the container MANUALLY. This is deliberate — the project does not
+# ship/maintain mappings for every CLI (paths, runtimes and login state differ
+# per host and per version). Copy docker-compose.override.example.yml to
+# docker-compose.override.yml, uncomment the CLIs you actually have, and adjust
+# the paths to your machine. Compose auto-merges the override on `up`.
+#
+# Native (systemd-on-host) deployment avoids all of this — the CLIs are already
+# installed and authed. See docs/ORACLE_DEPLOY.md. Use the container when you
+# only need the REST surface, or you're willing to map the CLIs by hand.
+#
+# Quick start:
+#   echo "DOCKER_UID=$(id -u)" >  .env
+#   echo "DOCKER_GID=$(id -g)" >> .env
+#   docker compose up --build        # API-only
+#   # …then add the override for CLIs.
+
+services:
+  swarm:
+    build:
+      context: .
+      args:
+        PORT: "8000"
+    image: open-swarm:local
+    # Run as your host user so any folders you later bind-mount (CLI auth, config)
+    # stay readable/writable and files the app writes don't end up root-owned.
+    user: "${DOCKER_UID:-1000}:${DOCKER_GID:-1000}"
+    ports:
+      - "8000:8000"
+    environment:
+      # Keep HOME identical to the host so configs that reference absolute paths
+      # resolve, and the bare CLI commands find their state once you map them in.
+      HOME: "${HOME}"
+      # The CLIs self-authenticate and local REST backends are commonly keyless,
+      # so the gateway itself needs no provider key. Front prod with OAuth/proxy.
+      SWARM_ALLOW_NO_AUTH: "true"
+      # Keep the DB and async task store on the writable mounted volume (the app
+      # runs as a non-root host UID and cannot write the image's /app).
+      SQLITE_DB_PATH: "${HOME}/.local/share/swarm/db.sqlite3"
+      SWARM_RESPONSES_DIR: "${HOME}/.local/share/swarm/responses"
+    volumes:
+      # Your swarm config (llm profiles + any cli_agents) — read-only.
+      - "${HOME}/.config/swarm:${HOME}/.config/swarm:ro"
+      # Writable state: SQLite DB + async /v1/responses task store.
+      - "${HOME}/.local/share/swarm:${HOME}/.local/share/swarm"
+    restart: unless-stopped


### PR DESCRIPTION
Deploy-support: run the gateway in a container.

- **`docker-compose.yml`** (new) — base service serves the **REST API only**; CLIs are host-bound and opt-in. Mounts swarm config (ro) + writable state dir, runs as host UID, `SWARM_ALLOW_NO_AUTH=true`.
- **`docker-compose.override.example.yml`** — full known-CLI catalog (claude/grok/gemini/codex/opencode) as opt-in mount blocks with per-CLI gotchas.

Docs/yaml only — no code paths touched. Both files validated with `docker compose config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)