### PR TITLE
SPIKE: Bootstrap 5.3 native dark mode (findings — do not merge yet)

### DIFF
--- a/src/swarm/templates/base.html
+++ b/src/swarm/templates/base.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-bs-theme="dark">
 <head>
     {% load static %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Open-Swarm</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="{% static 'css/rest_mode_style.css' %}" rel="stylesheet">
     <link href="{% static 'css/dropdown.css' %}" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{% static 'js/htmx.min.js' %}"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <!-- Prism: syntax highlighting for generated/blueprint code (dark theme to match) -->


### PR DESCRIPTION
**Exploratory spike — DRAFT, do not merge as-is.** Evaluates moving to Bootstrap 5.3's native dark mode (`data-bs-theme="dark"`) to retire most of the hand-written `rest_mode_style.css`.

## What I did
- base.html: Bootstrap `5.1.3 -> 5.3.3` + `data-bs-theme="dark"` on `<html>`.
- Captured the journey **with** custom CSS (zero regression) and **without** it (to see what 5.3 gives for free).

## Findings
**1. 5.3 native dark gives ~90% of the look for FREE.** With `rest_mode_style.css` fully disabled, pages like Teams Admin render almost identically — dark navbar, cards, **form controls**, tables, dropdowns, modals, muted text, buttons — all native. (Screenshot in the linked message.)

**2. The global Bootstrap component overrides in `rest_mode_style.css` are now redundant** and could retire: `.card`, `.form-control/.form-select`, `.table`, `.modal`, `.dropdown`, `.nav-tabs`, `.accordion`, `.list-group`, `.btn-*` dark overrides, `body` bg, `.bg-light/.bg-white` remaps — roughly **40–50% of the file**.

**3. What must STAY:** the `--os-*` design tokens, the `.os-*` helper classes (`os-chip`, `os-empty`, `os-stat`, `os-wrap`, `badge-status`, the focus-ring + WCAG contrast fixes), and each template's page-specific inline `<style>` (settings table, type tags, etc.). 5.3 doesn't provide these.

**4. Zero regressions + zero a11y regressions.** With custom CSS kept (this PR's state), all 13 journey pages render identical to main and **axe = 0 violations across all 5 audited pages**. So adopting 5.3 + `data-bs-theme` is a safe drop-in even before any cleanup.

## Recommendation
**Worth it, in two phases:**
- **Phase 1 (this PR, low-risk):** merge 5.3 + `data-bs-theme="dark"`, keep all custom CSS. Future-proofs Bootstrap, enables native dark, zero regression.
- **Phase 2 (incremental, a few careful PRs):** delete the redundant component overrides from `rest_mode_style.css`, re-capturing each page to verify. Net: ~40–50% less hand-written CSS to maintain.

Effort for Phase 2: moderate, low-risk if done incrementally with capture-verify. Awaiting your call to proceed.