### PR TITLE
fix(security): settings dashboard XSS — json_script instead of |safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security — settings dashboard XSS
+- `templates/settings_dashboard.html` injected server settings into a `<script>` via `{{ settings_groups|safe }}` — an XSS vector (any value containing `</script>` could break out) that also emitted invalid JS (a raw Python dict). Replaced with Django's `json_script` (auto-escapes `<`/`>`/`&`) read via `JSON.parse`. Sensitive values were already masked server-side. Regression tests added.
+
 ### Fixed — MCP server mode module name
 - `ENABLE_MCP_SERVER` mode was dead on a clean install: the code imported `django_mcp_server` while the `django-mcp-server` distribution actually installs the module **`mcp_server`**. Corrected the module name in `settings.py`/`urls.py`/`mcp/integration.py`, so the `/mcp/` mount loads cleanly once the package is present (verified: Django check passes, mount present). It's installed manually — `pip install django-mcp-server` — not as an extra, because its transitive `mcp` SDK dep needs pre-releases that would break `uv lock`. Note: the blueprint→tool *bridge* (`register_blueprints_with_mcp`) targets a flat `registry.register_tool` API that `mcp_server` ≥0.5 replaced with an `MCPToolset` paradigm — a no-op until ported (ROADMAP §3.3).
 

--- a/src/swarm/templates/settings_dashboard.html
+++ b/src/swarm/templates/settings_dashboard.html
@@ -563,8 +563,12 @@
 }
 </style>
 
+{{ settings_groups|json_script:"swarm-settings-data" }}
 <script>
-let settingsData = {{ settings_groups|safe }};
+// json_script auto-escapes </script>, <, >, & — safe even though sensitive
+// values are already masked server-side. Also fixes the previously-invalid JS
+// (a raw Python dict rendered True/None as bare identifiers).
+const settingsData = JSON.parse(document.getElementById("swarm-settings-data").textContent);
 
 function toggleGroup(groupId) {
   const content = document.getElementById(`content-${groupId}`);

--- a/tests/views/test_settings_dashboard_xss.py
+++ b/tests/views/test_settings_dashboard_xss.py
@@ -1,0 +1,50 @@
+"""Regression: the settings dashboard must not inject server data via |safe.
+
+It previously did `let settingsData = {{ settings_groups|safe }}` — an XSS vector
+(unescaped server values in a <script>) that also rendered invalid JS (a raw
+Python dict). The fix uses Django's `json_script`, which HTML-escapes the JSON.
+"""
+
+from __future__ import annotations
+
+import django
+import pytest
+
+django.setup()
+from django.contrib.auth import get_user_model  # noqa: E402
+from django.test import Client  # noqa: E402
+
+
+@pytest.mark.django_db
+def test_settings_dashboard_uses_json_script_not_safe_filter():
+    User = get_user_model()
+    User.objects.create_user(username="u", password="p")
+    client = Client()
+    client.login(username="u", password="p")
+
+    resp = client.get("/settings/")
+    assert resp.status_code == 200
+    html = resp.content.decode()
+
+    # The safe, escaped data island is present and consumed via JSON.parse.
+    assert 'id="swarm-settings-data"' in html
+    assert "JSON.parse(document.getElementById" in html
+    # The old unescaped injection is gone.
+    assert "settings_groups|safe" not in html
+    assert "let settingsData = {" not in html
+
+
+@pytest.mark.django_db
+def test_settings_dashboard_escapes_script_in_json_island():
+    # json_script must escape angle brackets so a value can't break out of the
+    # <script type="application/json"> container.
+    User = get_user_model()
+    User.objects.create_user(username="u2", password="p")
+    client = Client()
+    client.login(username="u2", password="p")
+    html = client.get("/settings/").content.decode()
+    # Find the data island; it must not contain a raw closing script tag.
+    start = html.find('id="swarm-settings-data"')
+    assert start != -1
+    island = html[start : html.find("</script>", start)]
+    assert "</script" not in island.replace("\\u003c", "")  # only escaped form allowed


### PR DESCRIPTION
From the critique audit (ROADMAP §4.1, top security finding).

`settings_dashboard.html:567` rendered `let settingsData = {{ settings_groups|safe }}` — server settings injected **unescaped** into a `<script>`. Any value containing `</script>` could break out (XSS); it also emitted invalid JS (a raw Python dict renders `True`/`None`).

**Fix:** Django `{{ settings_groups|json_script:"swarm-settings-data" }}` (auto-escapes `</script>`, `<`, `>`, `&`) read via `JSON.parse(...textContent)`. Behavior-preserving for the `settingsData` object used at lines 578/606, and it fixes the broken JS. Sensitive values (SECRET_KEY, API key) were already masked server-side.

**Tests:** `tests/views/test_settings_dashboard_xss.py` — page renders 200, the escaped data island is present + consumed via JSON.parse, and the `|safe` injection is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)