### PR TITLE
feat(prod): P0 auth, ownership, secrets, single-worker

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -261,10 +261,13 @@ environment / `.env`, never in `swarm_config.json` (reference them with
 | `DJANGO_ALLOWED_HOSTS` | Comma-separated allowed hosts (whitespace-trimmed, empties dropped). **Required in production.** | dev: `localhost,127.0.0.1` |
 | `DJANGO_CSRF_TRUSTED_ORIGINS` | Comma-separated trusted origins for CSRF on mutating routes (whitespace-trimmed, empties dropped). | `http://localhost:8000,http://127.0.0.1:8000` |
 | `API_AUTH_TOKEN` | Bearer token OpenAI clients present to the API. | none |
-| `ENABLE_API_AUTH` | Require auth on `/v1/*`. Auto-on when `API_AUTH_TOKEN` is set. | prod: on |
+| `ENABLE_API_AUTH` | Require auth on `/v1/*` (including `/v1/models` and `/v1/blueprints`). Auto-on when `API_AUTH_TOKEN` is set. | prod: on |
 | `SWARM_ALLOW_NO_AUTH` | Allow booting in production **without** a token (warns) — for when an external OAuth proxy / API gateway already gates access. | `false` |
 | `ALLOW_TESTUSER_AUTOLOGIN` | Dev-only auto-login (debug only, random password). | `false` |
 | `HOST` / `PORT` | Bind address/port for the server. | `0.0.0.0` / `8000` |
+| `SWARM_UVICORN_WORKERS` | uvicorn worker count. Prefer **1** — async cancel/inflight are process-local. | `1` |
+| `SWARM_ENFORCE_SINGLE_WORKER` | When true (default), refuse `SWARM_UVICORN_WORKERS` &gt; 1 at app startup. | `true` |
+| `SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY` | When true, scan user blueprint dirs (exec_module). Default off so creator saves are write-only. | `false` |
 
 ### Feature flags
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,9 @@ services:
       DJANGO_DB_NAME: "${HOME}/.local/share/swarm/db.sqlite3"
       SQLITE_DB_PATH: "${HOME}/.local/share/swarm/db.sqlite3"
       SWARM_RESPONSES_DIR: "${HOME}/.local/share/swarm/responses"
+      # Async /v1/responses cancel + inflight limits are process-local until a
+      # shared queue exists. Keep a single uvicorn worker (see Dockerfile CMD).
+      SWARM_UVICORN_WORKERS: "${SWARM_UVICORN_WORKERS:-1}"
     volumes:
       # Your swarm config (llm profiles + any cli_agents) — read-only.
       - "${HOME}/.config/swarm:${HOME}/.config/swarm:ro"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -62,6 +62,12 @@ docker compose up -d
 Point any OpenAI client at `http://<host>:8000/v1` with
 `Authorization: Bearer $API_AUTH_TOKEN`.
 
+> **Single worker until a shared queue exists.** Async `/v1/responses` cancel
+> and in-flight limits are **process-local**. Compose/Dockerfile default
+> `SWARM_UVICORN_WORKERS=1`. Setting workers > 1 is refused by default
+> (`SWARM_ENFORCE_SINGLE_WORKER=true`); only override if you accept broken
+> cross-worker cancel. Oracle systemd unit already uses `--workers 1`.
+
 > **Persist Responses state.** `/v1/responses` is stateful: stored responses (for
 > `previous_response_id` chaining and `GET`/`DELETE`) live under
 > `SWARM_RESPONSES_DIR` (default `~/.local/share/swarm/responses`). In Docker,

--- a/src/swarm/apps.py
+++ b/src/swarm/apps.py
@@ -82,9 +82,30 @@ class SwarmConfig(AppConfig):
         # Resume async /v1/responses tasks left in-flight by a restart — server
         # processes only (not migrate/test), guarded against the runserver
         # reloader's parent process to avoid double-resume.
+        self._check_uvicorn_workers()
         self._maybe_resume_async_tasks()
 
         logger.info("Swarm app initialization checks completed.")
+
+    @staticmethod
+    def _check_uvicorn_workers() -> None:
+        """Refuse/warn multi-worker async when serving (process-local cancel)."""
+        import sys
+
+        argv = " ".join(sys.argv)
+        if not any(s in argv for s in ("uvicorn", "swarm-api", "gunicorn", "daphne")):
+            # Still validate env when set so unit tests can exercise the helper.
+            if not os.environ.get("SWARM_UVICORN_WORKERS"):
+                return
+        try:
+            from swarm.core.concurrency import resolved_uvicorn_workers
+
+            resolved_uvicorn_workers()
+        except ValueError as e:
+            logger.error("Multi-worker async contract: %s", e)
+            raise
+        except Exception as e:
+            logger.debug("uvicorn workers check skipped: %s", e)
 
     @staticmethod
     def _maybe_resume_async_tasks() -> None:

--- a/src/swarm/auth.py
+++ b/src/swarm/auth.py
@@ -146,3 +146,26 @@ def api_permission_classes():
         return [HasValidTokenOrSession]
     return [AllowAny]
 
+
+def request_principal(request) -> str | None:
+    """Stable principal id for the request (ownership stamps).
+
+    - Session user → ``user:<username>``
+    - Static API token (request.auth) → ``token:<sha256-prefix>`` of the
+      presenting credential (single configured token ⇒ one principal; multi-key
+      is a future extension)
+    - Unauthenticated → ``None``
+    """
+    import hashlib
+
+    user = getattr(request, "user", None)
+    if user is not None and getattr(user, "is_authenticated", False):
+        return f"user:{user.get_username()}"
+
+    auth = getattr(request, "auth", None)
+    if auth is not None:
+        # request.auth is the raw token string from StaticTokenAuthentication
+        digest = hashlib.sha256(str(auth).encode("utf-8")).hexdigest()[:24]
+        return f"token:{digest}"
+    return None
+

--- a/src/swarm/core/concurrency.py
+++ b/src/swarm/core/concurrency.py
@@ -2,14 +2,48 @@
 
 Single-instance only — not a multi-worker distributed semaphore. Used to
 reject overload with a client-safe 429 instead of unbounded thread growth.
+
+Until a shared queue exists, async ``/v1/responses`` cancel + inflight are
+**per process**. Prefer a single uvicorn worker (``SWARM_UVICORN_WORKERS=1``).
 """
 from __future__ import annotations
 
+import logging
+import os
 import threading
 from contextlib import contextmanager
 
+logger = logging.getLogger(__name__)
+
 _lock = threading.Lock()
 _inflight = 0
+
+
+def resolved_uvicorn_workers() -> int:
+    """Resolve uvicorn worker count; warn or refuse multi-worker async.
+
+    Default 1. When ``SWARM_ENFORCE_SINGLE_WORKER`` is true (default), values
+    greater than 1 raise ``ValueError`` so operators cannot silently break
+    cancel/inflight. Set the env to false to allow multi-worker with a warning.
+    """
+    raw = os.getenv("SWARM_UVICORN_WORKERS", "1") or "1"
+    try:
+        n = int(raw)
+    except ValueError:
+        n = 1
+    n = max(1, n)
+    enforce = os.getenv("SWARM_ENFORCE_SINGLE_WORKER", "true").lower() in (
+        "true", "1", "yes", "y", "t",
+    )
+    if n > 1:
+        msg = (
+            f"SWARM_UVICORN_WORKERS={n} > 1: /v1/responses cancel and inflight "
+            "limits are process-local until a shared queue exists. Prefer workers=1."
+        )
+        if enforce:
+            raise ValueError(msg + " Set SWARM_ENFORCE_SINGLE_WORKER=false to override.")
+        logger.warning(msg)
+    return n
 
 
 def max_inflight() -> int:

--- a/src/swarm/core/responses_store.py
+++ b/src/swarm/core/responses_store.py
@@ -41,7 +41,11 @@ def _path_for(response_id: str, base_dir: Path | None) -> Path | None:
 
 
 def save(record: dict[str, Any], *, base_dir: Path | None = None) -> None:
-    """Persist a record (must have a valid ``id``). Atomic write; best-effort."""
+    """Persist a record (must have a valid ``id``). Atomic write; best-effort.
+
+    Optional top-level ``owner`` string stamps the creating principal for IDOR
+    checks when API auth is enabled (see responses detail/cancel views).
+    """
     rid = record.get("id", "")
     path = _path_for(rid, base_dir)
     if path is None:
@@ -69,6 +73,24 @@ def load(response_id: str, *, base_dir: Path | None = None) -> dict[str, Any] | 
             return json.load(f)
     except (OSError, json.JSONDecodeError):
         return None
+
+
+def owner_allows(record: dict[str, Any] | None, principal: str | None) -> bool:
+    """Whether ``principal`` may access ``record`` under ownership rules.
+
+    - No record → False (caller should 404 separately if desired)
+    - No owner on record → True (legacy records; auth still required at the view)
+    - principal None → False when owner is set
+    - else principal must equal record['owner']
+    """
+    if record is None:
+        return False
+    owner = record.get("owner")
+    if not owner:
+        return True
+    if not principal:
+        return False
+    return str(owner) == str(principal)
 
 
 def list_summaries(*, base_dir: Path | None = None, limit: int | None = 200) -> list[dict[str, Any]]:

--- a/src/swarm/settings.py
+++ b/src/swarm/settings.py
@@ -54,18 +54,29 @@ def _blueprint_extra_dirs() -> list[str]:
     Order: the user data 'blueprints' dir (where community packs are installed),
     then any paths in ``SWARM_BLUEPRINT_PATHS`` (os.pathsep-separated). The bundled
     dir always wins on name collisions (see ``discover_all_blueprints``).
+
+    User blueprint discovery (``exec_module`` of files under the user data dir)
+    is **off by default**. Set ``SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY=true`` to
+    include that dir — creator saves never execute code on the write path.
     """
     dirs: list[str] = []
-    try:
-        from swarm.core.paths import get_user_blueprints_dir
-        dirs.append(str(get_user_blueprints_dir()))
-    except Exception:
-        pass
+    allow_user = os.getenv("SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY", "").lower() in (
+        "true", "1", "yes", "y", "t",
+    )
+    if allow_user:
+        try:
+            from swarm.core.paths import get_user_blueprints_dir
+            dirs.append(str(get_user_blueprints_dir()))
+        except Exception:
+            pass
     extra = os.getenv("SWARM_BLUEPRINT_PATHS", "")
     dirs.extend(p for p in extra.split(os.pathsep) if p.strip())
     return dirs
 
 
+# User blueprint dirs (creator output) are only auto-discovered when operators
+# opt in — default ship path must not exec_module untrusted generated code.
+# See SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY in env / CONFIGURATION.md.
 BLUEPRINT_EXTRA_DIRS = _blueprint_extra_dirs()
 
 # Web UI Configuration

--- a/src/swarm/views/agent_creator_views.py
+++ b/src/swarm/views/agent_creator_views.py
@@ -8,11 +8,27 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
 
 from swarm.core import paths
+
+# Shared ban list for creator write paths (agent + team swarm saves).
+_BANNED_CODE_SNIPPETS = ("__import__", "subprocess", "os.system", "eval(", "exec(")
+
+
+def _banned_code_error(code: str) -> str | None:
+    """Return an error message if code contains unsandboxed-exec patterns."""
+    lowered = code.lower()
+    for banned in _BANNED_CODE_SNIPPETS:
+        if banned in lowered:
+            return (
+                f"Saved blueprints may not contain {banned!r} "
+                "(unsandboxed exec blocked)."
+            )
+    return None
 
 
 class BlueprintCodeValidator:
@@ -332,9 +348,10 @@ def agent_creator_page(request):
         return render(request, 'agent_creator.html', context)
 
 
+@login_required
 @require_http_methods(["POST"])
 def generate_agent_code(request):
-    """Generate agent code from form data"""
+    """Generate agent code from form data (authenticated operator session)."""
     try:
         data = json.loads(request.body)
 
@@ -371,9 +388,10 @@ def generate_agent_code(request):
         }, status=500)
 
 
