### PR TITLE
fix(mcp): correct module name django_mcp_server -> mcp_server (mount no longer dead)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed — MCP server mode module name
+- `ENABLE_MCP_SERVER` mode was dead on a clean install: the code imported `django_mcp_server` while the `django-mcp-server` distribution actually installs the module **`mcp_server`**. Corrected the module name in `settings.py`/`urls.py`/`mcp/integration.py`, so the `/mcp/` mount loads cleanly once the package is present (verified: Django check passes, mount present). It's installed manually — `pip install django-mcp-server` — not as an extra, because its transitive `mcp` SDK dep needs pre-releases that would break `uv lock`. Note: the blueprint→tool *bridge* (`register_blueprints_with_mcp`) targets a flat `registry.register_tool` API that `mcp_server` ≥0.5 replaced with an `MCPToolset` paradigm — a no-op until ported (ROADMAP §3.3).
+
 ### Changed — orchestration patterns published as `swarm_*` (aliases; `cli_*` kept)
 - The multi-agent *pattern* blueprints now have canonical `swarm_*` names — `swarm_ensemble`, `swarm_map`, `swarm_recurse`, `swarm_pipeline`, `swarm_roundtable`, `swarm_planner`, `swarm_orchestrator` — registered via a central alias map (same classes, canonical name advertised in metadata). They're Swarm primitives, not CLI wrappers, so `swarm_` is the honest brand. The `cli_*` names (and `cli_fusion`) keep working as back-compat aliases; `cli_agent` stays `cli_` (it runs one CLI). New `apply_blueprint_aliases()` / `BLUEPRINT_ALIASES` in `swarm.core.blueprint_discovery`.
 

--- a/docs/mcp_server_mode.md
+++ b/docs/mcp_server_mode.md
@@ -1,35 +1,42 @@
 # MCP Server Mode (`ENABLE_MCP_SERVER`)
 
-**Status: aspirational.** Setting `ENABLE_MCP_SERVER=true` does not currently expose a
-working MCP endpoint on any standard install. Worse, it breaks startup outright:
-`swarm/settings.py` appends `'django_mcp_server'` to `INSTALLED_APPS` when the flag is
-set, and since no package provides that module, `django.setup()` raises
-`ModuleNotFoundError` before any URL is served. (The `try/except` around the append is
-ineffective — appending a string never raises; the failure happens later in
-`apps.populate()`.)
+**Status: the `/mcp/` mount works once the package is installed; the
+blueprint→tool bridge is not yet ported.**
 
-Independently, `src/swarm/urls.py` tries to mount
-`path('mcp/', include('django_mcp_server.urls'))` when the flag is set; that import
-also fails, and the mount is skipped with a logged warning naming the missing package
-(previously this failed silently).
+`ENABLE_MCP_SERVER=true` makes `swarm/settings.py` add `'mcp_server'` to
+`INSTALLED_APPS` and `swarm/urls.py` mount `path('mcp/', include('mcp_server.urls'))`.
+Both are gated on the module being importable, so with the package **absent** the
+flag is a no-op with a clear logged warning (it no longer breaks startup).
 
-## Why no dependency is declared
+## Install
 
