### PR TITLE
feat(dev): auto-include CLI override in make dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ BIN ?= $(HOME)/.local/share/swarm/bin
 .PHONY: help dev test list-installed list-available build build-shim build-all-shims build-all-executables launch uninstall build-pyinstaller build-all-pyinstaller
 
 COMPOSE ?= docker compose
+# Host-coupled CLI mapping (gitignored). Auto-included by `make dev` when present
+# so the agentic CLIs (claude/opencode/qwen/grok) are mapped into the dev container;
+# a no-op on hosts without it. dev.yml stays LAST so its !override ports win.
+DEV_OVERRIDE := $(wildcard docker-compose.override.yml)
 
 help:
 	@echo "Open-Swarm Makefile"
@@ -37,7 +41,7 @@ help:
 # Bind-mounts the source via docker-compose.dev.yml; publishes host :8002 so it
 # coexists with the native :8001 service. Ctrl-C to stop.
 dev:
-	$(COMPOSE) -f docker-compose.yml -f docker-compose.dev.yml up --build
+	$(COMPOSE) -f docker-compose.yml $(if $(DEV_OVERRIDE),-f $(DEV_OVERRIDE)) -f docker-compose.dev.yml up --build
 
 test:
 	$(PY) python scripts/run_tests.py -q


### PR DESCRIPTION
## What & why
`make dev` (added in #211) used explicit `-f` flags, which **suppresses Compose's auto-merge** of the gitignored `docker-compose.override.yml`. Result: dev mode ran REST-only with **none of the host CLIs** (claude/opencode/qwen/grok) mapped in.

This auto-includes the override when it exists (no-op on hosts without it), keeping `docker-compose.dev.yml` **last** so its `!override` ports (`:8002`) still win.

```makefile
DEV_OVERRIDE := $(wildcard docker-compose.override.yml)
dev:
	$(COMPOSE) -f docker-compose.yml $(if $(DEV_OVERRIDE),-f $(DEV_OVERRIDE)) -f docker-compose.dev.yml up --build
```

## Verified live
- Merged config maps the CLI `volumes` + `PATH` and keeps only `:8002` published.
- Inside the running dev container: `claude`/`opencode`/`qwen` resolve to `~/.npm-global/bin`, `node` to `/usr/local/bin/node`; auth/config dirs (`.claude`, `.config/opencode`, `.qwen`) are mounted.
- API up on `:8002` (HTTP 200).

## Known caveat (not introduced here)
Executing the node-based CLIs inside the slim container hits host-coupling — node throws at `os.userInfo()` because the container runs as the host UID with no `/etc/passwd` entry. This is the documented reason **native `:8001` is preferred for CLIs**. The mapping is correctly wired; in-container execution is a separate, pre-existing limitation.

## Answer to "are CLIs/configs mapped via .env or override?"
Override. `.env` only carries provider keys + interpolation vars (and the base compose has no `env_file:`, so `.env` secrets aren't injected — CLIs self-auth via their mounted config dirs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)