### PR TITLE
chore(release): 0.5.1 — cli_recurse, cli_ensemble, community discovery, docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.1] — 2026-06-19
+
+### Added — Docker
+- API-only base `docker-compose.yml` (the gateway serving the REST surface; CLIs are host-bound and opt-in) plus a rewritten `docker-compose.override.example.yml` catalog of per-CLI mount blocks.
+
 ### Added — `cli_recurse` (recursive divide & conquer)
 - New blueprint that breaks a problem down to **any depth**: each node decides to solve directly or split into sub-problems, and every sub-problem is handed to a **freshly-instantiated child of the same blueprint** — recursing until each leaf is atomic, then synthesizing back up. Three limiters keep it finite: `max_depth`, `max_subproblems` (fan-out width), and `max_nodes` (a shared global budget; once spent, remaining nodes solve directly). Config block `cli_recurse` (decomposer/solver/synthesizer + limits), falls back to `cli_fusion`. The recursive generalization of `cli_map`'s single-level decompose.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-swarm"
-version = "0.5.0"
+version = "0.5.1"
 description = "Open Swarm: Orchestrating AI Agent Swarms with Django"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1782,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "open-swarm"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Release **v0.5.1**, bundling this session's `main` additions for PyPI.

## Included
- **`cli_recurse`** — recursive divide & conquer (self-instantiating, triple-limited). Proven live (claude, 3-level tree, all limiters fired).
- **`cli_ensemble`** — canonical rename of `cli_fusion` (alias kept).
- **Community-blueprint discovery foundation** — external roots + `SWARM_BLUEPRINT_PATHS`.
- **Docker** — API-only base compose + opt-in CLI mapping override.

## Version
`0.5.0` → `0.5.1`; CHANGELOG `[Unreleased]` promoted to `[0.5.1]`; uv.lock synced.

Publishing the GitHub release auto-triggers the PyPI workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)