### PR TITLE
feat(blueprints): publish cli_ensemble (canonical), keep cli_fusion alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed — `cli_fusion` → `cli_ensemble` (canonical rename, alias kept)
+- The multi-CLI deliberation blueprint is now published as **`cli_ensemble`** (ML-standard "ensemble" / Mixture-of-Agents terminology). **`cli_fusion` still works** as a back-compat model alias with identical behavior, and the shared `cli_fusion` config block / `cli_fusion_support` internals are unchanged (used family-wide). Renamed to avoid colliding with OpenRouter's "Fusion" — which is a *tool a model invokes*, the inverse of ours (the panel *is* the endpoint).
+
 ### Added — Community blueprints (discovery foundation)
 - Blueprint discovery now scans **external roots** in addition to the bundled set: the user data dir `$XDG_DATA_HOME/swarm/blueprints` (where community packs install) plus any paths in `SWARM_BLUEPRINT_PATHS`. External roots load under a synthetic module namespace so they can't shadow or collide with `swarm.blueprints`; the bundled set always wins on name collisions. New `merge_community_blueprints()` / `discover_all_blueprints()` in `swarm.core.blueprint_discovery`. This is the foundation for installing community blueprint packs from GitHub (explicit opt-in; running third-party blueprint code is a code-execution trust decision).
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -25,12 +25,18 @@ curl -s $B/chat/completions -d '{"model":"cli_agent","messages":[{"role":"user",
 ```
 One CLI, falls over to the next installed one if it's down.
 
-### Consensus panel — always (`cli_fusion`)
+### Consensus panel — always (`cli_ensemble`)
 ```bash
-curl -s $B/chat/completions -d '{"model":"cli_fusion","messages":[{"role":"user","content":"capital of Canada?"}],"params":{"preset":"tri","show_analysis":true}}'
+curl -s $B/chat/completions -d '{"model":"cli_ensemble","messages":[{"role":"user","content":"capital of Canada?"}],"params":{"preset":"tri","show_analysis":true}}'
 ```
-Fan to a panel in parallel → a judge synthesizes. `show_analysis` surfaces
-consensus / contradictions / gaps per model.
+Fan to a panel in parallel → a judge synthesizes (a Mixture-of-Agents ensemble
+over your CLIs). `show_analysis` surfaces consensus / contradictions / gaps per
+model. Configured via the shared `cli_fusion` config block.
+
+> **Naming:** `cli_ensemble` is the canonical name; **`cli_fusion` still works**
+> as a back-compat alias (same behavior, same config). We renamed it to avoid
+> colliding with OpenRouter's "Fusion" *tool* — ours is the inverse: the panel
+> *is* the endpoint you call, not a tool a model invokes.
 
 ### Gated consensus — router decides (`cli_orchestrator`)
 ```bash

