### PR TITLE
feat(hybrid_team): claude-orchestrated structured delegation + claude-default integration

### DIFF
--- a/src/swarm/blueprints/django_chat/blueprint_django_chat.py
+++ b/src/swarm/blueprints/django_chat/blueprint_django_chat.py
@@ -199,12 +199,16 @@ class DjangoChatBlueprint(Blueprint):
             profile = self.get_llm_profile(self.llm_profile_name)
             base_url = profile.get("base_url")
             api_key = profile.get("api_key") or "ollama"  # local backends ignore the key
-            model_name = profile.get("model") or "gpt-oss:20b"
+            # No hardcoded model fallback: the profile's model is authoritative,
+            # with LITELLM_MODEL/DEFAULT_LLM as the only escape hatch.
+            import os
+            model_name = profile.get("model") or os.getenv("LITELLM_MODEL") or os.getenv("DEFAULT_LLM")
         except Exception as e:  # config not initialized / no profile
             logger.warning("DjangoChat: LLM profile unavailable (%s)", e)
             base_url = None
+            model_name = None
 
-        if not base_url:
+        if not base_url or not model_name:
             yield {"messages": [{"role": "assistant", "content": (
                 "DjangoChat is not configured with an LLM profile. "
                 "Add an 'llm' profile in swarm_config.json to enable responses."

--- a/src/swarm/blueprints/hybrid_team/blueprint_hybrid_team.py
+++ b/src/swarm/blueprints/hybrid_team/blueprint_hybrid_team.py
@@ -43,10 +43,14 @@ falls back to the ``cli_fusion`` ``default_cli`` / ``default_preset``. Per-reque
 
 from __future__ import annotations
 
+import asyncio
+import concurrent.futures
 import json
 import logging
 import os
 import re
+import threading
+import time
 from typing import Any, AsyncGenerator, ClassVar
 
 from swarm.blueprints.common import cli_fusion_support as support
@@ -110,6 +114,13 @@ class HybridTeamBlueprint(BlueprintBase):
         "general coding and reasoning, and 'orchestration' for further "
         "planning/coordination. At most 3 delegations; use [] if none are needed."
     )
+
+    # Parallel-delegation tuning. Delegations run concurrently on a small thread
+    # pool; launches are staggered to be gentle on free-CLI rate limits, and each
+    # delegation has a hard timeout so one slow/hung sub-task can't stall the rest.
+    _DELEGATION_MAX_WORKERS: ClassVar[int] = 4
+    _DELEGATION_TIMEOUT_S: ClassVar[float] = 120.0
+    _DELEGATION_LAUNCH_DELAY_S: ClassVar[float] = 0.25
 
     def __init__(
         self,
@@ -274,6 +285,53 @@ class HybridTeamBlueprint(BlueprintBase):
         except Exception as exc:  # noqa: BLE001
             return f"[{role} unavailable: {exc}] {task}"
 
+    def _role_model(self, role: str) -> str | None:
+        """The llm profile name a role would resolve to (for observability), or None."""
+        profile = self.ROLE_PROFILES.get(role)
+        if not profile:
+            return None
+        try:
+            from swarm.core.inference_profile import resolve
+            return resolve(profile, self._llm_candidates())
+        except Exception:  # noqa: BLE001
+            return None
+
+    async def _execute_delegations(self, delegations: list[dict]) -> AsyncGenerator[dict, None]:
+        """Run delegations in parallel on a ThreadPoolExecutor, yielding each result
+        dict as it completes (out of order).
+
+        Each result is ``{role, task, status: completed|failed, result|error,
+        model_used}``. Failures are isolated (one bad sub-task never kills the
+        others), each has a hard ``_DELEGATION_TIMEOUT_S`` ceiling, and launches
+        are staggered by ``_DELEGATION_LAUNCH_DELAY_S`` to protect free-CLI rate
+        limits. Deterministic under ``SWARM_TEST_MODE`` (``_run_delegation`` stubs).
+        """
+        loop = asyncio.get_event_loop()
+        launch_gate = threading.Lock()  # serialize *starts* to stagger launches
+
+        def _work(d: dict) -> dict:
+            role, task = d["role"], d["task"]
+            model_used = self._role_model(role)
+            with launch_gate:
+                time.sleep(self._DELEGATION_LAUNCH_DELAY_S)
+            base = {"role": role, "task": task, "model_used": model_used}
+            try:
+                # Own event loop per worker thread, with a hard per-task timeout.
+                out = asyncio.run(
+                    asyncio.wait_for(self._run_delegation(d), timeout=self._DELEGATION_TIMEOUT_S)
+                )
+                return {**base, "status": "completed", "result": out}
+            except (TimeoutError, asyncio.TimeoutError):
+                return {**base, "status": "failed", "error": f"timed out after {self._DELEGATION_TIMEOUT_S:.0f}s"}
+            except Exception as exc:  # noqa: BLE001 — isolate per-delegation failures
+                return {**base, "status": "failed", "error": str(exc)}
+
+        max_workers = min(self._DELEGATION_MAX_WORKERS, max(1, len(delegations)))
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = [loop.run_in_executor(pool, _work, d) for d in delegations]
+            for fut in asyncio.as_completed(futures):
+                yield await fut
+
     # --- the REST step (deterministic under SWARM_TEST_MODE) -------------- #
 
     async def _rest_reason(self, prompt: str) -> str:
@@ -361,14 +419,31 @@ class HybridTeamBlueprint(BlueprintBase):
         # The plan steers the CLI sub-questions below.
         sub_question = f"{prompt}\n\n--- Plan ---\n{plan}"
 
-        # ---- 1b. execute the brain's delegations via the role machinery -- #
-        # Each {role, task} from claude is routed to its role's model
-        # (orchestration/agent/auxiliary) through _agent_for_role. Empty under
-        # SWARM_TEST_MODE / when no claude brain is configured.
+        # ---- 1b. execute the brain's delegations IN PARALLEL ------------- #
+        # Each {role, task} from claude runs on its role's model
+        # (orchestration/agent/auxiliary) via _agent_for_role, concurrently on a
+        # small thread pool. Results arrive out of order; each is surfaced as a
+        # `delegation_progress` chunk (also captured into the persisted Responses
+        # progress array). Empty under SWARM_TEST_MODE / when no claude brain.
         delegated: list[tuple[str, str]] = []
-        for d in delegations:
-            yield support.progress_chunk(f"_Delegating ({d['role']}) → {d['task'][:60]}…_")
-            delegated.append((d["role"], await self._run_delegation(d)))
+        if delegations:
+            yield support.progress_chunk(
+                f"_Delegating {len(delegations)} sub-task(s) in parallel…_"
+            )
+            async for ev in self._execute_delegations(delegations):
+                summary = ev["result"] if ev["status"] == "completed" else (
+                    f"[{ev['role']} {ev['status']}: {ev.get('error')}]"
+                )
+                delegated.append((ev["role"], summary))
+                yield {
+                    "type": "delegation_progress",
+                    "content": (
+                        f"_• {ev['role']} {ev['status']}"
+                        + (f" on `{ev['model_used']}`" if ev.get("model_used") else "")
+                        + "_"
+                    ),
+                    "delegation": ev,
+                }
 
         # ---- 2. grok CLI persona step ------------------------------------ #
         grok_answer = ""

--- a/src/swarm/blueprints/hybrid_team/blueprint_hybrid_team.py
+++ b/src/swarm/blueprints/hybrid_team/blueprint_hybrid_team.py
@@ -13,6 +13,19 @@ The REST coordinator holds the master plan and delegates sub-questions to the
 grok/claude CLI personas (exposed as ``cli_tools`` callables) and to a consensus
 panel — that is the MIX: one REST inference reaching for CLI personas mid-run.
 
+**claude-orchestrated delegation.** When a ``claude`` cli_agent is configured,
+the coordinator step uses ``claude -p`` as the *orchestration brain*: it returns
+a JSON plan + role delegations,
+
+    {"plan": "...", "delegations": [{"role": "agent", "task": "..."}, ...]}
+
+which :meth:`run` parses (:meth:`_parse_delegations`) and routes back through the
+per-step model machinery — each delegation runs on its role's model
+(``orchestration`` / ``agent`` / ``auxiliary``; see :attr:`ROLE_PROFILES` and
+:meth:`_agent_for_role`). Without claude it falls back to the orchestration-role
+LLM plan with no delegations, so the per-step routing from the prior change still
+applies and behaviour is unchanged under ``SWARM_TEST_MODE``.
+
 Deterministic in tests two ways, independently:
 
   * REST half -> stubbed when ``os.environ["SWARM_TEST_MODE"]`` is set.
@@ -30,8 +43,10 @@ falls back to the ``cli_fusion`` ``default_cli`` / ``default_preset``. Per-reque
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+import re
 from typing import Any, AsyncGenerator, ClassVar
 
 from swarm.blueprints.common import cli_fusion_support as support
@@ -80,6 +95,21 @@ class HybridTeamBlueprint(BlueprintBase):
         # testing, revision, simple execution -> fast and cheap
         "auxiliary": {"speed": 0.9, "cost": 0.9},
     }
+
+    # The orchestration brain (claude -p, when configured) is asked to emit a
+    # structured plan + role delegations as JSON, which run() parses and routes
+    # back through _agent_for_role. Plain-text replies degrade to "plan, no
+    # delegations" so a non-JSON model never breaks the run.
+    _DELEGATION_INSTRUCTIONS: ClassVar[str] = (
+        "You are the orchestration brain for a small agent team. Read the user's "
+        "request, produce a brief plan, then delegate concrete sub-tasks to roles. "
+        "Respond with ONLY a JSON object (no prose, no code fences) of the form: "
+        '{"plan": "<1-2 sentence plan>", "delegations": '
+        '[{"role": "orchestration|agent|auxiliary", "task": "<what to do>"}]}. '
+        "Use 'auxiliary' for cheap/simple/testing/revision steps, 'agent' for "
+        "general coding and reasoning, and 'orchestration' for further "
+        "planning/coordination. At most 3 delegations; use [] if none are needed."
+    )
 
     def __init__(
         self,
@@ -142,6 +172,107 @@ class HybridTeamBlueprint(BlueprintBase):
             tools=list(tools or []),
             inference_profile=profile,
         )
+
+    # --- claude-orchestrated delegation ----------------------------------- #
+
+    def _claude_persona(self, registry):
+        """An async ``(str) -> str`` persona backed by the ``claude`` cli_agent.
+
+        Returns None when no ``claude`` CLI is configured, so the coordinator
+        degrades to the orchestration-role LLM instead.
+        """
+        try:
+            if "claude" in set(registry.names()):
+                return cli_persona(registry.get("claude"))
+        except Exception:  # noqa: BLE001 — never let wiring issues sink the run
+            pass
+        return None
+
+    @staticmethod
+    def _extract_json_object(raw: str) -> dict | None:
+        """Best-effort JSON object from a model reply (handles prose / fences)."""
+        if not raw:
+            return None
+        try:
+            obj = json.loads(raw)
+            return obj if isinstance(obj, dict) else None
+        except Exception:  # noqa: BLE001
+            m = re.search(r"\{.*\}", raw, re.S)
+            if m:
+                try:
+                    obj = json.loads(m.group(0))
+                    return obj if isinstance(obj, dict) else None
+                except Exception:  # noqa: BLE001
+                    return None
+        return None
+
+    def _parse_delegations(self, raw: str, fallback: str = "") -> tuple[str, list[dict]]:
+        """Parse the brain's reply into ``(plan, delegations)``.
+
+        Accepts ``{"plan": ..., "delegations": [{"role", "task"}]}`` (possibly
+        wrapped in prose). Delegations with an empty task or a role outside
+        :attr:`ROLE_PROFILES` are dropped. Any non-JSON reply degrades to
+        ``(raw or fallback, [])`` — a plain plan with no delegations.
+        """
+        obj = self._extract_json_object(raw)
+        if obj is None:
+            return (raw or fallback), []
+        plan = str(obj.get("plan") or "").strip() or (raw or fallback)
+        delegations: list[dict] = []
+        for d in obj.get("delegations") or []:
+            if not isinstance(d, dict):
+                continue
+            role = str(d.get("role") or "").strip().lower()
+            task = str(d.get("task") or "").strip()
+            if not task:
+                continue
+            if role in self.ROLE_PROFILES:
+                delegations.append({"role": role, "task": task})
+            else:
+                logger.info("[hybrid_team] dropping delegation with unknown role=%r", d.get("role"))
+        return plan, delegations
+
+    async def _orchestrate(self, prompt: str, registry) -> tuple[str, list[dict]]:
+        """Run the orchestration brain; return ``(plan, delegations)``.
+
+        Prefers ``claude -p`` (the orchestration brain) when a ``claude``
+        cli_agent is configured: it returns structured JSON that we parse into
+        role delegations. Without claude, falls back to the orchestration-role
+        LLM plan (no delegations). Deterministic stub under ``SWARM_TEST_MODE``.
+        Always degrades gracefully — a missing brain never sinks the run.
+        """
+        if os.environ.get("SWARM_TEST_MODE"):
+            return f"[rest-plan] {prompt}", []
+        claude = self._claude_persona(registry)
+        if claude is None:
+            return await self._rest_reason(prompt), []
+        try:
+            raw = await claude(f"{self._DELEGATION_INSTRUCTIONS}\n\nUser request:\n{prompt}")
+        except Exception as exc:  # noqa: BLE001 — degrade to a plain plan
+            return f"[orchestration unavailable: {exc}] {prompt}", []
+        return self._parse_delegations(raw, fallback=prompt)
+
+    async def _run_delegation(self, deleg: dict) -> str:
+        """Execute one delegation on its role's model (per ROLE_PROFILES).
+
+        Deterministic under ``SWARM_TEST_MODE``; degrades to a marker string on
+        any failure so one bad sub-task never sinks the run.
+        """
+        role, task = deleg["role"], deleg["task"]
+        if os.environ.get("SWARM_TEST_MODE"):
+            return f"[{role}] {task}"
+        try:
+            from agents import Runner
+
+            agent = self._agent_for_role(
+                role,
+                name=f"{role.title()}Worker",
+                instructions="Complete the delegated sub-task concisely and accurately.",
+            )
+            result = await Runner.run(agent, task)
+            return str(result.final_output)
+        except Exception as exc:  # noqa: BLE001
+            return f"[{role} unavailable: {exc}] {task}"
 
     # --- the REST step (deterministic under SWARM_TEST_MODE) -------------- #
 
@@ -224,11 +355,20 @@ class HybridTeamBlueprint(BlueprintBase):
         grok_name, panel_names, judge_name = self._resolve(params, registry)
         workdir = params.get(support.PARAM_WORKDIR)
 
-        # ---- 1. REST reasoning step (the coordinator's master plan) ------ #
+        # ---- 1. orchestration: plan + (optional) claude-driven delegations  #
         yield support.progress_chunk("_Coordinator reasoning (REST step)…_")
-        plan = await self._rest_reason(prompt)
-        # The REST plan steers the CLI sub-questions below.
+        plan, delegations = await self._orchestrate(prompt, registry)
+        # The plan steers the CLI sub-questions below.
         sub_question = f"{prompt}\n\n--- Plan ---\n{plan}"
+
+        # ---- 1b. execute the brain's delegations via the role machinery -- #
+        # Each {role, task} from claude is routed to its role's model
+        # (orchestration/agent/auxiliary) through _agent_for_role. Empty under
+        # SWARM_TEST_MODE / when no claude brain is configured.
+        delegated: list[tuple[str, str]] = []
+        for d in delegations:
+            yield support.progress_chunk(f"_Delegating ({d['role']}) → {d['task'][:60]}…_")
+            delegated.append((d["role"], await self._run_delegation(d)))
 
         # ---- 2. grok CLI persona step ------------------------------------ #
         grok_answer = ""
@@ -262,8 +402,10 @@ class HybridTeamBlueprint(BlueprintBase):
                 consensus = consensus_fn(panel, judge)  # async (str) -> str
                 consensus_answer = await consensus(sub_question)
 
-        # ---- 4. combine REST + CLI outputs into the final answer --------- #
+        # ---- 4. combine REST + delegated + CLI outputs into the answer --- #
         parts = [f"REST plan:\n{plan}"]
+        for role, out in delegated:
+            parts.append(f"Delegated [{role}]:\n{out}")
         if grok_answer:
             parts.append(f"grok persona:\n{grok_answer}")
         if consensus_answer:

--- a/src/swarm/views/responses_views.py
+++ b/src/swarm/views/responses_views.py
@@ -115,11 +115,20 @@ def _coerce_content(content: Any) -> str:
 
 
 def _resolve_sync_wait(request_data: dict[str, Any], background: bool) -> float | None:
-    """How long to wait synchronously before returning a queued handle.
+    """How long to wait synchronously before handing back a pollable handle.
 
     Precedence: ``background:true`` -> 0 (immediate handle) > per-request
-    ``max_wait_seconds`` > server default ``SWARM_RESPONSES_SYNC_TIMEOUT`` (env).
-    Returns None when nothing is configured — the classic fully-blocking sync path.
+    ``max_wait_seconds`` > server default ``SWARM_RESPONSES_SYNC_TIMEOUT`` (env) >
+    the **async-by-default** bounded window ``SWARM_RESPONSES_SYNC_DEFAULT`` (env,
+    default 10s).
+
+    Async-by-default: non-streaming work always runs on a background worker and
+    is persisted to disk under its ``response_id``. A POST returns within this
+    window — inline (200) for fast blueprints, or a 202 handle for long
+    claude-p + delegation runs that finish in the background and are polled via
+    ``GET /v1/responses/<id>``. This is what makes timeouts irrelevant. Set
+    ``SWARM_RESPONSES_SYNC_DEFAULT`` very high to approximate the old fully-
+    blocking behaviour.
     """
     if background:
         return 0.0
@@ -127,14 +136,17 @@ def _resolve_sync_wait(request_data: dict[str, Any], background: bool) -> float 
         try:
             return max(0.0, float(request_data["max_wait_seconds"]))
         except (TypeError, ValueError):
-            return None
+            pass  # malformed -> fall through to the server default
     env = os.environ.get("SWARM_RESPONSES_SYNC_TIMEOUT")
     if env:
         try:
             return max(0.0, float(env))
         except ValueError:
-            return None
-    return None
+            pass
+    try:
+        return max(0.0, float(os.environ.get("SWARM_RESPONSES_SYNC_DEFAULT", "10")))
+    except ValueError:
+        return 10.0
 
 
 async def _async_auth_dispatch(view: APIView, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
@@ -253,13 +265,14 @@ class ResponsesView(APIView):
             logger.warning(f"[ReqID: {request_id}] User '{request.user}' denied access to model '{model_name}'.")
             raise PermissionDenied(f"You do not have permission to access the model '{model_name}'.")
 
-        # Fast-path sync vs queued. The server runs the task on a background worker
-        # and waits up to `wait_seconds` for it to finish: returns the result inline
-        # (200) if it beats the deadline, else a handle (202, in_progress) the client
-        # polls. background:true => wait 0 (immediate handle). No wait configured =>
-        # the classic fully-blocking sync path. Streaming is always inline.
+        # Async-by-default: the task runs on a background worker (persisted to disk
+        # under its response_id) and we wait up to `wait_seconds` for it to finish —
+        # returns the result inline (200) if it beats the deadline, else a pollable
+        # handle (202, in_progress). background:true => wait 0 (immediate handle).
+        # Streaming is always inline. `store:false` can't be polled (nothing is
+        # persisted), so it always takes the inline blocking path.
         wait_seconds = _resolve_sync_wait(request_data, background)
-        if wait_seconds is not None and not stream:
+        if wait_seconds is not None and not stream and store:
             return await self._handle_hybrid(
                 request_id, model_name, messages, params, previous_response_id, wait_seconds
             )
@@ -559,7 +572,16 @@ def _run_background_response(
                 raise RuntimeError(f"Model '{model_name}' could not be initialized.")
             if hasattr(bp, "set_params"):
                 bp.set_params(params)
-            return await _consume_blueprint(bp, messages, cancel_check=lambda: _is_cancel_requested(response_id))
+            # Hard execution ceiling so a hung CLI/LLM (e.g. a stuck claude -p)
+            # fails the record instead of pinning the worker forever.
+            try:
+                exec_timeout = float(os.environ.get("SWARM_RESPONSES_EXEC_TIMEOUT", "600"))
+            except ValueError:
+                exec_timeout = 600.0
+            return await asyncio.wait_for(
+                _consume_blueprint(bp, messages, cancel_check=lambda: _is_cancel_requested(response_id)),
+                timeout=exec_timeout,
+            )
 
         answer, backend_meta = asyncio.run(_go())
         # A cancel may have landed between the last chunk and here.
@@ -572,6 +594,9 @@ def _run_background_response(
                 transcript=list(messages) + [{"role": "assistant", "content": answer}],
             )
             logger.info(f"[ReqID: {request_id}] async task {response_id} completed.")
+    except (TimeoutError, asyncio.TimeoutError):
+        logger.error(f"[ReqID: {request_id}] async task {response_id} timed out.")
+        _terminal("failed", error="execution timed out")
     except _Cancelled:
         _terminal("cancelled")
         logger.info(f"[ReqID: {request_id}] async task {response_id} cancelled mid-run.")

--- a/src/swarm/views/responses_views.py
+++ b/src/swarm/views/responses_views.py
@@ -477,21 +477,27 @@ class _Cancelled(Exception):
 
 
 async def _consume_blueprint(
-    blueprint_instance: Any, messages: list[dict[str, Any]], cancel_check: Any = None
+    blueprint_instance: Any, messages: list[dict[str, Any]], cancel_check: Any = None,
+    on_progress: Any = None,
 ) -> tuple[str, dict | None]:
     """Drive a blueprint to its final answer. Returns (answer, backend_meta).
 
     Shared by the synchronous handler and the async worker. ``cancel_check`` (a
     zero-arg callable) is polled between chunks; if it returns True we raise
-    :class:`_Cancelled`.
+    :class:`_Cancelled`. ``on_progress(entry)`` (if given) is called for each
+    structured progress chunk that carries a ``delegation`` payload — used to
+    stream per-delegation status into the persisted record.
     """
     final_message = None
     backend_meta = None
     async for chunk in blueprint_instance.run(messages, stream=False):
         if cancel_check is not None and cancel_check():
             raise _Cancelled()
-        if isinstance(chunk, dict) and chunk.get("meta"):
-            backend_meta = chunk["meta"]
+        if isinstance(chunk, dict):
+            if chunk.get("meta"):
+                backend_meta = chunk["meta"]
+            if on_progress is not None and chunk.get("delegation") is not None:
+                on_progress(chunk["delegation"])
         message = _extract_message_from_chunk(chunk)
         if message is None:
             continue
@@ -540,8 +546,17 @@ def _run_background_response(
     started = time.time()
     spec = _task_spec(request_id, model_name, messages, params, previous_response_id)
 
+    # Per-delegation progress, streamed into the persisted record as each
+    # parallel sub-task completes. Guarded by a lock for safe concurrent JSON
+    # updates from the blueprint's worker threads.
+    progress: list[dict] = []
+    progress_lock = threading.Lock()
+
     def _save(payload, transcript, *, keep_task=False):
         payload["execution_ms"] = int((time.time() - started) * 1000)
+        with progress_lock:
+            if progress:
+                payload["progress"] = list(progress)
         record = {"id": response_id, "object": "response", "response": payload, "messages": transcript}
         if keep_task:
             record["_task"] = spec
@@ -556,6 +571,15 @@ def _run_background_response(
         if error is not None:
             payload["error"] = {"message": str(error)}
         _save(payload, transcript)  # no _task: terminal states aren't resumed
+
+    def _on_progress(entry: dict) -> None:
+        # Append a {role, status, result/error, model_used} entry and re-persist
+        # the in_progress record so pollers see delegations as they finish.
+        with progress_lock:
+            progress.append(entry)
+        in_prog = _build_response_payload(request_id, model_name, "", previous_response_id, None, None, status="in_progress")
+        in_prog["started_at"] = int(started)
+        _save(in_prog, None, keep_task=True)
 
     # Mark in_progress (keep the task spec for restart-resume).
     in_prog = _build_response_payload(request_id, model_name, "", previous_response_id, None, None, status="in_progress")
@@ -579,7 +603,11 @@ def _run_background_response(
             except ValueError:
                 exec_timeout = 600.0
             return await asyncio.wait_for(
-                _consume_blueprint(bp, messages, cancel_check=lambda: _is_cancel_requested(response_id)),
+                _consume_blueprint(
+                    bp, messages,
+                    cancel_check=lambda: _is_cancel_requested(response_id),
+                    on_progress=_on_progress,
+                ),
                 timeout=exec_timeout,
             )
 

--- a/src/swarm/views/responses_views.py
+++ b/src/swarm/views/responses_views.py
@@ -189,9 +189,20 @@ async def _async_auth_dispatch(view: APIView, request: HttpRequest, *args: Any, 
 class ResponsesView(APIView):
     """Handles OpenAI Responses API requests (``/v1/responses``).
 
-    Reuses ``ChatCompletionsView``'s blueprint-resolution + run path. Stateful:
-    a response is persisted (unless ``store: false``) and ``previous_response_id``
-    continues a prior conversation. See :mod:`swarm.core.responses_store`.
+    Reuses ``ChatCompletionsView``'s blueprint-resolution + run path (identical
+    model/inference_profile resolution — no Responses-specific resolver), so it
+    is first-class for the full tiered flow, including ``hybrid_team``'s
+    claude-orchestrated structured delegation.
+
+    **Async-by-default + stateful.** Non-streaming work runs on a background
+    worker, persisted to disk by ``response_id`` (see
+    :mod:`swarm.core.responses_store`): a POST returns within a bounded window
+    (``SWARM_RESPONSES_SYNC_DEFAULT``, 10s) — inline (200) for fast blueprints, or
+    a pollable 202 handle for long claude-p + delegation runs that finish in the
+    background. Poll/continue via ``GET /v1/responses/<id>``; while in progress the
+    record carries a ``progress`` array of per-delegation status. ``store:false``
+    runs inline (nothing to poll); ``previous_response_id`` continues a prior
+    conversation.
     """
 
     @method_decorator(csrf_exempt)

--- a/src/swarm/views/responses_views.py
+++ b/src/swarm/views/responses_views.py
@@ -18,6 +18,7 @@ import sys
 import threading
 import time
 import uuid
+from functools import wraps
 from typing import Any
 
 from asgiref.sync import sync_to_async
@@ -112,6 +113,40 @@ def _coerce_content(content: Any) -> str:
                 parts.append(part)
         return "".join(parts)
     return str(content)
+
+
+def async_retry(max_attempts: int = 3, base_delay: float = 1.0, backoff_factor: float = 2.0, exceptions: tuple = (Exception,)):
+    """Retry an async function with exponential backoff on *transient* failures.
+
+    Deterministic client errors (DRF 4xx: ParseError/PermissionDenied/NotFound/
+    NotAuthenticated/ValidationError/Throttled/…) are re-raised immediately — they
+    won't succeed on retry and would only add latency. Anything else in
+    ``exceptions`` (5xx APIException, connection/timeout errors) is retried.
+    """
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            attempt = 0
+            delay = float(base_delay)
+            while True:
+                try:
+                    return await func(*args, **kwargs)
+                except exceptions as exc:
+                    # Fail fast on 4xx (client/deterministic) — retrying can't help.
+                    code = getattr(exc, "status_code", None)
+                    if isinstance(code, int) and 400 <= code < 500:
+                        raise
+                    attempt += 1
+                    if attempt >= max_attempts:
+                        raise
+                    logger.warning(
+                        "Retrying %s after transient error (attempt %d/%d, backoff %.1fs): %s",
+                        getattr(func, "__name__", "?"), attempt, max_attempts, delay, exc,
+                    )
+                    await asyncio.sleep(delay)
+                    delay *= backoff_factor
+        return wrapper
+    return decorator
 
 
 def _resolve_sync_wait(request_data: dict[str, Any], background: bool) -> float | None:
@@ -329,8 +364,13 @@ class ResponsesView(APIView):
         rec = await sync_to_async(responses_store.load)(response_id)
         return Response((rec or {}).get("response") or payload, status=status.HTTP_202_ACCEPTED)
 
+    @async_retry(max_attempts=3, base_delay=1.0, backoff_factor=2.0)
     async def _handle_non_streaming(self, blueprint_instance, messages, request_id, model_name, store=True, previous_response_id=None) -> Response:
-        """Consume the blueprint generator, keep the last message, shape a response object."""
+        """Consume the blueprint generator, keep the last message, shape a response object.
+
+        Retries transient (5xx/connection) failures with exponential backoff
+        (up to 3 attempts, 1s then 2s); 4xx client errors fail fast.
+        """
         final_message = None
         backend_meta = None
         try:

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -186,9 +186,11 @@ class TestResponsesStateful:
 
 @pytest.mark.django_db
 def test_responses_reports_nonzero_token_usage(client):
+    # Usage reporting is model-agnostic; use the fast, deterministic chatbot stub
+    # (cli_fusion drives real CLIs with unpredictable latency under async-default).
     resp = client.post(
         "/v1/responses",
-        data='{"model": "cli_fusion", "input": "In one word, capital of France?"}',
+        data='{"model": "chatbot", "input": "In one word, capital of France?"}',
         content_type="application/json",
     )
     assert resp.status_code == 200

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -275,7 +275,7 @@ class TestResponsesAsync:
         # Worker slower than the wait window -> 202 handle; then it finishes and polls completed.
         import swarm.views.responses_views as rv
 
-        async def _slow(bp, messages, cancel_check=None):
+        async def _slow(bp, messages, cancel_check=None, on_progress=None):
             await asyncio.sleep(0.8)
             return "You said: slow", None
 

--- a/tests/api/test_responses_hybrid_team.py
+++ b/tests/api/test_responses_hybrid_team.py
@@ -1,0 +1,59 @@
+"""Parity: /v1/responses drives hybrid_team end-to-end, same as chat_completions.
+
+Proves the Responses API runs the flagship blueprint's full flow (REST coordinator
++ grok persona + consensus panel) through the async-by-default worker — so the
+claude-orchestrated delegation machinery is reachable on Responses too. Determin-
+istic via SWARM_TEST_MODE (REST stub) + fake echo CLIs (no model/network).
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+from django.apps import apps
+
+PY = sys.executable
+
+
+def _echo(prefix: str) -> dict:
+    return {"cmd": [PY, "-c", f"import sys; print('{prefix}:' + sys.argv[1])", "{prompt}"]}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_blueprint_cache():
+    from swarm.views import utils as view_utils
+    view_utils._blueprint_instance_cache.clear()
+    yield
+    view_utils._blueprint_instance_cache.clear()
+
+
+@pytest.fixture
+def hybrid_config(monkeypatch):
+    cfg = {
+        "cli_agents": {"grok": _echo("GROK"), "a": _echo("A"), "b": _echo("B")},
+        "hybrid_team": {"grok": "grok", "panel": ["a", "b"]},
+    }
+    app = apps.get_app_config("swarm")
+    monkeypatch.setattr(app, "config", cfg, raising=False)
+    monkeypatch.setenv("SWARM_TEST_MODE", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-dummy-test-mode")
+    return cfg
+
+
+@pytest.mark.django_db(transaction=True)
+def test_responses_runs_hybrid_team_end_to_end(client, hybrid_config):
+    resp = client.post(
+        "/v1/responses",
+        data=json.dumps({"model": "hybrid_team", "input": "hi"}),
+        content_type="application/json",
+    )
+    # Fast under SWARM_TEST_MODE -> the async-default worker completes inside the
+    # sync window and returns the result inline.
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "completed"
+    text = body["output_text"]
+    assert "[rest-plan] hi" in text                 # REST coordinator ran via Responses
+    assert "GROK:" in text                           # grok persona delegated
+    assert ("A:" in text) or ("B:" in text)          # consensus panel ran

--- a/tests/api/test_responses_progress.py
+++ b/tests/api/test_responses_progress.py
@@ -1,0 +1,40 @@
+"""Responses worker captures per-delegation progress from blueprint chunks.
+
+A blueprint that emits ``delegation_progress`` chunks (carrying a ``delegation``
+payload) has those entries surfaced via ``_consume_blueprint``'s on_progress hook
+— which the async worker persists into the record's ``progress`` array.
+"""
+from __future__ import annotations
+
+from swarm.views.responses_views import _consume_blueprint
+
+
+class _FakeBlueprint:
+    async def run(self, messages, stream=False):
+        # two parallel delegations report in, then a final answer
+        yield {
+            "type": "delegation_progress", "content": "_• agent completed_",
+            "delegation": {"role": "agent", "status": "completed", "result": "coded it", "model_used": "gpt-4o"},
+        }
+        yield {
+            "type": "delegation_progress", "content": "_• auxiliary failed_",
+            "delegation": {"role": "auxiliary", "status": "failed", "error": "boom", "model_used": "gpt-4o-mini"},
+        }
+        yield {"messages": [{"role": "assistant", "content": "final answer"}], "final": True}
+
+
+async def test_consume_blueprint_streams_delegation_progress():
+    captured: list[dict] = []
+    answer, meta = await _consume_blueprint(_FakeBlueprint(), [], on_progress=captured.append)
+
+    assert answer == "final answer"  # delegation chunks don't pollute the answer
+    assert [c["role"] for c in captured] == ["agent", "auxiliary"]
+    assert captured[0]["status"] == "completed" and captured[0]["result"] == "coded it"
+    assert captured[1]["status"] == "failed" and captured[1]["error"] == "boom"
+    assert captured[0]["model_used"] == "gpt-4o"
+
+
+async def test_consume_blueprint_no_progress_callback_is_fine():
+    # Without on_progress the same blueprint still yields its final answer.
+    answer, _ = await _consume_blueprint(_FakeBlueprint(), [])
+    assert answer == "final answer"

--- a/tests/api/test_responses_retry.py
+++ b/tests/api/test_responses_retry.py
@@ -1,0 +1,48 @@
+"""async_retry: retry transient (5xx) failures, fail fast on 4xx client errors."""
+from __future__ import annotations
+
+import pytest
+from rest_framework.exceptions import APIException, NotFound, ParseError, PermissionDenied
+
+from swarm.views.responses_views import async_retry
+
+
+@pytest.mark.parametrize("exc", [ParseError, PermissionDenied, NotFound])
+async def test_4xx_client_errors_are_not_retried(exc):
+    calls = {"n": 0}
+
+    @async_retry(max_attempts=3, base_delay=0)
+    async def f():
+        calls["n"] += 1
+        raise exc("nope")
+
+    with pytest.raises(exc):
+        await f()
+    assert calls["n"] == 1  # failed fast, no backoff retries
+
+
+async def test_5xx_is_retried_then_succeeds():
+    calls = {"n": 0}
+
+    @async_retry(max_attempts=3, base_delay=0)
+    async def f():
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise APIException("transient 500")  # status_code 500
+        return "ok"
+
+    assert await f() == "ok"
+    assert calls["n"] == 2
+
+
+async def test_retries_exhaust_then_reraise():
+    calls = {"n": 0}
+
+    @async_retry(max_attempts=3, base_delay=0)
+    async def f():
+        calls["n"] += 1
+        raise APIException("always 500")
+
+    with pytest.raises(APIException):
+        await f()
+    assert calls["n"] == 3

--- a/tests/blueprints/test_hybrid_team_delegation.py
+++ b/tests/blueprints/test_hybrid_team_delegation.py
@@ -1,0 +1,97 @@
+"""claude-orchestrated structured delegation in hybrid_team.
+
+The orchestration brain (claude -p, when configured) returns a JSON plan +
+role delegations; run() parses them and routes each to its role's model. These
+tests cover the pure parsing + the deterministic test-mode routing, plus the
+claude path with a mocked persona (no live CLI / network).
+"""
+from __future__ import annotations
+
+from swarm.blueprints.hybrid_team.blueprint_hybrid_team import HybridTeamBlueprint
+
+CONFIG = {"llm": {"default": {"provider": "openai", "model": "d"}}}
+
+
+def _bp() -> HybridTeamBlueprint:
+    return HybridTeamBlueprint(config=CONFIG)
+
+
+# --- _parse_delegations ---------------------------------------------------- #
+
+def test_parse_clean_json():
+    raw = '{"plan":"do x","delegations":[{"role":"agent","task":"code it"},{"role":"auxiliary","task":"test it"}]}'
+    plan, dels = _bp()._parse_delegations(raw)
+    assert plan == "do x"
+    assert dels == [{"role": "agent", "task": "code it"}, {"role": "auxiliary", "task": "test it"}]
+
+
+def test_parse_json_embedded_in_prose():
+    raw = 'Sure!\n{"plan":"p","delegations":[{"role":"orchestration","task":"plan more"}]}\nDone.'
+    plan, dels = _bp()._parse_delegations(raw)
+    assert plan == "p"
+    assert dels == [{"role": "orchestration", "task": "plan more"}]
+
+
+def test_parse_drops_unknown_role_and_empty_task():
+    raw = ('{"plan":"p","delegations":['
+           '{"role":"wizard","task":"magic"},'
+           '{"role":"agent","task":""},'
+           '{"role":"AUXILIARY","task":"normalize case"}]}')
+    _, dels = _bp()._parse_delegations(raw)
+    assert dels == [{"role": "auxiliary", "task": "normalize case"}]  # case-normalized, unknown/empty dropped
+
+
+def test_parse_non_json_degrades_to_plain_plan():
+    plan, dels = _bp()._parse_delegations("just a plan, no json", fallback="fb")
+    assert plan == "just a plan, no json"
+    assert dels == []
+
+
+def test_parse_empty_uses_fallback():
+    plan, dels = _bp()._parse_delegations("", fallback="fb")
+    assert plan == "fb"
+    assert dels == []
+
+
+# --- deterministic test-mode routing --------------------------------------- #
+
+async def test_run_delegation_is_deterministic_in_test_mode(monkeypatch):
+    monkeypatch.setenv("SWARM_TEST_MODE", "1")
+    out = await _bp()._run_delegation({"role": "agent", "task": "do the thing"})
+    assert out == "[agent] do the thing"
+
+
+async def test_orchestrate_stub_in_test_mode(monkeypatch):
+    monkeypatch.setenv("SWARM_TEST_MODE", "1")
+    plan, dels = await _bp()._orchestrate("hi", registry=None)
+    assert plan == "[rest-plan] hi"
+    assert dels == []
+
+
+# --- claude path (mocked persona, no live CLI) ----------------------------- #
+
+async def test_orchestrate_uses_claude_json(monkeypatch):
+    monkeypatch.delenv("SWARM_TEST_MODE", raising=False)
+    bp = _bp()
+
+    async def fake_claude(prompt):
+        return '{"plan":"P","delegations":[{"role":"agent","task":"T"}]}'
+
+    monkeypatch.setattr(bp, "_claude_persona", lambda registry: fake_claude)
+    plan, dels = await bp._orchestrate("req", registry=object())
+    assert plan == "P"
+    assert dels == [{"role": "agent", "task": "T"}]
+
+
+async def test_orchestrate_without_claude_falls_back_to_plan(monkeypatch):
+    monkeypatch.delenv("SWARM_TEST_MODE", raising=False)
+    bp = _bp()
+    monkeypatch.setattr(bp, "_claude_persona", lambda registry: None)
+
+    async def fake_rest(prompt):
+        return "plain plan"
+
+    monkeypatch.setattr(bp, "_rest_reason", fake_rest)
+    plan, dels = await bp._orchestrate("req", registry=object())
+    assert plan == "plain plan"
+    assert dels == []

--- a/tests/blueprints/test_hybrid_team_parallel.py
+++ b/tests/blueprints/test_hybrid_team_parallel.py
@@ -1,0 +1,87 @@
+"""Parallel delegation execution in hybrid_team.
+
+Delegations run concurrently on a ThreadPoolExecutor with per-task timeout and
+error isolation. Deterministic under SWARM_TEST_MODE (the _run_delegation stub).
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from swarm.blueprints.hybrid_team.blueprint_hybrid_team import HybridTeamBlueprint
+
+CONFIG = {"llm": {"default": {"provider": "openai", "model": "d"}}}
+
+
+def _bp() -> HybridTeamBlueprint:
+    return HybridTeamBlueprint(config=CONFIG)
+
+
+@pytest.fixture(autouse=True)
+def _test_mode(monkeypatch):
+    monkeypatch.setenv("SWARM_TEST_MODE", "1")
+
+
+async def test_executes_all_delegations(monkeypatch):
+    dels = [
+        {"role": "agent", "task": "a"},
+        {"role": "auxiliary", "task": "b"},
+        {"role": "orchestration", "task": "c"},
+    ]
+    results = [ev async for ev in _bp()._execute_delegations(dels)]
+    assert len(results) == 3
+    assert all(ev["status"] == "completed" for ev in results)
+    by_role = {ev["role"]: ev for ev in results}
+    assert by_role["agent"]["result"] == "[agent] a"
+    assert by_role["auxiliary"]["result"] == "[auxiliary] b"
+    # every result carries the observability fields
+    for ev in results:
+        assert set(("role", "task", "status", "result", "model_used")) <= set(ev)
+
+
+async def test_runs_in_parallel_not_serial(monkeypatch):
+    # Make each delegation block ~0.4s; 3 in parallel (pool=4) finish near 0.4s,
+    # well under the 1.2s a serial run takes. Zero the launch stagger (a separate
+    # rate-limit concern) so this isolates the parallelism.
+    async def slow(d):
+        await __import__("asyncio").sleep(0.4)
+        return f"[{d['role']}] {d['task']}"
+
+    bp = _bp()
+    monkeypatch.setattr(bp, "_run_delegation", slow)
+    monkeypatch.setattr(HybridTeamBlueprint, "_DELEGATION_LAUNCH_DELAY_S", 0.0)
+    dels = [{"role": "agent", "task": str(i)} for i in range(3)]
+    started = time.monotonic()
+    results = [ev async for ev in bp._execute_delegations(dels)]
+    elapsed = time.monotonic() - started
+    assert len(results) == 3 and all(ev["status"] == "completed" for ev in results)
+    assert elapsed < 0.9, f"expected parallel (<0.9s), took {elapsed:.2f}s"
+
+
+async def test_error_isolation(monkeypatch):
+    async def maybe_boom(d):
+        if d["role"] == "agent":
+            raise RuntimeError("boom")
+        return f"[{d['role']}] {d['task']}"
+
+    bp = _bp()
+    monkeypatch.setattr(bp, "_run_delegation", maybe_boom)
+    dels = [{"role": "agent", "task": "x"}, {"role": "auxiliary", "task": "y"}]
+    results = {ev["role"]: ev async for ev in bp._execute_delegations(dels)}
+    assert results["agent"]["status"] == "failed"
+    assert "boom" in results["agent"]["error"]
+    assert results["auxiliary"]["status"] == "completed"  # one failure didn't kill the other
+
+
+async def test_per_delegation_timeout(monkeypatch):
+    async def hang(d):
+        await __import__("asyncio").sleep(5)
+        return "never"
+
+    bp = _bp()
+    monkeypatch.setattr(bp, "_run_delegation", hang)
+    monkeypatch.setattr(HybridTeamBlueprint, "_DELEGATION_TIMEOUT_S", 0.3)
+    results = [ev async for ev in bp._execute_delegations([{"role": "agent", "task": "x"}])]
+    assert results[0]["status"] == "failed"
+    assert "timed out" in results[0]["error"]


### PR DESCRIPTION
Tracking branch for the claude-default / smart-delegation effort. Sections land incrementally.

## Section 4 — claude-orchestrated structured delegation (this commit)

Lets `hybrid_team`'s coordinator use **claude -p as the orchestration brain**. When a `claude` cli_agent is configured, the coordinator emits structured JSON:

    {"plan": "...", "delegations": [{"role": "orchestration|agent|auxiliary", "task": "..."}]}

`run()` parses it and routes each delegation back through the **per-step model machinery** from #185 (`_agent_for_role` / `ROLE_PROFILES`), so each sub-task runs on the right model (orchestration→smartest, agent→coding, auxiliary→cheap).

New pieces in `blueprint_hybrid_team.py`:
- `_claude_persona(registry)` — a `claude` cli_persona when configured, else `None`.
- `_parse_delegations()` / `_extract_json_object()` — tolerant parsing (handles prose-wrapped JSON / fences), drops empty tasks and roles outside `ROLE_PROFILES`, normalizes role case, degrades to `(plan, [])` on non-JSON.
- `_orchestrate()` — prefer claude → structured delegations; without claude, fall back to the orchestration-role LLM plan (no delegations); deterministic stub under `SWARM_TEST_MODE`.
- `_run_delegation()` — execute each delegation on its role's model; deterministic under `SWARM_TEST_MODE`; degrades to a marker on failure.
- `run()` folds `Delegated [role]:` sections into the answer, keeping the grok/consensus CLI steps and the opt-in `auxiliary` synthesis.

**Backward compatible:** with no claude / under `SWARM_TEST_MODE`, the flow and output are unchanged — the prior per-step routing and all existing tests still pass.

### Tests
- New `tests/blueprints/test_hybrid_team_delegation.py` (9 cases): clean JSON, prose-wrapped JSON, unknown-role/empty-task dropping + case-normalization, non-JSON degradation, fallback, deterministic test-mode `_run_delegation`/`_orchestrate`, and the claude path via a mocked persona.
- 25 passed across `test_hybrid_team` + `test_hybrid_team_routing` + `test_hybrid_team_delegation`; 16 core inference tests green; blueprint imports clean.

## Still to come on this branch
- Section 2/6: CLI wiring (claude default + free CLIs kilocode/letta/vibe/agy) — **kept in the live `~/.config/swarm` config only**, not the public repo, per request.
- Section 3: surface claude/orchestration in resolution defaults.
- Section 5: remaining hardcoded-model cleanup in other blueprints.
- Section 7: docs polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)