### PR TITLE
feat(webui): Django-canonical shell and SPA demotion

### DIFF
--- a/src/swarm/static/css/rest_mode_style.css
+++ b/src/swarm/static/css/rest_mode_style.css
@@ -228,10 +228,13 @@ input[type="password"], input[type="email"], input[type="number"] {
 
 /* ---- blueprint cards: compact, clamped description ---------------------- */
 .blueprint-card .bp-desc {
-  display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical;
-  overflow: hidden; font-size: .88rem; color: var(--os-muted); margin: 0 0 .6rem;
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+  overflow: hidden; font-size: .85rem; color: var(--os-muted); margin: 0 0 .5rem;
+  line-height: 1.35;
 }
-.blueprint-card .bp-avatar { width: 44px; height: 44px; flex: 0 0 44px; }
+.blueprint-card .card-body { padding: 0.85rem 0.95rem; }
+.blueprint-card .bp-avatar { width: 36px; height: 36px; flex: 0 0 36px; }
+.blueprint-card .card-title { font-size: 0.95rem; }
 .min-w-0 { min-width: 0; }
 
 /* ---- accordion (de-clutter: collapse long forms / sections) ------------- */
@@ -241,3 +244,88 @@ input[type="password"], input[type="email"], input[type="number"] {
 .accordion-button:focus { box-shadow: 0 0 0 .2rem rgba(59, 130, 246, .25); border-color: var(--os-accent); }
 .accordion-button::after { filter: invert(.7); }
 .accordion-body { background: var(--os-panel); color: var(--os-text); }
+
+/* ---- UX fleet P0: compact shell + mobile primary tabs -------------------- */
+.os-header .os-navbar {
+  min-height: 48px;
+  border-bottom: 1px solid var(--os-border);
+}
+.os-navbar .navbar-brand {
+  font-size: 1.05rem;
+  letter-spacing: 0.01em;
+}
+.os-navbar .nav-link {
+  font-size: 0.92rem;
+  padding: 0.4rem 0.65rem !important;
+}
+.os-navbar .nav-link.active {
+  color: #fff !important;
+  font-weight: 600;
+  border-bottom: 2px solid var(--os-accent);
+}
+.os-main {
+  max-width: 1400px;
+  margin-left: auto;
+  margin-right: auto;
+}
+/* Room for fixed bottom nav on small screens (+ safe-area / thumb clearance) */
+@media (max-width: 991.98px) {
+  body.os-app {
+    /* Keep primary CTAs (Generate, Launch, Save) above the 3.5rem bottom bar */
+    padding-bottom: calc(6.5rem + env(safe-area-inset-bottom, 0px));
+  }
+  .os-main {
+    padding-bottom: 1.5rem;
+  }
+  .ac-wrap,
+  .se-wrap,
+  .agent-creator-pro {
+    padding-bottom: 1rem;
+  }
+}
+.os-bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1030;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  align-items: stretch;
+  height: 3.5rem;
+  background: var(--os-panel);
+  border-top: 1px solid var(--os-border);
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.35);
+}
+.os-bottom-nav__item {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  color: var(--os-muted);
+  font-size: 0.7rem;
+  min-width: 0;
+  padding: 0.25rem;
+}
+.os-bottom-nav__item.is-active {
+  color: var(--os-link);
+  font-weight: 600;
+}
+.os-bottom-nav__label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+/* Sessions list: slightly tighter cards on mobile */
+@media (max-width: 767.98px) {
+  .os-main .card {
+    margin-bottom: 0.65rem;
+  }
+  .os-main .table {
+    font-size: 0.85rem;
+  }
+}

--- a/src/swarm/templates/agent_creator.html
+++ b/src/swarm/templates/agent_creator.html
@@ -3,6 +3,10 @@
 {% block content %}
 <style>
   .ac-wrap { max-width: 1200px; margin: 1.5rem auto; padding: 0 1rem; }
+  @media (max-width: 991.98px) {
+    .ac-wrap { padding-bottom: 5rem; }
+    .ac-wrap .d-grid.gap-2 { margin-bottom: 2rem; }
+  }
   .ac-head { margin-bottom: 1rem; }
   .ac-grid { display:grid; grid-template-columns: minmax(340px, 1fr) 1.3fr; gap:1rem; align-items:start; }
   @media (max-width: 900px) { .ac-grid { grid-template-columns: 1fr; } }
@@ -40,13 +44,21 @@
                 </h2>
                 <div id="acc-identity" class="accordion-collapse collapse show">
                   <div class="accordion-body">