-The closest PyPI distribution, [`django-mcp-server`](https://pypi.org/project/django-mcp-server/)
-(v0.5.7 as of Oct 2025, actively maintained, Python >= 3.10, Django 4/5), installs the
-module **`mcp_server`** — not `django_mcp_server` — and requires adding `'mcp_server'`
-to `INSTALLED_APPS` plus `path('', include('mcp_server.urls'))`. Pinning it without
-those settings changes would still leave the flag dead, so it is intentionally not
-declared yet.
+The endpoint is provided by the [`django-mcp-server`](https://pypi.org/project/django-mcp-server/)
+distribution, whose import module is **`mcp_server`** (not `django_mcp_server` —
+that mismatch is what previously made the flag dead on a clean install). Install
+it manually:
 
-## Real options for serving MCP from this project
+```bash
+pip install django-mcp-server
+export ENABLE_MCP_SERVER=true
+```
 
-1. Adopt `django-mcp-server`: add it as an optional extra, register `'mcp_server'`
-   (not `'django_mcp_server'`) in `INSTALLED_APPS`, and switch the include in
-   `swarm/urls.py` to `mcp_server.urls`.
-2. Mount the official MCP Python SDK (`mcp` on PyPI) as an ASGI sub-application
-   (e.g. Streamable HTTP transport) alongside Django.
-3. Leave the flag aspirational (current state) — the warning makes that explicit.
+It is **not** declared as an `open-swarm` extra: its transitive `mcp` SDK
+dependency only resolves with pre-releases enabled, which would break
+`uv lock --check` in CI. Verified working at the Django layer — with the package
+installed and the flag set, `manage.py check` passes and `/mcp/` is mounted.
 
-`tests/mcp/test_mcp_urls.py` exercises the mount by stubbing `django_mcp_server` in
-`sys.modules`; `tests/mcp/test_mcp_missing_package_warning.py` guards the warning path.
+## Known gap — blueprint→tool bridge
+
+`swarm/mcp/integration.py::register_blueprints_with_mcp()` was written against a
+flat `registry.register_tool(...)` API. `mcp_server` ≥0.5 replaced that with an
+`MCPToolset` / decorator paradigm, so the bridge is currently a **no-op** (it
+returns 0 without raising). Porting it to expose Open Swarm blueprints as MCP
+tools is tracked in [ROADMAP.md §3.3](../ROADMAP.md). Until then, the `/mcp/`
+mount serves django-mcp-server's own toolset surface, not the blueprints.
+
+## Tests
+
+`tests/mcp/test_mcp_urls.py` exercises the mount by stubbing `mcp_server` in
+`sys.modules`; `tests/mcp/test_mcp_missing_package_warning.py` guards the
+warning path by masking `mcp_server.urls` (hermetic whether or not the real
+package is installed).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,11 @@ memory = [
     # "langmem>=0.1.0",
     # "papr>=0.1.0",
 ]
+# NOTE: MCP server mode (ENABLE_MCP_SERVER) needs the `django-mcp-server`
+# distribution (module `mcp_server`). It is NOT declared as an extra here because
+# its transitive `mcp` SDK dependency only resolves with pre-releases enabled,
+# which would break `uv lock --check`. Install it manually when you need MCP
+# server mode: `pip install django-mcp-server` (see docs/mcp_server_mode.md).
 dev = [
     "pytest>=8.0.0",
     "pytest-django>=4.7.0",

--- a/src/swarm/mcp/integration.py
+++ b/src/swarm/mcp/integration.py
@@ -15,10 +15,17 @@ def register_blueprints_with_mcp() -> int:
 
     Returns the number of tools registered. If the MCP server module is missing,
     returns 0 without raising.
+
+    NOTE (2026-06-19): `django-mcp-server` (module `mcp_server`) ≥0.5 exposes an
+    ``MCPToolset`` / decorator API, NOT the flat ``registry.register_tool(...)``
+    this was written against — so this bridge is a **no-op** today and needs
+    porting to the toolset paradigm (tracked in ROADMAP §3.3). The mount itself
+    (``/mcp/`` via ``mcp_server.urls``) does work once the ``[mcp]`` extra is
+    installed; only the blueprint→tool bridge below is unported.
     """
     try:
-        # Expected simple registry API in django-mcp-server
-        from django_mcp_server import registry  # type: ignore
+        # Legacy/expected flat registry API — absent in mcp_server >=0.5 (see note).
+        from mcp_server import registry  # type: ignore
     except Exception:
         return 0
 

--- a/src/swarm/settings.py
+++ b/src/swarm/settings.py
@@ -104,18 +104,21 @@ ENABLE_MCP_SERVER = is_enable_mcp_server()
 if ENABLE_MCP_SERVER:
     import importlib.util
     import sys as _sys
+    # The `django-mcp-server` distribution installs the `mcp_server` module
+    # (NOT `django_mcp_server`). Install it manually: `pip install django-mcp-server`.
     try:
-        _mcp_available = importlib.util.find_spec('django_mcp_server') is not None
+        _mcp_available = importlib.util.find_spec('mcp_server') is not None
     except ValueError:
         # Module placed in sys.modules without a __spec__ (e.g. test stubs).
-        _mcp_available = 'django_mcp_server' in _sys.modules
+        _mcp_available = 'mcp_server' in _sys.modules
     if _mcp_available:
-        INSTALLED_APPS += ['django_mcp_server']
+        INSTALLED_APPS += ['mcp_server']
     else:
         import logging as _logging
         _logging.getLogger(__name__).warning(
-            "ENABLE_MCP_SERVER is set but no 'django_mcp_server' module is "
-            "installed; skipping app registration (see docs/mcp_server_mode.md)."
+            "ENABLE_MCP_SERVER is set but the 'mcp_server' module is not installed; "
+            "skipping app registration. Install it with `pip install django-mcp-server` "
+            "(see docs/mcp_server_mode.md)."
         )
 
 # Optional GitHub marketplace discovery (disabled by default)

--- a/src/swarm/urls.py
+++ b/src/swarm/urls.py
@@ -155,17 +155,16 @@ if os.getenv('ENABLE_MCP_SERVER', '').lower() in ('true', '1', 'yes'):
     try:
         from django.urls import include
         urlpatterns += [
-            path('mcp/', include('django_mcp_server.urls')),
+            path('mcp/', include('mcp_server.urls')),
         ]
     except Exception as exc:
         import logging
 
         logging.getLogger(__name__).warning(
             "ENABLE_MCP_SERVER is set but the '/mcp/' mount was skipped: could not "
-            "import 'django_mcp_server.urls' (%s). No installed package provides a "
-            "'django_mcp_server' module; the PyPI distribution 'django-mcp-server' "
-            "exposes 'mcp_server' instead and needs INSTALLED_APPS changes. "
-            "See docs/mcp_server_mode.md for the supported options.",
+            "import 'mcp_server.urls' (%s). Install the MCP server package with "
+            "`pip install django-mcp-server` (provides the 'mcp_server' module). "
+            "See docs/mcp_server_mode.md.",
             exc,
         )
 

--- a/tests/mcp/test_integration_register.py
+++ b/tests/mcp/test_integration_register.py
@@ -14,8 +14,8 @@ def test_register_blueprints_with_mcp(monkeypatch):
     }
 
     # Stub registry module
-    reg_pkg = ModuleType("django_mcp_server")
-    reg_mod = ModuleType("django_mcp_server.registry")
+    reg_pkg = ModuleType("mcp_server")
+    reg_mod = ModuleType("mcp_server.registry")
     calls = []
 
     def register_tool(name, parameters, description, handler):  # noqa: D401
@@ -24,8 +24,8 @@ def test_register_blueprints_with_mcp(monkeypatch):
     # Add the register_tool function to the module's namespace
     reg_mod.register_tool = register_tool  # type: ignore
     reg_pkg.registry = reg_mod  # type: ignore
-    sys.modules["django_mcp_server"] = reg_pkg
-    sys.modules["django_mcp_server.registry"] = reg_mod
+    sys.modules["mcp_server"] = reg_pkg
+    sys.modules["mcp_server.registry"] = reg_mod
 
     from swarm.mcp import provider as prov
     monkeypatch.setattr(prov, "discover_blueprints", lambda _: fake_discovered)

--- a/tests/mcp/test_mcp_missing_package_warning.py
+++ b/tests/mcp/test_mcp_missing_package_warning.py
@@ -1,9 +1,10 @@
 """Guard: ENABLE_MCP_SERVER without the package logs a warning, not silence.
 
-The '/mcp/' mount in swarm.urls imports 'django_mcp_server.urls', which no
-installable package provides (the PyPI 'django-mcp-server' distribution exposes
-'mcp_server' instead — see docs/mcp_server_mode.md). When the import fails the
-except branch must emit a clear warning naming the missing module.
+The '/mcp/' mount in swarm.urls imports 'mcp_server.urls' (provided by the
+'django-mcp-server' distribution, installed via `pip install open-swarm[mcp]`).
+When that import fails the except branch must emit a clear warning naming the
+missing module. We force the import to fail hermetically (whether or not the
+package happens to be installed in the dev env) by masking it in sys.modules.
 """
 
 import importlib
@@ -17,9 +18,9 @@ import pytest
 def test_missing_mcp_package_logs_warning(monkeypatch, caplog, client):
     monkeypatch.setenv("ENABLE_MCP_SERVER", "true")
 
-    # Ensure no stub from other tests masks the missing package.
-    monkeypatch.delitem(sys.modules, "django_mcp_server.urls", raising=False)
-    monkeypatch.delitem(sys.modules, "django_mcp_server", raising=False)
+    # Force the '/mcp/' mount import to fail regardless of whether the real
+    # package is installed: a None entry in sys.modules makes `import` raise.
+    monkeypatch.setitem(sys.modules, "mcp_server.urls", None)
 
     # settings.LOGGING sets propagate=False on the 'swarm' logger; let records
     # reach the root handler so caplog can capture them.
@@ -34,7 +35,7 @@ def test_missing_mcp_package_logs_warning(monkeypatch, caplog, client):
             importlib.reload(urls_mod)
 
         messages = [rec.getMessage() for rec in caplog.records]
-        assert any("django_mcp_server" in msg for msg in messages), messages
+        assert any("mcp_server" in msg for msg in messages), messages
         assert any("ENABLE_MCP_SERVER" in msg for msg in messages), messages
 
         # The mount must not exist (SPA fallback excludes mcp/, so plain 404).

--- a/tests/mcp/test_mcp_urls.py
+++ b/tests/mcp/test_mcp_urls.py
@@ -8,8 +8,8 @@ from django.urls import path
 
 
 def _stub_mcp_urls_module():
-    pkg = ModuleType("django_mcp_server")
-    mod = ModuleType("django_mcp_server.urls")
+    pkg = ModuleType("mcp_server")
+    mod = ModuleType("mcp_server.urls")
 
     def health(_request):
         return HttpResponse("OK", content_type="text/plain")
@@ -27,8 +27,8 @@ def test_mcp_urls_included_when_enabled(monkeypatch, client):
 
     # Stub out module tree
     pkg, urls = _stub_mcp_urls_module()
-    sys.modules["django_mcp_server"] = pkg
-    sys.modules["django_mcp_server.urls"] = urls
+    sys.modules["mcp_server"] = pkg
+    sys.modules["mcp_server.urls"] = urls
 
     # Reload settings/urls
     settings_mod = importlib.import_module("swarm.settings")

--- a/tests/mcp/test_provider_edge_cases.py
+++ b/tests/mcp/test_provider_edge_cases.py
@@ -487,8 +487,8 @@ def test_run_blueprint_sync_with_string_result(monkeypatch):
 # ============================================================================
 
 
-def test_register_blueprints_missing_django_mcp_server(monkeypatch):
-    """Test register_blueprints_with_mcp when django_mcp_server is not installed."""
+def test_register_blueprints_missing_mcp_server(monkeypatch):
+    """Test register_blueprints_with_mcp when mcp_server is not installed."""
     fake_discovered = {
         "test_bp": {
             "metadata": {"name": "Test", "description": "Test blueprint"},
@@ -499,9 +499,9 @@ def test_register_blueprints_missing_django_mcp_server(monkeypatch):
     from swarm.mcp import provider as prov
     monkeypatch.setattr(prov, "discover_blueprints", lambda _: fake_discovered)
 
-    # Remove django_mcp_server from modules if present
+    # Remove mcp_server from modules if present
     for mod in list(sys.modules.keys()):
-        if mod.startswith("django_mcp_server"):
+        if mod.startswith("mcp_server"):
             del sys.modules[mod]
 
     from swarm.mcp import integration as integ
@@ -528,8 +528,8 @@ def test_register_blueprints_registration_error(monkeypatch):
     monkeypatch.setattr(prov, "discover_blueprints", lambda _: fake_discovered)
 
     # Create stub registry that fails for one tool
-    reg_pkg = ModuleType("django_mcp_server")
-    reg_mod = ModuleType("django_mcp_server.registry")
+    reg_pkg = ModuleType("mcp_server")
+    reg_mod = ModuleType("mcp_server.registry")
     calls = []
 
     def register_tool(name, parameters, description, handler):
@@ -539,8 +539,8 @@ def test_register_blueprints_registration_error(monkeypatch):
 
     reg_mod.register_tool = register_tool
     reg_pkg.registry = reg_mod
-    sys.modules["django_mcp_server"] = reg_pkg
-    sys.modules["django_mcp_server.registry"] = reg_mod
+    sys.modules["mcp_server"] = reg_pkg
+    sys.modules["mcp_server.registry"] = reg_mod
 
     from swarm.mcp import integration as integ
     importlib.reload(integ)
@@ -572,8 +572,8 @@ def test_register_blueprints_handler_execution(monkeypatch):
     mock_blueprint_cls.return_value = mock_instance
 
     # Create stub registry
-    reg_pkg = ModuleType("django_mcp_server")
-    reg_mod = ModuleType("django_mcp_server.registry")
+    reg_pkg = ModuleType("mcp_server")
+    reg_mod = ModuleType("mcp_server.registry")
     registered_handler = None
 
     def register_tool(name, parameters, description, handler):
@@ -582,8 +582,8 @@ def test_register_blueprints_handler_execution(monkeypatch):
 
     reg_mod.register_tool = register_tool
     reg_pkg.registry = reg_mod
-    sys.modules["django_mcp_server"] = reg_pkg
-    sys.modules["django_mcp_server.registry"] = reg_mod
+    sys.modules["mcp_server"] = reg_pkg
+    sys.modules["mcp_server.registry"] = reg_mod
 
     from swarm.mcp import integration as integ
     importlib.reload(integ)


### PR DESCRIPTION
Milestone #16 (ROADMAP §3.3).

## The bug
`ENABLE_MCP_SERVER` mode was dead on a clean install — the code imported `django_mcp_server`, but the `django-mcp-server` PyPI distribution installs the module **`mcp_server`**. (Confirmed by inspecting the wheel: top-level package is `mcp_server`.)

## Fix
- Corrected the module name in `settings.py`, `urls.py`, `mcp/integration.py`.
- **Verified**: with `pip install django-mcp-server` + `ENABLE_MCP_SERVER=true`, `manage.py check` passes and `/mcp/` is mounted.
- Installed **manually**, not as an `open-swarm` extra — its transitive `mcp` SDK dep only resolves with pre-releases, which would break `uv lock --check`. Documented in `docs/mcp_server_mode.md`.

## Honest gap
The blueprint→tool bridge (`register_blueprints_with_mcp`) targets a flat `registry.register_tool` API that `mcp_server` ≥0.5 replaced with an `MCPToolset` paradigm — it's a **no-op until ported** (ROADMAP §3.3). The `/mcp/` mount itself works.

## Tests
MCP tests updated to the new module name and made hermetic (force-absence via `sys.modules` masking, so they pass whether or not the optional package is installed). 66 MCP tests pass; full suite **1308 passed**; `uv lock --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)