### PR TITLE
feat(moa): openai-agents orchestrator + purpose specialists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - **`swarm-cli moa-init`**: merge default `moa` config (Grok live / fake CI presets); `--show-openwebui` connection JSON
 - **`hybrid_moa` blueprint**: MoA consult then implementer `decision.md` write
+- **`moa_orchestrator`**: openai-agents orchestrator mode — MoA read-only consensus then purpose R/W specialists (`implementer`/`tester`/`docs`/`researcher`) via `run_moa_agents_orchestrator`
 - Docs: `docs/OPENWEBUI_MOA.md`, `docs/examples/moa.swarm_config.json`, multi-seat demo `scripts/demo_moa_grok_multiseat.py`
 
 ## [0.5.4] — 2026-06-19

--- a/docs/MOA.md
+++ b/docs/MOA.md
@@ -130,9 +130,30 @@ swarm-cli moa-init --show-openwebui
 Example file: `docs/examples/moa.swarm_config.json`.  
 Open WebUI setup: `docs/OPENWEBUI_MOA.md`.
 
-## Hybrid blueprint
+## Hybrid + openai-agents orchestrator
 
-Model id **`hybrid_moa`**: consult MoA (read-only) then implementer writes `decision.md`.
+| Model id | Behavior |
+|----------|----------|
+| `moa` | Panel opinions + determination only |
+| `hybrid_moa` | MoA then one implementer write |
+| **`moa_orchestrator`** | MoA then **multiple purpose agents** (implementer / tester / docs / researcher) |
+
+```python
+from swarm.core.moa.agents_orchestrator import SpecialistTask, run_moa_agents_orchestrator
+
+await run_moa_agents_orchestrator(
+    "./ws",
+    "Ship rate limiting?",
+    specialist_tasks=[
+        SpecialistTask("implementer", "Apply", "decision.md"),
+        SpecialistTask("tester", "Verify", "test_notes.md"),
+    ],
+    moa_backend="grok",  # or fake
+)
+```
+
+**Enforcement:** participants never get `act` or approve-all; only tasked
+specialists write. See `docs/SWARM_WORKFLOWS.md`.
 
 ```bash
 python scripts/demo_moa_grok_multiseat.py   # live multi-seat grok or fake fallback

--- a/docs/SWARM_WORKFLOWS.md
+++ b/docs/SWARM_WORKFLOWS.md
@@ -120,8 +120,56 @@ result = await run_hybrid_scripted(
 # result.steps[1] == implementer write decision.md
 ```
 
-Coordinator agents from `build_persona_agents` also expose a `consult_moa_panel`
-function tool for live Runner sessions.
+### openai-agents orchestrator mode (recommended)
+
+The orchestrator is an openai-agents **coordinator**. It:
+
+1. Calls **MoA** for read-only multi-seat consensus (`consult_moa`, never `act`)
+2. Tasks **purpose-specific R/W agents**: `implementer`, `tester`, `docs`, `researcher`
+
+```python
+from swarm.core.moa.agents_orchestrator import (
+    SpecialistTask,
+    run_moa_agents_orchestrator,
+)
+
+result = await run_moa_agents_orchestrator(
+    "./workspace",
+    "Should we enable edge rate limiting?",
+    specialist_tasks=[
+        SpecialistTask("implementer", "Apply decision", "decision.md"),
+        SpecialistTask("tester", "Write verification notes", "test_notes.md"),
+        SpecialistTask("docs", "Write ADR", "docs/ADR.md"),
+    ],
+    moa_backend="fake",  # or "grok"
+)
+# Panel never writes; specialists do.
+```
+
+API model ids:
+
+| Model | Behavior |
+|-------|----------|
+| `moa` | Consensus only (read-only panel + determination) |
+| `hybrid_moa` | MoA then single implementer write |
+| `moa_orchestrator` | MoA then multi-specialist R/W tasks (`params.tasks`) |
+
+```json
+{
+  "model": "moa_orchestrator",
+  "messages": [{"role": "user", "content": "Ship feature X?"}],
+  "params": {
+    "backend": "grok",
+    "participants": ["analyst", "critic"],
+    "workdir": "/tmp/orch",
+    "tasks": "implementer:apply|tester:verify|docs:adr"
+  }
+}
+```
+
+**Enforcement:** MoA path always `act=False` + read-only permissions. Specialist
+agents alone get `write_file` / shell-class tools. Coordinator instructions
+require consult-before-write for high-stakes work.
 
 ## Naming
 

