### PR TITLE
feat(blueprints): publish orchestration patterns as swarm_* (cli_* aliased)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed — orchestration patterns published as `swarm_*` (aliases; `cli_*` kept)
+- The multi-agent *pattern* blueprints now have canonical `swarm_*` names — `swarm_ensemble`, `swarm_map`, `swarm_recurse`, `swarm_pipeline`, `swarm_roundtable`, `swarm_planner`, `swarm_orchestrator` — registered via a central alias map (same classes, canonical name advertised in metadata). They're Swarm primitives, not CLI wrappers, so `swarm_` is the honest brand. The `cli_*` names (and `cli_fusion`) keep working as back-compat aliases; `cli_agent` stays `cli_` (it runs one CLI). New `apply_blueprint_aliases()` / `BLUEPRINT_ALIASES` in `swarm.core.blueprint_discovery`.
+
 ## [0.5.1] — 2026-06-19
 
 ### Added — Docker

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -19,6 +19,13 @@ Base URL in examples: `http://localhost:8000/v1` (swap for your host). Add
 Every team is selected by the `model` field; per-request options go in `params`.
 Most work with **config defaults** — `params` only overrides.
 
+> **Naming:** the multi-agent orchestration *patterns* are published as
+> **`swarm_*`** — `swarm_ensemble`, `swarm_map`, `swarm_recurse`, `swarm_pipeline`,
+> `swarm_roundtable`, `swarm_planner`, `swarm_orchestrator` — because they're Swarm
+> primitives, not CLI wrappers. The older **`cli_*`** names (and `cli_fusion`) still
+> work as aliases. `cli_agent` keeps its name (it literally runs one CLI). Examples
+> below use the `cli_*` names; swap in `swarm_*` freely.
+
 ### Single agent (with failover)
 ```bash
 curl -s $B/chat/completions -d '{"model":"cli_agent","messages":[{"role":"user","content":"explain async/await"}],"params":{"cli":"claude"}}'

--- a/src/swarm/core/blueprint_discovery.py
+++ b/src/swarm/core/blueprint_discovery.py
@@ -254,12 +254,52 @@ def merge_community_blueprints(
     return merged
 
 
+# Canonical 'swarm_*' names for the multi-agent orchestration *patterns*. The
+# implementations live in the original 'cli_*' dirs (the prefix once meant "runs
+# over CLIs"); these patterns are really Swarm primitives, so 'swarm_*' is the
+# promoted public name while 'cli_*' stays as a back-compat alias. cli_agent
+# keeps its name — it literally runs one CLI. Maps canonical -> implementation key.
+BLUEPRINT_ALIASES: dict[str, str] = {
+    "swarm_ensemble": "cli_fusion",
+    "swarm_map": "cli_map",
+    "swarm_recurse": "cli_recurse",
+    "swarm_pipeline": "cli_pipeline",
+    "swarm_roundtable": "cli_roundtable",
+    "swarm_planner": "cli_planner",
+    "swarm_orchestrator": "cli_orchestrator",
+}
+
+
+def apply_blueprint_aliases(
+    blueprints: dict[str, DiscoveredBlueprintInfo],
+) -> dict[str, DiscoveredBlueprintInfo]:
+    """Register canonical ``swarm_*`` aliases for discovered ``cli_*`` patterns.
+
+    Each alias points at the SAME class as its target but advertises the canonical
+    name in its metadata. The ``model`` value the client sends is what drives the
+    ``system_fingerprint``, so ``swarm_recurse`` and ``cli_recurse`` both work and
+    self-describe correctly. Skips an alias whose target wasn't discovered, and
+    never overwrites a real blueprint of the same name.
+    """
+    for alias, target in BLUEPRINT_ALIASES.items():
+        if alias in blueprints or target not in blueprints:
+            continue
+        info = dict(blueprints[target])
+        meta = dict(info.get("metadata") or {})
+        meta["name"] = alias
+        info["metadata"] = meta
+        blueprints[alias] = info
+    return blueprints
+
+
 def discover_all_blueprints(
     bundled_dir: str,
     extra_dirs: "list[str] | None" = None,
 ) -> dict[str, DiscoveredBlueprintInfo]:
-    """Convenience: discover the bundled root, then merge community roots."""
-    return merge_community_blueprints(discover_blueprints(bundled_dir), extra_dirs)
+    """Convenience: discover the bundled root, merge community roots, add aliases."""
+    return apply_blueprint_aliases(
+        merge_community_blueprints(discover_blueprints(bundled_dir), extra_dirs)
+    )
 
 
 if __name__ == '__main__':

--- a/src/swarm/mcp/provider.py
+++ b/src/swarm/mcp/provider.py
@@ -18,6 +18,7 @@ import time
 from typing import Any
 
 from swarm.core.blueprint_discovery import (
+    apply_blueprint_aliases,
     discover_blueprints,
     merge_community_blueprints,
 )
@@ -52,8 +53,10 @@ class BlueprintMCPProvider:
 
     def refresh(self) -> None:
         """Re-discover blueprints and rebuild the internal index."""
-        discovered = merge_community_blueprints(
-            discover_blueprints(self._blueprint_dir), BLUEPRINT_EXTRA_DIRS
+        discovered = apply_blueprint_aliases(
+            merge_community_blueprints(
+                discover_blueprints(self._blueprint_dir), BLUEPRINT_EXTRA_DIRS
+            )
         )
         index: dict[str, dict[str, Any]] = {}
         for key, info in discovered.items():

--- a/src/swarm/views/library_api.py
+++ b/src/swarm/views/library_api.py
@@ -29,6 +29,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from swarm.core.blueprint_discovery import (
+    apply_blueprint_aliases,
     discover_blueprints,
     merge_community_blueprints,
 )
@@ -101,8 +102,10 @@ class LibraryAPIView(APIView):
                 )
 
             # Verify the blueprint exists, mirroring add_blueprint_to_library.
-            discovered = merge_community_blueprints(
-                discover_blueprints(BLUEPRINT_DIRECTORY), BLUEPRINT_EXTRA_DIRS
+            discovered = apply_blueprint_aliases(
+                merge_community_blueprints(
+                    discover_blueprints(BLUEPRINT_DIRECTORY), BLUEPRINT_EXTRA_DIRS
+                )
             )
             if name not in discovered:
                 return Response(

--- a/src/swarm/views/utils.py
+++ b/src/swarm/views/utils.py
@@ -8,6 +8,7 @@ from swarm.blueprints.dynamic_team.blueprint_dynamic_team import DynamicTeamBlue
 
 # Assuming the discovery functions are correctly located now
 from swarm.core.blueprint_discovery import (
+    apply_blueprint_aliases,
     discover_blueprints,
     merge_community_blueprints,
 )
@@ -108,6 +109,7 @@ def _load_all_blueprint_metadata_sync():
     blueprint_classes = merge_community_blueprints(
         blueprint_classes, getattr(settings, "BLUEPRINT_EXTRA_DIRS", None)
     )
+    blueprint_classes = apply_blueprint_aliases(blueprint_classes)
 
     # Merge dynamic teams as blueprints
     dyn = load_dynamic_registry()

--- a/tests/core/test_blueprint_aliases.py
+++ b/tests/core/test_blueprint_aliases.py
@@ -1,0 +1,45 @@
+"""Canonical swarm_* aliases for the cli_* orchestration patterns."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from swarm.core.blueprint_discovery import (
+    BLUEPRINT_ALIASES,
+    apply_blueprint_aliases,
+    discover_blueprints,
+)
+
+
+def _discovered():
+    return apply_blueprint_aliases(discover_blueprints(str(Path("src/swarm/blueprints").resolve())))
+
+
+def test_every_alias_resolves_to_its_target_class():
+    d = _discovered()
+    for alias, target in BLUEPRINT_ALIASES.items():
+        assert alias in d, f"{alias} not registered"
+        assert target in d, f"{target} (target of {alias}) missing"
+        assert d[alias]["class_type"] is d[target]["class_type"]
+
+
+def test_alias_advertises_canonical_name():
+    d = _discovered()
+    assert d["swarm_recurse"]["metadata"]["name"] == "swarm_recurse"
+    assert d["swarm_ensemble"]["metadata"]["name"] == "swarm_ensemble"
+
+
+def test_cli_names_still_present():
+    d = _discovered()
+    for cli_name in ("cli_agent", "cli_fusion", "cli_recurse", "cli_map"):
+        assert cli_name in d  # back-compat preserved
+
+
+def test_cli_agent_has_no_swarm_alias():
+    # cli_agent is the CLI primitive, intentionally not aliased to swarm_.
+    assert "swarm_agent" not in BLUEPRINT_ALIASES
+
+
+def test_aliases_are_idempotent():
+    d = apply_blueprint_aliases(_discovered())  # apply twice
+    assert d["swarm_recurse"]["class_type"] is d["cli_recurse"]["class_type"]


### PR DESCRIPTION
Answers "why `cli_`?" — the orchestration *patterns* are Swarm primitives, not CLI wrappers, so they now have canonical **`swarm_*`** names.

## What
- Canonical: `swarm_ensemble`, `swarm_map`, `swarm_recurse`, `swarm_pipeline`, `swarm_roundtable`, `swarm_planner`, `swarm_orchestrator`.
- `cli_*` (and `cli_fusion`) keep working as **back-compat aliases**.
- `cli_agent` stays `cli_` — it literally runs one CLI.

## How (zero-risk)
Central `apply_blueprint_aliases()` / `BLUEPRINT_ALIASES` registered post-discovery at every call site. Aliases point at the same class and advertise the canonical name in metadata; the `model` value the client sends drives `system_fingerprint`, so both names self-describe. No implementation moved.

## Verification
- `tests/core/test_blueprint_aliases.py` (resolution, canonical name, cli_* preserved, idempotent).
- Full suite **1308 passed**.

Docs: EXAMPLES.md naming note; CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)