### PR TITLE
chore(release): 0.5.4 — django_chat actually resolves its LLM profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.5.4] — 2026-06-19
+
+### Fixed — `django_chat` actually resolves its LLM profile
+- Follow-up to 0.5.2: `django_chat` returned "not configured" at runtime even with a valid `llm` profile, because its `__init__` re-assigned `self._config = config if config is not None else None` (and nulled `_llm_profile_name`) *after* the base `__init__` had already loaded the config — clobbering it. Removed those redundant overrides; verified live (real answer over the local backend). Regression tests added.
+
 ## [0.5.3] — 2026-06-19
 
 ### Fixed — SPA loading buttons show a spinner (DaisyUI 5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "open-swarm"
-version = "0.5.3"
+version = "0.5.4"
 description = "Open Swarm: Orchestrating AI Agent Swarms with Django"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/swarm/blueprints/django_chat/blueprint_django_chat.py
+++ b/src/swarm/blueprints/django_chat/blueprint_django_chat.py
@@ -118,9 +118,10 @@ class DjangoChatBlueprint(Blueprint):
         super().__init__(blueprint_id, config=config, config_path=config_path, **kwargs)
         self.blueprint_id = blueprint_id
         self.config_path = config_path
-        self._config = config if config is not None else None
-        self._llm_profile_name = None
-        self._llm_profile_data = None
+        # NOTE: do NOT re-assign self._config / self._llm_profile_name here — the
+        # base __init__ already loads the config (from app.config when none is
+        # passed). Nulling them broke LLM-profile resolution at runtime (the
+        # blueprint reported "not configured" even with a valid llm profile).
         self._markdown_output = None
         class DummyLLM:
             def chat_completion_stream(self, _messages, **_):

--- a/tests/blueprints/test_django_chat_config.py
+++ b/tests/blueprints/test_django_chat_config.py
@@ -1,0 +1,35 @@
+"""Regression: django_chat must retain its loaded config / LLM profile.
+
+The blueprint's __init__ previously re-assigned `self._config = config if config
+is not None else None` (and nulled `_llm_profile_name`) AFTER the base __init__
+had already loaded the config — so at runtime it reported "not configured" even
+with a valid `llm` profile. These guard that it keeps the config.
+"""
+
+from __future__ import annotations
+
+from swarm.blueprints.django_chat.blueprint_django_chat import DjangoChatBlueprint
+
+_CFG = {
+    "llm": {"default": {"provider": "openai", "model": "m", "base_url": "http://x/v1", "api_key": "k"}}
+}
+
+
+def test_init_does_not_null_passed_config():
+    bp = DjangoChatBlueprint(config=_CFG)
+    assert bp._config == _CFG  # not overwritten to None
+    assert bp.get_llm_profile(bp.llm_profile_name).get("base_url") == "http://x/v1"
+
+
+def test_unconfigured_degrades_gracefully():
+    bp = DjangoChatBlueprint(config={})
+    # No usable profile -> a clear message, never the old "Would respond to:" stub.
+    import asyncio
+
+    async def _collect():
+        return [c async for c in bp.run([{"role": "user", "content": "hi"}])]
+
+    chunks = asyncio.get_event_loop().run_until_complete(_collect())
+    content = chunks[-1]["messages"][0]["content"]
+    assert "not configured" in content
+    assert "Would respond to" not in content

--- a/tests/blueprints/test_django_chat_config.py
+++ b/tests/blueprints/test_django_chat_config.py
@@ -21,15 +21,10 @@ def test_init_does_not_null_passed_config():
     assert bp.get_llm_profile(bp.llm_profile_name).get("base_url") == "http://x/v1"
 
 
-def test_unconfigured_degrades_gracefully():
+async def test_unconfigured_degrades_gracefully():
     bp = DjangoChatBlueprint(config={})
     # No usable profile -> a clear message, never the old "Would respond to:" stub.
-    import asyncio
-
-    async def _collect():
-        return [c async for c in bp.run([{"role": "user", "content": "hi"}])]
-
-    chunks = asyncio.get_event_loop().run_until_complete(_collect())
+    chunks = [c async for c in bp.run([{"role": "user", "content": "hi"}])]
     content = chunks[-1]["messages"][0]["content"]
     assert "not configured" in content
     assert "Would respond to" not in content

--- a/uv.lock
+++ b/uv.lock
@@ -1782,7 +1782,7 @@ wheels = [
 
 [[package]]
 name = "open-swarm"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Follow-up to v0.5.2, found by live-testing.

**Bug:** `django_chat` returned `"…not configured…"` at runtime even with a valid `llm` profile. Its `__init__` re-assigned `self._config = config if config is not None else None` (and nulled `_llm_profile_name`) **after** the base `__init__` had already loaded the config from `app.config` — clobbering it to `None`. The old stub never used config, so this was masked until 0.5.2 wired the real call.

**Fix:** removed the redundant/harmful overrides (they were never read again). **Verified live**: django_chat now returns a real answer ("Django is a high-level… web framework…") over the local backend. `chatbot` already worked, confirming it was django_chat-specific.

**Tests:** `test_django_chat_config.py` — config not nulled + profile resolves; unconfigured still degrades gracefully (never the old `"Would respond to:"` stub). Full suite **1293 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)