### PR TITLE
chore(release): 0.5.3 — DaisyUI-5 loading spinner fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.3] — 2026-06-19
+
+### Fixed — SPA loading buttons show a spinner (DaisyUI 5)
+- `Button` used the bare `loading` class, which DaisyUI 5 no longer renders as a spinner — so every mutating action (save/delete/create) across Teams/Blueprints/Agent-Creator showed a disabled button with **no visible feedback**. Now renders an explicit `loading loading-spinner` element (with `aria-busy`/SR text retained). Tests added.
+
+
 ### Removed — test cruft + orphan CLI
 - Deleted ~15 low-quality tests (tautological dict/`isinstance` checks, import-only smokes, over-mocked tests that only verify their own mock, and a suite testing an orphan root `swarm_cli.py`). Removed that orphan `swarm_cli.py` (a stale `click` CLI superseded by `swarm.core.swarm_cli:app`). Net: leaner, higher-signal suite (1293 passing).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-swarm"
-version = "0.5.2"
+version = "0.5.3"
 description = "Open Swarm: Orchestrating AI Agent Swarms with Django"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1782,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "open-swarm"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/webui/frontend/src/components/DaisyUI/Button.tsx
+++ b/webui/frontend/src/components/DaisyUI/Button.tsx
@@ -52,8 +52,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(({
     glass ? 'glass' : '',
     // Animation
     noAnimation ? 'no-animation' : '',
-    // Loading state
-    loading ? 'loading' : '',
     // Custom classes
     className
   ].filter(Boolean);
@@ -67,6 +65,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(({
       aria-busy={loading}
       {...props}
     >
+      {/* DaisyUI 5: the bare `loading` btn class no longer renders a spinner —
+          an explicit loading-spinner span is required for visible feedback. */}
+      {loading && <span className="loading loading-spinner loading-sm" aria-hidden="true" />}
       {loading && <span className="sr-only">Loading</span>}
       {children}
     </button>

--- a/webui/frontend/src/components/DaisyUI/__tests__/Button.test.tsx
+++ b/webui/frontend/src/components/DaisyUI/__tests__/Button.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { Button } from '../Button'
+
+describe('Button loading state (DaisyUI 5)', () => {
+  it('renders a visible spinner element when loading', () => {
+    const { container } = render(<Button loading>Save</Button>)
+    // DaisyUI 5 needs an explicit loading-spinner span (the bare `loading` btn
+    // class no longer renders one).
+    const spinner = container.querySelector('.loading.loading-spinner')
+    expect(spinner).not.toBeNull()
+  })
+
+  it('does not add the deprecated bare `loading` class to the button', () => {
+    const { container } = render(<Button loading>Save</Button>)
+    const btn = container.querySelector('button')!
+    const classes = btn.className.split(/\s+/)
+    expect(classes).not.toContain('loading') // only on the span, not the btn
+  })
+
+  it('marks the button busy + disabled and exposes SR text while loading', () => {
+    render(<Button loading>Save</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn).toBeDisabled()
+    expect(btn).toHaveAttribute('aria-busy', 'true')
+    expect(screen.getByText('Loading')).toHaveClass('sr-only')
+  })
+
+  it('renders no spinner when not loading', () => {
+    const { container } = render(<Button>Save</Button>)
+    expect(container.querySelector('.loading-spinner')).toBeNull()
+  })
+})


### PR DESCRIPTION
Patch release. From the critique audit (ROADMAP §4.2/§4.6).

**Fix:** the SPA `Button` used the bare `loading` class — DaisyUI 5 no longer renders it as a spinner, so every mutating action (save/delete/create) across Teams/Blueprints/Agent-Creator showed a disabled button with **no visible feedback**. Now renders an explicit `loading loading-spinner` span; `aria-busy` + SR 'Loading' text retained.

**Tests:** new `Button.test.tsx` (4 cases — spinner present, no deprecated class, busy/disabled+SR, none when idle). Full frontend vitest: **65 passed**.

Also bundles the already-merged **test-cruft cleanup** (~15 low-quality tests + orphan `swarm_cli.py`). Bump 0.5.2→0.5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)