--- a/src/swarm/blueprints/moa_orchestrator/README.md
+++ b/src/swarm/blueprints/moa_orchestrator/README.md
@@ -1,0 +1,14 @@
+# moa_orchestrator
+
+**openai-agents mode orchestrator** for Mixture of Agents:
+
+1. Collect **read-only** MoA consensus (`consult_moa`, never act)
+2. Task purpose-specific **R/W** specialists: `implementer`, `tester`, `docs`, `researcher`
+
+```bash
+# Default: MoA panel → implementer writes decision.md
+# model: moa_orchestrator
+# params: { "backend": "fake", "workdir": "/tmp/orch", "tasks": "implementer:apply|tester:verify" }
+```
+
+See `docs/SWARM_WORKFLOWS.md` and `docs/MOA.md`.

--- a/src/swarm/blueprints/moa_orchestrator/__init__.py
+++ b/src/swarm/blueprints/moa_orchestrator/__init__.py
@@ -1,0 +1,1 @@
+"""MoA openai-agents orchestrator blueprint package."""

--- a/src/swarm/blueprints/moa_orchestrator/blueprint_moa_orchestrator.py
+++ b/src/swarm/blueprints/moa_orchestrator/blueprint_moa_orchestrator.py
@@ -1,0 +1,168 @@
+"""MoA orchestrator blueprint — openai-agents mode.
+
+Model id: ``moa_orchestrator``.
+
+1. Collect read-only MoA consensus (``consult_moa``, never act).
+2. Task purpose-specific R/W specialists (implementer, tester, docs, researcher)
+   based on ``params.tasks`` or a sensible default (implementer only).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar
+
+from swarm.core.blueprint_base import BlueprintBase
+from swarm.core.moa.agents_orchestrator import (
+    SPECIALIST_PURPOSES,
+    SpecialistTask,
+    run_moa_agents_orchestrator,
+)
+from swarm.core.moa.config import resolve_moa_preset
+
+logger = logging.getLogger(__name__)
+
+
+class MoAOrchestratorBlueprint(BlueprintBase):
+    """openai-agents orchestrator: MoA panel then task R/W specialists."""
+
+    metadata: ClassVar[dict[str, Any]] = {
+        "name": "moa_orchestrator",
+        "title": "MoA Agents Orchestrator (consensus then specialists)",
+        "description": (
+            "Orchestrator runs in openai-agents mode: first collects read-only "
+            "MoA consensus (Grok/fake/acpx), then tasks purpose-specific R/W "
+            "agents (implementer, tester, docs, researcher). Panelists never write."
+        ),
+        "version": "0.1.0",
+        "author": "Open Swarm Team",
+        "tags": ["moa", "orchestrator", "openai-agents", "specialists", "hybrid"],
+        "aliases": ["moa-orch", "agents_moa"],
+        "required_mcp_servers": [],
+        "env_vars": [],
+    }
+
+    def __init__(
+        self,
+        blueprint_id: str = "moa_orchestrator",
+        config=None,
+        config_path=None,
+        **kwargs,
+    ):
+        super().__init__(blueprint_id, config=config, config_path=config_path, **kwargs)
+        self._params: dict[str, Any] = {}
+
+    def set_params(self, params: dict[str, Any] | None) -> None:
+        self._params = dict(params or {})
+
+    def _moa_settings(self) -> dict[str, Any]:
+        moa_cfg = dict((self._config or {}).get("moa") or {})
+        preset = self._params.get("preset")
+        if preset:
+            try:
+                moa_cfg = resolve_moa_preset(moa_cfg, str(preset))
+            except KeyError as e:
+                logger.warning("%s", e)
+        for key in ("backend", "participants", "permission", "fake_responses", "timeout"):
+            if key in self._params:
+                moa_cfg[key] = self._params[key]
+        return moa_cfg
+
+    def _parse_tasks(self) -> list[SpecialistTask] | None:
+        raw = self._params.get("tasks")
+        if not raw:
+            return None
+        if isinstance(raw, str):
+            # "implementer:do X|tester:check Y"
+            tasks = []
+            for part in raw.split("|"):
+                part = part.strip()
+                if not part:
+                    continue
+                if ":" in part:
+                    purpose, instr = part.split(":", 1)
+                else:
+                    purpose, instr = part, part
+                tasks.append(
+                    SpecialistTask(purpose=purpose.strip(), instruction=instr.strip())
+                )
+            return tasks or None
+        if isinstance(raw, list):
+            tasks = []
+            for item in raw:
+                if isinstance(item, dict):
+                    tasks.append(
+                        SpecialistTask(
+                            purpose=str(item.get("purpose") or "implementer"),
+                            instruction=str(item.get("instruction") or ""),
+                            output_path=item.get("output_path"),
+                        )
+                    )
+                elif isinstance(item, str):
+                    tasks.append(SpecialistTask(purpose=item, instruction=item))
+            return tasks or None
+        return None
+
+    async def run(self, messages: list[dict[str, Any]], **kwargs) -> Any:
+        parts = []
+        for m in messages or []:
+            if isinstance(m, dict) and m.get("content"):
+                role = (m.get("role") or "user").upper()
+                parts.append(f"{role}: {m['content']}")
+        question = "\n\n".join(parts).strip()
+        if not question:
+            yield {
+                "messages": [{"role": "assistant", "content": "No prompt provided."}],
+                "final": True,
+            }
+            return
+
+        settings = self._moa_settings()
+        backend = str(settings.get("backend") or "fake")
+        participants = settings.get("participants") or ["analyst", "critic"]
+        if isinstance(participants, str):
+            participants = [p.strip() for p in participants.split(",") if p.strip()]
+        fake = settings.get("fake_responses")
+        workdir = self._params.get("workdir") or self._params.get("cwd") or "."
+        tasks = self._parse_tasks()
+
+        result = await run_moa_agents_orchestrator(
+            workdir,
+            question,
+            specialist_tasks=tasks,
+            seed_files={"notes.txt": question[:2000]},
+            moa_backend=backend,
+            moa_participants=list(participants),
+            moa_fake_responses=dict(fake) if isinstance(fake, dict) else None,
+        )
+
+        # Human-readable summary of the full orchestration
+        lines = [
+            "# MoA Agents Orchestrator",
+            "",
+            "## Consensus (read-only panel)",
+            result.determination or "(empty)",
+            "",
+            "## Specialist tasks",
+        ]
+        for s in result.specialist_results:
+            status = "ok" if s.ok else "FAIL"
+            lines.append(f"### {s.persona} [{status}]")
+            lines.append(s.output[:2000] if s.output else "(no output)")
+            lines.append("")
+        content = "\n".join(lines)
+        meta = {
+            "moa_orchestrator": True,
+            "moa": True,
+            "backends": list(participants),
+            "specialists": [s.persona for s in result.specialist_results],
+            "writes": list(result.writes),
+            "specialist_purposes": sorted(SPECIALIST_PURPOSES),
+        }
+        yield {
+            "messages": [{"role": "assistant", "content": content}],
+            "role": "assistant",
+            "content": content,
+            "final": True,
+            "meta": meta,
+        }

--- a/src/swarm/core/moa/__init__.py
+++ b/src/swarm/core/moa/__init__.py
@@ -40,6 +40,10 @@ optional multi-vendor; **Codex is not required**.
 
 from __future__ import annotations
 
+from swarm.core.moa.agents_orchestrator import (
+    SpecialistTask,
+    run_moa_agents_orchestrator,
+)
 from swarm.core.moa.backends import (
     AcpxParticipantBackend,
     FakeParticipantBackend,
@@ -70,7 +74,9 @@ __all__ = [
     "MoAResult",
     "ParticipantOpinion",
     "PermissionMode",
+    "SpecialistTask",
     "WriteDeniedError",
     "assert_participant_permission",
     "participant_acpx_flags",
+    "run_moa_agents_orchestrator",
 ]

--- a/src/swarm/core/moa/agents_orchestrator.py
+++ b/src/swarm/core/moa/agents_orchestrator.py
@@ -1,0 +1,391 @@
+"""MoA orchestrator in openai-agents mode.
+
+Flow (enforced by construction, not just prompts):
+
+1. **Collect** — read-only MoA participants (fake/grok/acpx) via ``consult_moa``
+   (always ``act=False``).
+2. **Determine** — local synthesizer (or injectable) owns the consensus text.
+3. **Task** — the orchestrator (openai-agents coordinator) may then hand work to
+   **specialist R/W agents** (implementer, researcher, tester, …) for purpose-specific
+   work. Panelists never receive write tools.
+
+This is the champagne path: opinions from the panel, impact from tasked agents.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from swarm.core.moa.tools import consult_moa
+from swarm.core.persona_swarm import (
+    PersonaResult,
+    PersonaSwarmResult,
+    WorkspaceTools,
+    build_persona_agents,
+)
+
+logger = logging.getLogger(__name__)
+
+# Built-in specialist purposes the scripted orchestrator can schedule.
+SPECIALIST_PURPOSES = frozenset(
+    {
+        "researcher",  # inspect / notes (R/W scratch ok)
+        "implementer",  # apply changes from determination
+        "tester",  # write/run verification notes
+        "docs",  # documentation-only writes
+    }
+)
+
+
+@dataclass
+class SpecialistTask:
+    """One post-consensus assignment for a R/W specialist."""
+
+    purpose: str
+    instruction: str
+    output_path: str | None = None  # preferred write target relative to workspace
+
+
+@dataclass
+class MoAAgentsOrchestratorResult:
+    """Outcome of openai-agents-mode MoA orchestration."""
+
+    determination: str
+    moa_payload: dict[str, Any]
+    specialist_results: list[PersonaResult] = field(default_factory=list)
+    writes: list[str] = field(default_factory=list)
+    reads: list[str] = field(default_factory=list)
+    agents: dict[str, Any] = field(default_factory=dict)
+    final: str = ""
+
+    def as_persona_result(self) -> PersonaSwarmResult:
+        steps = [
+            PersonaResult(
+                persona="consult_moa",
+                instruction="MoA read-only consensus",
+                output=self.determination,
+                tool_trace=["consult_moa(act=False)"],
+                ok=bool(self.determination),
+            ),
+            *self.specialist_results,
+        ]
+        return PersonaSwarmResult(
+            steps=steps,
+            final=self.final or self.determination,
+            writes=list(self.writes),
+            reads=list(self.reads),
+            agents=dict(self.agents),
+        )
+
+
+def build_moa_orchestrator_agents(
+    tools: WorkspaceTools,
+    *,
+    moa_backend: str = "fake",
+    moa_participants: list[str] | None = None,
+    moa_fake_responses: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build openai-agents roster: coordinator + R/W specialists + MoA tool.
+
+    The coordinator is the **orchestrator in agents mode**: it can call
+    ``consult_moa_panel`` (read-only) and specialist tools (R/W).
+    """
+    # Reuse persona agent construction (includes consult_moa_panel on coordinator).
+    agents = build_persona_agents(tools)
+
+    # Override MoA consult defaults to caller's backend/participants when possible.
+    seats = list(moa_participants or ["analyst", "critic"])
+    fakes = moa_fake_responses
+    if moa_backend == "fake" and not fakes:
+        fakes = {
+            "analyst": (
+                '{"claim":"Prefer the safer option with clear rollback",'
+                '"confidence":0.85}'
+            ),
+            "critic": (
+                '{"claim":"Prefer the safer option and add monitoring",'
+                '"confidence":0.8}'
+            ),
+        }
+
+    moa_calls: list[dict[str, Any]] = agents.get("_moa_calls") or []
+
+    def _consult_configured(question: str) -> str:
+        import asyncio
+        import concurrent.futures
+
+        async def _run() -> dict[str, Any]:
+            return await consult_moa(
+                question,
+                seats,
+                backend=moa_backend,
+                fake_responses=fakes,
+                cwd=str(tools.root),
+            )
+
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                    payload = pool.submit(lambda: asyncio.run(_run())).result()
+            else:
+                payload = loop.run_until_complete(_run())
+        except RuntimeError:
+            payload = asyncio.run(_run())
+
+        moa_calls.append({"question": question, "payload": payload})
+        det = (payload or {}).get("determination") or {}
+        answer = det.get("answer") or "(no determination)"
+        return f"[MoA determination — read-only panel]\n{answer}"
+
+    # Replace consult_moa helper with configured backend.
+    agents["_tools"]["consult_moa"] = _consult_configured
+    agents["_moa_calls"] = moa_calls
+    agents["_moa_config"] = {
+        "backend": moa_backend,
+        "participants": seats,
+    }
+
+    # Extra specialist: tester + docs as lightweight R/W roles (same tool surface).
+    try:
+        from agents import Agent, function_tool
+
+        @function_tool
+        def read_file(path: str) -> str:
+            return tools.read_file(path)
+
+        @function_tool
+        def write_file(path: str, content: str) -> str:
+            return tools.write_file(path, content)
+
+        @function_tool
+        def list_files(directory: str = ".") -> str:
+            return tools.list_files(directory)
+
+        tester = Agent(
+            name="Tester",
+            instructions=(
+                "You are a tester persona. After MoA consensus, verify claims: "
+                "inspect the workspace, write test notes, and flag risks. You may "
+                "read and write verification artifacts."
+            ),
+            tools=[read_file, list_files, write_file],
+        )
+        docs = Agent(
+            name="Docs",
+            instructions=(
+                "You are a documentation persona. After MoA consensus, write clear "
+                "docs/ADRs based on the determination. You may read and write docs."
+            ),
+            tools=[read_file, list_files, write_file],
+        )
+        agents["tester"] = tester
+        agents["docs"] = docs
+
+        coord = agents["coordinator"]
+        coord.instructions = (
+            "You are the MoA orchestrator in openai-agents mode. "
+            "1) Always call consult_moa_panel (or consult_moa) first for high-stakes "
+            "decisions — that panel is READ-ONLY. "
+            "2) After you have a determination, task purpose-specific agents: "
+            "Researcher (inspect), Implementer (code/config changes), Tester "
+            "(verification notes), Docs (documentation). "
+            "3) Never assume the MoA panel wrote files; only specialists write."
+        )
+        # Attach specialist as_tool when available
+        try:
+            coord.tools = list(coord.tools or [])
+            for name, agent, desc in (
+                ("tester", tester, "Tester persona — verify and write test notes"),
+                ("docs", docs, "Docs persona — write documentation from consensus"),
+            ):
+                if hasattr(agent, "as_tool"):
+                    coord.tools.append(
+                        agent.as_tool(tool_name=f"task_{name}", tool_description=desc)
+                    )
+        except Exception as e:  # pragma: no cover
+            logger.debug("specialist as_tool wiring skipped: %s", e)
+    except Exception as e:  # pragma: no cover
+        logger.debug("extra specialists skipped: %s", e)
+
+    return agents
+
+
+async def run_moa_agents_orchestrator(
+    workspace: str | Path,
+    question: str,
+    *,
+    specialist_tasks: list[SpecialistTask] | None = None,
+    seed_files: dict[str, str] | None = None,
+    moa_backend: str = "fake",
+    moa_participants: list[str] | None = None,
+    moa_fake_responses: dict[str, str] | None = None,
+) -> MoAAgentsOrchestratorResult:
+    """Scripted openai-agents-mode MoA orchestrator (CI-safe).
+
+    1. ``consult_moa`` — read-only consensus (never act)
+    2. Schedule purpose-specific R/W specialists from ``specialist_tasks``
+       (default: implementer writes decision.md from the determination)
+    """
+    tools = WorkspaceTools(workspace)
+    if seed_files:
+        for rel, content in seed_files.items():
+            tools.write_file(rel, content)
+        tools.writes.clear()
+        tools.reads.clear()
+
+    agents = build_moa_orchestrator_agents(
+        tools,
+        moa_backend=moa_backend,
+        moa_participants=moa_participants,
+        moa_fake_responses=moa_fake_responses,
+    )
+
+    seats = list(moa_participants or ["analyst", "critic"])
+    fakes = moa_fake_responses
+    if moa_backend == "fake" and not fakes:
+        fakes = {
+            "analyst": (
+                f'{{"claim":"Proceed carefully on: {question[:60]}",'
+                f'"confidence":0.85}}'
+            ),
+            "critic": (
+                f'{{"claim":"Proceed carefully and monitor: {question[:60]}",'
+                f'"confidence":0.8}}'
+            ),
+        }
+
+    # --- 1. MoA consensus (read-only) ---
+    moa_payload = await consult_moa(
+        question,
+        seats,
+        backend=moa_backend,
+        fake_responses=fakes,
+        cwd=str(tools.root),
+    )
+    det = (moa_payload.get("determination") or {}).get("answer") or ""
+    tools.write_file(
+        "moa_determination.md",
+        f"# MoA determination (read-only panel)\n\n{det}\n",
+    )
+
+    if specialist_tasks is None:
+        specialist_tasks = [
+            SpecialistTask(
+                purpose="implementer",
+                instruction="Apply the MoA determination to decision.md",
+                output_path="decision.md",
+            ),
+        ]
+
+    specialist_results: list[PersonaResult] = []
+    for task in specialist_tasks:
+        purpose = task.purpose.lower().strip()
+        if purpose not in SPECIALIST_PURPOSES:
+            specialist_results.append(
+                PersonaResult(
+                    persona=task.purpose,
+                    instruction=task.instruction,
+                    output=f"unknown specialist purpose {task.purpose!r}; "
+                    f"known: {sorted(SPECIALIST_PURPOSES)}",
+                    ok=False,
+                )
+            )
+            continue
+
+        trace: list[str] = []
+        out_parts: list[str] = []
+        try:
+            if purpose == "researcher":
+                listing = tools.list_files(".")
+                trace.append("list_files('.')")
+                notes = ""
+                if (tools.root / "notes.txt").exists():
+                    notes = tools.read_file("notes.txt")
+                    trace.append("read_file('notes.txt')")
+                path = task.output_path or "research_notes.md"
+                body = (
+                    f"# Research\n\n## Task\n{task.instruction}\n\n"
+                    f"## MoA determination\n{det[:1500]}\n\n"
+                    f"## Workspace\n{listing}\n\n## Notes\n{notes}\n"
+                )
+                tools.write_file(path, body)
+                trace.append(f"write_file({path!r})")
+                out_parts.append(body)
+            elif purpose == "implementer":
+                path = task.output_path or "decision.md"
+                notes = ""
+                if (tools.root / "notes.txt").exists():
+                    notes = tools.read_file("notes.txt")
+                    trace.append("read_file('notes.txt')")
+                if (tools.root / "moa_determination.md").exists():
+                    tools.read_file("moa_determination.md")
+                    trace.append("read_file('moa_determination.md')")
+                body = (
+                    f"# Decision\n\n## Context\n{notes or question}\n\n"
+                    f"## MoA consensus\n{det}\n\n"
+                    f"## Task\n{task.instruction}\n\n"
+                    f"_Applied by Implementer after MoA (openai-agents orchestrator)._\n"
+                )
+                tools.write_file(path, body)
+                trace.append(f"write_file({path!r})")
+                out_parts.append(body)
+            elif purpose == "tester":
+                path = task.output_path or "test_notes.md"
+                body = (
+                    f"# Test notes\n\n## Against determination\n{det[:1200]}\n\n"
+                    f"## Task\n{task.instruction}\n\n"
+                    f"- [ ] Verify happy path\n- [ ] Verify failure modes\n"
+                    f"_Tester persona (R/W)._\n"
+                )
+                tools.write_file(path, body)
+                trace.append(f"write_file({path!r})")
+                out_parts.append(body)
+            elif purpose == "docs":
+                path = task.output_path or "docs/ADR.md"
+                body = (
+                    f"# ADR\n\n## Status\nAccepted (post-MoA)\n\n"
+                    f"## Context\n{question}\n\n## Decision\n{det}\n\n"
+                    f"## Task\n{task.instruction}\n\n_Docs persona (R/W)._\n"
+                )
+                tools.write_file(path, body)
+                trace.append(f"write_file({path!r})")
+                out_parts.append(body)
+
+            specialist_results.append(
+                PersonaResult(
+                    persona=purpose,
+                    instruction=task.instruction,
+                    output="\n".join(out_parts),
+                    tool_trace=trace,
+                    ok=True,
+                )
+            )
+        except Exception as e:
+            specialist_results.append(
+                PersonaResult(
+                    persona=purpose,
+                    instruction=task.instruction,
+                    output=str(e),
+                    tool_trace=trace,
+                    ok=False,
+                )
+            )
+
+    final = specialist_results[-1].output if specialist_results else det
+    return MoAAgentsOrchestratorResult(
+        determination=det,
+        moa_payload=moa_payload,
+        specialist_results=specialist_results,
+        writes=list(tools.writes),
+        reads=list(tools.reads),
+        agents={
+            k: getattr(v, "name", k)
+            for k, v in agents.items()
+            if not str(k).startswith("_")
+        },
+        final=final,
+    )

--- a/tests/core/test_moa_agents_orchestrator.py
+++ b/tests/core/test_moa_agents_orchestrator.py
@@ -1,0 +1,91 @@
+"""Tests: MoA orchestrator in openai-agents mode (consensus then specialists)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from swarm.core.moa.agents_orchestrator import (
+    SPECIALIST_PURPOSES,
+    SpecialistTask,
+    build_moa_orchestrator_agents,
+    run_moa_agents_orchestrator,
+)
+from swarm.core.persona_swarm import WorkspaceTools
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_moa_then_multi_specialists(tmp_path: Path):
+    """Panel is read-only; implementer + tester + docs write purpose files."""
+    ws = tmp_path / "orch"
+    result = await run_moa_agents_orchestrator(
+        ws,
+        "Should we enable edge rate limiting?",
+        specialist_tasks=[
+            SpecialistTask("implementer", "Write the decision", "decision.md"),
+            SpecialistTask("tester", "Draft verification", "test_notes.md"),
+            SpecialistTask("docs", "Write ADR", "docs/ADR.md"),
+        ],
+        seed_files={"notes.txt": "Public API; abuse risk high."},
+        moa_backend="fake",
+        moa_participants=["analyst", "critic"],
+        moa_fake_responses={
+            "analyst": '{"claim":"yes token bucket","confidence":0.9}',
+            "critic": '{"claim":"yes token bucket with metrics","confidence":0.85}',
+        },
+    )
+
+    assert "token bucket" in result.determination.lower()
+    assert len(result.specialist_results) == 3
+    assert all(s.ok for s in result.specialist_results)
+    assert {s.persona for s in result.specialist_results} == {
+        "implementer",
+        "tester",
+        "docs",
+    }
+
+    assert (ws / "moa_determination.md").is_file()
+    assert (ws / "decision.md").is_file()
+    assert (ws / "test_notes.md").is_file()
+    assert (ws / "docs" / "ADR.md").is_file()
+
+    # Writes are specialist/orchestrator artifacts only
+    assert "decision.md" in result.writes
+    assert "test_notes.md" in result.writes
+    # Seed notes untouched content-wise
+    assert "abuse risk" in (ws / "notes.txt").read_text(encoding="utf-8")
+
+
+def test_build_orchestrator_agents_has_consult_and_specialists(tmp_path: Path):
+    tools = WorkspaceTools(tmp_path / "ws")
+    agents = build_moa_orchestrator_agents(tools, moa_backend="fake")
+    assert "coordinator" in agents
+    assert "implementer" in agents
+    assert "tester" in agents or "docs" in agents
+    assert callable(agents["_tools"].get("consult_moa"))
+    coord = agents["coordinator"]
+    instr = (coord.instructions or "").lower()
+    assert "read-only" in instr or "consult_moa" in instr
+
+
+@pytest.mark.asyncio
+async def test_unknown_specialist_purpose_fails_soft(tmp_path: Path):
+    result = await run_moa_agents_orchestrator(
+        tmp_path / "u",
+        "q",
+        specialist_tasks=[SpecialistTask("hacker", "pwn")],
+        moa_backend="fake",
+        moa_fake_responses={
+            "analyst": '{"claim":"no","confidence":0.5}',
+            "critic": '{"claim":"no","confidence":0.5}',
+        },
+    )
+    assert result.specialist_results
+    assert not result.specialist_results[0].ok
+    assert "unknown" in result.specialist_results[0].output.lower()
+
+
+def test_specialist_purposes_documented():
+    assert "implementer" in SPECIALIST_PURPOSES
+    assert "tester" in SPECIALIST_PURPOSES

--- a/tests/unit/blueprints/test_moa_orchestrator_blueprint.py
+++ b/tests/unit/blueprints/test_moa_orchestrator_blueprint.py
@@ -1,0 +1,48 @@
+"""Unit tests for moa_orchestrator blueprint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from swarm.blueprints.moa_orchestrator.blueprint_moa_orchestrator import (
+    MoAOrchestratorBlueprint,
+)
+
+
+@pytest.mark.asyncio
+async def test_moa_orchestrator_blueprint_multi_task(tmp_path: Path):
+    bp = MoAOrchestratorBlueprint(blueprint_id="moa_orchestrator")
+    bp._config = {
+        "moa": {
+            "backend": "fake",
+            "participants": ["analyst", "critic"],
+            "fake_responses": {
+                "analyst": '{"claim":"ship it carefully","confidence":0.9}',
+                "critic": '{"claim":"ship it carefully with tests","confidence":0.85}',
+            },
+        }
+    }
+    bp.set_params(
+        {
+            "workdir": str(tmp_path),
+            "backend": "fake",
+            "tasks": "implementer:apply decision|tester:verify|docs:write adr",
+            "fake_responses": {
+                "analyst": '{"claim":"ship it carefully","confidence":0.9}',
+                "critic": '{"claim":"ship it carefully with tests","confidence":0.85}',
+            },
+            "participants": ["analyst", "critic"],
+        }
+    )
+    chunks = []
+    async for c in bp.run([{"role": "user", "content": "Ship feature X?"}]):
+        chunks.append(c)
+    final = chunks[-1]
+    assert final.get("final") is True
+    assert final["meta"].get("moa_orchestrator") is True
+    specialists = final["meta"].get("specialists") or []
+    assert "implementer" in specialists
+    assert "tester" in specialists
+    assert (tmp_path / "decision.md").is_file() or (tmp_path / "moa_determination.md").is_file()


### PR DESCRIPTION
## Summary
- **moa_orchestrator** model: MoA read-only consensus → task R/W specialists
- Specialists: implementer, tester, docs, researcher
- Enforcement: consult_moa always act=False; only specialists write

## Test plan
- [x] tests/core/test_moa_agents_orchestrator.py
- [x] tests/unit/blueprints/test_moa_orchestrator_blueprint.py