### PR TITLE
feat(moa): moa-init, hybrid_moa, Open WebUI preset, multi-seat Grok demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **`swarm-cli moa-init`**: merge default `moa` config (Grok live / fake CI presets); `--show-openwebui` connection JSON
+- **`hybrid_moa` blueprint**: MoA consult then implementer `decision.md` write
+- Docs: `docs/OPENWEBUI_MOA.md`, `docs/examples/moa.swarm_config.json`, multi-seat demo `scripts/demo_moa_grok_multiseat.py`
+
 ## [0.5.4] — 2026-06-19
 
 ### Fixed — `django_chat` actually resolves its LLM profile
@@ -262,6 +267,7 @@ Turn the agentic CLIs you already have installed (`claude`, `gemini`, `codex`,
 - Fixed Django 4 SPA `re_path` import; chat non-streaming generator `aclose`; discovery skip of same-class alias re-exports.
 - **Grok first-class MoA participant** (`GrokParticipantBackend` in `backends.py`); multi-seat labels; CLI defaults no longer Codex-centric (`analyst,critic` / fake); docs state Codex not required.
 - **Hybrid A←B:** `run_hybrid_scripted` + coordinator `consult_moa_panel` tool (read-only MoA then implementer write).
+- **`swarm-cli moa-init`**, `docs/examples/moa.swarm_config.json`, Open WebUI preset (`docs/OPENWEBUI_MOA.md`), blueprint **`hybrid_moa`**, multi-seat demo script.
 - Comprehensive unit tests for low-coverage modules: `audit.py`, `progress.py`, `output_formatters.py`, and `ansi_box.py`
 - Test coverage for `ChucksAngelsBlueprint` class
 - Test coverage for `DiffFormatter` and `StatusFormatter` classes

--- a/docs/MOA.md
+++ b/docs/MOA.md
@@ -119,9 +119,29 @@ Participants may emit free text **or** structured JSON:
 {"claim": "use redis with TTL", "confidence": 0.9, "evidence": ["shared cache"]}
 ```
 
+## Config init
+
+```bash
+swarm-cli moa-init              # dry-run print default moa block
+swarm-cli moa-init --write      # merge into XDG / discovered swarm_config.json
+swarm-cli moa-init --show-openwebui
+```
+
+Example file: `docs/examples/moa.swarm_config.json`.  
+Open WebUI setup: `docs/OPENWEBUI_MOA.md`.
+
+## Hybrid blueprint
+
+Model id **`hybrid_moa`**: consult MoA (read-only) then implementer writes `decision.md`.
+
+```bash
+python scripts/demo_moa_grok_multiseat.py   # live multi-seat grok or fake fallback
+```
+
 ## Tests
 
 ```bash
 pytest tests/core/test_moa*.py tests/cli/test_moa_command.py \
-  tests/api/test_moa*.py tests/integration/test_swarm_workflows_proof.py -q --no-cov
+  tests/api/test_moa*.py tests/integration/test_swarm_workflows_proof.py \
+  tests/integration/test_hybrid_moa_persona.py tests/core/test_moa_config.py -q --no-cov
 ```

--- a/docs/OPENWEBUI_MOA.md
+++ b/docs/OPENWEBUI_MOA.md
@@ -1,0 +1,58 @@
+# Open WebUI / OpenAI client preset for MoA
+
+Point any OpenAI-compatible client (Open WebUI, Continue, curl) at **swarm-api**.
+
+## Connection
+
+| Field | Value |
+|-------|--------|
+| Base URL | `http://localhost:8000/v1` (or your deployed host) |
+| API key | `SWARM_API_KEY` / token configured for the API |
+| Model | `moa` (aliases: `mixture_of_agents`, `cli_fusion`, `cli_ensemble`) |
+| Hybrid | `hybrid_moa` — MoA consult then write `decision.md` |
+
+## Example request
+
+```bash
+curl -s "$OPENAI_BASE_URL/chat/completions" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "moa",
+    "messages": [{"role": "user", "content": "Should we rate-limit the public API?"}],
+    "params": {
+      "backend": "grok",
+      "participants": ["analyst", "critic"]
+    }
+  }'
+```
+
+CI-safe (no live CLI):
+
+```json
+"params": {
+  "backend": "fake",
+  "participants": ["analyst", "critic"],
+  "fake_responses": {
+    "analyst": "{\"claim\":\"yes token bucket\",\"confidence\":0.9}",
+    "critic": "{\"claim\":\"yes with metrics\",\"confidence\":0.85}"
+  }
+}
+```
+
+`system_fingerprint` looks like `moa:analyst+critic`.
+
+## Open WebUI UI steps
+
+1. Admin → Connections → OpenAI → add connection with Base URL + API key above  
+2. Enable model **`moa`** (and optionally **`hybrid_moa`**)  
+3. In chat advanced/body params, pass `params` as custom body if your Open WebUI build supports it; otherwise configure defaults via `swarm_config.json` `moa` block  
+
+## Config init
+
+```bash
+swarm-cli moa-init --write
+# or merge into a specific file:
+swarm-cli moa-init --config ./swarm_config.json --write
+swarm-cli moa-init --show-openwebui   # print connection JSON
+```

--- a/docs/examples/moa.swarm_config.json
+++ b/docs/examples/moa.swarm_config.json
@@ -1,0 +1,37 @@
+{
+  "_comment": "Mixture of Agents (read-only consensus). Merge the 'moa' block into your swarm_config.json. Live path uses local grok CLI; Codex is not required. See docs/MOA.md.",
+
+  "llm": {
+    "default": {
+      "provider": "openai",
+      "model": "gpt-4o",
+      "base_url": "https://api.openai.com/v1",
+      "api_key": "${OPENAI_API_KEY}"
+    }
+  },
+
+  "moa": {
+    "backend": "grok",
+    "participants": ["analyst", "critic"],
+    "permission": "approve-reads",
+    "default_timeout": 300,
+    "presets": {
+      "default": {
+        "backend": "grok",
+        "participants": ["analyst", "critic"]
+      },
+      "ci": {
+        "backend": "fake",
+        "participants": ["analyst", "critic"],
+        "fake_responses": {
+          "analyst": "{\"claim\":\"Prefer a simple safe option\",\"confidence\":0.85}",
+          "critic": "{\"claim\":\"Prefer a simple safe option with monitoring\",\"confidence\":0.8}"
+        }
+      },
+      "single-grok": {
+        "backend": "grok",
+        "participants": ["grok"]
+      }
+    }
+  }
+}

--- a/scripts/demo_moa_grok_multiseat.py
+++ b/scripts/demo_moa_grok_multiseat.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Live multi-seat Grok MoA demo (or fake fallback). Writes an artifact directory."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+OUT = Path(
+    __import__("os").environ.get(
+        "MOA_DEMO_OUT",
+        str(ROOT / "docs" / "proofs" / "moa_grok_multiseat"),
+    )
+)
+
+
+async def main() -> int:
+    from swarm.core.moa import GrokParticipantBackend
+    from swarm.core.moa.cli import run_moa_cli
+
+    OUT.mkdir(parents=True, exist_ok=True)
+    question = (
+        "Should open-swarm default public APIs to token-bucket rate limiting "
+        "at the edge? Answer with a short recommendation."
+    )
+    seats = ["analyst", "critic"]
+    grok = GrokParticipantBackend()
+    use_grok = grok.is_available()
+    backend = "grok" if use_grok else "fake"
+    fake = None
+    if not use_grok:
+        fake = {
+            "analyst": (
+                '{"claim":"Yes — token bucket at the edge with clear defaults",'
+                '"confidence":0.88,"evidence":["abuse risk"]}'
+            ),
+            "critic": (
+                '{"claim":"Yes — token bucket plus metrics and a kill switch",'
+                '"confidence":0.84,"evidence":["operability"]}'
+            ),
+        }
+
+    payload = await run_moa_cli(
+        question,
+        seats,
+        backend=backend,
+        fake_responses=fake,
+        cwd=str(ROOT),
+        timeout=120.0,
+        act=False,
+        trace_path=str(OUT / "trace.json"),
+    )
+
+    report = {
+        "when": datetime.now(timezone.utc).isoformat(),
+        "backend": backend,
+        "grok_available": use_grok,
+        "question": question,
+        "seats": seats,
+        "opinions": payload.get("opinions"),
+        "determination": payload.get("determination"),
+    }
+    (OUT / "report.json").write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    det = (payload.get("determination") or {}).get("answer") or ""
+    (OUT / "determination.md").write_text(
+        f"# MoA multi-seat demo\n\nBackend: `{backend}`\n\n## Question\n{question}\n\n"
+        f"## Determination\n\n{det}\n",
+        encoding="utf-8",
+    )
+    print(json.dumps({"backend": backend, "ok": bool(det), "out": str(OUT)}, indent=2))
+    print("--- determination preview ---")
+    print(det[:800] if det else "(empty)")
+    return 0 if det else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/swarm/blueprints/hybrid_moa/README.md
+++ b/src/swarm/blueprints/hybrid_moa/README.md
@@ -1,0 +1,14 @@
+# hybrid_moa
+
+Hybrid champagne: **MoA consult (read-only)** then **implementer write**.
+
+```bash
+# Via API
+curl -s localhost:8000/v1/chat/completions \
+  -H "Authorization: Bearer $SWARM_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"hybrid_moa","messages":[{"role":"user","content":"Enable rate limits?"}],
+       "params":{"backend":"fake","preset":"ci","workdir":"/tmp/hybrid-demo"}}'
+```
+
+See `docs/MOA.md` and `docs/SWARM_WORKFLOWS.md`.