+@login_required
 @require_http_methods(["POST"])
 def validate_agent_code(request):
-    """Validate user-provided agent code"""
+    """Validate user-provided agent code via AST only — never exec."""
     try:
         data = json.loads(request.body)
         code = data.get('code', '')
@@ -404,9 +422,16 @@ def validate_agent_code(request):
         }, status=500)
 
 
+@login_required
 @require_http_methods(["POST"])
 def save_custom_agent(request):
-    """Save a custom agent blueprint"""
+    """Save a custom agent blueprint (write-only; not executed on save).
+
+    Generated code is **not** imported/exec'd on this path. Discovery of
+    user-written blueprints requires ``SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY``
+    (see settings._blueprint_extra_dirs) so the default ship path never
+    exec_module untrusted creator output.
+    """
     try:
         data = json.loads(request.body)
         code = data.get('code', '')
@@ -418,7 +443,7 @@ def save_custom_agent(request):
                 'error': 'Missing code or agent name'
             }, status=400)
 
-        # Validate the code first
+        # Validate the code first (AST/structure only — no exec)
         validation_result = validator.validate_blueprint_code(code)
         if not validation_result['valid']:
             return JsonResponse({
@@ -427,7 +452,11 @@ def save_custom_agent(request):
                 'validation': validation_result
             }, status=400)
 
