### PR TITLE
fix(security): resolve skeptic residual hardening

### DIFF
--- a/src/swarm/core/responses_store.py
+++ b/src/swarm/core/responses_store.py
@@ -78,16 +78,20 @@ def load(response_id: str, *, base_dir: Path | None = None) -> dict[str, Any] | 
 def owner_allows(record: dict[str, Any] | None, principal: str | None) -> bool:
     """Whether ``principal`` may access ``record`` under ownership rules.
 
+    Fail-closed: unowned (legacy) records are not readable by any principal.
+    Views skip this check entirely when ``ENABLE_API_AUTH`` is off, so open
+    deployments still allow access without an owner stamp.
+
     - No record → False (caller should 404 separately if desired)
-    - No owner on record → True (legacy records; auth still required at the view)
-    - principal None → False when owner is set
+    - No owner on record → False (legacy / missing stamp; deny when auth on)
+    - principal None → False
     - else principal must equal record['owner']
     """
     if record is None:
         return False
     owner = record.get("owner")
     if not owner:
-        return True
+        return False
     if not principal:
         return False
     return str(owner) == str(principal)
@@ -97,8 +101,9 @@ def list_summaries(*, base_dir: Path | None = None, limit: int | None = 200) -> 
     """Lightweight summaries of stored sessions, newest first.
 
     Each summary: ``{id, model, status, created_at, execution_ms, output_preview,
-    delegations}`` where ``delegations`` is the per-role progress array (possibly
-    empty). Used by the Session Explorer web UI; reads each record once.
+    delegations, owner}`` where ``delegations`` is the per-role progress array
+    (possibly empty) and ``owner`` is the creating principal (or None for legacy).
+    Used by the Session Explorer web UI; reads each record once.
     """
     base = base_dir or _store_dir()
     if not base.is_dir():
@@ -120,6 +125,7 @@ def list_summaries(*, base_dir: Path | None = None, limit: int | None = 200) -> 
             "execution_ms": resp.get("execution_ms"),
             "output_preview": (text[:160] + "…") if len(text) > 160 else text,
             "delegations": resp.get("progress") or [],
+            "owner": record.get("owner"),
         })
     summaries.sort(key=lambda s: s.get("created_at") or 0, reverse=True)
     return summaries[:limit] if limit else summaries

--- a/src/swarm/utils/redact.py
+++ b/src/swarm/utils/redact.py
@@ -14,10 +14,19 @@ DEFAULT_SENSITIVE_KEYS = [
     "apikey",
     "token",
     "access_token",
+    "access_key",
+    "access_key_id",
     "client_secret",
     "authorization",
     "private_key",
     "credentials",
+    # Connection strings / DB URLs (exact match; avoid bare "url" so base_url stays public)
+    "database_url",
+    "redis_url",
+    "mongodb_uri",
+    "mongo_url",
+    "connection_string",
+    "dsn",
 ]
 _DEFAULT_SENSITIVE_KEYS_LOWER = {k.lower() for k in DEFAULT_SENSITIVE_KEYS}
 
@@ -28,6 +37,11 @@ SENSITIVE_PATTERNS = [
     r'ssh-rsa\s+[a-zA-Z0-9+/]+={0,2}',  # SSH keys
 ]
 _COMPILED_SENSITIVE_PATTERNS = [re.compile(p) for p in SENSITIVE_PATTERNS]
+
+# scheme://user:password@host — mask only the password segment (not bare https URLs).
+_URI_CREDENTIALS_PATTERN = re.compile(
+    r"([a-zA-Z][a-zA-Z0-9+.-]*://[^:/?#\s]+):([^@/\s]+)@"
+)
 
 
 def _normalize_key(key: str) -> str:
@@ -60,6 +74,13 @@ def is_sensitive_key(key: str, sensitive_keys: set[str] | None = None) -> bool:
             if parts[i : i + n] == sk_parts:
                 return True
     return False