--- a/src/swarm/blueprints/cli_ensemble/blueprint_cli_ensemble.py
+++ b/src/swarm/blueprints/cli_ensemble/blueprint_cli_ensemble.py
@@ -1,0 +1,45 @@
+"""CLI Ensemble — the canonical name for multi-CLI deliberation.
+
+Fan a prompt to a panel of configured agentic CLIs in parallel, then a judge
+synthesizes one answer (a Mixture-of-Agents / ensemble over your installed CLIs).
+
+This is the **promoted public name** for the pattern. The implementation lives in
+:class:`~swarm.blueprints.cli_fusion.blueprint_cli_fusion.CliFusionBlueprint` —
+``cli_fusion`` remains the internal primitive (the shared ``cli_fusion`` config
+block and ``cli_fusion_support`` helpers are used family-wide) and still resolves
+as a back-compat model alias. ``cli_ensemble`` reads the same ``cli_fusion``
+config block, so no extra configuration is needed to switch names.
+
+Why not just call it "fusion": OpenRouter Fusion is a hosted *tool a model
+invokes*; ours is the *endpoint itself* (panel → judge as the surface you call).
+"Ensemble" is the neutral ML term for combining several models into one output.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from swarm.blueprints.cli_fusion.blueprint_cli_fusion import CliFusionBlueprint
+
+
+class CliEnsembleBlueprint(CliFusionBlueprint):
+    """Multi-CLI deliberation (panel → judge → synthesize). Canonical name."""
+
+    metadata: ClassVar[dict[str, Any]] = {
+        "name": "cli_ensemble",
+        "title": "CLI Ensemble (multi-CLI deliberation)",
+        "description": (
+            "Fan a prompt to a panel of configured agentic CLIs in parallel, "
+            "judge and synthesize their answers into one. A Mixture-of-Agents "
+            "ensemble over your installed CLIs. (Formerly cli_fusion, which "
+            "still works as an alias.)"
+        ),
+        "version": "0.1.0",
+        "author": "Open Swarm Team",
+        "tags": ["cli", "ensemble", "consensus", "multi-agent", "deliberation", "openai-compatible"],
+        "required_mcp_servers": [],
+        "env_vars": [],
+    }
+
+    def __init__(self, blueprint_id: str = "cli_ensemble", config=None, config_path=None, **kwargs):
+        super().__init__(blueprint_id, config=config, config_path=config_path, **kwargs)

--- a/tests/blueprints/test_cli_ensemble.py
+++ b/tests/blueprints/test_cli_ensemble.py
@@ -1,0 +1,58 @@
+"""cli_ensemble is the canonical name for cli_fusion (multi-CLI deliberation).
+
+It must subclass the fusion implementation, be discovered under its own key, and
+run over the shared ``cli_fusion`` config block exactly like cli_fusion.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from swarm.blueprints.cli_ensemble.blueprint_cli_ensemble import CliEnsembleBlueprint
+from swarm.blueprints.cli_fusion.blueprint_cli_fusion import CliFusionBlueprint
+from swarm.core.blueprint_discovery import discover_blueprints
+
+PY = sys.executable
+
+
+def _echo(prefix: str) -> dict:
+    return {"cmd": [PY, "-c", f"import sys; print('{prefix}:' + sys.argv[1])", "{prompt}"]}
+
+
+def _judge_emitting(obj: dict) -> dict:
+    payload = json.dumps(obj).replace("'", "\\'")
+    return {"cmd": [PY, "-c", f"import sys; print('{payload}')", "{prompt}"]}
+
+
+def _config() -> dict:
+    return {
+        "cli_agents": {"a": _echo("A"), "b": _echo("B"), "judge": _judge_emitting({"answer": "SYNTHESIZED", "done": True})},
+        "cli_fusion": {"presets": {"p": {"panel": ["a", "b"], "judge": "judge"}}, "default_preset": "p", "max_rounds": 1},
+    }
+
+
+def test_is_subclass_of_fusion():
+    assert issubclass(CliEnsembleBlueprint, CliFusionBlueprint)
+    assert CliEnsembleBlueprint.metadata["name"] == "cli_ensemble"
+
+
+def test_discovered_as_cli_ensemble():
+    found = discover_blueprints(str(Path("src/swarm/blueprints").resolve()))
+    assert "cli_ensemble" in found
+    assert "cli_fusion" in found  # alias still discovered
+    # Discovery re-execs the module, so compare by qualified name, not identity.
+    assert found["cli_ensemble"]["class_type"].__name__ == "CliEnsembleBlueprint"
+
+
+async def test_runs_over_shared_fusion_config():
+    bp = CliEnsembleBlueprint(config=_config())
+    bp.set_params({})
+    chunks = [c async for c in bp.run([{"role": "user", "content": "q"}])]
+    final = None
+    for c in chunks:
+        msgs = c.get("messages") if isinstance(c, dict) else None
+        if msgs and msgs[0].get("content") is not None:
+            final = msgs[0]["content"]
+    assert final == "SYNTHESIZED"  # judge synthesized, identical to cli_fusion


### PR DESCRIPTION
Renames the multi-CLI deliberation blueprint's **public name** to `cli_ensemble` (ML-standard "ensemble" / Mixture-of-Agents), while keeping `cli_fusion` as a working alias.

## Why
OpenRouter's "Fusion" is a *tool a model invokes*; ours is the *endpoint itself* (panel → judge as the surface you call) — the inverse. "Ensemble" is the neutral, accurate term and avoids appropriating their brand.

## Surgical by design (low risk, pre-deploy)
- `cli_ensemble` is a **thin subclass** of `CliFusionBlueprint` with its own `metadata.name`.
- `cli_fusion` still resolves (model name) with identical behavior.
- The shared **`cli_fusion` config block** and **`cli_fusion_support`** internals are untouched — they're read family-wide by ~9 blueprints, so renaming them would be high-risk churn. `cli_ensemble` reads the same config block.

## Verification
- New `tests/blueprints/test_cli_ensemble.py` (subclass, discovery under both keys, judged run over shared config).
- 147 passed across fusion/ensemble/hybrid/orchestrator/discovery/fingerprint.

Docs: EXAMPLES.md leads with `cli_ensemble` + an alias note; CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)