### PR TITLE
fix(security): low-hanging skeptic residual fruit

### DIFF
--- a/src/swarm/apps.py
+++ b/src/swarm/apps.py
@@ -79,6 +79,8 @@ class SwarmConfig(AppConfig):
                 raise
             logger.warning("Test-mode guard check failed: %s", e)
 
+        self._warn_if_api_auth_disabled()
+
         # Resume async /v1/responses tasks left in-flight by a restart — server
         # processes only (not migrate/test), guarded against the runserver
         # reloader's parent process to avoid double-resume.
@@ -86,6 +88,25 @@ class SwarmConfig(AppConfig):
         self._maybe_resume_async_tasks()
 
         logger.info("Swarm app initialization checks completed.")
+
+    @staticmethod
+    def _warn_if_api_auth_disabled() -> None:
+        """Surface the DEBUG / missing-token footgun when the process is serving."""
+        import sys
+
+        argv = " ".join(sys.argv)
+        serving = any(
+            s in argv for s in ("uvicorn", "swarm-api", "gunicorn", "daphne", "runserver")
+        )
+        if not serving:
+            return
+        if bool(getattr(settings, "ENABLE_API_AUTH", False)):
+            return
+        logger.warning(
+            "API authentication is OFF (ENABLE_API_AUTH=false — typically DEBUG "
+            "without API_AUTH_TOKEN / SWARM_API_KEY). Fine for local development; "
+            "do not expose this process on a network without setting an API token."
+        )
 
     @staticmethod
     def _check_uvicorn_workers() -> None:

--- a/src/swarm/tool_executor.py
+++ b/src/swarm/tool_executor.py
@@ -37,30 +37,27 @@ def redact_sensitive_data(data: Any) -> Any:
     """
     Redact sensitive information from data for logging purposes.
 
-    Args:
-        data: The data to redact
-
-    Returns:
-        Redacted version of the data
+    Delegates to :func:`swarm.utils.redact.redact_sensitive_data` so tool-call
+    logs use the same key taxonomy and URI masking as the settings path.
+    Top-level strings also get pattern / URI scrubbing (log lines may be plain
+    text rather than structured dicts).
     """
-    if isinstance(data, dict):
-        redacted = {}
-        for key, value in data.items():
-            if any(sensitive in str(key).lower() for sensitive in ['key', 'token', 'secret', 'password', 'auth']):
-                if isinstance(value, str) and len(value) > 4:
-                    redacted[key] = value[:2] + '*' * (len(value) - 4) + value[-2:]
-                else:
-                    redacted[key] = '***'
-            else:
-                redacted[key] = redact_sensitive_data(value)
+    from swarm.utils.redact import (
+        _COMPILED_SENSITIVE_PATTERNS,
+        redact_sensitive_data as _shared_redact,
+        redact_uri_credentials,
+    )
+
+    if isinstance(data, str):
+        redacted = data
+        for pattern in _COMPILED_SENSITIVE_PATTERNS:
+            redacted = pattern.sub("[REDACTED]", redacted)
+        redacted = redact_uri_credentials(redacted)
+        # Extra log-oriented heuristics (Basic auth / JWT-ish prefixes).
+        if redacted == data and re.search(r"(?:sk-|Bearer |Basic |eyJ)", data):
+            return "***REDACTED***"
         return redacted
-    elif isinstance(data, list):
-        return [redact_sensitive_data(item) for item in data]
-    elif isinstance(data, str):
-        # Simple heuristic for API keys in strings
-        if re.search(r'(?:sk-|Bearer |Basic |eyJ)', data):
-            return '***REDACTED***'
-    return data
+    return _shared_redact(data)
 
 # Utility to convert function signatures to JSON schema (if needed, though less common now with direct calls)
 # from .util import function_to_json # Commented out if not used directly here

--- a/src/swarm/utils/redact.py
+++ b/src/swarm/utils/redact.py
@@ -38,9 +38,10 @@ SENSITIVE_PATTERNS = [
 ]
 _COMPILED_SENSITIVE_PATTERNS = [re.compile(p) for p in SENSITIVE_PATTERNS]
 
-# scheme://user:password@host — mask only the password segment (not bare https URLs).
+# scheme://user:password@host and scheme://:password@host (empty user).
+# User part may be empty; bare https://host (no credentials) does not match.
 _URI_CREDENTIALS_PATTERN = re.compile(
-    r"([a-zA-Z][a-zA-Z0-9+.-]*://[^:/?#\s]+):([^@/\s]+)@"
+    r"([a-zA-Z][a-zA-Z0-9+.-]*://[^@/\s:]*):([^@/\s]+)@"
 )
 
 