--- a/src/swarm/blueprints/hybrid_moa/__init__.py
+++ b/src/swarm/blueprints/hybrid_moa/__init__.py
@@ -1,0 +1,1 @@
+"""Hybrid MoA blueprint package — persona coordinator + MoA consult."""

--- a/src/swarm/blueprints/hybrid_moa/blueprint_hybrid_moa.py
+++ b/src/swarm/blueprints/hybrid_moa/blueprint_hybrid_moa.py
@@ -1,0 +1,113 @@
+"""Hybrid MoA blueprint — workflow B coordinator consults MoA (A) then acts.
+
+Model id: ``hybrid_moa``.
+
+Flow:
+1. ``consult_moa`` (read-only panel → orchestrator determination, no act)
+2. Return determination; optional workspace write of decision.md when workdir set
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, ClassVar
+
+from swarm.core.blueprint_base import BlueprintBase
+from swarm.core.moa.config import resolve_moa_preset
+from swarm.core.persona_swarm import run_hybrid_scripted
+
+logger = logging.getLogger(__name__)
+
+
+class HybridMoABlueprint(BlueprintBase):
+    """Persona implementer applies MoA consensus (champagne A←B)."""
+
+    metadata: ClassVar[dict[str, Any]] = {
+        "name": "hybrid_moa",
+        "title": "Hybrid MoA (consult panel, then write decision)",
+        "description": (
+            "Coordinator runs Mixture of Agents (read-only participants) then "
+            "the implementer persona writes decision.md. Grok-backed panel by "
+            "default when configured; fake for CI."
+        ),
+        "version": "0.1.0",
+        "author": "Open Swarm Team",
+        "tags": ["moa", "hybrid", "persona", "consensus", "readonly-panel"],
+        "aliases": ["moa_hybrid", "hybrid-consensus"],
+        "required_mcp_servers": [],
+        "env_vars": [],
+    }
+
+    def __init__(self, blueprint_id: str = "hybrid_moa", config=None, config_path=None, **kwargs):
+        super().__init__(blueprint_id, config=config, config_path=config_path, **kwargs)
+        self._params: dict[str, Any] = {}
+
+    def set_params(self, params: dict[str, Any] | None) -> None:
+        self._params = dict(params or {})
+
+    def _moa_settings(self) -> dict[str, Any]:
+        moa_cfg = dict((self._config or {}).get("moa") or {})
+        preset = self._params.get("preset")
+        if preset:
+            try:
+                moa_cfg = resolve_moa_preset(moa_cfg, str(preset))
+            except KeyError as e:
+                logger.warning("%s", e)
+        # Per-request overrides
+        for key in ("backend", "participants", "permission", "fake_responses", "timeout"):
+            if key in self._params:
+                moa_cfg[key] = self._params[key]
+        return moa_cfg
+
+    async def run(self, messages: list[dict[str, Any]], **kwargs) -> Any:
+        parts = []
+        for m in messages or []:
+            if isinstance(m, dict) and m.get("content"):
+                role = (m.get("role") or "user").upper()
+                parts.append(f"{role}: {m['content']}")
+        question = "\n\n".join(parts).strip()
+        if not question:
+            yield {
+                "messages": [{"role": "assistant", "content": "No prompt provided."}],
+                "final": True,
+            }
+            return
+
+        settings = self._moa_settings()
+        backend = str(settings.get("backend") or "fake")
+        participants = settings.get("participants") or ["analyst", "critic"]
+        if isinstance(participants, str):
+            participants = [p.strip() for p in participants.split(",") if p.strip()]
+        fake = settings.get("fake_responses")
+        workdir = self._params.get("workdir") or self._params.get("cwd") or "."
+        seed = {}
+        notes_path = Path(workdir) / "notes.txt"
+        if notes_path.is_file():
+            seed = None  # use existing workspace
+        else:
+            seed = {"notes.txt": question[:2000]}
+
+        result = await run_hybrid_scripted(
+            workdir,
+            question,
+            seed_files=seed,
+            moa_backend=backend,
+            moa_participants=list(participants),
+            moa_fake_responses=dict(fake) if isinstance(fake, dict) else None,
+        )
+        content = result.final or (result.steps[0].output if result.steps else "")
+        meta = {
+            "hybrid_moa": True,
+            "moa": True,
+            "backends": list(participants),
+            "writes": list(result.writes),
+            "steps": [s.persona for s in result.steps],
+        }
+        yield {
+            "messages": [{"role": "assistant", "content": content}],
+            "role": "assistant",
+            "content": content,
+            "final": True,
+            "meta": meta,
+        }

--- a/src/swarm/core/moa/config.py
+++ b/src/swarm/core/moa/config.py
@@ -1,0 +1,120 @@
+"""MoA config helpers — default block + merge into swarm_config.json."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MOA_BLOCK: dict[str, Any] = {
+    "backend": "grok",
+    "participants": ["analyst", "critic"],
+    "permission": "approve-reads",
+    "default_timeout": 300,
+    "presets": {
+        "default": {
+            "backend": "grok",
+            "participants": ["analyst", "critic"],
+        },
+        "ci": {
+            "backend": "fake",
+            "participants": ["analyst", "critic"],
+            "fake_responses": {
+                "analyst": (
+                    '{"claim":"Prefer a simple safe option","confidence":0.85}'
+                ),
+                "critic": (
+                    '{"claim":"Prefer a simple safe option with monitoring",'
+                    '"confidence":0.8}'
+                ),
+            },
+        },
+        "single-grok": {
+            "backend": "grok",
+            "participants": ["grok"],
+        },
+    },
+}
+
+# Open WebUI / OpenAI-compatible client preset (document + export helper).
+OPENWEBUI_MOA_CONNECTION: dict[str, Any] = {
+    "name": "Open Swarm MoA",
+    "model": "moa",
+    "base_url": "http://localhost:8000/v1",
+    "api_key": "${SWARM_API_KEY}",
+    "params": {
+        "backend": "grok",
+        "participants": ["analyst", "critic"],
+    },
+    "notes": (
+        "Point Open WebUI (or any OpenAI client) at the swarm-api base URL. "
+        "model id 'moa' (aliases: mixture_of_agents, cli_fusion, cli_ensemble). "
+        "Use params.backend=fake + fake_responses for CI."
+    ),
+}
+
+
+def merge_moa_config(
+    existing: dict[str, Any] | None,
+    *,
+    overwrite: bool = False,
+    backend: str | None = None,
+    participants: list[str] | None = None,
+) -> dict[str, Any]:
+    """Return a full config dict with a ``moa`` block merged in."""
+    cfg = deepcopy(existing) if existing else {}
+    if "moa" in cfg and not overwrite:
+        # Still allow field-level defaults for missing keys
+        moa = dict(cfg["moa"])
+        for k, v in DEFAULT_MOA_BLOCK.items():
+            moa.setdefault(k, deepcopy(v))
+    else:
+        moa = deepcopy(DEFAULT_MOA_BLOCK)
+    if backend:
+        moa["backend"] = backend
+    if participants:
+        moa["participants"] = list(participants)
+    cfg["moa"] = moa
+    cfg.setdefault("llm", cfg.get("llm") or {})
+    return cfg
+
+
+def write_moa_config(
+    path: Path,
+    *,
+    overwrite: bool = False,
+    backend: str | None = None,
+    participants: list[str] | None = None,
+) -> Path:
+    """Load-or-create swarm_config.json at ``path`` and merge MoA defaults."""
+    path = Path(path)
+    existing: dict[str, Any] = {}
+    if path.is_file():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(existing, dict):
+                existing = {}
+        except json.JSONDecodeError:
+            existing = {}
+    cfg = merge_moa_config(
+        existing, overwrite=overwrite, backend=backend, participants=participants
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def resolve_moa_preset(
+    moa_cfg: dict[str, Any] | None, preset: str | None
+) -> dict[str, Any]:
+    """Flatten a named preset onto the moa config (preset fields win)."""
+    base = dict(moa_cfg or {})
+    if not preset:
+        return base
+    presets = base.get("presets") or {}
+    if preset not in presets:
+        raise KeyError(f"unknown moa preset {preset!r}; known: {sorted(presets)}")
+    overlay = dict(presets[preset] or {})
+    out = {**base, **overlay}
+    return out

--- a/src/swarm/core/swarm_cli.py
+++ b/src/swarm/core/swarm_cli.py
@@ -559,6 +559,100 @@ import shutil as _shutil
 from pathlib import Path as _Path
 
 
+@app.command(name="moa-init")
+def moa_init(
+    config: str = typer.Option(
+        None,
+        "--config",
+        help="Path to swarm_config.json (default: XDG user config or find_config_file).",
+    ),
+    write: bool = typer.Option(
+        False,
+        "--write",
+        help="Write merged MoA block to the config file (otherwise dry-run print).",
+    ),
+    overwrite: bool = typer.Option(
+        False,
+        "--overwrite",
+        help="Replace existing moa block entirely (default merges missing keys only).",
+    ),
+    backend: str = typer.Option(
+        None,
+        "--backend",
+        help="Override moa.backend (fake|grok|acpx). Default template uses grok.",
+    ),
+    participants: str = typer.Option(
+        None,
+        "--participants",
+        "-p",
+        help="Comma-separated seat names for moa.participants.",
+    ),
+    show_openwebui: bool = typer.Option(
+        False,
+        "--show-openwebui",
+        help="Print Open WebUI / OpenAI client connection JSON and exit.",
+    ),
+):
+    """Install default Mixture of Agents (moa) config block (Grok live; no Codex)."""
+    import json as _json
+    from pathlib import Path as _Path
+
+    from swarm.core import paths as _paths
+    from swarm.core.config_loader import find_config_file
+    from swarm.core.moa.config import (
+        DEFAULT_MOA_BLOCK,
+        OPENWEBUI_MOA_CONNECTION,
+        merge_moa_config,
+        write_moa_config,
+    )
+
+    if show_openwebui:
+        typer.echo(_json.dumps(OPENWEBUI_MOA_CONNECTION, indent=2))
+        raise typer.Exit(code=0)
+
+    if config:
+        cfg_path = _Path(config)
+    else:
+        found = find_config_file()
+        cfg_path = found if found else (
+            _paths.get_user_config_dir_for_swarm() / "swarm_config.json"
+        )
+
+    seats = None
+    if participants:
+        seats = [s.strip() for s in participants.split(",") if s.strip()]
+
+    existing = {}
+    if cfg_path.is_file():
+        try:
+            existing = _json.loads(cfg_path.read_text(encoding="utf-8"))
+        except Exception:
+            existing = {}
+
+    merged = merge_moa_config(
+        existing if isinstance(existing, dict) else {},
+        overwrite=overwrite,
+        backend=backend,
+        participants=seats,
+    )
+
+    if not write:
+        typer.echo(f"# Dry-run — would write moa block to {cfg_path}")
+        typer.echo(_json.dumps({"moa": merged.get("moa", DEFAULT_MOA_BLOCK)}, indent=2))
+        typer.echo("\nRe-run with --write to persist. See docs/OPENWEBUI_MOA.md")
+        raise typer.Exit(code=0)
+
+    path = write_moa_config(
+        cfg_path,
+        overwrite=overwrite,
+        backend=backend,
+        participants=seats,
+    )
+    typer.echo(f"Wrote MoA config to {path}")
+    typer.echo(f"  backend={merged['moa'].get('backend')} participants={merged['moa'].get('participants')}")
+    typer.echo("Models: moa | hybrid_moa | mixture_of_agents (legacy: cli_fusion, cli_ensemble)")
+
+
 @app.command(name="config")
 def config_cmd(
     action: str = typer.Argument(..., help="list | add | remove"),

--- a/tests/cli/test_moa_init_command.py
+++ b/tests/cli/test_moa_init_command.py
@@ -1,0 +1,65 @@
+"""Tests for swarm-cli moa-init."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_moa_init_write(tmp_path: Path):
+    cfg = tmp_path / "swarm_config.json"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT / "src")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from swarm.core.swarm_cli import app; import sys; "
+            "sys.argv=['swarm-cli']+sys.argv[1:]; app()",
+            "moa-init",
+            "--config",
+            str(cfg),
+            "--write",
+            "--backend",
+            "fake",
+            "-p",
+            "a,b",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(ROOT),
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    data = json.loads(cfg.read_text(encoding="utf-8"))
+    assert data["moa"]["backend"] == "fake"
+    assert data["moa"]["participants"] == ["a", "b"]
+
+
+def test_moa_init_show_openwebui():
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT / "src")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from swarm.core.swarm_cli import app; import sys; "
+            "sys.argv=['swarm-cli']+sys.argv[1:]; app()",
+            "moa-init",
+            "--show-openwebui",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(ROOT),
+        timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr
+    data = json.loads(proc.stdout)
+    assert data["model"] == "moa"

--- a/tests/core/test_moa_config.py
+++ b/tests/core/test_moa_config.py
@@ -1,0 +1,57 @@
+"""Tests for MoA config merge / init helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from swarm.core.moa.config import (
+    DEFAULT_MOA_BLOCK,
+    OPENWEBUI_MOA_CONNECTION,
+    merge_moa_config,
+    resolve_moa_preset,
+    write_moa_config,
+)
+
+
+def test_merge_moa_config_defaults():
+    cfg = merge_moa_config({})
+    assert "moa" in cfg
+    assert cfg["moa"]["backend"] == "grok"
+    assert "analyst" in cfg["moa"]["participants"]
+    assert "presets" in cfg["moa"]
+
+
+def test_merge_preserves_existing_unless_overwrite():
+    existing = {"moa": {"backend": "fake", "participants": ["only"]}, "llm": {"default": {}}}
+    cfg = merge_moa_config(existing, overwrite=False)
+    assert cfg["moa"]["backend"] == "fake"
+    assert cfg["moa"]["participants"] == ["only"]
+    # missing keys filled
+    assert "permission" in cfg["moa"]
+    cfg2 = merge_moa_config(existing, overwrite=True)
+    assert cfg2["moa"]["backend"] == DEFAULT_MOA_BLOCK["backend"]
+
+
+def test_write_moa_config(tmp_path: Path):
+    path = tmp_path / "swarm_config.json"
+    write_moa_config(path, backend="fake", participants=["a", "b"])
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["moa"]["backend"] == "fake"
+    assert data["moa"]["participants"] == ["a", "b"]
+
+
+def test_resolve_moa_preset():
+    moa = merge_moa_config({})["moa"]
+    ci = resolve_moa_preset(moa, "ci")
+    assert ci["backend"] == "fake"
+    assert "fake_responses" in ci
+    with pytest.raises(KeyError):
+        resolve_moa_preset(moa, "nope")
+
+
+def test_openwebui_connection_preset():
+    assert OPENWEBUI_MOA_CONNECTION["model"] == "moa"
+    assert "/v1" in OPENWEBUI_MOA_CONNECTION["base_url"]

--- a/tests/unit/blueprints/test_hybrid_moa_blueprint.py
+++ b/tests/unit/blueprints/test_hybrid_moa_blueprint.py
@@ -1,0 +1,40 @@
+"""Unit tests for hybrid_moa blueprint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from swarm.blueprints.hybrid_moa.blueprint_hybrid_moa import HybridMoABlueprint
+
+
+@pytest.mark.asyncio
+async def test_hybrid_moa_blueprint_run(tmp_path: Path):
+    bp = HybridMoABlueprint(blueprint_id="hybrid_moa")
+    bp._config = {
+        "moa": {
+            "backend": "fake",
+            "participants": ["analyst", "critic"],
+            "presets": {
+                "ci": {
+                    "backend": "fake",
+                    "participants": ["analyst", "critic"],
+                    "fake_responses": {
+                        "analyst": '{"claim":"yes bucket","confidence":0.9}',
+                        "critic": '{"claim":"yes bucket+metrics","confidence":0.8}',
+                    },
+                }
+            },
+        }
+    }
+    bp.set_params({"preset": "ci", "workdir": str(tmp_path), "backend": "fake"})
+    chunks = []
+    async for c in bp.run([{"role": "user", "content": "Rate limit the API?"}]):
+        chunks.append(c)
+    final = chunks[-1]
+    assert final.get("final") is True
+    content = final["messages"][0]["content"]
+    assert "bucket" in content.lower() or "MoA" in content or "decision" in content.lower()
+    assert (tmp_path / "decision.md").is_file() or (tmp_path / "moa_determination.md").is_file()
+    assert final["meta"].get("hybrid_moa") is True


### PR DESCRIPTION
## Summary
- `swarm-cli moa-init` merges default `moa` config (Grok live + CI fake presets)
- Blueprint **`hybrid_moa`** (consult MoA → write decision)
- Docs: `OPENWEBUI_MOA.md`, `docs/examples/moa.swarm_config.json`
- Live multi-seat demo: `scripts/demo_moa_grok_multiseat.py`

## Test plan
- [x] `pytest tests/core/test_moa_config.py tests/cli/test_moa_init_command.py tests/unit/blueprints/test_hybrid_moa_blueprint.py tests/integration/test_hybrid_moa_persona.py -q`
- [x] Live multi-seat grok demo produced determination
- [ ] CI green