### PR TITLE
feat: use DATABASE_URL (Postgres) when set; restore .env injection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,12 +43,22 @@ services:
     # Run as your host user so any folders you later bind-mount (CLI auth, config)
     # stay readable/writable and files the app writes don't end up root-owned.
     user: "${DOCKER_UID:-1000}:${DOCKER_GID:-1000}"
+    # Inject provider keys / app config from .env (e.g. DATABASE_URL, *_API_KEY).
+    # required:false keeps this portable — a no-op when no .env is present.
+    # Explicit `environment:` below still wins over anything in .env.
+    env_file:
+      - path: .env
+        required: false
     ports:
       # Portable default. On a host where 8000 is taken (e.g. another service),
       # remap with an override rather than editing this published default.
       # For live-reload dev, use: make dev  (docker-compose.dev.yml, host :8002).
       - "8000:8000"
     environment:
+      # Pin the in-container listen port. `environment` wins over `env_file`, so
+      # this shields the container from a host-oriented PORT in .env (e.g. the
+      # gateway's 8765) — the published `ports:` mapping alone sets the host port.
+      PORT: "8000"
       # Keep HOME identical to the host so configs that reference absolute paths
       # resolve, and the bare CLI commands find their state once you map them in.
       HOME: "${HOME}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "uvicorn>=0.23.0",
     "gunicorn>=21.0.0",
     "psycopg2-binary>=2.9.0",
+    "dj-database-url>=2.1.0",
     "django-extensions>=3.2.0",
     "drf-yasg>=1.21.0",
     "channels>=4.0",

--- a/src/swarm/settings.py
+++ b/src/swarm/settings.py
@@ -167,19 +167,31 @@ TEMPLATES = [
 WSGI_APPLICATION = 'swarm.wsgi.application'
 ASGI_APPLICATION = 'swarm.asgi.application'
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.environ.get('DJANGO_DB_NAME', '/tmp/db.sqlite3'),
-        'TEST': {
-            'NAME': os.environ.get('DJANGO_TEST_DB_NAME', '/tmp/test_db.sqlite3'),
-            'OPTIONS': {
-                'timeout': 20,
-                'init_command': "PRAGMA journal_mode=WAL;",
-            },
-        },
+# Database — use Postgres (or any Django-supported backend) when DATABASE_URL is
+# set, e.g. DATABASE_URL=postgres://user:pass@host:5432/dbname. Otherwise fall
+# back to the zero-config SQLite default used for local/dev/tests.
+DATABASE_URL = os.environ.get('DATABASE_URL')
+if DATABASE_URL:
+    import dj_database_url
+    DATABASES = {
+        'default': dj_database_url.parse(
+            DATABASE_URL, conn_max_age=600, conn_health_checks=True
+        ),
     }
-}
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': os.environ.get('DJANGO_DB_NAME', '/tmp/db.sqlite3'),
+            'TEST': {
+                'NAME': os.environ.get('DJANGO_TEST_DB_NAME', '/tmp/test_db.sqlite3'),
+                'OPTIONS': {
+                    'timeout': 20,
+                    'init_command': "PRAGMA journal_mode=WAL;",
+                },
+            },
+        }
+    }
 
 AUTH_PASSWORD_VALIDATORS = [
     {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',},


### PR DESCRIPTION
## What & why
You added a valid Postgres `DATABASE_URL` to `.env`, but the app ignored it and `.env` wasn't even reaching the container.

- **`settings.py`** — `DATABASES` switches to **Postgres** (or any Django backend) when `DATABASE_URL` is set; otherwise the existing **SQLite** default (kept for local/dev/tests).
- **`pyproject.toml`** — add `dj-database-url` (the `psycopg2-binary` driver was already a dep but unused).
- **`docker-compose.yml`** — **restore `env_file: .env`** (`required: false`). The `.yaml`→`.yml` consolidation dropped it, so no `.env` vars (`DATABASE_URL`, `*_API_KEY`) reached the container. Now they do.
- **`docker-compose.yml`** — **pin `PORT=8000`** in `environment` (wins over `env_file`) so a host-oriented `PORT` in `.env` (the gateway's `8765`) can't hijack the container's listen port. The `ports:` mapping alone sets the host port.

## Verified live
In the dev container against the real Neon `DATABASE_URL`:
- `DB vendor: postgresql` (`neondb`), **24 migrations applied**
- `/v1/models` → **200** on `:8002`, in-container bind `0.0.0.0:8000`
- SQLite fallback retained when `DATABASE_URL` is unset (CI/local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)