### PR TITLE
fix(security): redact MCP env-style keys in settings

### DIFF
--- a/src/swarm/utils/redact.py
+++ b/src/swarm/utils/redact.py
@@ -7,7 +7,18 @@ import re
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_SENSITIVE_KEYS = ["secret", "password", "api_key", "apikey", "token", "access_token", "client_secret"]
+DEFAULT_SENSITIVE_KEYS = [
+    "secret",
+    "password",
+    "api_key",
+    "apikey",
+    "token",
+    "access_token",
+    "client_secret",
+    "authorization",
+    "private_key",
+    "credentials",
+]
 _DEFAULT_SENSITIVE_KEYS_LOWER = {k.lower() for k in DEFAULT_SENSITIVE_KEYS}
 
 SENSITIVE_PATTERNS = [
@@ -17,6 +28,29 @@ SENSITIVE_PATTERNS = [
     r'ssh-rsa\s+[a-zA-Z0-9+/]+={0,2}',  # SSH keys
 ]
 _COMPILED_SENSITIVE_PATTERNS = [re.compile(p) for p in SENSITIVE_PATTERNS]
+
+
+def _normalize_key(key: str) -> str:
+    """Lowercase and unify separators so OPENAI-API-KEY matches api_key heuristics."""
+    return key.lower().replace("-", "_")
+
+
+def is_sensitive_key(key: str, sensitive_keys: set[str] | None = None) -> bool:
+    """
+    True if *key* is an exact sensitive name or embeds one (OPENAI_API_KEY, GITHUB_TOKEN).
+
+    Exact match alone misses common env-style names; substring match closes that gap
+    without requiring every provider prefix to be enumerated.
+    """
+    keys = sensitive_keys if sensitive_keys is not None else _DEFAULT_SENSITIVE_KEYS_LOWER
+    kl = _normalize_key(key)
+    if kl in keys:
+        return True
+    for sk in keys:
+        if sk and sk in kl:
+            return True
+    return False
+
 
 def redact_sensitive_data(
     data: str | dict | list,
@@ -37,7 +71,7 @@ def redact_sensitive_data(
         if isinstance(sensitive_keys, set):
             keys_to_redact = sensitive_keys
         else:
-            keys_to_redact = {k.lower() for k in sensitive_keys}
+            keys_to_redact = {_normalize_key(k) for k in sensitive_keys}
     else:
         keys_to_redact = _DEFAULT_SENSITIVE_KEYS_LOWER
 
@@ -67,7 +101,7 @@ def redact_sensitive_data(
     if isinstance(data, dict):
         redacted_dict = {}
         for k, v in data.items():
-            if isinstance(k, str) and k.lower() in keys_to_redact:
+            if isinstance(k, str) and is_sensitive_key(k, keys_to_redact):
                 redacted_dict[k] = smart_mask(v)
             elif isinstance(v, dict | list):
                 redacted_dict[k] = redact_sensitive_data(v, keys_to_redact, reveal_chars, mask)

--- a/src/swarm/utils/redact.py
+++ b/src/swarm/utils/redact.py
@@ -37,18 +37,28 @@ def _normalize_key(key: str) -> str:
 
 def is_sensitive_key(key: str, sensitive_keys: set[str] | None = None) -> bool:
     """
-    True if *key* is an exact sensitive name or embeds one (OPENAI_API_KEY, GITHUB_TOKEN).
+    True if *key* is an exact sensitive name or embeds one as underscore segments.
 
-    Exact match alone misses common env-style names; substring match closes that gap
-    without requiring every provider prefix to be enumerated.
+    Exact match alone misses env-style names (OPENAI_API_KEY, GITHUB_TOKEN).
+    Segment match treats ``api_key`` / ``token`` as contiguous underscore parts so
+    provider-prefixed env vars redact without matching accidental substrings
+    like ``mytokenized`` (no underscore boundary).
     """
     keys = sensitive_keys if sensitive_keys is not None else _DEFAULT_SENSITIVE_KEYS_LOWER
     kl = _normalize_key(key)
     if kl in keys:
         return True
+    parts = [p for p in kl.split("_") if p]
+    if not parts:
+        return False
     for sk in keys:
-        if sk and sk in kl:
-            return True
+        sk_parts = [p for p in sk.split("_") if p]
+        if not sk_parts:
+            continue
+        n = len(sk_parts)
+        for i in range(len(parts) - n + 1):
+            if parts[i : i + n] == sk_parts:
+                return True
     return False
 
 

--- a/src/swarm/views/settings_manager.py
+++ b/src/swarm/views/settings_manager.py
@@ -420,13 +420,22 @@ class SettingsManager:
             mcp_settings = {}
 
             for server_name, server_config in mcp_config.items():
+                # MCP configs almost always carry env tokens/keys — mark sensitive so
+                # dashboard/API redaction never treats them as plain metadata.
+                sensitive = True
+                if isinstance(server_config, dict):
+                    env = server_config.get("env") or {}
+                    headers = server_config.get("headers") or {}
+                    if not env and not headers:
+                        # No credential surfaces — still recurse-redact nested dicts.
+                        sensitive = False
                 mcp_settings[f'MCP_{server_name.upper()}'] = {
                     'value': server_config,
                     'env_var': None,
                     'type': 'object',
                     'description': f'MCP server configuration for {server_name}',
                     'category': 'server',
-                    'sensitive': False
+                    'sensitive': sensitive,
                 }
 
             if not mcp_settings:

--- a/tests/core/test_redact_sensitive_data.py
+++ b/tests/core/test_redact_sensitive_data.py
@@ -8,7 +8,8 @@ def test_redacts_api_keys_and_tokens():
         "client_secret": "secretvalue",
         "nested": {
             "password": "hunter2",
-            "not_secret": "hello"
+            # Use a key without sensitive segments (…_secret would redact).
+            "plain_field": "hello"
         },
         "list": [
             {"access_token": "acc-1234"},
@@ -23,7 +24,7 @@ def test_redacts_api_keys_and_tokens():
     assert redacted["client_secret"] == "[REDACTED]"
     # Check nested dict
     assert redacted["nested"]["password"] == "[REDACTED]"
-    assert redacted["nested"]["not_secret"] == "hello"
+    assert redacted["nested"]["plain_field"] == "hello"
     # Check list of dicts
     assert redacted["list"][0]["access_token"] == "[REDACTED]"
     assert redacted["list"][1] == "not_a_secret"

--- a/tests/unit/test_prod_p0_secrets_creator_workers.py
+++ b/tests/unit/test_prod_p0_secrets_creator_workers.py
@@ -21,6 +21,18 @@ class TestSettingsRedaction:
             "profiles": {
                 "prod": {"api_key": "sk-profile-secret", "base_url": "https://api.openai.com/v1"},
             },
+            # Env-style keys (not exact "api_key"/"token") — must still redact.
+            "mcpServers": {
+                "demo": {
+                    "command": "npx",
+                    "args": ["-y", "demo-mcp"],
+                    "env": {
+                        "OPENAI_API_KEY": "sk-mcp-openai-must-not-leak",
+                        "GITHUB_TOKEN": "ghp_mcp_github_must_not_leak",
+                        "MONDAY_API_KEY": "mon_mcp_monday_must_not_leak",
+                    },
+                },
+            },
         }
 
     def _client_with_leaky_settings(self):
@@ -33,6 +45,16 @@ class TestSettingsRedaction:
         mgr = sm_mod.SettingsManager()
         return client, sm_mod, mgr
 
+    def _assert_no_leaks(self, body: str) -> None:
+        for secret in (
+            "sk-super-secret-key-should-not-leak",
+            "sk-profile-secret",
+            "sk-mcp-openai-must-not-leak",
+            "ghp_mcp_github_must_not_leak",
+            "mon_mcp_monday_must_not_leak",
+        ):
+            assert secret not in body, f"secret leaked in settings payload: {secret}"
+
     def test_settings_api_hides_profile_secrets(self, monkeypatch):
         client, sm_mod, mgr = self._client_with_leaky_settings()
         with patch("swarm.views.settings_manager.load_config", return_value=self._leaky_config()):
@@ -40,8 +62,7 @@ class TestSettingsRedaction:
                 resp = client.get("/settings/api/")
         assert resp.status_code == 200
         body = resp.content.decode()
-        assert "sk-super-secret-key-should-not-leak" not in body
-        assert "sk-profile-secret" not in body
+        self._assert_no_leaks(body)
         assert "***HIDDEN***" in body or "REDACTED" in body or "***SET***" in body
 
     def test_settings_dashboard_json_script_hides_secrets(self):
@@ -52,9 +73,29 @@ class TestSettingsRedaction:
                 resp = client.get("/settings/")
         assert resp.status_code == 200
         body = resp.content.decode()
-        assert "sk-super-secret-key-should-not-leak" not in body
-        assert "sk-profile-secret" not in body
+        self._assert_no_leaks(body)
         assert "swarm-settings-data" in body
+
+    def test_settings_api_hides_mcp_env_style_keys(self):
+        """Regression: OPENAI_API_KEY / GITHUB_TOKEN under MCP env must not appear raw."""
+        client, sm_mod, mgr = self._client_with_leaky_settings()
+        with patch("swarm.views.settings_manager.load_config", return_value=self._leaky_config()):
+            with patch.object(sm_mod, "settings_manager", mgr):
+                resp = client.get("/settings/api/")
+        assert resp.status_code == 200
+        data = resp.json()
+        # API wraps groups under settings: {success, settings: {mcp_servers: ...}}
+        groups = data.get("settings") or data
+        mcp = (groups.get("mcp_servers") or {}).get("settings") or {}
+        assert any(k.startswith("MCP_") for k in mcp), list(mcp.keys())
+        body = resp.content.decode()
+        self._assert_no_leaks(body)
+        # Nested env values must be masked, not raw.
+        demo = next(iter(mcp.values()))
+        env = (demo.get("value") or {}).get("env") or {}
+        for k, v in env.items():
+            if any(s in k.lower() for s in ("key", "token", "secret")):
+                assert v in ("***HIDDEN***", "[REDACTED]") or "HIDDEN" in str(v) or "REDACTED" in str(v)
 
 
 @pytest.mark.django_db

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -91,5 +91,7 @@ def test_is_sensitive_key_helper():
     assert is_sensitive_key("OPENAI_API_KEY")
     assert is_sensitive_key("github-token")
     assert is_sensitive_key("client_secret")
+    assert is_sensitive_key("not_secret")  # segment "secret"
     assert not is_sensitive_key("model")
     assert not is_sensitive_key("base_url")
+    assert not is_sensitive_key("mytokenized")  # no underscore boundary

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -65,3 +65,31 @@ def test_sensitive_key_with_structured_value_is_masked():
     # A dict/list under a sensitive key must be masked wholesale, not passed through.
     assert redact_sensitive_data({"secret": {"inner": "leak"}})["secret"] == "[REDACTED]"
     assert redact_sensitive_data({"token": ["leak1", "leak2"]})["token"] == "[REDACTED]"
+
+
+def test_env_style_keys_are_redacted_by_substring():
+    """OPENAI_API_KEY / GITHUB_TOKEN style names embed sensitive tokens — must redact."""
+    data = {
+        "env": {
+            "OPENAI_API_KEY": "sk-mcp-openai",
+            "GITHUB_TOKEN": "ghp_xxx",
+            "MONDAY_API_KEY": "mon_xxx",
+            "NORMAL_PATH": "/usr/bin/npx",
+        }
+    }
+    redacted = redact_sensitive_data(data, mask="***HIDDEN***")
+    assert redacted["env"]["OPENAI_API_KEY"] == "***HIDDEN***"
+    assert redacted["env"]["GITHUB_TOKEN"] == "***HIDDEN***"
+    assert redacted["env"]["MONDAY_API_KEY"] == "***HIDDEN***"
+    assert redacted["env"]["NORMAL_PATH"] == "/usr/bin/npx"
+
+
+def test_is_sensitive_key_helper():
+    from swarm.utils.redact import is_sensitive_key
+
+    assert is_sensitive_key("api_key")
+    assert is_sensitive_key("OPENAI_API_KEY")
+    assert is_sensitive_key("github-token")
+    assert is_sensitive_key("client_secret")
+    assert not is_sensitive_key("model")
+    assert not is_sensitive_key("base_url")

--- a/tests/unit/test_redact_extra.py
+++ b/tests/unit/test_redact_extra.py
@@ -36,8 +36,8 @@ def test_redact_sensitive_data_deeply_nested_lists_and_dicts():
         "meta": {"count": 2},
     }
     out = redact_sensitive_data(data)
-    # First user password masked
-    assert out["users"][0]["credentials"]["password"] == "[REDACTED]"
+    # "credentials" is a sensitive key → whole structured value masked
+    assert out["users"][0]["credentials"] == "[REDACTED]"
     # Nested list token masked
     assert out["users"][1][0]["token"] == "[REDACTED]"
     # Deep list inside dict masked for api_key, preserves non-sensitive


### PR DESCRIPTION
# Summary

Closes the post-#258 skeptic gap on AC3: settings API and dashboard no longer emit raw MCP env values for common names like `OPENAI_API_KEY`, `GITHUB_TOKEN`, and `MONDAY_API_KEY`. Redaction now treats sensitive tokens as substrings of keys (not exact match only), and MCP server entries that carry `env`/`headers` are marked sensitive.

## Problem it solves

Skeptic final audit after #258 marked AC3 **PARTIAL**: `_collect_mcp_settings` set `sensitive: False`, and `redact_sensitive_data` only matched exact keys (`api_key`, `token`, …). Live probe showed MCP nested env secrets surviving into `/settings/` and `/settings/api/`.

## How it works

- `swarm.utils.redact`: add `is_sensitive_key()` with normalized hyphen/underscore and substring match against the sensitive-key set; export helper for reuse/tests.
- `settings_manager._collect_mcp_settings`: mark MCP server configs `sensitive=True` when `env` or `headers` are present.
- Settings dashboard/API already run `redact_settings_groups` over nested dicts; the redactor fix is what actually masks env-style keys.

## Measured impact

- P0 + redact suite: **30 passed** (was 19 + unit redact before this change).
- No runtime dependency or image changes.

## Test coverage

- `tests/unit/test_redact.py`: env-style key substring redaction + `is_sensitive_key` helper.
- `tests/unit/test_prod_p0_secrets_creator_workers.py`: leaky MCP config in fixture; API/dashboard assert secrets absent; dedicated MCP env regression test checks nested env values are `***HIDDEN***`.
- Re-ran: `tests/unit/test_prod_p0_secrets_creator_workers.py`, `tests/unit/test_redact.py`, `tests/api/test_prod_p0_auth_ownership.py` → 30 passed.

## Risks / follow-ups

- Substring match can over-redact benign keys that embed `token`/`secret` (e.g. `token_limit`). Acceptable for settings export; prefer over secret leak.
- Residual private-gateway risks from skeptic audit (shared API token principal, legacy owner-less responses, session explorer global list) are unchanged.
- Rollback: revert this commit; prior exact-key behavior returns.

## Build footprint

None — pure Python redaction/settings metadata; no new deps, services, or CI jobs.