### PR TITLE
a11y(spa): accessible names for reusable icon-only controls

### DIFF
--- a/webui/frontend/src/App.tsx
+++ b/webui/frontend/src/App.tsx
@@ -63,14 +63,18 @@ function App() {
                     </div>
                   </div>
                   <div className="flex items-center space-x-4">
-                    <label className="btn btn-ghost btn-sm btn-circle swap swap-rotate" aria-label="Toggle dark mode">
+                    <label
+                      className="btn btn-ghost btn-sm btn-circle swap swap-rotate"
+                      aria-label={darkMode ? 'Switch to light theme' : 'Switch to dark theme'}
+                    >
                       <input
                         type="checkbox"
                         checked={darkMode}
                         onChange={() => setDarkMode(!darkMode)}
+                        aria-label={darkMode ? 'Switch to light theme' : 'Switch to dark theme'}
                       />
-                      <Sun className="swap-on h-5 w-5" />
-                      <Moon className="swap-off h-5 w-5" />
+                      <Sun className="swap-on h-5 w-5" aria-hidden="true" />
+                      <Moon className="swap-off h-5 w-5" aria-hidden="true" />
                     </label>
                     <Link to="/settings" className="btn btn-ghost btn-sm" aria-label="Settings">
                       <Settings className="h-5 w-5" />

--- a/webui/frontend/src/components/DaisyUI/Pagination.tsx
+++ b/webui/frontend/src/components/DaisyUI/Pagination.tsx
@@ -70,8 +70,9 @@ export const Pagination = ({
         onClick={() => onPageChange(1)}
         disabled={currentPage === 1}
         className={buttonSize[size]}
+        aria-label="First page"
       >
-        <ChevronsLeft className="h-4 w-4" />
+        <ChevronsLeft className="h-4 w-4" aria-hidden="true" />
       </Button>
 
       {/* Previous page button */}
@@ -81,8 +82,9 @@ export const Pagination = ({
         onClick={() => onPageChange(currentPage - 1)}
         disabled={currentPage === 1}
         className={buttonSize[size]}
+        aria-label="Previous page"
       >
-        <ChevronLeft className="h-4 w-4" />
+        <ChevronLeft className="h-4 w-4" aria-hidden="true" />
       </Button>
 
       {/* Page numbers */}
@@ -105,8 +107,9 @@ export const Pagination = ({
         onClick={() => onPageChange(currentPage + 1)}
         disabled={currentPage === totalPages}
         className={buttonSize[size]}
+        aria-label="Next page"
       >
-        <ChevronRight className="h-4 w-4" />
+        <ChevronRight className="h-4 w-4" aria-hidden="true" />
       </Button>
 
       {/* Last page button */}
@@ -116,8 +119,9 @@ export const Pagination = ({
         onClick={() => onPageChange(totalPages)}
         disabled={currentPage === totalPages}
         className={buttonSize[size]}
+        aria-label="Last page"
       >
-        <ChevronsRight className="h-4 w-4" />
+        <ChevronsRight className="h-4 w-4" aria-hidden="true" />
       </Button>
     </div>
   );

--- a/webui/frontend/src/components/DaisyUI/Toast.tsx
+++ b/webui/frontend/src/components/DaisyUI/Toast.tsx
@@ -155,8 +155,9 @@ const ToastItem = ({ toast, removeToast }: ToastItemProps) => {
       <button
         className="btn btn-sm btn-ghost btn-circle ml-2"
         onClick={() => removeToast(toast.id)}
+        aria-label="Dismiss notification"
       >
-        <X className="h-4 w-4" />
+        <X className="h-4 w-4" aria-hidden="true" />
       </button>
     </div>
   );


### PR DESCRIPTION
Labels the reusable SPA components that lacked accessible names: the Toast close button (app-wide), the Pagination first/prev/next/last chevrons, and a stateful theme-toggle label. aria-hidden on decorative icons. **Non-visual** (accessibility tree only) — no screenshot diff; SPA built clean and all pages render.