+
+
+def redact_uri_credentials(text: str, mask: str = "[REDACTED]") -> str:
+    """Mask password segment in URIs like ``scheme://user:password@host``."""
+    if not isinstance(text, str) or "://" not in text or "@" not in text:
+        return text
+    return _URI_CREDENTIALS_PATTERN.sub(lambda m: f"{m.group(1)}:{mask}@", text)
 
 
 def redact_sensitive_data(
@@ -106,6 +127,7 @@ def redact_sensitive_data(
         redacted = text
         for pattern in _COMPILED_SENSITIVE_PATTERNS:
             redacted = pattern.sub(mask, redacted)
+        redacted = redact_uri_credentials(redacted, mask=mask)
         return redacted
 
     if isinstance(data, dict):

--- a/src/swarm/views/api_views.py
+++ b/src/swarm/views/api_views.py
@@ -5,7 +5,6 @@ import time
 from asgiref.sync import async_to_sync
 from drf_spectacular.utils import extend_schema, inline_serializer
 from rest_framework import serializers, status
-from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -309,7 +308,8 @@ class CustomBlueprintDetailView(APIView):
 
 
 class MarketplaceGitHubBlueprintsView(APIView):
-    permission_classes = [AllowAny]
+    def get_permissions(self):
+        return [perm() for perm in api_permission_classes()]
 
     def get(self, request, *_args, **_kwargs):
         if not ENABLE_GITHUB_MARKETPLACE:
@@ -341,7 +341,8 @@ class MarketplaceGitHubBlueprintsView(APIView):
 
 
 class MarketplaceGitHubMCPConfigsView(APIView):
-    permission_classes = [AllowAny]
+    def get_permissions(self):
+        return [perm() for perm in api_permission_classes()]
 
     def get(self, request, *_args, **_kwargs):
         if not ENABLE_GITHUB_MARKETPLACE:

--- a/src/swarm/views/message_views.py
+++ b/src/swarm/views/message_views.py
@@ -2,19 +2,20 @@
 Views related to Chat Messages.
 """
 from drf_spectacular.utils import extend_schema
-from rest_framework.permissions import AllowAny
 from rest_framework.viewsets import ModelViewSet
 
+from swarm.auth import api_permission_classes
 from swarm.models import ChatMessage
 from swarm.serializers import ChatMessageSerializer
 
 
 class ChatMessageViewSet(ModelViewSet):
     """API viewset for managing chat messages."""
-    authentication_classes = []
-    permission_classes = [AllowAny]
-    queryset = ChatMessage.objects.all().order_by('-timestamp') # Order by timestamp descending
+    queryset = ChatMessage.objects.all().order_by('-timestamp')  # Order by timestamp descending
     serializer_class = ChatMessageSerializer
+
+    def get_permissions(self):
+        return [perm() for perm in api_permission_classes()]
 
     @extend_schema(summary="List all chat messages")
     def list(self, request, *args, **kwargs):

--- a/src/swarm/views/session_explorer.py
+++ b/src/swarm/views/session_explorer.py
@@ -12,6 +12,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import Http404, JsonResponse
 from django.shortcuts import render
 
+from swarm.auth import request_principal
 from swarm.core import responses_store
 
 # Default page size for first paint + live poll. Hard ceiling prevents multi-MB
@@ -27,10 +28,18 @@ def _parse_limit(request, default: int = _DEFAULT_LIMIT) -> int:
         return default
 
 
-def _session_inventory() -> tuple[list[dict], dict[str, int]]:
-    """Full inventory (newest first) + status counts. ``limit=None`` so totals
-    are not silently capped at the store helper's default of 200."""
-    all_sessions = responses_store.list_summaries(limit=None)
+def _session_inventory(request) -> tuple[list[dict], dict[str, int]]:
+    """Principal-scoped inventory (newest first) + status counts.
+
+    ``limit=None`` so totals are not silently capped at the store helper's
+    default of 200. Sessions without an owner, or owned by another principal,
+    are excluded via :func:`responses_store.owner_allows` (fail-closed).
+    """
+    principal = request_principal(request)
+    all_sessions = [
+        s for s in responses_store.list_summaries(limit=None)
+        if responses_store.owner_allows(s, principal)
+    ]
     counts: dict[str, int] = {}
     for s in all_sessions:
         key = s.get("status") or "unknown"
@@ -41,7 +50,7 @@ def _session_inventory() -> tuple[list[dict], dict[str, int]]:
 @login_required
 def session_explorer(request):
     """Session list page (authenticated — transcripts may contain secrets)."""
-    all_sessions, counts = _session_inventory()
+    all_sessions, counts = _session_inventory(request)
     limit = _parse_limit(request)
     sessions = all_sessions[:limit]
     total = len(all_sessions)
@@ -61,6 +70,9 @@ def session_detail(request, response_id: str):
     record = responses_store.load(response_id)
     if record is None:
         raise Http404(f"Session '{response_id}' not found")
+    principal = request_principal(request)
+    if not responses_store.owner_allows(record, principal):
+        raise Http404(f"Session '{response_id}' not found")
     resp = record.get("response") or {}
     return render(request, "session_detail.html", {
         "session": resp,
@@ -76,7 +88,7 @@ def session_list_api(request):
     Honours the same ``?limit=`` contract as the HTML explorer so the default-
     checked 3s poll cannot blow past the first-paint cap and desync the banner.
     """
-    all_sessions, counts = _session_inventory()
+    all_sessions, counts = _session_inventory(request)
     limit = _parse_limit(request)
     sessions = all_sessions[:limit]
     total = len(all_sessions)

--- a/src/swarm/views/settings_views.py
+++ b/src/swarm/views/settings_views.py
@@ -125,18 +125,21 @@ def settings_api(_request):
 @require_http_methods(["GET"])
 def environment_variables(_request):
     """Get all environment variables related to Open Swarm (authenticated)."""
+    from swarm.utils.redact import is_sensitive_key
+
     try:
         # Collect all environment variables that might be relevant
         relevant_prefixes = [
             'DJANGO_', 'SWARM_', 'API_', 'ENABLE_', 'OPENAI_',
-            'ANTHROPIC_', 'OLLAMA_', 'REDIS_', 'LOG'
+            'ANTHROPIC_', 'OLLAMA_', 'REDIS_', 'LOG', 'DATABASE_',
+            'AWS_', 'MONGODB_', 'MONGO_',
         ]
 
         env_vars = {}
         for key, value in os.environ.items():
             if any(key.startswith(prefix) for prefix in relevant_prefixes):
-                # Hide sensitive values
-                if any(sensitive in key.lower() for sensitive in ['key', 'token', 'secret', 'password']):
+                # Use shared redaction heuristics (access_key, database_url, …)
+                if is_sensitive_key(key):
                     env_vars[key] = '***SET***' if value else 'Not Set'
                 else:
                     env_vars[key] = value

--- a/tests/api/test_prod_p0_auth_ownership.py
+++ b/tests/api/test_prod_p0_auth_ownership.py
@@ -99,8 +99,11 @@ class TestResponseOwnership:
         rec = {"id": "resp_x", "owner": "user:alice"}
         assert responses_store.owner_allows(rec, "user:alice") is True
         assert responses_store.owner_allows(rec, "user:bob") is False
-        assert responses_store.owner_allows({"id": "resp_y"}, "user:bob") is True  # legacy
+        # Legacy unowned records fail closed (views skip check when auth off).
+        assert responses_store.owner_allows({"id": "resp_y"}, "user:bob") is False
+        assert responses_store.owner_allows({"id": "resp_y", "owner": None}, "user:bob") is False
         assert responses_store.owner_allows(rec, None) is False
+        assert responses_store.owner_allows(None, "user:alice") is False
 
     def test_get_refuses_foreign_principal(self, store):
         User = get_user_model()
@@ -171,3 +174,146 @@ class TestResponseOwnership:
             drf2.user, drf2.auth = pair
             p = request_principal(drf2)
             assert p is not None and p.startswith("token:")
+
+
+# --- Full HTTP (ASGI AsyncClient) ownership refusal when auth is on --------- #
+
+@pytest.mark.django_db(transaction=True)
+class TestResponseOwnershipHTTP:
+    """GET / cancel / delete must refuse foreign + legacy-unowned when auth on."""
+
+    def _save(self, rid: str, owner: str | None, *, status_str: str = "completed"):
+        rec = {
+            "id": rid,
+            "object": "response",
+            "response": {
+                "id": rid,
+                "object": "response",
+                "status": status_str,
+                "output_text": "hello",
+                "output": [],
+            },
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        if owner is not None:
+            rec["owner"] = owner
+        # Explicitly omit owner key when None to model true legacy records.
+        responses_store.save(rec)
+
+    @pytest.fixture
+    async def alice_client(self, db):
+        from asgiref.sync import sync_to_async
+        from django.contrib.auth import get_user_model
+        from django.test import AsyncClient
+
+        User = get_user_model()
+        user, _ = await sync_to_async(User.objects.get_or_create)(username="http_alice")
+        if not user.has_usable_password():
+            await sync_to_async(user.set_password)("x")
+            await sync_to_async(user.save)()
+        client = AsyncClient()
+        await sync_to_async(client.force_login)(user)
+        return client
+
+    @pytest.fixture
+    async def bob_client(self, db):
+        from asgiref.sync import sync_to_async
+        from django.contrib.auth import get_user_model
+        from django.test import AsyncClient
+
+        User = get_user_model()
+        user, _ = await sync_to_async(User.objects.get_or_create)(username="http_bob")
+        if not user.has_usable_password():
+            await sync_to_async(user.set_password)("x")
+            await sync_to_async(user.save)()
+        client = AsyncClient()
+        await sync_to_async(client.force_login)(user)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_get_refuses_foreign_owner_http(self, store, alice_client, bob_client, settings):
+        settings.ENABLE_API_AUTH = True
+        settings.SWARM_API_KEY = TOKEN
+        self._save("resp_http_alice", "user:http_alice")
+
+        # Owner can read
+        ok = await alice_client.get("/v1/responses/resp_http_alice", SERVER_NAME="localhost")
+        assert ok.status_code == 200
+        assert json.loads(ok.content)["id"] == "resp_http_alice"
+
+        # Foreign principal denied
+        denied = await bob_client.get("/v1/responses/resp_http_alice", SERVER_NAME="localhost")
+        assert denied.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_get_refuses_legacy_unowned_when_auth_on(self, store, bob_client, settings):
+        settings.ENABLE_API_AUTH = True
+        settings.SWARM_API_KEY = TOKEN
+        self._save("resp_http_legacy", None)  # no owner field
+
+        denied = await bob_client.get("/v1/responses/resp_http_legacy", SERVER_NAME="localhost")
+        assert denied.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_legacy_unowned_open_when_auth_off(self, store, bob_client, settings):
+        settings.ENABLE_API_AUTH = False
+        self._save("resp_http_legacy_open", None)
+
+        ok = await bob_client.get("/v1/responses/resp_http_legacy_open", SERVER_NAME="localhost")
+        assert ok.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_cancel_refuses_foreign_and_legacy_http(self, store, alice_client, bob_client, settings):
+        settings.ENABLE_API_AUTH = True
+        settings.SWARM_API_KEY = TOKEN
+        self._save("resp_http_cancel_alice", "user:http_alice", status_str="in_progress")
+        self._save("resp_http_cancel_legacy", None, status_str="in_progress")
+
+        foreign = await bob_client.post(
+            "/v1/responses/resp_http_cancel_alice/cancel", SERVER_NAME="localhost"
+        )
+        assert foreign.status_code == 403
+
+        legacy = await bob_client.post(
+            "/v1/responses/resp_http_cancel_legacy/cancel", SERVER_NAME="localhost"
+        )
+        assert legacy.status_code == 403
+
+        # Owner can cancel
+        ok = await alice_client.post(
+            "/v1/responses/resp_http_cancel_alice/cancel", SERVER_NAME="localhost"
+        )
+        assert ok.status_code == 200
+        assert json.loads(ok.content)["status"] == "cancelled"
+
+    @pytest.mark.asyncio
+    async def test_delete_refuses_foreign_and_legacy_http(self, store, alice_client, bob_client, settings):
+        settings.ENABLE_API_AUTH = True
+        settings.SWARM_API_KEY = TOKEN
+        self._save("resp_http_del_alice", "user:http_alice")
+        self._save("resp_http_del_legacy", None)
+
+        foreign = await bob_client.delete(
+            "/v1/responses/resp_http_del_alice", SERVER_NAME="localhost"
+        )
+        assert foreign.status_code == 403
+        assert responses_store.load("resp_http_del_alice") is not None  # still there
+
+        legacy = await bob_client.delete(
+            "/v1/responses/resp_http_del_legacy", SERVER_NAME="localhost"
+        )
+        assert legacy.status_code == 403
+        assert responses_store.load("resp_http_del_legacy") is not None
+
+        ok = await alice_client.delete(
+            "/v1/responses/resp_http_del_alice", SERVER_NAME="localhost"
+        )
+        assert ok.status_code == 200
+        assert responses_store.load("resp_http_del_alice") is None
+
+    def test_list_summaries_includes_owner(self, store):
+        self._save("resp_sum_owned", "user:alice")
+        self._save("resp_sum_legacy", None)
+        rows = {r["id"]: r for r in responses_store.list_summaries()}
+        assert rows["resp_sum_owned"]["owner"] == "user:alice"
+        assert rows["resp_sum_legacy"].get("owner") is None

--- a/tests/api/test_prod_p0_auth_ownership.py
+++ b/tests/api/test_prod_p0_auth_ownership.py
@@ -317,3 +317,131 @@ class TestResponseOwnershipHTTP:
         rows = {r["id"]: r for r in responses_store.list_summaries()}
         assert rows["resp_sum_owned"]["owner"] == "user:alice"
         assert rows["resp_sum_legacy"].get("owner") is None
+
+# --- Session Explorer principal filter + residual AllowAny surfaces --------- #
+
+
+@pytest.mark.django_db
+class TestSessionExplorerOwnership:
+    """Session Explorer only shows sessions owned by the logged-in principal."""
+
+    def _save(self, rid: str, owner: str | None, *, output: str = "hello", created: int = 1):
+        rec = {
+            "id": rid,
+            "object": "response",
+            "response": {
+                "id": rid,
+                "object": "response",
+                "status": "completed",
+                "model": "hybrid_team",
+                "created_at": created,
+                "output_text": output,
+                "execution_ms": 1,
+                "progress": [],
+            },
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        if owner is not None:
+            rec["owner"] = owner
+        responses_store.save(rec)
+
+    def test_list_only_returns_own_sessions(self, store, client, django_user_model):
+        from django.urls import reverse
+
+        django_user_model.objects.create_user(username="se_alice", password="x")
+        django_user_model.objects.create_user(username="se_bob", password="x")
+        self._save("resp_se_alice", "user:se_alice", output="alice-only", created=2)
+        self._save("resp_se_bob", "user:se_bob", output="bob-only", created=3)
+        self._save("resp_se_legacy", None, output="no-owner", created=4)
+
+        assert client.login(username="se_alice", password="x")
+        resp = client.get(reverse("session-explorer"))
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "resp_se_alice" in body and "alice-only" in body
+        assert "resp_se_bob" not in body
+        assert "resp_se_legacy" not in body
+        assert "bob-only" not in body
+        assert "no-owner" not in body
+
+        feed = client.get(reverse("session-list-api"))
+        assert feed.status_code == 200
+        data = json.loads(feed.content)
+        ids = [s["id"] for s in data["sessions"]]
+        assert ids == ["resp_se_alice"]
+        assert data["total"] == 1
+
+    def test_foreign_and_unowned_detail_404(self, store, client, django_user_model):
+        from django.urls import reverse
+
+        django_user_model.objects.create_user(username="se_viewer", password="x")
+        self._save("resp_se_foreign", "user:someone_else", output="secret")
+        self._save("resp_se_no_owner", None, output="legacy")
+
+        assert client.login(username="se_viewer", password="x")
+        foreign = client.get(reverse("session-detail", kwargs={"response_id": "resp_se_foreign"}))
+        assert foreign.status_code == 404
+        unowned = client.get(reverse("session-detail", kwargs={"response_id": "resp_se_no_owner"}))
+        assert unowned.status_code == 404
+
+        # Own session still loads.
+        self._save("resp_se_mine", "user:se_viewer", output="mine-ok")
+        mine = client.get(reverse("session-detail", kwargs={"response_id": "resp_se_mine"}))
+        assert mine.status_code == 200
+        assert b"mine-ok" in mine.content
+
+
+@pytest.mark.django_db
+class TestResidualApiAuthSurfaces:
+    """Marketplace list views + ChatMessageViewSet respect ENABLE_API_AUTH."""
+
+    def test_marketplace_blueprints_requires_auth_when_enabled(self):
+        factory = APIRequestFactory()
+        request = factory.get("/marketplace/github/blueprints/")
+        from swarm.views.api_views import MarketplaceGitHubBlueprintsView
+
+        view = MarketplaceGitHubBlueprintsView.as_view()
+        with override_settings(ENABLE_API_AUTH=True, SWARM_API_KEY=TOKEN):
+            response = view(request)
+        assert response.status_code in (401, 403)
+
+    def test_marketplace_mcp_requires_auth_when_enabled(self):
+        factory = APIRequestFactory()
+        request = factory.get("/marketplace/github/mcp-configs/")
+        from swarm.views.api_views import MarketplaceGitHubMCPConfigsView
+
+        view = MarketplaceGitHubMCPConfigsView.as_view()
+        with override_settings(ENABLE_API_AUTH=True, SWARM_API_KEY=TOKEN):
+            response = view(request)
+        assert response.status_code in (401, 403)
+
+    def test_marketplace_open_when_api_auth_disabled(self):
+        factory = APIRequestFactory()
+        request = factory.get("/marketplace/github/blueprints/")
+        from swarm.views.api_views import MarketplaceGitHubBlueprintsView
+
+        view = MarketplaceGitHubBlueprintsView.as_view()
+        with override_settings(ENABLE_API_AUTH=False, SWARM_API_KEY=None, ENABLE_GITHUB_MARKETPLACE=False):
+            response = view(request)
+        assert response.status_code == 200
+
+    def test_chat_messages_require_auth_when_enabled(self):
+        factory = APIRequestFactory()
+        request = factory.get("/v1/chat-messages/")
+        from swarm.views.message_views import ChatMessageViewSet
+
+        view = ChatMessageViewSet.as_view({"get": "list"})
+        with override_settings(ENABLE_API_AUTH=True, SWARM_API_KEY=TOKEN):
+            response = view(request)
+        assert response.status_code in (401, 403)
+
+    def test_chat_messages_open_when_api_auth_disabled(self):
+        factory = APIRequestFactory()
+        request = factory.get("/v1/chat-messages/")
+        from swarm.views.message_views import ChatMessageViewSet
+
+        view = ChatMessageViewSet.as_view({"get": "list"})
+        with override_settings(ENABLE_API_AUTH=False, SWARM_API_KEY=None):
+            response = view(request)
+        assert response.status_code == 200
+

--- a/tests/api/test_session_explorer.py
+++ b/tests/api/test_session_explorer.py
@@ -9,8 +9,9 @@ from django.urls import reverse
 from swarm.core import responses_store
 
 
-def _save(rid, *, status="completed", model="hybrid_team", output="hello", progress=None, created=1):
-    responses_store.save({
+def _save(rid, *, status="completed", model="hybrid_team", output="hello", progress=None, created=1, owner="user:explorer"):
+    """Persist a session; default owner matches auth_client principal (user:explorer)."""
+    record = {
         "id": rid, "object": "response",
         "response": {
             "id": rid, "model": model, "status": status, "created_at": created,
@@ -18,7 +19,10 @@ def _save(rid, *, status="completed", model="hybrid_team", output="hello", progr
             "progress": progress or [],
         },
         "messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": output}],
-    })
+    }
+    if owner is not None:
+        record["owner"] = owner
+    responses_store.save(record)
 
 
 @pytest.fixture

--- a/tests/unit/test_prod_p0_secrets_creator_workers.py
+++ b/tests/unit/test_prod_p0_secrets_creator_workers.py
@@ -30,6 +30,8 @@ class TestSettingsRedaction:
                         "OPENAI_API_KEY": "sk-mcp-openai-must-not-leak",
                         "GITHUB_TOKEN": "ghp_mcp_github_must_not_leak",
                         "MONDAY_API_KEY": "mon_mcp_monday_must_not_leak",
+                        "AWS_ACCESS_KEY_ID": "AKIA_mcp_aws_must_not_leak",
+                        "DATABASE_URL": "postgres://u:db_secret_must_not_leak@db/app",
                     },
                 },
             },
@@ -52,6 +54,8 @@ class TestSettingsRedaction:
             "sk-mcp-openai-must-not-leak",
             "ghp_mcp_github_must_not_leak",
             "mon_mcp_monday_must_not_leak",
+            "AKIA_mcp_aws_must_not_leak",
+            "db_secret_must_not_leak",
         ):
             assert secret not in body, f"secret leaked in settings payload: {secret}"
 
@@ -93,9 +97,17 @@ class TestSettingsRedaction:
         # Nested env values must be masked, not raw.
         demo = next(iter(mcp.values()))
         env = (demo.get("value") or {}).get("env") or {}
+        from swarm.utils.redact import is_sensitive_key
+
         for k, v in env.items():
-            if any(s in k.lower() for s in ("key", "token", "secret")):
+            if is_sensitive_key(k):
                 assert v in ("***HIDDEN***", "[REDACTED]") or "HIDDEN" in str(v) or "REDACTED" in str(v)
+        assert env.get("AWS_ACCESS_KEY_ID") in ("***HIDDEN***", "[REDACTED]") or (
+            env.get("AWS_ACCESS_KEY_ID") and "HIDDEN" in str(env.get("AWS_ACCESS_KEY_ID"))
+        )
+        assert env.get("DATABASE_URL") in ("***HIDDEN***", "[REDACTED]") or (
+            env.get("DATABASE_URL") and "HIDDEN" in str(env.get("DATABASE_URL"))
+        )
 
 
 @pytest.mark.django_db

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -95,3 +95,99 @@ def test_is_sensitive_key_helper():
     assert not is_sensitive_key("model")
     assert not is_sensitive_key("base_url")
     assert not is_sensitive_key("mytokenized")  # no underscore boundary
+
+def test_aws_access_key_id_and_access_key_segments():
+    """AWS_ACCESS_KEY_ID / access_key must redact via segment match."""
+    from swarm.utils.redact import is_sensitive_key, redact_sensitive_data
+
+    assert is_sensitive_key("AWS_ACCESS_KEY_ID")
+    assert is_sensitive_key("access_key")
+    assert is_sensitive_key("access_key_id")
+    assert is_sensitive_key("aws-access-key-id")
+
+    data = {
+        "env": {
+            "AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
+            "AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "NORMAL_PATH": "/usr/bin/npx",
+        }
+    }
+    redacted = redact_sensitive_data(data, mask="***HIDDEN***")
+    assert redacted["env"]["AWS_ACCESS_KEY_ID"] == "***HIDDEN***"
+    assert redacted["env"]["AWS_SECRET_ACCESS_KEY"] == "***HIDDEN***"
+    assert redacted["env"]["NORMAL_PATH"] == "/usr/bin/npx"
+
+
+def test_connection_url_keys_are_sensitive():
+    """DATABASE_URL / REDIS_URL / connection secrets must fully mask."""
+    from swarm.utils.redact import is_sensitive_key, redact_sensitive_data
+
+    for key in (
+        "DATABASE_URL",
+        "REDIS_URL",
+        "MONGODB_URI",
+        "MONGO_URL",
+        "connection_string",
+        "DSN",
+    ):
+        assert is_sensitive_key(key), key
+
+    # Do not treat generic base_url as a secret key name.
+    assert not is_sensitive_key("base_url")
+    assert not is_sensitive_key("webhook_url")
+
+    data = {
+        "env": {
+            "DATABASE_URL": "postgres://user:supersecret@db:5432/app",
+            "REDIS_URL": "redis://:redispass@localhost:6379/0",
+            "MONGODB_URI": "mongodb://admin:mongopass@mongo:27017/db",
+            "PUBLIC_SITE": "https://example.com",
+        }
+    }
+    redacted = redact_sensitive_data(data, mask="***HIDDEN***")
+    assert redacted["env"]["DATABASE_URL"] == "***HIDDEN***"
+    assert redacted["env"]["REDIS_URL"] == "***HIDDEN***"
+    assert redacted["env"]["MONGODB_URI"] == "***HIDDEN***"
+    assert redacted["env"]["PUBLIC_SITE"] == "https://example.com"
+    assert "supersecret" not in str(redacted)
+    assert "redispass" not in str(redacted)
+    assert "mongopass" not in str(redacted)
+
+
+def test_uri_credentials_redacted_in_non_sensitive_values():
+    """Credentialed URIs under non-secret keys still mask the password segment."""
+    from swarm.utils.redact import redact_sensitive_data, redact_uri_credentials
+
+    assert (
+        redact_uri_credentials("postgres://user:s3cret@host/db", mask="***")
+        == "postgres://user:***@host/db"
+    )
+    # Plain URLs without userinfo are untouched.
+    assert redact_uri_credentials("https://api.example.com/v1") == "https://api.example.com/v1"
+
+    data = {"callback": "https://svc:leakedpass@internal.example/hook"}
+    redacted = redact_sensitive_data(data, mask="***HIDDEN***")
+    assert "leakedpass" not in redacted["callback"]
+    assert "***HIDDEN***" in redacted["callback"]
+
+
+def test_mcp_env_aws_and_database_url_nested():
+    """MCP nested env with AWS_ACCESS_KEY_ID and DATABASE_URL must not leak raw."""
+    data = {
+        "mcpServers": {
+            "demo": {
+                "env": {
+                    "AWS_ACCESS_KEY_ID": "AKIA_MUST_NOT_LEAK",
+                    "DATABASE_URL": "postgres://u:db_pass_must_not_leak@h/db",
+                    "NODE_ENV": "production",
+                }
+            }
+        }
+    }
+    redacted = redact_sensitive_data(data, mask="***HIDDEN***")
+    env = redacted["mcpServers"]["demo"]["env"]
+    assert env["AWS_ACCESS_KEY_ID"] == "***HIDDEN***"
+    assert env["DATABASE_URL"] == "***HIDDEN***"
+    assert env["NODE_ENV"] == "production"
+    assert "AKIA_MUST_NOT_LEAK" not in str(redacted)
+    assert "db_pass_must_not_leak" not in str(redacted)


### PR DESCRIPTION
# Summary

Closes the main fixable residual risks from the post-#259 skeptic audit: broader secret taxonomy (AWS access keys, DB/connection URLs), fail-closed ownership for legacy unowned responses, real HTTP ownership tests, Session Explorer principal filtering, and residual API surfaces (marketplace, ChatMessage) that stayed hard-coded `AllowAny` when API auth is on.

## Problem it solves

Skeptic residual list after #252–#259 still called out:
1. Incomplete secret redaction (`AWS_ACCESS_KEY_ID`, `DATABASE_URL`)
2. Legacy responses without `owner` readable by any authenticated principal
3. Ownership tests only hit helpers, not HTTP GET/cancel/delete
4. Session Explorer listed all sessions for any logged-in user
5. Marketplace GitHub + ChatMessageViewSet hard-coded `AllowAny`

## How it works

1. **Redaction** — expand sensitive key set (`access_key`/`access_key_id`, connection URL keys), URI credential masking, tighter env dump heuristics.
2. **Ownership** — `owner_allows` is fail-closed when `owner` is missing; `list_summaries` emits `owner`; AsyncClient HTTP tests cover GET/cancel/delete.
3. **Explorer** — filter inventory and detail by `request_principal` + `owner_allows`.
4. **API surfaces** — marketplace and ChatMessage use `api_permission_classes()` so they lock when `ENABLE_API_AUTH` is on.

## Measured impact

- Combined suite: **64 passed** (`test_prod_p0_auth_ownership`, `test_session_explorer`, redact + secrets P0 tests).
- No new dependencies.

## Test coverage

- New HTTP ownership cases (foreign, legacy unowned, auth on/off).
- Explorer own-only list + foreign/unowned detail 404.
- Marketplace/ChatMessage auth when enabled.
- Redact regression for AWS keys, DATABASE_URL, nested MCP env.

## Risks / follow-ups

- **Still outstanding (structural):** single shared API token principal (not multi-tenant keys), process-local cancel under multi-worker override, creator ban-list is not a sandbox, DEBUG without token leaves API open, incomplete secret taxonomy edge cases remain possible.
- Legacy unowned records become inaccessible when auth is on (by design); operators must re-create or stamp owners if needed.
- Rollback: revert this PR.

## Build footprint

None.