+                    {# Progressive disclosure: essentials first; advanced in collapsed panels #}
                     <div class="mb-3">
                       <label for="agentName" class="form-label">Agent Name *</label>
-                      <input type="text" class="form-control" id="agentName" name="name" required>
+                      <input type="text" class="form-control" id="agentName" name="name" required
+                             placeholder="e.g. Code Reviewer">
+                    </div>
+                    <div class="mb-3">
+                      <label for="agentDescription" class="form-label">Description *</label>
+                      <textarea class="form-control" id="agentDescription" name="description" rows="2" required
+                                placeholder="One-line purpose for this agent"></textarea>
                     </div>
                     <div class="mb-0">
-                      <label for="agentDescription" class="form-label">Description *</label>
-                      <textarea class="form-control" id="agentDescription" name="description" rows="3" required></textarea>
+                      <label for="instructions" class="form-label">Special Instructions *</label>
+                      <textarea class="form-control" id="instructions" name="instructions" rows="4"
+                                placeholder="How should this agent behave? What are its specific capabilities?" required></textarea>
                     </div>
                   </div>
                 </div>
@@ -80,18 +92,13 @@
                   </div>
                 </div>
               </div>
-              <!-- Behavior -->
+              <!-- Tags / extras (collapsed by default) -->
               <div class="accordion-item">
                 <h2 class="accordion-header">
-                  <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#acc-behavior">Behavior</button>
+                  <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#acc-behavior">Tags <span class="os-meta ms-2">optional</span></button>
                 </h2>
-                <div id="acc-behavior" class="accordion-collapse collapse show">
+                <div id="acc-behavior" class="accordion-collapse collapse">
                   <div class="accordion-body">
-                    <div class="mb-3">
-                      <label for="instructions" class="form-label">Special Instructions *</label>
-                      <textarea class="form-control" id="instructions" name="instructions" rows="4"
-                                placeholder="How should this agent behave? What are its specific capabilities?" required></textarea>
-                    </div>
                     <div class="mb-0">
                       <label for="tags" class="form-label">Tags</label>
                       <input type="text" class="form-control" id="tags" name="tags"

--- a/src/swarm/templates/agent_creator_pro.html
+++ b/src/swarm/templates/agent_creator_pro.html
@@ -89,11 +89,11 @@
 
           <form id="agentFormPro" class="config-form">
             {% csrf_token %}
-            <!-- Basic Info Section -->
+            <!-- Essentials first (progressive disclosure) -->
             <div class="form-section">
               <h4 class="section-title">
                 <span class="section-icon">📋</span>
-                Basic Information
+                Essentials
               </h4>
               
               <div class="form-group">
@@ -106,19 +106,25 @@
               <div class="form-group">
                 <label for="agentDescription" class="form-label">Description *</label>
                 <textarea class="form-control enhanced" id="agentDescription" name="description" 
-                          rows="3" placeholder="Describe what this agent does and its primary purpose" required></textarea>
+                          rows="2" placeholder="Describe what this agent does and its primary purpose" required></textarea>
+                <div class="form-feedback"></div>
+              </div>
+
+              <div class="form-group">
+                <label for="instructions" class="form-label">Special Instructions *</label>
+                <textarea class="form-control enhanced" id="instructions" name="instructions" 
+                          rows="4" placeholder="Detailed instructions on how this agent should behave, what it should focus on, and any specific guidelines" required></textarea>
                 <div class="form-feedback"></div>
               </div>
             </div>
 
-            <!-- Personality Section -->
-            <div class="form-section">
-              <h4 class="section-title">
+            <!-- Optional: collapsed by default -->
+            <details class="form-section acp-optional">
+              <summary class="section-title" style="cursor:pointer;list-style:revert;">
                 <span class="section-icon">🎭</span>
-                Personality & Style
-              </h4>
-              
-              <div class="form-group">
+                Personality &amp; Style <span class="os-meta">optional</span>
+              </summary>
+              <div class="form-group mt-2">
                 <label for="personality" class="form-label">Personality</label>
                 <select class="form-select enhanced" id="personality" name="personality">
                   {% for option in form_data.personality_options %}
@@ -126,7 +132,6 @@
                   {% endfor %}
                 </select>
               </div>
-              
               <div class="form-group">
                 <label for="communicationStyle" class="form-label">Communication Style</label>
                 <select class="form-select enhanced" id="communicationStyle" name="communication_style">
@@ -135,16 +140,14 @@
                   {% endfor %}
                 </select>
               </div>
-            </div>
+            </details>
 
-            <!-- Expertise Section -->
-            <div class="form-section">
-              <h4 class="section-title">
+            <details class="form-section acp-optional">
+              <summary class="section-title" style="cursor:pointer;list-style:revert;">
                 <span class="section-icon">🎯</span>
-                Expertise & Capabilities
-              </h4>
-              
-              <div class="form-group">
+                Expertise &amp; Capabilities <span class="os-meta">optional</span>
+              </summary>
+              <div class="form-group mt-2">
                 <label class="form-label">Areas of Expertise</label>
                 <div class="expertise-grid">
                   {% for option in form_data.expertise_options %}
@@ -155,28 +158,19 @@
                   {% endfor %}
                 </div>
               </div>
-            </div>
+            </details>
 
-            <!-- Instructions Section -->
-            <div class="form-section">
-              <h4 class="section-title">
-                <span class="section-icon">📝</span>
-                Behavior & Instructions
-              </h4>
-              
-              <div class="form-group">
-                <label for="instructions" class="form-label">Special Instructions *</label>
-                <textarea class="form-control enhanced" id="instructions" name="instructions" 
-                          rows="4" placeholder="Detailed instructions on how this agent should behave, what it should focus on, and any specific guidelines" required></textarea>
-                <div class="form-feedback"></div>
-              </div>
-              
-              <div class="form-group">
+            <details class="form-section acp-optional">
+              <summary class="section-title" style="cursor:pointer;list-style:revert;">
+                <span class="section-icon">🏷️</span>
+                Tags <span class="os-meta">optional</span>
+              </summary>
+              <div class="form-group mt-2">
                 <label for="tags" class="form-label">Tags</label>
                 <input type="text" class="form-control enhanced" id="tags" name="tags" 
                        placeholder="custom, helpful, coding (comma-separated)">
               </div>
-            </div>
+            </details>
 
             <!-- Action Buttons -->
             <div class="action-buttons">

--- a/src/swarm/templates/base.html
+++ b/src/swarm/templates/base.html
@@ -4,84 +4,116 @@
     {% load static %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Open-Swarm</title>
+    <title>{% block title %}Open Swarm{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="{% static 'css/rest_mode_style.css' %}" rel="stylesheet">
     <link href="{% static 'css/dropdown.css' %}" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{% static 'js/htmx.min.js' %}"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    <!-- Prism: syntax highlighting for generated/blueprint code (dark theme to match) -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css">
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script>
 </head>
-<body>
-    <header>
-        <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-            <div class="container-fluid">
-                <a class="navbar-brand" href="/">🚀 Open-Swarm</a>
-                
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+<body class="os-app">
+    {% with path=request.path %}
+    <header class="os-header sticky-top">
+        <nav class="navbar navbar-expand-lg navbar-dark bg-dark os-navbar py-1">
+            <div class="container-fluid px-3">
+                <a class="navbar-brand fw-semibold" href="/">Open Swarm</a>
+
+                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+                        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
                 </button>
-                
+
                 <div class="collapse navbar-collapse" id="navbarNav">
-                    <ul class="navbar-nav me-auto">
+                    {# Primary IA: Home · Blueprints · Teams · Sessions · Settings #}
+                    <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                         <li class="nav-item">
-                            <a class="nav-link" href="/sessions/">🧭 Sessions</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/teams/">👥 Teams Admin</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/teams/launch/">🚀 Team Launcher</a>
+                            <a class="nav-link {% if path == '/' %}active{% endif %}"
+                               href="/" {% if path == '/' %}aria-current="page"{% endif %}>Home</a>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle" href="#" id="creatorDropdown" role="button" data-bs-toggle="dropdown">
-                                🛠️ Creators
+                            <a class="nav-link dropdown-toggle {% if '/blueprint' in path or '/agent-creator' in path or '/team-creator' in path %}active{% endif %}"
+                               href="/blueprint-library/" id="blueprintNavDropdown" role="button"
+                               data-bs-toggle="dropdown" aria-expanded="false">
+                                Blueprints
                             </a>
-                            <ul class="dropdown-menu">
-                                <li><a class="dropdown-item" href="/agent-creator/">🤖 Agent Creator</a></li>
-                                <li><a class="dropdown-item" href="/agent-creator-pro/">⭐ Agent Creator Pro</a></li>
-                                <li><a class="dropdown-item" href="/team-creator/">👥 Team Creator</a></li>
+                            <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="blueprintNavDropdown">
+                                <li><a class="dropdown-item" href="/blueprint-library/">Library</a></li>
+                                <li><a class="dropdown-item" href="/blueprint-library/my-blueprints/">My Blueprints</a></li>
+                                <li><a class="dropdown-item" href="/blueprint-library/creator/">Create custom</a></li>
+                                <li><hr class="dropdown-divider"></li>
+                                <li><a class="dropdown-item" href="/agent-creator/">Agent creator</a></li>
+                                <li><a class="dropdown-item" href="/agent-creator-pro/">Agent creator Pro</a></li>
+                                <li><a class="dropdown-item" href="/team-creator/">Team creator</a></li>
                             </ul>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle" href="#" id="blueprintNavDropdown" role="button" data-bs-toggle="dropdown">
-                                📚 Blueprints
+                            <a class="nav-link dropdown-toggle {% if path|slice:':7' == '/teams/' or path|slice:':10' == '/profiles/' %}active{% endif %}"
+                               href="/teams/launch/" id="teamsNavDropdown" role="button"
+                               data-bs-toggle="dropdown" aria-expanded="false">
+                                Teams
                             </a>
-                            <ul class="dropdown-menu">
-                                <li><a class="dropdown-item" href="/blueprint-library/">📖 Blueprint Library</a></li>
-                                <li><a class="dropdown-item" href="/blueprint-library/creator/">✨ Create Custom</a></li>
-                                <li><a class="dropdown-item" href="/blueprint-library/my-blueprints/">📋 My Blueprints</a></li>
+                            <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="teamsNavDropdown">
+                                <li><a class="dropdown-item" href="/teams/launch/">Launch</a></li>
+                                <li><a class="dropdown-item" href="/teams/">Admin / registry</a></li>
+                                <li><a class="dropdown-item" href="/profiles/">LLM profiles</a></li>
                             </ul>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link {% if path|slice:':10' == '/sessions/' %}active{% endif %}"
+                               href="/sessions/"
+                               {% if path|slice:':10' == '/sessions/' %}aria-current="page"{% endif %}>Sessions</a>
                         </li>
                     </ul>
-                    <ul class="navbar-nav">
+                    <ul class="navbar-nav ms-lg-auto">
                         <li class="nav-item">
-                            <a class="nav-link" href="/settings/">⚙️ Settings</a>
+                            <a class="nav-link {% if path|slice:':10' == '/settings/' %}active{% endif %}"
+                               href="/settings/"
+                               {% if path|slice:':10' == '/settings/' %}aria-current="page"{% endif %}>Settings</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="https://github.com/matthewhand/open-swarm" target="_blank">
-                                📚 GitHub
-                            </a>
+                        <li class="nav-item dropdown d-none d-lg-block">
+                            <a class="nav-link dropdown-toggle opacity-75" href="#" id="moreNavDropdown"
+                               role="button" data-bs-toggle="dropdown" aria-expanded="false">More</a>
+                            <ul class="dropdown-menu dropdown-menu-dark dropdown-menu-end" aria-labelledby="moreNavDropdown">
+                                <li>
+                                    <a class="dropdown-item" href="https://github.com/matthewhand/open-swarm"
+                                       target="_blank" rel="noopener noreferrer">GitHub</a>
+                                </li>
+                            </ul>
                         </li>
                     </ul>
                 </div>
             </div>
         </nav>
     </header>
-    <main>
-        <div class="dropdown blueprint-select" hx-get="/v1/models" hx-trigger="click" hx-target="#blueprintDropdown" hx-swap="innerHTML">
-            <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton">
-                Select a Blueprint
-            </button>
-            <div class="dropdown-menu" id="blueprintDropdown">
-                <p class="dropdown-item disabled"></p>
-            </div>
-        </div>
+    {% endwith %}
+
+    <main class="os-main container-fluid px-3 px-md-4 py-3">
         {% block content %}{% endblock %}
     </main>
+
+    {# Mobile primary tabs — thumb reach without opening hamburger #}
+    {% with path=request.path %}
+    <nav class="os-bottom-nav d-lg-none" aria-label="Mobile primary">
+        <a class="os-bottom-nav__item {% if path == '/' %}is-active{% endif %}" href="/">
+            <span class="os-bottom-nav__label">Home</span>
+        </a>
+        <a class="os-bottom-nav__item {% if '/blueprint' in path %}is-active{% endif %}" href="/blueprint-library/">
+            <span class="os-bottom-nav__label">Blueprints</span>
+        </a>
+        <a class="os-bottom-nav__item {% if path|slice:':7' == '/teams/' or path|slice:':10' == '/profiles/' %}is-active{% endif %}" href="/teams/launch/">
+            <span class="os-bottom-nav__label">Teams</span>
+        </a>
+        <a class="os-bottom-nav__item {% if path|slice:':10' == '/sessions/' %}is-active{% endif %}" href="/sessions/">
+            <span class="os-bottom-nav__label">Sessions</span>
+        </a>
+        <a class="os-bottom-nav__item {% if path|slice:':10' == '/settings/' %}is-active{% endif %}" href="/settings/">
+            <span class="os-bottom-nav__label">Settings</span>
+        </a>
+    </nav>
+    {% endwith %}
 </body>
 </html>

--- a/src/swarm/templates/blueprint_library.html
+++ b/src/swarm/templates/blueprint_library.html
@@ -127,14 +127,20 @@
                 </div>
                 <span class="os-meta" id="bpSearchCount"></span>
             </div>
-            <div class="row" id="allBlueprintsGrid">
+            <div class="row g-3" id="allBlueprintsGrid">
                 {% for category_id, blueprints in blueprints_by_category.items %}
                     {% for blueprint in blueprints %}
-                    <div class="col-lg-4 col-md-6 mb-4 bp-grid-item" data-bp-name="{{ blueprint.name|lower }}">
+                    <div class="col-xl-3 col-lg-4 col-md-6 bp-grid-item" data-bp-name="{{ blueprint.name|lower }}">
                         {% include "blueprint_card.html" with blueprint=blueprint %}
                     </div>
                     {% endfor %}
                 {% endfor %}
+            </div>
+            <div class="text-center mt-3 mb-2" id="bpShowMoreWrap" style="display:none;">
+                <button type="button" class="btn btn-outline-secondary btn-sm" id="bpShowMore" onclick="showMoreBlueprints()">
+                    Show more blueprints
+                </button>
+                <div class="os-meta mt-1" id="bpPageMeta"></div>
             </div>
             <div id="bpSearchEmpty" class="os-empty" style="display:none;">
                 <div class="os-empty-icon"><i class="fas fa-magnifying-glass"></i></div>
@@ -145,9 +151,9 @@
         <!-- Category-specific tabs -->
         {% for category_id, blueprints in blueprints_by_category.items %}
         <div class="tab-pane fade" id="{{ category_id }}" role="tabpanel">
-            <div class="row">
+            <div class="row g-3">
                 {% for blueprint in blueprints %}
-                <div class="col-lg-4 col-md-6 mb-4">
+                <div class="col-xl-3 col-lg-4 col-md-6">
                     {% include "blueprint_card.html" with blueprint=blueprint %}
                 </div>
                 {% endfor %}
@@ -200,24 +206,67 @@
 </div>
 
 <script>
-// Live client-side filter over the "All Blueprints" grid (by name).
-function filterBlueprints() {
+// Client-side page size for "All Blueprints" to avoid card explosion.
+const BP_PAGE_SIZE = 12;
+let bpVisibleLimit = BP_PAGE_SIZE;
+
+function applyBlueprintVisibility() {
     const input = document.getElementById('bpSearch');
-    if (!input) return;
-    const q = input.value.trim().toLowerCase();
-    const items = document.querySelectorAll('#allBlueprintsGrid .bp-grid-item');
-    let shown = 0;
+    const q = input ? input.value.trim().toLowerCase() : '';
+    const items = Array.from(document.querySelectorAll('#allBlueprintsGrid .bp-grid-item'));
+    let matchCount = 0;
+    let rendered = 0;
     items.forEach(el => {
         const match = !q || (el.dataset.bpName || '').includes(q);
-        el.style.display = match ? '' : 'none';
-        if (match) shown++;
+        if (!match) {
+            el.style.display = 'none';
+            return;
+        }
+        matchCount++;
+        if (rendered < bpVisibleLimit) {
+            el.style.display = '';
+            rendered++;
+        } else {
+            el.style.display = 'none';
+        }
     });
     const countEl = document.getElementById('bpSearchCount');
-    if (countEl) countEl.textContent = q
-        ? shown + ' match' + (shown === 1 ? '' : 'es')
-        : items.length + ' blueprints';
+    if (countEl) {
+        countEl.textContent = q
+            ? matchCount + ' match' + (matchCount === 1 ? '' : 'es')
+            : (matchCount ? matchCount + ' blueprints' : '');
+    }
     const emptyEl = document.getElementById('bpSearchEmpty');
-    if (emptyEl) emptyEl.style.display = (q && shown === 0) ? '' : 'none';
+    if (emptyEl) emptyEl.style.display = matchCount === 0 ? '' : 'none';
+    const moreWrap = document.getElementById('bpShowMoreWrap');
+    const meta = document.getElementById('bpPageMeta');
+    if (moreWrap) {
+        const hasMore = matchCount > bpVisibleLimit;
+        moreWrap.style.display = hasMore || (matchCount > BP_PAGE_SIZE) ? '' : 'none';
+        const btn = document.getElementById('bpShowMore');
+        if (btn) {
+            btn.style.display = hasMore ? '' : 'none';
+            btn.textContent = hasMore
+                ? 'Show more (' + Math.min(BP_PAGE_SIZE, matchCount - bpVisibleLimit) + ')'
+                : 'Show more blueprints';
+        }
+        if (meta) {
+            meta.textContent = matchCount
+                ? 'Showing ' + Math.min(bpVisibleLimit, matchCount) + ' of ' + matchCount
+                : '';
+        }
+    }
+}
+
+function showMoreBlueprints() {
+    bpVisibleLimit += BP_PAGE_SIZE;
+    applyBlueprintVisibility();
+}
+
+// Live client-side filter over the "All Blueprints" grid (by name).
+function filterBlueprints() {
+    bpVisibleLimit = BP_PAGE_SIZE;
+    applyBlueprintVisibility();
 }
 
 document.addEventListener('DOMContentLoaded', filterBlueprints);

--- a/src/swarm/templates/profiles.html
+++ b/src/swarm/templates/profiles.html
@@ -22,9 +22,13 @@
           <td>{{ p.provider }}</td>
           <td>{{ p.model }}</td>
           <td class="max-w-xs truncate">
+            {% if p.base_url and p.base_url != 'None' and p.base_url != 'null' %}
             <a href="{{ p.base_url }}" target="_blank" rel="noopener noreferrer" class="link link-primary truncate">
               {{ p.base_url }}
             </a>
+            {% else %}
+            <span class="text-muted">Not set</span>
+            {% endif %}
           </td>
         </tr>
         {% empty %}

--- a/src/swarm/urls.py
+++ b/src/swarm/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import path, re_path
 from django.http import HttpResponse, FileResponse
+from django.views.generic import RedirectView
 from django.views.static import serve
 from pathlib import Path
 
@@ -176,7 +177,35 @@ if os.getenv('ENABLE_MCP_SERVER', '').lower() in ('true', '1', 'yes'):
             exc,
         )
 
-# SPA Fallback for React Router - must be last
+# Canonical product UI is Django (trailing-slash). Bare SPA-style paths that used
+# to dual-mount the React shell now redirect so users never hit two different UIs
+# for the same concept (e.g. /teams vs /teams/).
+urlpatterns += [
+    path(
+        "teams",
+        RedirectView.as_view(url="/teams/launch/", permanent=False, query_string=True),
+        name="spa_teams_to_django",
+    ),
+    path(
+        "blueprints",
+        RedirectView.as_view(url="/blueprint-library/", permanent=False, query_string=True),
+        name="spa_blueprints_to_django",
+    ),
+    path(
+        "settings",
+        RedirectView.as_view(url="/settings/", permanent=False, query_string=True),
+        name="spa_settings_to_django",
+    ),
+    # Bare /agent-creator (no slash) used to hit an empty SPA shell; canonical
+    # creator is Django at /agent-creator/.
+    path(
+        "agent-creator",
+        RedirectView.as_view(url="/agent-creator/", permanent=False, query_string=True),
+        name="spa_agent_creator_to_django",
+    ),
+]
+
+# SPA Fallback for React Router - must be last (home `/` and experimental routes).
 def _get_frontend_path():
     """Get the path to the built frontend assets."""
     frontend_path = Path("webui/frontend/dist")
@@ -203,5 +232,5 @@ if frontend_path and frontend_path.exists():
         return HttpResponse("Not Found", status=404)
     
     urlpatterns += [
-        re_path(r'^(?!api/|admin/|static/|assets/|mcp/|marketplace/|v1/|teams/|blueprint-library/|agent-creator/|settings/|accounts/|login/).*$', spa_fallback),
+        re_path(r'^(?!api/|admin/|static/|assets/|mcp/|marketplace/|v1/|teams/|blueprint-library/|agent-creator/|settings/|accounts/|login/|profiles/|sessions/|webui/).*$', spa_fallback),
     ]

--- a/tests/views/test_spa_django_canonical_routes.py
+++ b/tests/views/test_spa_django_canonical_routes.py
@@ -1,0 +1,153 @@
+"""UX fleet: bare SPA dual-paths redirect to canonical Django operator UI.
+
+These exercise the *shipped* urlpatterns (RedirectView entries in swarm.urls)
+via the Django test client — not a reimplementation of the map.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+
+
+@pytest.fixture
+def webui_on(settings, monkeypatch):
+    """Ensure Web UI views are not gated off (env + settings)."""
+    monkeypatch.setenv("ENABLE_WEBUI", "true")
+    settings.ENABLE_WEBUI = True
+    return settings
+
+
+@pytest.mark.django_db
+class TestSpaToDjangoCanonicalRedirects:
+    """Bare paths that used to dual-mount the React shell must 302 to Django."""
+
+    @pytest.mark.parametrize(
+        "path,expected_location",
+        [
+            ("/teams", "/teams/launch/"),
+            ("/blueprints", "/blueprint-library/"),
+            ("/settings", "/settings/"),
+            ("/agent-creator", "/agent-creator/"),
+        ],
+    )
+    def test_bare_spa_path_redirects_to_django(self, client, path, expected_location):
+        response = client.get(path)
+        assert response.status_code == 302, (
+            f"{path} should redirect to canonical Django UI, got {response.status_code}"
+        )
+        assert response.url == expected_location
+
+    def test_query_string_preserved_on_teams_redirect(self, client):
+        response = client.get("/teams?blueprint=hybrid_team")
+        assert response.status_code == 302
+        assert response.url.startswith("/teams/launch/")
+        assert "blueprint=hybrid_team" in response.url
+
+    def test_named_redirect_routes_exist(self):
+        assert reverse("spa_teams_to_django") == "/teams"
+        assert reverse("spa_blueprints_to_django") == "/blueprints"
+        assert reverse("spa_settings_to_django") == "/settings"
+        assert reverse("spa_agent_creator_to_django") == "/agent-creator"
+
+    def test_trailing_slash_django_routes_not_redirect_loops(self, client, webui_on):
+        """Canonical Django routes keep working (no redirect-to-self loops)."""
+        from django.contrib.auth.models import User
+
+        user = User.objects.create_user(username="uxcanon", password="ux-canon-pass")
+        client.force_login(user)
+        for path in ("/teams/", "/teams/launch/", "/settings/", "/blueprint-library/"):
+            response = client.get(path)
+            assert response.status_code in (200, 302, 301), (
+                f"{path} unexpected status {response.status_code}: "
+                f"{response.content[:120]!r}"
+            )
+            if response.status_code in (301, 302):
+                assert response.url != path
+
+
+@pytest.mark.django_db
+class TestUxShellTemplateContracts:
+    """Structural contracts for shell IA / density shipped in templates."""
+
+    def test_base_shell_has_five_primary_destinations_and_more(self, client):
+        # base.html is extended by many pages; settings requires login often.
+        # Use login page which extends base, or force_login.
+        from django.contrib.auth.models import User
+
+        user = User.objects.create_user(username="uxshell", password="ux-shell-pass")
+        client.force_login(user)
+        response = client.get("/settings/")
+        assert response.status_code == 200
+        html = response.content.decode()
+        for label in ("Home", "Blueprints", "Teams", "Sessions", "Settings"):
+            assert label in html
+        assert "More" in html
+        assert "os-bottom-nav" in html
+        # GitHub not a bare primary peer string next to Settings as sole link —
+        # demoted under More dropdown.
+        assert 'id="moreNavDropdown"' in html
+
+    def test_profiles_marks_teams_active_in_shell(self, client):
+        from django.contrib.auth.models import User
+
+        user = User.objects.create_user(username="uxprof", password="ux-prof-pass")
+        client.force_login(user)
+        response = client.get("/profiles/")
+        assert response.status_code == 200
+        html = response.content.decode()
+        # Desktop Teams dropdown active rule includes /profiles/
+        assert "nav-link dropdown-toggle active" in html or 'aria-current="page"' in html
+        # Mobile bottom: Teams is-active for profiles path
+        assert "os-bottom-nav__item" in html
+        assert "/profiles/" in html or "profiles" in html.lower()
+
+    def test_blueprint_library_ships_client_pagination(self, client):
+        from django.contrib.auth.models import User
+
+        user = User.objects.create_user(username="uxlib", password="ux-lib-pass")
+        client.force_login(user)
+        response = client.get("/blueprint-library/")
+        assert response.status_code == 200
+        html = response.content.decode()
+        assert "BP_PAGE_SIZE" in html
+        assert "Show more" in html
+        assert "bpShowMore" in html
+
+    def test_session_explorer_ships_scroll_containment(self, client):
+        from django.contrib.auth.models import User
+
+        user = User.objects.create_user(username="uxsess", password="ux-sess-pass")
+        client.force_login(user)
+        response = client.get("/sessions/")
+        assert response.status_code == 200
+        html = response.content.decode()
+        assert "se-list-scroll" in html
+
+    def test_agent_creator_progressive_disclosure(self, client):
+        from django.contrib.auth.models import User
+
+        user = User.objects.create_user(username="uxac", password="ux-ac-pass")
+        client.force_login(user)
+        response = client.get("/agent-creator/")
+        assert response.status_code == 200
+        html = response.content.decode()
+        # Persona / Tags optional panels collapsed by default
+        assert 'data-bs-target="#acc-persona"' in html
+        assert "accordion-button collapsed" in html
+        assert 'id="acc-persona" class="accordion-collapse collapse"' in html
+        assert 'id="acc-behavior" class="accordion-collapse collapse"' in html
+        # Essentials open
+        assert 'id="acc-identity" class="accordion-collapse collapse show"' in html
+
+    def test_agent_creator_pro_optional_sections_collapsed(self, client):
+        from django.contrib.auth.models import User
+
+        user = User.objects.create_user(username="uxacp", password="ux-acp-pass")
+        client.force_login(user)
+        response = client.get("/agent-creator-pro/")
+        assert response.status_code == 200
+        html = response.content.decode()
+        assert "acp-optional" in html
+        assert "<details" in html
+        assert "Essentials" in html

--- a/webui/frontend/src/App.tsx
+++ b/webui/frontend/src/App.tsx
@@ -1,303 +1,379 @@
 import { useState, useEffect } from 'react'
-import { BrowserRouter as Router, Routes, Route, Link, useNavigate } from 'react-router-dom'
+import { BrowserRouter as Router, Routes, Route, Link, useLocation, Navigate } from 'react-router-dom'
 import { Home, Settings, Bot, Book, Users, PlusCircle } from 'lucide-react'
-import { Button, Card, Alert, Badge, LoadingSpinner } from './components/DaisyUI'
+import { Button, Card, Alert, Badge } from './components/DaisyUI'
 import TeamsPage from './pages/TeamsPage'
 import BlueprintsPage from './pages/BlueprintsPage'
+import ChatPage from './pages/ChatPage'
 
 function App() {
-  const [darkMode, setDarkMode] = useState(false)
+  const [darkMode, setDarkMode] = useState(true)
 
   return (
     <Router>
-      <div className={`min-h-screen ${darkMode ? 'bg-gray-900 text-white' : 'bg-gray-50 text-gray-900'}`} data-theme={darkMode ? 'dark' : 'light'}>
-        {/* Navbar */}
-        <nav className="bg-base-200 shadow-sm border-b">
+      <div
+        className={`min-h-screen pb-20 lg:pb-0 ${darkMode ? 'bg-gray-900 text-white' : 'bg-gray-50 text-gray-900'}`}
+        data-theme={darkMode ? 'dark' : 'light'}
+      >
+        <nav className="bg-base-200 shadow-sm border-b sticky top-0 z-40" aria-label="Primary">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex justify-between h-16">
-              <div className="flex items-center">
+            <div className="flex justify-between h-14">
+              <div className="flex items-center gap-6">
                 <Link to="/" className="flex items-center space-x-2">
-                  <Bot className="h-8 w-8 text-primary" />
-                  <span className="text-xl font-bold">Open Swarm MCP</span>
+                  <Bot className="h-7 w-7 text-primary" aria-hidden />
+                  <span className="text-lg font-bold">Open Swarm</span>
                 </Link>
+                <div className="hidden lg:flex items-center gap-1">
+                  <NavLink to="/">Home</NavLink>
+                  <a className="btn btn-ghost btn-sm" href="/blueprint-library/">
+                    Blueprints
+                  </a>
+                  <a className="btn btn-ghost btn-sm" href="/teams/launch/">
+                    Teams
+                  </a>
+                  <a className="btn btn-ghost btn-sm" href="/sessions/">
+                    Sessions
+                  </a>
+                  <a className="btn btn-ghost btn-sm" href="/settings/">
+                    Settings
+                  </a>
+                </div>
               </div>
-              <div className="flex items-center space-x-4">
+              <div className="flex items-center space-x-2">
                 <button
+                  type="button"
                   onClick={() => setDarkMode(!darkMode)}
                   className="btn btn-ghost btn-sm"
                 >
-                  {darkMode ? 'Light Mode' : 'Dark Mode'}
+                  {darkMode ? 'Light' : 'Dark'}
                 </button>
-                <Link to="/settings" className="btn btn-ghost btn-sm">
+                <a href="/settings/" className="btn btn-ghost btn-sm" aria-label="Settings">
                   <Settings className="h-5 w-5" />
-                </Link>
+                </a>
               </div>
             </div>
           </div>
         </nav>
 
-        {/* Main Content */}
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           <Routes>
             <Route path="/" element={<Dashboard />} />
+            <Route path="/chat" element={<ChatPage />} />
+            {/* Client-side leftovers: prefer Django operator UI for primary surfaces */}
             <Route path="/teams" element={<TeamsPage />} />
             <Route path="/blueprints" element={<BlueprintsPage />} />
             <Route path="/settings" element={<SettingsPage />} />
+            {/* Unknown SPA paths: never show a blank shell (was a screenshot P0) */}
+            <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </div>
 
-        {/* Bottom Navigation (Mobile) */}
-        <div className="btm-nav lg:hidden">
-          <Link to="/" className="active">
-            <Home className="h-5 w-5" />
-            <span className="btm-nav-label">Home</span>
-          </Link>
-          <Link to="/teams">
-            <Users className="h-5 w-5" />
-            <span className="btm-nav-label">Teams</span>
-          </Link>
-          <Link to="/blueprints">
-            <Book className="h-5 w-5" />
-            <span className="btm-nav-label">Blueprints</span>
-          </Link>
-          <Link to="/settings">
-            <Settings className="h-5 w-5" />
-            <span className="btm-nav-label">Settings</span>
-          </Link>
-        </div>
+        {/* Fixed horizontal bottom nav on small screens */}
+        <nav
+          className="lg:hidden fixed bottom-0 inset-x-0 z-50 border-t border-base-300 bg-base-200 flex justify-around items-stretch h-16"
+          aria-label="Mobile primary"
+        >
+          <MobileTab to="/" icon={<Home className="h-5 w-5" />} label="Home" />
+          <MobileTab href="/blueprint-library/" icon={<Book className="h-5 w-5" />} label="Blueprints" />
+          <MobileTab href="/teams/launch/" icon={<Users className="h-5 w-5" />} label="Teams" />
+          <MobileTab href="/sessions/" icon={<PlusCircle className="h-5 w-5" />} label="Sessions" />
+          <MobileTab href="/settings/" icon={<Settings className="h-5 w-5" />} label="Settings" />
+        </nav>
       </div>
     </Router>
   )
 }
 
+function NavLink({ to, children }: { to: string; children: React.ReactNode }) {
+  const { pathname } = useLocation()
+  const active = to === '/' ? pathname === '/' : pathname.startsWith(to)
+  return (
+    <Link
+      to={to}
+      className={`btn btn-ghost btn-sm ${active ? 'btn-active' : ''}`}
+      aria-current={active ? 'page' : undefined}
+    >
+      {children}
+    </Link>
+  )
+}
+
+function MobileTab({
+  to,
+  href,
+  icon,
+  label,
+}: {
+  to?: string
+  href?: string
+  icon: React.ReactNode
+  label: string
+}) {
+  const { pathname } = useLocation()
+  const target = href || to || '/'
+  const active = to === '/' ? pathname === '/' : false
+  const className = `flex flex-col items-center justify-center flex-1 gap-0.5 text-xs ${
+    active ? 'text-primary font-semibold' : 'text-base-content/70'
+  }`
+  if (href) {
+    return (
+      <a href={href} className={className}>
+        {icon}
+        <span>{label}</span>
+      </a>
+    )
+  }
+  return (
+    <Link to={target} className={className} aria-current={active ? 'page' : undefined}>
+      {icon}
+      <span>{label}</span>
+    </Link>
+  )
+}
+
 function Dashboard() {
-  const [blueprintCount, setBlueprintCount] = useState<number | null>(null);
-  const [modelCount, setModelCount] = useState<number | null>(null);
-  const [teamsCount, setTeamsCount] = useState<number | null>(null);
-  const [loadingStats, setLoadingStats] = useState(true);
-  const [errorStats, setErrorStats] = useState<string | null>(null);
-  const [apiHealth, setApiHealth] = useState<{models?: string; blueprints?: string; teams?: string}>({});
-  const navigate = useNavigate();
+  const [blueprintCount, setBlueprintCount] = useState<number | null>(null)
+  const [modelCount, setModelCount] = useState<number | null>(null)
+  const [teamsCount, setTeamsCount] = useState<number | null>(null)
+  const [loadingStats, setLoadingStats] = useState(true)
+  const [errorStats, setErrorStats] = useState<string | null>(null)
+  const [apiOnline, setApiOnline] = useState<boolean | null>(null)
 
   useEffect(() => {
-    let cancelled = false;
+    let cancelled = false
     const fetchStats = async () => {
-      setLoadingStats(true);
-      setErrorStats(null);
-      const health: any = {};
+      setLoadingStats(true)
+      setErrorStats(null)
       try {
-        const [bpRes, mRes, tRes] = await Promise.all([
+        const [bpRes, mRes, tRes, healthRes] = await Promise.all([
           fetch('/v1/blueprints'),
           fetch('/v1/models'),
-          fetch('/teams/export?format=json')
-        ]);
-        const bpJson = bpRes.ok ? await bpRes.json() : {data: []};
-        const mJson = mRes.ok ? await mRes.json() : {data: []};
-        let tCount = 0;
-        if (tRes.ok) {
-          const tJson = await tRes.json();
-          tCount = tJson && typeof tJson === 'object' ? Object.keys(tJson).length : 0;
-          health.teams = 'ok';
+          fetch('/v1/teams/').catch(() => fetch('/teams/export?format=json')),
+          fetch('/health').catch(() => null),
+        ])
+        const bpJson = bpRes.ok ? await bpRes.json() : { data: [] }
+        const mJson = mRes.ok ? await mRes.json() : { data: [] }
+        let tCount = 0
+        if (tRes && tRes.ok) {
+          const tJson = await tRes.json()
+          if (Array.isArray(tJson?.data)) tCount = tJson.data.length
+          else if (tJson && typeof tJson === 'object') tCount = Object.keys(tJson).length
         }
         if (!cancelled) {
-          setBlueprintCount(Array.isArray(bpJson?.data) ? bpJson.data.length : 0);
-          setModelCount(Array.isArray(mJson?.data) ? mJson.data.length : 0);
-          setTeamsCount(tCount);
-          health.models = mRes.ok ? 'ok' : 'fail';
-          health.blueprints = bpRes.ok ? 'ok' : 'fail';
-          setApiHealth(health);
+          setBlueprintCount(Array.isArray(bpJson?.data) ? bpJson.data.length : 0)
+          setModelCount(Array.isArray(mJson?.data) ? mJson.data.length : 0)
+          setTeamsCount(tCount)
+          setApiOnline(healthRes ? healthRes.ok : bpRes.ok || mRes.ok)
         }
-      } catch (e: any) {
-        if (!cancelled) setErrorStats('Partial live data (some fetches failed; check vite proxy + backend).');
+      } catch {
+        if (!cancelled) {
+          setErrorStats('Could not load live stats. Is the API running?')
+          setApiOnline(false)
+        }
       } finally {
-        if (!cancelled) setLoadingStats(false);
+        if (!cancelled) setLoadingStats(false)
       }
-    };
-    fetchStats();
-    return () => { cancelled = true; };
-  }, []);
+    }
+    fetchStats()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   return (
     <div className="space-y-6">
-      {/* Welcome Alert */}
+      <header>
+        <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
+        <p className="text-sm opacity-70 mt-1">
+          Open Swarm — multi-agent blueprints behind an OpenAI-compatible API.
+        </p>
+      </header>
+
       <Alert type="info" icon={<Home className="h-5 w-5" />}>
-        <span className="font-medium">Welcome to Open Swarm MCP!</span> 
-        <span className="text-sm">Your AI agent orchestration platform is ready. Real data loaded from backend where possible.</span>
+        <span className="font-medium">Welcome to Open Swarm.</span>{' '}
+        <span className="text-sm">
+          Live counts load from the API when available. Quick Actions open the full operator UI
+          (Django) for teams, blueprints, and settings.
+        </span>
+      </Alert>
+      <Alert type="warning">
+        <span className="text-sm">
+          This React shell is a lightweight dashboard. Full library, sessions, creators, and
+          settings live on the Django paths (trailing slash).
+        </span>
       </Alert>
 
-      {/* Stats Cards - semi-real from APIs */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      {errorStats && (
+        <Alert type="warning">
+          <span className="text-sm">{errorStats}</span>
+        </Alert>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         <Card compact bordered>
           <div className="stat">
-            <div className="stat-title">Active Teams</div>
-            {loadingStats ? (
-              <div className="stat-value text-primary">...</div>
-            ) : (
-              <div className="stat-value text-primary">{teamsCount ?? 4}</div>
-            )}
-            <div className="stat-desc">{errorStats ? 'Partial' : 'From /teams/export (live dynamic registry)'}</div>
+            <div className="stat-title">Teams</div>
+            <div className="stat-value text-primary">
+              {loadingStats ? '…' : (teamsCount ?? 0)}
+            </div>
+            <div className="stat-desc">Registered teams</div>
           </div>
         </Card>
-
         <Card compact bordered>
           <div className="stat">
             <div className="stat-title">Blueprints</div>
-            {loadingStats ? (
-              <div className="stat-value text-secondary">...</div>
-            ) : (
-              <div className="stat-value text-secondary">{blueprintCount ?? '?'}</div>
-            )}
-            <div className="stat-desc">{errorStats ? 'Error loading' : 'From /v1/blueprints (live)'}</div>
+            <div className="stat-value text-secondary">
+              {loadingStats ? '…' : (blueprintCount ?? 0)}
+            </div>
+            <div className="stat-desc">Discoverable blueprints</div>
           </div>
         </Card>
-
         <Card compact bordered>
           <div className="stat">
-            <div className="stat-title">Models / Agents</div>
-            {loadingStats ? (
-              <div className="stat-value text-accent">...</div>
-            ) : (
-              <div className="stat-value text-accent">{modelCount ?? 24}</div>
-            )}
-            <div className="stat-desc">{errorStats ? 'Error' : 'From /v1/models (live)'}</div>
-          </div>
-        </Card>
-
-        <Card compact bordered>
-          <div className="stat">
-            <div className="stat-title">Completion Rate</div>
-            <div className="stat-value text-success">85%</div>
-            <div className="stat-desc">Demo / mock</div>
+            <div className="stat-title">Models</div>
+            <div className="stat-value text-accent">
+              {loadingStats ? '…' : (modelCount ?? 0)}
+            </div>
+            <div className="stat-desc">Exposed as OpenAI models</div>
           </div>
         </Card>
       </div>
 
-      {/* Quick Actions */}
       <Card title="Quick Actions" bordered>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <Button variant="primary" size="md" className="w-full">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <Button
+            variant="primary"
+            size="md"
+            className="w-full"
+            onClick={() => {
+              window.location.href = '/teams/launch/'
+            }}
+          >
             <PlusCircle className="h-5 w-5 mr-2" />
-            New Team
+            Launch Team
           </Button>
-          <Button variant="secondary" size="md" className="w-full">
+          <Button
+            variant="secondary"
+            size="md"
+            className="w-full"
+            onClick={() => {
+              window.location.href = '/blueprint-library/'
+            }}
+          >
             <Book className="h-5 w-5 mr-2" />
             Browse Blueprints
           </Button>
-          <Button variant="accent" size="md" className="w-full">
+          <Button
+            variant="accent"
+            size="md"
+            className="w-full"
+            onClick={() => {
+              window.location.href = '/teams/'
+            }}
+          >
             <Users className="h-5 w-5 mr-2" />
-            Team Manager
+            Manage Teams
           </Button>
-          <Button variant="info" size="md" className="w-full">
+          <Button
+            variant="info"
+            size="md"
+            className="w-full"
+            onClick={() => {
+              window.location.href = '/settings/'
+            }}
+          >
             <Settings className="h-5 w-5 mr-2" />
-            Configure
+            Settings
           </Button>
         </div>
       </Card>
 
-      {/* Recent Activity */}
-      <Card title="Recent Activity" bordered>
-        <div className="overflow-x-auto">
-          <table className="table table-zebra">
-            <thead>
-              <tr>
-                <th>Team</th>
-                <th>Status</th>
-                <th>Last Activity</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>
-                  <div className="flex items-center gap-2">
-                    <Badge type="success">Active</Badge>
-                    <span>Code Review Team</span>
-                  </div>
-                </td>
-                <td><Badge type="success">Active</Badge></td>
-                <td className="text-sm text-gray-500">2 minutes ago</td>
-              </tr>
-              <tr>
-                <td>
-                  <div className="flex items-center gap-2">
-                    <Badge type="warning">Idle</Badge>
-                    <span>Documentation Squad</span>
-                  </div>
-                </td>
-                <td><Badge type="warning">Idle</Badge></td>
-                <td className="text-sm text-gray-500">15 minutes ago</td>
-              </tr>
-              <tr>
-                <td>
-                  <div className="flex items-center gap-2">
-                    <Badge type="error">Error</Badge>
-                    <span>Data Processing</span>
-                  </div>
-                </td>
-                <td><Badge type="error">Error</Badge></td>
-                <td className="text-sm text-gray-500">1 hour ago</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+      <Card title="Getting started" bordered>
+        {(teamsCount === 0 || teamsCount === null) && !loadingStats ? (
+          <div className="space-y-3 text-sm">
+            <p>No teams registered yet. Launch a blueprint team to expose a custom model id on the API.</p>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => {
+                window.location.href = '/teams/launch/'
+              }}
+            >
+              Launch your first team
+            </Button>
+          </div>
+        ) : (
+          <ul className="list-disc pl-5 text-sm space-y-1 opacity-90">
+            <li>
+              Point OpenAI clients at <code className="text-xs">/v1</code> with your API token.
+            </li>
+            <li>
+              Browse blueprints at <code className="text-xs">/blueprint-library/</code>, then launch via
+              Teams or <code className="text-xs">swarm-cli</code>.
+            </li>
+            <li>
+              Sessions, creators, and full settings live on the Django shell (
+              <code className="text-xs">ENABLE_WEBUI=true</code>).
+            </li>
+          </ul>
+        )}
       </Card>
 
-      {/* System Status */}
-      <Card title="System Status" bordered>
-        <div className="space-y-3">
-          <div className="flex items-center justify-between p-3 bg-base-200 rounded-lg">
-            <div className="flex items-center gap-3">
-              <div className="w-3 h-3 bg-success rounded-full"></div>
-              <span>API Gateway</span>
-            </div>
-            <Badge type="success">Online</Badge>
+      <Card title="API status" bordered>
+        <div className="flex items-center justify-between p-3 bg-base-200 rounded-lg">
+          <div className="flex items-center gap-3">
+            <div
+              className={`w-3 h-3 rounded-full ${
+                apiOnline === null ? 'bg-base-300' : apiOnline ? 'bg-success' : 'bg-error'
+              }`}
+            />
+            <span>OpenAI-compatible API</span>
           </div>
-
-          <div className="flex items-center justify-between p-3 bg-base-200 rounded-lg">
-            <div className="flex items-center gap-3">
-              <div className="w-3 h-3 bg-success rounded-full"></div>
-              <span>Database</span>
-            </div>
-            <Badge type="success">Online</Badge>
-          </div>
-
-          <div className="flex items-center justify-between p-3 bg-base-200 rounded-lg">
-            <div className="flex items-center gap-3">
-              <div className="w-3 h-3 bg-warning rounded-full"></div>
-              <span>Cache</span>
-            </div>
-            <Badge type="warning">Degraded</Badge>
-          </div>
+          <Badge type={apiOnline ? 'success' : apiOnline === false ? 'error' : 'ghost'}>
+            {apiOnline === null ? 'Checking…' : apiOnline ? 'Reachable' : 'Unreachable'}
+          </Badge>
         </div>
       </Card>
     </div>
   )
 }
 
-// Duplicate local page definitions removed - using imported real pages from ./pages/
-// (BlueprintsPage, TeamsPage now contain real API integration + reduced mocks)
-
 function SettingsPage() {
+  // Bare /settings redirects to Django; this route remains only if linked in-app.
   return (
-    <div className="max-w-2xl">
-      <h1 className="text-3xl font-bold mb-6">Settings</h1>
+    <div className="max-w-2xl space-y-4">
+      <div className="flex items-center gap-3">
+        <h1 className="text-3xl font-bold">Settings</h1>
+        <Badge type="warning">Redirected</Badge>
+      </div>
+      <Alert type="info">
+        <span className="text-sm">
+          Prefer the full settings dashboard at{' '}
+          <a className="link font-semibold" href="/settings/">
+            /settings/
+          </a>
+          .
+        </span>
+      </Alert>
       <Card title="Application Settings" bordered>
-        <div className="space-y-4">
+        <div className="space-y-4 text-sm">
           <div>
-            <h3 className="font-semibold mb-2">Auth</h3>
-            <p className="text-sm">When ENABLE_API_AUTH, use <code>Authorization: Bearer &lt;token&gt;</code> or <code>X-API-Key</code> header.</p>
+            <h2 className="font-semibold mb-2">Auth</h2>
+            <p>
+              When API auth is enabled, send{' '}
+              <code>Authorization: Bearer &lt;token&gt;</code> or <code>X-API-Key</code>.
+            </p>
           </div>
           <div>
-            <h3 className="font-semibold mb-2">Streaming</h3>
-            <p className="text-sm">Backend supports <code>stream: true</code> on <code>/v1/chat/completions</code>. UI can use EventSource / fetch + reader.</p>
-          </div>
-          <div>
-            <h3 className="font-semibold mb-2">Teams / Dynamic Registry</h3>
-            <p className="text-sm">Teams created via /teams/ POST appear live in /v1/models and /v1/blueprints (merged in utils.py).</p>
+            <h2 className="font-semibold mb-2">Streaming</h2>
+            <p>
+              Use <code>stream: true</code> on <code>/v1/chat/completions</code>.
+            </p>
           </div>
         </div>
       </Card>
     </div>
-  );
+  )
 }
 
 export default App


### PR DESCRIPTION
# Summary
Make Django trailing-slash routes the operator UI of record: 5-destination shell, redirect bare SPA dual paths, denser blueprint library with Show more, progressive agent creators, and SPA dashboard that deep-links into Django (including `/chat` route).

## Problem it solves
Dual SPA/Django surfaces for teams/settings/blueprints confused operators and screenshots; agent creator walls and unbounded library grids hurt UX.

## How it works
- `urls.py` RedirectView for bare `/teams`, `/blueprints`, `/settings`, `/agent-creator`.
- `base.html` + CSS: primary IA, More/GitHub, mobile bottom nav, safe-area padding.
- Library client page size 12; creator accordions/details collapsed by default.
- `App.tsx`: Sessions in chrome, Django hrefs, ChatPage mounted, catch-all home.
- Contract tests in `test_spa_django_canonical_routes.py`.

## Measured impact
Redirect client tests 302 to canonical paths; template contract tests green for pagination/disclosure markers.

## Test coverage
- `tests/views/test_spa_django_canonical_routes.py`
- Run: `pytest tests/views/test_spa_django_canonical_routes.py -q`
- SPA dist is gitignored; rebuild with `npm run build` where deployed.

## Risks / follow-ups
SPA leftover pages still in tree; multi-design-system chrome remains. Rebuild frontend dist in deploy images.

## Build footprint
None in-repo (dist ignored); no new services.