-        # Save to user_blueprints directory
+        banned = _banned_code_error(code)
+        if banned:
+            return JsonResponse({'success': False, 'error': banned}, status=400)
+
+        # Save to user_blueprints directory (not auto-discovered unless env allows).
         user_blueprints_dir = Path('user_blueprints')
         agent_dir = user_blueprints_dir / agent_name.lower().replace(' ', '_')
         agent_dir.mkdir(parents=True, exist_ok=True)
@@ -716,9 +745,14 @@ def _render_swarm_blueprint_code(team: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+@login_required
 @require_http_methods(["POST"])
 def save_team_swarm(request):
-    """Persist a multi-bot swarm blueprint from the Team Creator UI."""
+    """Persist a multi-bot swarm blueprint from the Team Creator UI.
+
+    Authenticated write-only path: generated code is not exec'd on save.
+    User blueprint discovery remains opt-in via SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY.
+    """
     try:
         data = json.loads(request.body.decode("utf-8"))
     except Exception:
@@ -746,6 +780,13 @@ def save_team_swarm(request):
         if bot_name.lower() in seen:
             return JsonResponse({"success": False, "error": f"Duplicate bot name: {bot_name}"}, status=400)
         seen.add(bot_name.lower())
+        # Refuse dangerous patterns in free-text prompts that end up in source.
+        for field in ("system_prompt", "instructions", "description", "role"):
+            val = agent.get(field) or ""
+            if isinstance(val, str):
+                banned = _banned_code_error(val)
+                if banned:
+                    return JsonResponse({"success": False, "error": banned}, status=400)
         cleaned_agents.append({
             "name": bot_name,
             "role": (agent.get("role") or bot_name).strip(),
@@ -769,6 +810,9 @@ def save_team_swarm(request):
     }
 
     code = _render_swarm_blueprint_code(team)
+    banned = _banned_code_error(code)
+    if banned:
+        return JsonResponse({"success": False, "error": banned}, status=400)
 
     user_blueprints_dir = Path("user_blueprints")
     swarm_dir = user_blueprints_dir / blueprint_id

--- a/src/swarm/views/api_views.py
+++ b/src/swarm/views/api_views.py
@@ -52,7 +52,9 @@ class ModelsListView(APIView):
     """
     API view to list available models (blueprints) compatible with OpenAI's /v1/models format.
     """
-    permission_classes = [AllowAny]
+    # Respect ENABLE_API_AUTH (was hard-coded AllowAny — open discovery when locked down).
+    def get_permissions(self):
+        return [perm() for perm in api_permission_classes()]
 
     def get(self, request, *_args, **_kwargs):
         try:
@@ -95,7 +97,8 @@ class BlueprintsListView(APIView):
     """
     API view to list available blueprints with richer metadata than /v1/models.
     """
-    permission_classes = [AllowAny]
+    def get_permissions(self):
+        return [perm() for perm in api_permission_classes()]
 
     def get(self, request, *_args, **_kwargs):
         try:

--- a/src/swarm/views/responses_views.py
+++ b/src/swarm/views/responses_views.py
@@ -42,6 +42,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from swarm.auth import request_principal
 from swarm.core import responses_store
 
 from .chat_views import _chunk_is_final, _extract_message_from_chunk
@@ -248,6 +249,8 @@ class ResponsesView(APIView):
     async def post(self, request: Request, *_args: Any, **_kwargs: Any) -> HttpResponseBase:
         request_id = str(uuid.uuid4())
         logger.info(f"[ReqID: {request_id}] Processing /v1/responses POST request.")
+        # Stamp owner for store records (IDOR protection on GET/cancel/delete).
+        self._owner_principal = request_principal(request)
 
         # --- Request body parsing ---
         try:
@@ -287,6 +290,7 @@ class ResponsesView(APIView):
             prior = await sync_to_async(responses_store.load)(str(previous_response_id))
             if prior is None:
                 raise NotFound(f"Previous response '{previous_response_id}' not found.")
+            _assert_owner_access(request, prior)
             messages = list(prior.get("messages") or []) + messages
 
         # --- Model access validation (same helper as ChatCompletionsView) ---
@@ -348,8 +352,10 @@ class ResponsesView(APIView):
             request_id, model_name, "", previous_response_id, None, None, status="queued"
         )
         # The _task spec lets a server restart resume this (see resume_pending_responses).
+        owner = getattr(self, "_owner_principal", None)
         await sync_to_async(responses_store.save)({
             "id": response_id, "object": "response", "response": payload, "messages": None,
+            "owner": owner,
             "_task": _task_spec(request_id, model_name, list(messages), params, previous_response_id),
         })
         # Daemon thread with its own event loop — decoupled from the request
@@ -409,7 +415,9 @@ class ResponsesView(APIView):
 
         payload = _build_response_payload(request_id, model_name, answer, previous_response_id, messages, backend_meta)
         if store:
-            await sync_to_async(_persist)(payload, messages, answer)
+            await sync_to_async(_persist)(
+                payload, messages, answer, owner=getattr(self, "_owner_principal", None)
+            )
         return Response(payload, status=status.HTTP_200_OK)
 
     async def _handle_streaming(self, blueprint_instance, messages, request_id, model_name, store=True, previous_response_id=None) -> StreamingHttpResponse:
@@ -442,7 +450,9 @@ class ResponsesView(APIView):
                 final_text = "".join(full_text_parts)
                 payload = _build_response_payload(request_id, model_name, final_text, previous_response_id, messages, backend_meta)
                 if store:
-                    await sync_to_async(_persist)(payload, messages, final_text)
+                    await sync_to_async(_persist)(
+                        payload, messages, final_text, owner=getattr(self, "_owner_principal", None)
+                    )
                 completed = {"type": "response.completed", "response": payload}
                 yield f"data: {json.dumps(completed)}\n\n"
                 yield "data: [DONE]\n\n"
@@ -501,16 +511,34 @@ def _build_response_payload(
     }
 
 
-def _persist(payload: dict[str, Any], messages: list[dict[str, Any]], answer: str) -> None:
+def _persist(
+    payload: dict[str, Any],
+    messages: list[dict[str, Any]],
+    answer: str,
+    *,
+    owner: str | None = None,
+) -> None:
     """Save a response record so it can be retrieved and chained from later."""
+    # Preserve existing owner on update if present.
+    existing = responses_store.load(payload["id"]) or {}
     record = {
         "id": payload["id"],
         "object": "response",
         "response": payload,
         # Full transcript incl. the assistant reply, so previous_response_id replays it.
         "messages": list(messages) + [{"role": "assistant", "content": answer}],
+        "owner": owner if owner is not None else existing.get("owner"),
     }
     responses_store.save(record)
+
+
+def _assert_owner_access(request: Request, record: dict[str, Any] | None) -> None:
+    """Refuse cross-principal access when API auth is on and owner is stamped."""
+    if not bool(getattr(settings, "ENABLE_API_AUTH", False)):
+        return
+    principal = request_principal(request)
+    if not responses_store.owner_allows(record, principal):
+        raise PermissionDenied("You do not have access to this response.")
 
 
 # --- Cancellation registry -------------------------------------------------- #
@@ -665,7 +693,14 @@ def _run_background_response_body(
         with progress_lock:
             if progress:
                 payload["progress"] = list(progress)
-        record = {"id": response_id, "object": "response", "response": payload, "messages": transcript}
+        existing = responses_store.load(response_id) or {}
+        record = {
+            "id": response_id,
+            "object": "response",
+            "response": payload,
+            "messages": transcript,
+            "owner": existing.get("owner") or spec.get("owner"),
+        }
         if keep_task:
             record["_task"] = spec
         responses_store.save(record)
@@ -792,13 +827,18 @@ class ResponsesDetailView(APIView):
     async def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
         return await _async_auth_dispatch(self, request, *args, **kwargs)
 
-    async def get(self, _request: Request, response_id: str, *_a: Any, **_k: Any) -> Response:
+    async def get(self, request: Request, response_id: str, *_a: Any, **_k: Any) -> Response:
         record = await sync_to_async(responses_store.load)(response_id)
         if record is None:
             raise NotFound(f"Response '{response_id}' not found.")
+        _assert_owner_access(request, record)
         return Response(record.get("response") or record, status=status.HTTP_200_OK)
 
-    async def delete(self, _request: Request, response_id: str, *_a: Any, **_k: Any) -> Response:
+    async def delete(self, request: Request, response_id: str, *_a: Any, **_k: Any) -> Response:
+        record = await sync_to_async(responses_store.load)(response_id)
+        if record is None:
+            raise NotFound(f"Response '{response_id}' not found.")
+        _assert_owner_access(request, record)
         deleted = await sync_to_async(responses_store.delete)(response_id)
         if not deleted:
             raise NotFound(f"Response '{response_id}' not found.")
@@ -817,10 +857,11 @@ class ResponsesCancelView(APIView):
         description="Cooperatively cancel an in-flight async task. No request body. Idempotent on finished tasks.",
         request=None,
     )
-    async def post(self, _request: Request, response_id: str, *_a: Any, **_k: Any) -> Response:
+    async def post(self, request: Request, response_id: str, *_a: Any, **_k: Any) -> Response:
         record = await sync_to_async(responses_store.load)(response_id)
         if record is None:
             raise NotFound(f"Response '{response_id}' not found.")
+        _assert_owner_access(request, record)
         payload = record.get("response") or {}
         current = payload.get("status")
         # No-op on already-finished tasks (idempotent) — return the current state.
@@ -831,6 +872,12 @@ class ResponsesCancelView(APIView):
         _request_cancel(response_id)
         payload["status"] = "cancelled"
         await sync_to_async(responses_store.save)(
-            {"id": response_id, "object": "response", "response": payload, "messages": record.get("messages")}
+            {
+                "id": response_id,
+                "object": "response",
+                "response": payload,
+                "messages": record.get("messages"),
+                "owner": record.get("owner"),
+            }
         )
         return Response(payload, status=status.HTTP_200_OK)

--- a/src/swarm/views/settings_manager.py
+++ b/src/swarm/views/settings_manager.py
@@ -275,18 +275,27 @@ class SettingsManager:
 
             llm_settings = {}
 
-            # LLM providers
+            # LLM providers — mark sensitive when api keys present (API redacts value).
             for provider, config_data in llm_config.items():
+                sensitive = False
+                if isinstance(config_data, dict):
+                    sensitive = any(
+                        k.lower() in ("api_key", "apikey", "token", "secret", "password")
+                        or "key" in k.lower()
+                        for k in config_data
+                    )
+                else:
+                    sensitive = "api_key" in str(config_data).lower()
                 llm_settings[f'LLM_{provider.upper()}'] = {
                     'value': config_data,
                     'env_var': None,
                     'type': 'object',
                     'description': f'Configuration for {provider} LLM provider',
                     'category': 'provider',
-                    'sensitive': 'api_key' in str(config_data).lower()
+                    'sensitive': sensitive,
                 }
 
-            # LLM profiles
+            # LLM profiles often embed api_key / base_url secrets — always treat as sensitive.
             for profile, profile_data in profiles_config.items():
                 llm_settings[f'PROFILE_{profile.upper()}'] = {
                     'value': profile_data,
@@ -294,7 +303,7 @@ class SettingsManager:
                     'type': 'object',
                     'description': f'LLM profile configuration for {profile}',
                     'category': 'profile',
-                    'sensitive': False
+                    'sensitive': True,
                 }
 
             # Environment variables for common LLM providers

--- a/src/swarm/views/settings_views.py
+++ b/src/swarm/views/settings_views.py
@@ -26,11 +26,14 @@ if _this_mod is not None:
 
 @login_required
 def settings_dashboard(request):
-    """Render the comprehensive settings dashboard (authenticated)."""
+    """Render the comprehensive settings dashboard (authenticated).
+
+    ``settings_groups`` is redacted before template/json_script so viewObject
+    never surfaces raw api_key values.
+    """
     try:
         all_settings = settings_manager.collect_all_settings()
-
-        # Calculate statistics
+        # Stats from raw collection (configured counts), display uses redacted copy.
         total_settings = sum(len(group['settings']) for group in all_settings.values())
         configured_settings = sum(
             1 for group in all_settings.values()
@@ -42,10 +45,11 @@ def settings_dashboard(request):
             for setting in group['settings'].values()
             if setting.get('sensitive', False)
         )
+        safe_groups = redact_settings_groups(all_settings)
 
         context = {
             'page_title': 'Settings Dashboard',
-            'settings_groups': all_settings,
+            'settings_groups': safe_groups,
             'stats': {
                 'total': total_settings,
                 'configured': configured_settings,
@@ -60,28 +64,50 @@ def settings_dashboard(request):
         return HttpResponse(f"Error loading settings: {str(e)}", status=500)
 
 
+def _redact_setting_value(value, *, sensitive: bool):
+    """Redact sensitive setting values for API/export using the real redactor."""
+    from swarm.utils.redact import redact_sensitive_data
+
+    if sensitive:
+        # Never emit raw secrets/objects marked sensitive.
+        if isinstance(value, dict | list):
+            return redact_sensitive_data(value, mask="***HIDDEN***")
+        if value in (None, "", "Not Set"):
+            return value
+        return "***HIDDEN***"
+    # Even non-sensitive dicts may embed api_key-like keys — run recursive redaction.
+    if isinstance(value, dict | list):
+        return redact_sensitive_data(value, mask="***HIDDEN***")
+    return value
+
+
+def redact_settings_groups(all_settings: dict) -> dict:
+    """Deep-copy settings groups with secrets redacted (dashboard + API + json_script)."""
+    safe_settings: dict = {}
+    for group_name, group_data in all_settings.items():
+        safe_settings[group_name] = {
+            "title": group_data["title"],
+            "description": group_data["description"],
+            "icon": group_data["icon"],
+            "settings": {},
+        }
+        for setting_name, setting_data in group_data["settings"].items():
+            safe_setting = setting_data.copy()
+            safe_setting["value"] = _redact_setting_value(
+                setting_data.get("value"),
+                sensitive=bool(setting_data.get("sensitive", False)),
+            )
+            safe_settings[group_name]["settings"][setting_name] = safe_setting
+    return safe_settings
+
+
 @login_required
 @require_http_methods(["GET"])
 def settings_api(_request):
     """API endpoint to get all settings as JSON (authenticated)."""
     try:
         all_settings = settings_manager.collect_all_settings()
-
-        # Remove sensitive values for API response
-        safe_settings = {}
-        for group_name, group_data in all_settings.items():
-            safe_settings[group_name] = {
-                'title': group_data['title'],
-                'description': group_data['description'],
-                'icon': group_data['icon'],
-                'settings': {}
-            }
-
-            for setting_name, setting_data in group_data['settings'].items():
-                safe_setting = setting_data.copy()
-                if setting_data.get('sensitive', False):
-                    safe_setting['value'] = '***HIDDEN***'
-                safe_settings[group_name]['settings'][setting_name] = safe_setting
+        safe_settings = redact_settings_groups(all_settings)
 
         return JsonResponse({
             'success': True,

--- a/tests/api/test_prod_p0_auth_ownership.py
+++ b/tests/api/test_prod_p0_auth_ownership.py
@@ -1,0 +1,173 @@
+"""Production P0: discovery auth lock + response ownership (IDOR refuse).
+
+Drives real permissioned views (ModelsListView / BlueprintsListView /
+Responses detail/cancel) — not reimplemented stubs.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client, override_settings
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from swarm.auth import StaticTokenAuthentication, request_principal
+from swarm.core import responses_store
+from swarm.views.api_views import BlueprintsListView, ModelsListView
+from swarm.views.responses_views import ResponsesCancelView, ResponsesDetailView
+
+
+TOKEN = "prod-p0-test-token-xyz"
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("SWARM_RESPONSES_DIR", str(tmp_path))
+    return tmp_path
+
+
+@pytest.mark.django_db
+class TestDiscoveryAuthLock:
+    def test_models_open_when_api_auth_disabled(self):
+        factory = APIRequestFactory()
+        request = factory.get("/v1/models")
+        view = ModelsListView.as_view()
+        with override_settings(ENABLE_API_AUTH=False, SWARM_API_KEY=None):
+            response = view(request)
+        assert response.status_code == 200
+
+    def test_models_requires_auth_when_enabled(self):
+        factory = APIRequestFactory()
+        request = factory.get("/v1/models")
+        view = ModelsListView.as_view()
+        with override_settings(ENABLE_API_AUTH=True, SWARM_API_KEY=TOKEN):
+            response = view(request)
+        # DRF permission denied → 403
+        assert response.status_code in (401, 403)
+
+    def test_models_ok_with_bearer_token(self):
+        factory = APIRequestFactory()
+        request = factory.get("/v1/models", HTTP_AUTHORIZATION=f"Bearer {TOKEN}")
+        # Run authentication so request.auth is set
+        with override_settings(ENABLE_API_AUTH=True, SWARM_API_KEY=TOKEN):
+            auth = StaticTokenAuthentication()
+            user_auth = auth.authenticate(request)
+            assert user_auth is not None
+            request.user, request.auth = user_auth
+            view = ModelsListView.as_view()
+            response = view(request)
+        assert response.status_code == 200
+        assert "data" in response.data
+
+    def test_blueprints_requires_auth_when_enabled(self):
+        factory = APIRequestFactory()
+        request = factory.get("/v1/blueprints")
+        view = BlueprintsListView.as_view()
+        with override_settings(ENABLE_API_AUTH=True, SWARM_API_KEY=TOKEN):
+            response = view(request)
+        assert response.status_code in (401, 403)
+
+    def test_blueprints_ok_with_token(self):
+        factory = APIRequestFactory()
+        request = factory.get("/v1/blueprints", HTTP_AUTHORIZATION=f"Bearer {TOKEN}")
+        with override_settings(ENABLE_API_AUTH=True, SWARM_API_KEY=TOKEN):
+            auth = StaticTokenAuthentication()
+            user_auth = auth.authenticate(request)
+            request.user, request.auth = user_auth
+            response = BlueprintsListView.as_view()(request)
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestResponseOwnership:
+    def _save(self, rid: str, owner: str | None):
+        responses_store.save({
+            "id": rid,
+            "object": "response",
+            "owner": owner,
+            "response": {
+                "id": rid,
+                "object": "response",
+                "status": "completed",
+                "output_text": "hello",
+            },
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+
+    def test_owner_allows_helper(self, store):
+        rec = {"id": "resp_x", "owner": "user:alice"}
+        assert responses_store.owner_allows(rec, "user:alice") is True
+        assert responses_store.owner_allows(rec, "user:bob") is False
+        assert responses_store.owner_allows({"id": "resp_y"}, "user:bob") is True  # legacy
+        assert responses_store.owner_allows(rec, None) is False
+
+    def test_get_refuses_foreign_principal(self, store):
+        User = get_user_model()
+        alice = User.objects.create_user(username="alice_p0", password="x")
+        bob = User.objects.create_user(username="bob_p0", password="x")
+        self._save("resp_owned_alice", "user:alice_p0")
+
+        from rest_framework.request import Request
+        from rest_framework.exceptions import PermissionDenied
+        from swarm.views.responses_views import _assert_owner_access
+
+        factory = APIRequestFactory()
+        req = factory.get("/v1/responses/resp_owned_alice")
+        force_authenticate(req, user=bob)
+        drf_req = Request(req)
+        drf_req.user = bob
+        drf_req.auth = None
+        rec = responses_store.load("resp_owned_alice")
+        with override_settings(ENABLE_API_AUTH=True, SWARM_API_KEY=TOKEN):
+            assert request_principal(drf_req) == "user:bob_p0"
+            with pytest.raises(PermissionDenied):
+                _assert_owner_access(drf_req, rec)
+
+        # Same principal OK
+        force_authenticate(req, user=alice)
+        drf_req.user = alice
+        with override_settings(ENABLE_API_AUTH=True, SWARM_API_KEY=TOKEN):
+            _assert_owner_access(drf_req, rec)  # no raise
+
+    def test_cancel_refuses_foreign_owner(self, store):
+        User = get_user_model()
+        alice = User.objects.create_user(username="alice_c", password="x")
+        bob = User.objects.create_user(username="bob_c", password="x")
+        self._save("resp_cancel_alice", "user:alice_c")
+        factory = APIRequestFactory()
+        req = factory.post("/v1/responses/resp_cancel_alice/cancel")
+        force_authenticate(req, user=bob)
+        from rest_framework.request import Request
+        from rest_framework.exceptions import PermissionDenied
+        from swarm.views.responses_views import _assert_owner_access
+
+        drf_req = Request(req)
+        drf_req.user = bob
+        rec = responses_store.load("resp_cancel_alice")
+        with override_settings(ENABLE_API_AUTH=True, SWARM_API_KEY=TOKEN):
+            with pytest.raises(PermissionDenied):
+                _assert_owner_access(drf_req, rec)
+
+    def test_request_principal_session_and_token(self):
+        User = get_user_model()
+        u = User.objects.create_user(username="prin_user", password="x")
+        factory = APIRequestFactory()
+        req = factory.get("/")
+        force_authenticate(req, user=u)
+        from rest_framework.request import Request
+
+        drf = Request(req)
+        drf.user = u
+        drf.auth = None
+        assert request_principal(drf) == "user:prin_user"
+
+        req2 = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {TOKEN}")
+        with override_settings(SWARM_API_KEY=TOKEN):
+            pair = StaticTokenAuthentication().authenticate(req2)
+            assert pair is not None
+            req2.user, req2.auth = pair
+            drf2 = Request(req2)
+            drf2.user, drf2.auth = pair
+            p = request_principal(drf2)
+            assert p is not None and p.startswith("token:")

--- a/tests/unit/test_prod_p0_secrets_creator_workers.py
+++ b/tests/unit/test_prod_p0_secrets_creator_workers.py
@@ -1,0 +1,168 @@
+"""Production P0: settings redaction, creator write auth, workers=1 helper."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client, override_settings
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+class TestSettingsRedaction:
+    def _leaky_config(self):
+        return {
+            "llm": {
+                "openai": {"api_key": "sk-super-secret-key-should-not-leak", "model": "gpt-4"},
+            },
+            "profiles": {
+                "prod": {"api_key": "sk-profile-secret", "base_url": "https://api.openai.com/v1"},
+            },
+        }
+
+    def _client_with_leaky_settings(self):
+        User = get_user_model()
+        User.objects.create_user(username="setuser", password="setpass")
+        client = Client()
+        assert client.login(username="setuser", password="setpass")
+        from swarm.views import settings_manager as sm_mod
+
+        mgr = sm_mod.SettingsManager()
+        return client, sm_mod, mgr
+
+    def test_settings_api_hides_profile_secrets(self, monkeypatch):
+        client, sm_mod, mgr = self._client_with_leaky_settings()
+        with patch("swarm.views.settings_manager.load_config", return_value=self._leaky_config()):
+            with patch.object(sm_mod, "settings_manager", mgr):
+                resp = client.get("/settings/api/")
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "sk-super-secret-key-should-not-leak" not in body
+        assert "sk-profile-secret" not in body
+        assert "***HIDDEN***" in body or "REDACTED" in body or "***SET***" in body
+
+    def test_settings_dashboard_json_script_hides_secrets(self):
+        """Dashboard embeds settings_groups via json_script for viewObject — must redact."""
+        client, sm_mod, mgr = self._client_with_leaky_settings()
+        with patch("swarm.views.settings_manager.load_config", return_value=self._leaky_config()):
+            with patch.object(sm_mod, "settings_manager", mgr):
+                resp = client.get("/settings/")
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "sk-super-secret-key-should-not-leak" not in body
+        assert "sk-profile-secret" not in body
+        assert "swarm-settings-data" in body
+
+
+@pytest.mark.django_db
+class TestCreatorWriteAuth:
+    def test_save_custom_agent_requires_login(self):
+        client = Client()
+        resp = client.post(
+            "/agent-creator/save/",
+            data='{"name":"x","code":"class A(BlueprintBase):\\n  pass\\n"}',
+            content_type="application/json",
+        )
+        # login_required → redirect to login or 403
+        assert resp.status_code in (302, 401, 403)
+
+    def test_save_team_swarm_requires_login(self):
+        client = Client()
+        payload = {
+            "name": "Evil Team",
+            "description": "team",
+            "agents": [
+                {"name": "a", "system_prompt": "You are a"},
+                {"name": "b", "system_prompt": "You are b"},
+            ],
+        }
+        resp = client.post(
+            "/team-creator/save/",
+            data=json_dumps(payload),
+            content_type="application/json",
+        )
+        assert resp.status_code in (302, 401, 403)
+
+    def test_save_custom_agent_blocks_exec_in_source(self, tmp_path, monkeypatch):
+        User = get_user_model()
+        User.objects.create_user(username="creator", password="cpass")
+        client = Client()
+        assert client.login(username="creator", password="cpass")
+        monkeypatch.chdir(tmp_path)
+        code = '''
+from swarm.core.blueprint_base import BlueprintBase
+from typing import Any, AsyncGenerator
+class Evil(BlueprintBase):
+    metadata = {"name": "evil"}
+    async def run(self, messages, stream=False) -> AsyncGenerator:
+        exec("print(1)")
+        if False:
+            yield {}
+'''
+        resp = client.post(
+            "/agent-creator/save/",
+            data=json_dumps({"name": "EvilAgent", "code": code, "description": "x"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        data = resp.json()
+        assert data.get("success") is False
+        assert "exec" in data.get("error", "").lower() or "unsandboxed" in data.get("error", "").lower()
+
+    def test_validate_blueprint_code_does_not_exec(self):
+        """Structural: validator uses AST only — no exec() in module path for validation."""
+        from swarm.views.agent_creator_views import BlueprintCodeValidator
+        import inspect
+
+        src = inspect.getsource(BlueprintCodeValidator.validate_blueprint_code)
+        assert "exec(" not in src
+        assert "exec_module" not in src
+        v = BlueprintCodeValidator()
+        # Valid-ish minimal code
+        result = v.validate_blueprint_code("class Foo:\n    pass\n")
+        assert "syntax_valid" in result
+
+
+def json_dumps(obj):
+    import json
+    return json.dumps(obj)
+
+
+class TestWorkersSingleContract:
+    def test_resolved_uvicorn_workers_default_one(self, monkeypatch):
+        monkeypatch.delenv("SWARM_UVICORN_WORKERS", raising=False)
+        monkeypatch.delenv("SWARM_ENFORCE_SINGLE_WORKER", raising=False)
+        from swarm.core.concurrency import resolved_uvicorn_workers
+
+        assert resolved_uvicorn_workers() == 1
+
+    def test_resolved_uvicorn_workers_refuses_multi(self, monkeypatch):
+        monkeypatch.setenv("SWARM_UVICORN_WORKERS", "4")
+        monkeypatch.setenv("SWARM_ENFORCE_SINGLE_WORKER", "true")
+        from swarm.core.concurrency import resolved_uvicorn_workers
+
+        with pytest.raises(ValueError, match="process-local"):
+            resolved_uvicorn_workers()
+
+    def test_resolved_uvicorn_workers_override_warns(self, monkeypatch):
+        monkeypatch.setenv("SWARM_UVICORN_WORKERS", "2")
+        monkeypatch.setenv("SWARM_ENFORCE_SINGLE_WORKER", "false")
+        from swarm.core.concurrency import resolved_uvicorn_workers
+
+        assert resolved_uvicorn_workers() == 2
+
+    def test_user_blueprint_discovery_off_by_default(self, monkeypatch):
+        monkeypatch.delenv("SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY", raising=False)
+        monkeypatch.delenv("SWARM_BLUEPRINT_PATHS", raising=False)
+        # Re-import helper
+        from swarm import settings as s
+
+        dirs = s._blueprint_extra_dirs()
+        # Without allow flag, user dir should not appear (paths may still include SWARM_BLUEPRINT_PATHS only)
+        from swarm.core.paths import get_user_blueprints_dir
+
+        user = str(get_user_blueprints_dir())
+        assert user not in dirs


### PR DESCRIPTION
# Summary
Ship production-readiness P0s: discovery endpoint auth lock, response ownership (IDOR refuse), settings secret redaction (API + dashboard), creator write auth without unsandboxed exec, and single-worker async honesty.

## Problem it solves
With API auth enabled, models/blueprints were still AllowAny; any authenticated principal could read/cancel any response id; settings UI/API could embed raw LLM profile keys; creator/team save lacked session gates; multi-worker silently broke cancel.

## How it works
- ModelsListView/BlueprintsListView use `api_permission_classes()`.
- Responses store `owner` principal; detail/cancel/delete call `_assert_owner_access`.
- `redact_settings_groups` feeds settings API and dashboard `json_script`.
- Agent/team save: `@login_required`, banned-snippet check, user blueprint discovery opt-in.
- `resolved_uvicorn_workers()` + compose/docs default workers=1.

## Measured impact
57 targeted tests green (auth ownership, secrets/creator/workers, plan-A gates, responses).

## Test coverage
- `tests/api/test_prod_p0_auth_ownership.py`
- `tests/unit/test_prod_p0_secrets_creator_workers.py`
- Regression: plan_a + test_responses

## Risks / follow-ups
Single shared API token still one principal (multi-key is P1). No Redis queue yet. Fly path still not hardened.

## Build footprint
None.