--- a/src/swarm/views/responses_views.py
+++ b/src/swarm/views/responses_views.py
@@ -533,7 +533,12 @@ def _persist(
 
 
 def _assert_owner_access(request: Request, record: dict[str, Any] | None) -> None:
-    """Refuse cross-principal access when API auth is on and owner is stamped."""
+    """Refuse access when API auth is on and the principal is not the owner.
+
+    Fail-closed: legacy records without an ``owner`` stamp are also denied
+    (see :func:`responses_store.owner_allows`). Skipped entirely when API auth
+    is off (open local-dev mode).
+    """
     if not bool(getattr(settings, "ENABLE_API_AUTH", False)):
         return
     principal = request_principal(request)

--- a/tests/core/test_tool_executor.py
+++ b/tests/core/test_tool_executor.py
@@ -40,106 +40,90 @@ from swarm.types import Agent, Result
 
 
 class TestRedactSensitiveData:
-    """Tests for redact_sensitive_data function."""
+    """tool_executor.redact_sensitive_data delegates to swarm.utils.redact."""
 
     def test_redacts_dict_with_sensitive_keys(self):
-        """Keys containing 'key', 'token', 'secret', 'password', 'auth' are redacted."""
         data = {
-            "api_key": "sk-1234567890abcdef",  # 19 chars
-            "token": "tok-abcdef123456",  # 16 chars
-            "client_secret": "secretvalue",  # 11 chars
-            "password": "hunter2",  # 7 chars
-            "auth_header": "Bearer xyz",  # 10 chars
+            "api_key": "sk-1234567890abcdef",
+            "token": "tok-abcdef123456",
+            "client_secret": "secretvalue",
+            "password": "hunter2",
+            "authorization": "Bearer xyz",
+            "model": "gpt-4",
         }
         redacted = redact_sensitive_data(data)
-
-        # Long strings (>4 chars) get partial redaction: first 2 + * (len-4) + last 2
-        # sk-1234567890abcdef (19 chars) -> sk + 15 asterisks + ef
-        assert redacted["api_key"] == "sk" + "*" * 15 + "ef"
-        # tok-abcdef123456 (16 chars) -> to + 12 asterisks + 56
-        assert redacted["token"] == "to" + "*" * 12 + "56"
-        # secretvalue (11 chars) -> se + 7 asterisks + ue
-        assert redacted["client_secret"] == "se" + "*" * 7 + "ue"
-        # hunter2 (7 chars) -> hu + 3 asterisks + r2
-        assert redacted["password"] == "hu" + "*" * 3 + "r2"
-        # Bearer xyz (10 chars) -> Be + 6 asterisks + yz
-        assert redacted["auth_header"] == "Be" + "*" * 6 + "yz"
+        assert redacted["api_key"] == "[REDACTED]"
+        assert redacted["token"] == "[REDACTED]"
+        assert redacted["client_secret"] == "[REDACTED]"
+        assert redacted["password"] == "[REDACTED]"
+        assert redacted["authorization"] == "[REDACTED]"
+        assert redacted["model"] == "gpt-4"
 
     def test_redacts_nested_dicts(self):
-        """Nested dictionaries are recursively redacted."""
         data = {
             "nested": {
-                "api_key": "sk-test-key",  # 11 chars
+                "api_key": "sk-test-key",
                 "normal_field": "visible",
             }
         }
         redacted = redact_sensitive_data(data)
-
-        # sk-test-key (11 chars) -> sk + 7 asterisks + ey
-        assert redacted["nested"]["api_key"] == "sk" + "*" * 7 + "ey"
+        assert redacted["nested"]["api_key"] == "[REDACTED]"
         assert redacted["nested"]["normal_field"] == "visible"
 
     def test_redacts_lists(self):
-        """Lists are recursively processed."""
         data = [
-            {"api_key": "sk-secret"},  # 9 chars
+            {"api_key": "sk-secret"},
             "plain string",
-            {"nested": {"token": "abc123xyz"}},  # 9 chars
+            {"nested": {"token": "abc123xyz"}},
         ]
         redacted = redact_sensitive_data(data)
-
-        # sk-secret (9 chars) -> sk + 5 asterisks + et
-        assert redacted[0]["api_key"] == "sk" + "*" * 5 + "et"
+        assert redacted[0]["api_key"] == "[REDACTED]"
         assert redacted[1] == "plain string"
-        # abc123xyz (9 chars) -> ab + 5 asterisks + yz
-        assert redacted[2]["nested"]["token"] == "ab" + "*" * 5 + "yz"
+        assert redacted[2]["nested"]["token"] == "[REDACTED]"
 
     def test_redacts_strings_with_api_key_patterns(self):
-        """Strings containing API key patterns are redacted."""
-        # Pattern: sk- prefix
-        assert redact_sensitive_data("sk-1234567890") == "***REDACTED***"
-        # Pattern: Bearer prefix
-        assert redact_sensitive_data("Bearer token123") == "***REDACTED***"
-        # Pattern: Basic auth prefix
+        assert redact_sensitive_data("sk-1234567890") == "[REDACTED]"
+        assert redact_sensitive_data("Bearer token123") == "[REDACTED]"
         assert redact_sensitive_data("Basic dXNlcjpwYXNz") == "***REDACTED***"
-        # Pattern: JWT-like (eyJ prefix)
         assert redact_sensitive_data("eyJhbGciOiJIUzI1NiJ9") == "***REDACTED***"
 
     def test_does_not_redact_normal_strings(self):
-        """Normal strings without sensitive patterns pass through."""
         assert redact_sensitive_data("hello world") == "hello world"
         assert redact_sensitive_data("not-sensitive-key") == "not-sensitive-key"
 
     def test_handles_non_string_values_in_dict(self):
-        """Non-string values in sensitive fields get '***'."""
         data = {
             "api_key": 12345,
             "token": None,
             "secret": True,
         }
         redacted = redact_sensitive_data(data)
-
-        assert redacted["api_key"] == "***"
-        assert redacted["token"] == "***"
-        assert redacted["secret"] == "***"
+        assert redacted["api_key"] == "[REDACTED]"
+        assert redacted["token"] == "[REDACTED]"
+        assert redacted["secret"] == "[REDACTED]"
 
     def test_handles_empty_and_none_inputs(self):
-        """Empty containers and None pass through."""
         assert redact_sensitive_data({}) == {}
         assert redact_sensitive_data([]) == []
         assert redact_sensitive_data(None) is None
         assert redact_sensitive_data("") == ""
 
     def test_short_sensitive_values_get_masked(self):
-        """Short sensitive values (<=4 chars) get '***'."""
         data = {
-            "api_key": "abcd",  # 4 chars - gets ***
-            "token": "xyz",  # 3 chars - gets ***
+            "api_key": "abcd",
+            "token": "xyz",
         }
         redacted = redact_sensitive_data(data)
+        assert redacted["api_key"] == "[REDACTED]"
+        assert redacted["token"] == "[REDACTED]"
 
-        assert redacted["api_key"] == "***"
-        assert redacted["token"] == "***"
+    def test_env_style_and_empty_user_uri(self):
+        redacted = redact_sensitive_data({
+            "OPENAI_API_KEY": "sk-log-leak",
+            "notes": "redis://:onlypass@host:6379",
+        })
+        assert redacted["OPENAI_API_KEY"] == "[REDACTED]"
+        assert "onlypass" not in redacted["notes"]
 
 
 # =============================================================================

--- a/tests/e2e_visual/test_golden_journey.py
+++ b/tests/e2e_visual/test_golden_journey.py
@@ -131,15 +131,25 @@ def test_dark_mode_toggle(page, live_server_url):
 
     Note: this SPA carries ``data-theme`` on the app root <div> (App.tsx),
     not on documentElement, so assert on the actual attribute carrier.
+
+    After Django-canonical shell (#254), ``/`` may not mount the SPA at all.
+    Skip cleanly when the SPA toggle is absent instead of timing out CI.
     """
     page.goto(live_server_url + "/", wait_until="networkidle")
+    toggle = page.get_by_label("Toggle dark mode")
+    if toggle.count() == 0:
+        pytest.skip(
+            "SPA dark-mode toggle not present on / "
+            "(Django-canonical shell; SPA theme test N/A)"
+        )
+
     themed = page.locator("[data-theme]").first
     themed.wait_for(state="attached", timeout=10_000)
 
     theme_before = themed.get_attribute("data-theme")
     bg_before = _computed(page, themed, "backgroundColor")
 
-    page.get_by_label("Toggle dark mode").click()
+    toggle.click()
     page.wait_for_timeout(250)  # let React re-render + CSS vars resolve
 
     theme_after = themed.get_attribute("data-theme")

--- a/tests/unit/test_api_auth_startup_warn.py
+++ b/tests/unit/test_api_auth_startup_warn.py
@@ -1,0 +1,43 @@
+"""Startup footgun: warn when serving with API auth off."""
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.django_db
+def test_warns_when_serving_without_api_auth(settings, monkeypatch):
+    from swarm import apps as apps_mod
+    from swarm.apps import SwarmConfig
+
+    settings.ENABLE_API_AUTH = False
+    monkeypatch.setattr(sys, "argv", ["uvicorn", "swarm.asgi:application"])
+    with patch.object(apps_mod.logger, "warning") as warn:
+        SwarmConfig._warn_if_api_auth_disabled()
+    warn.assert_called_once()
+    assert "API authentication is OFF" in warn.call_args[0][0]
+
+
+@pytest.mark.django_db
+def test_no_warn_when_api_auth_on(settings, monkeypatch):
+    from swarm import apps as apps_mod
+    from swarm.apps import SwarmConfig
+
+    settings.ENABLE_API_AUTH = True
+    monkeypatch.setattr(sys, "argv", ["uvicorn", "swarm.asgi:application"])
+    with patch.object(apps_mod.logger, "warning") as warn:
+        SwarmConfig._warn_if_api_auth_disabled()
+    warn.assert_not_called()
+
+
+def test_no_warn_when_not_serving(settings, monkeypatch):
+    from swarm import apps as apps_mod
+    from swarm.apps import SwarmConfig
+
+    settings.ENABLE_API_AUTH = False
+    monkeypatch.setattr(sys, "argv", ["pytest"])
+    with patch.object(apps_mod.logger, "warning") as warn:
+        SwarmConfig._warn_if_api_auth_disabled()
+    warn.assert_not_called()

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -84,6 +84,22 @@ def test_env_style_keys_are_redacted_by_substring():
     assert redacted["env"]["NORMAL_PATH"] == "/usr/bin/npx"
 
 
+def test_empty_user_uri_credentials_are_redacted():
+    """redis://:password@host (empty user) must not leak the password."""
+    from swarm.utils.redact import redact_uri_credentials
+
+    assert "onlypass" not in redact_uri_credentials("redis://:onlypass@host:6379")
+    assert "hunter2" not in redact_uri_credentials("postgres://admin:hunter2@db/prod")
+    plain = "https://example.com/path"
+    assert redact_uri_credentials(plain) == plain
+    nested = redact_sensitive_data(
+        {"notes": "cache at redis://:onlypass@host:6379/0"},
+        mask="***HIDDEN***",
+    )
+    assert "onlypass" not in nested["notes"]
+    assert "***HIDDEN***" in nested["notes"]
+
+
 def test_is_sensitive_key_helper():
     from swarm.utils.redact import is_sensitive_key
 


### PR DESCRIPTION
# Summary

Implements low-hanging items from the post-#260 outstanding list: unify dual redactors, close empty-user URI password leak, surface DEBUG/auth-off serve footgun, and stop golden-journey dark-mode from timing out when Django-canonical `/` has no SPA toggle.

## Problem it solves

Skeptic residual caveats that were cheap to close:
1. Dual redactor in `tool_executor` weaker than shared `utils.redact`
2. `redis://:password@host` (empty user) leaked under non-sensitive keys
3. DEBUG / no-token auth-off is a silent footgun when serving
4. golden-journey `test_dark_mode_toggle` 30s timeout on Django shell
5. Stale `_assert_owner_access` docstring

## How it works

- `tool_executor.redact_sensitive_data` delegates to shared redactor (+ top-level string patterns for log lines)
- URI regex allows empty user before `:password@`
- `SwarmConfig._warn_if_api_auth_disabled()` logs WARNING when argv looks like a server and `ENABLE_API_AUTH` is false
- E2E dark-mode test skips if toggle label absent
- Docstring documents fail-closed ownership

## Measured impact

Targeted suite **75+** green (redact + tool_executor + ownership + startup warn). No deps.

## Test coverage

- `tests/unit/test_redact.py` empty-user URI case
- `tests/core/test_tool_executor.py` updated to shared-redactor semantics
- `tests/unit/test_api_auth_startup_warn.py` warn/no-warn cases
- golden-journey skip path (no Playwright run required for unit CI)

## Risks / follow-ups

- Tool log redaction is now full-mask (`[REDACTED]`) not partial prefix/suffix — safer, slightly less debug-friendly
- Multi-token tenancy, distributed cancel, blueprint sandbox remain outstanding (not low-hanging)
- Rollback: revert commit

## Build footprint

None.