### PR TITLE
feat(security): multi-token, shared cancel, sandbox, create→run, public defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,8 +40,11 @@ DJANGO_ALLOWED_HOSTS=""
 # REQUIRED when DJANGO_DEBUG is not true — the server REFUSES TO START without
 # it so production can never silently run with API auth disabled.
 # (SWARM_API_KEY is accepted as a legacy alias if API_AUTH_TOKEN is unset.)
+# Optional multi-key: API_AUTH_TOKENS or SWARM_API_KEYS as comma-separated list
+# (merged with the single vars). Each key gets a distinct ownership principal.
 # Generate one with: python -c "import secrets; print(secrets.token_urlsafe(32))"
 API_AUTH_TOKEN=""
+# API_AUTH_TOKENS=""
 
 # Comma-separated origins trusted for CSRF-protected (POST) requests.
 # Default: http://localhost:8000,http://127.0.0.1:8000

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -260,10 +260,12 @@ environment / `.env`, never in `swarm_config.json` (reference them with
 | `DJANGO_DEBUG` | Debug mode (verbose errors, DEBUG logging, relaxed auth). Keep **off** in prod. | `false` |
 | `DJANGO_ALLOWED_HOSTS` | Comma-separated allowed hosts (whitespace-trimmed, empties dropped). **Required in production.** | dev: `localhost,127.0.0.1` |
 | `DJANGO_CSRF_TRUSTED_ORIGINS` | Comma-separated trusted origins for CSRF on mutating routes (whitespace-trimmed, empties dropped). | `http://localhost:8000,http://127.0.0.1:8000` |
-| `API_AUTH_TOKEN` | Bearer token OpenAI clients present to the API. Primary when set. | none |
+| `API_AUTH_TOKEN` | Bearer token OpenAI clients present to the API. Primary when set. **Required in production** (`DEBUG=False`) unless `SWARM_ALLOW_NO_AUTH=true` — server refuses to start without any token. | none |
 | `SWARM_API_KEY` | Legacy alias for `API_AUTH_TOKEN` (used if the latter is unset). | none |
 | `API_AUTH_TOKENS` / `SWARM_API_KEYS` | Optional comma-separated list of additional (or sole) accepted Bearer secrets. Merged with the single-token vars; each key maps to a distinct ownership principal (`token:<sha256-prefix>`). | none |
 | `ENABLE_API_AUTH` | Require auth on `/v1/*` (including `/v1/models` and `/v1/blueprints`). Auto-on when any API auth token is set. | prod: on |
+| `SWARM_SECURE_COOKIES` | When `DEBUG=False`, force `SESSION_COOKIE_SECURE` / `CSRF_COOKIE_SECURE`. Default **on** in production; set `false` for HTTP-only staging. | prod: true |
+| `DJANGO_X_FRAME_OPTIONS` | Clickjacking header when `DEBUG=False` (Django `XFrameOptionsMiddleware`). | `DENY` |
 | `SWARM_ALLOW_NO_AUTH` | Allow booting in production **without** a token (warns) — for when an external OAuth proxy / API gateway already gates access. | `false` |
 | `ALLOW_TESTUSER_AUTOLOGIN` | Dev-only auto-login (debug only, random password). | `false` |
 | `HOST` / `PORT` | Bind address/port for the server. | `0.0.0.0` / `8000` |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -267,7 +267,7 @@ environment / `.env`, never in `swarm_config.json` (reference them with
 | `SWARM_ALLOW_NO_AUTH` | Allow booting in production **without** a token (warns) — for when an external OAuth proxy / API gateway already gates access. | `false` |
 | `ALLOW_TESTUSER_AUTOLOGIN` | Dev-only auto-login (debug only, random password). | `false` |
 | `HOST` / `PORT` | Bind address/port for the server. | `0.0.0.0` / `8000` |
-| `SWARM_UVICORN_WORKERS` | uvicorn worker count. Prefer **1** — async cancel/inflight are process-local. | `1` |
+| `SWARM_UVICORN_WORKERS` | uvicorn worker count. Prefer **1** — inflight limits are process-local; cancel is filesystem-shared when workers share `SWARM_RESPONSES_DIR`. | `1` |
 | `SWARM_ENFORCE_SINGLE_WORKER` | When true (default), refuse `SWARM_UVICORN_WORKERS` &gt; 1 at app startup. | `true` |
 | `SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY` | When true, scan user blueprint dirs (exec_module). Default off so creator saves are write-only. | `false` |
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -260,8 +260,10 @@ environment / `.env`, never in `swarm_config.json` (reference them with
 | `DJANGO_DEBUG` | Debug mode (verbose errors, DEBUG logging, relaxed auth). Keep **off** in prod. | `false` |
 | `DJANGO_ALLOWED_HOSTS` | Comma-separated allowed hosts (whitespace-trimmed, empties dropped). **Required in production.** | dev: `localhost,127.0.0.1` |
 | `DJANGO_CSRF_TRUSTED_ORIGINS` | Comma-separated trusted origins for CSRF on mutating routes (whitespace-trimmed, empties dropped). | `http://localhost:8000,http://127.0.0.1:8000` |
-| `API_AUTH_TOKEN` | Bearer token OpenAI clients present to the API. | none |
-| `ENABLE_API_AUTH` | Require auth on `/v1/*` (including `/v1/models` and `/v1/blueprints`). Auto-on when `API_AUTH_TOKEN` is set. | prod: on |
+| `API_AUTH_TOKEN` | Bearer token OpenAI clients present to the API. Primary when set. | none |
+| `SWARM_API_KEY` | Legacy alias for `API_AUTH_TOKEN` (used if the latter is unset). | none |
+| `API_AUTH_TOKENS` / `SWARM_API_KEYS` | Optional comma-separated list of additional (or sole) accepted Bearer secrets. Merged with the single-token vars; each key maps to a distinct ownership principal (`token:<sha256-prefix>`). | none |
+| `ENABLE_API_AUTH` | Require auth on `/v1/*` (including `/v1/models` and `/v1/blueprints`). Auto-on when any API auth token is set. | prod: on |
 | `SWARM_ALLOW_NO_AUTH` | Allow booting in production **without** a token (warns) — for when an external OAuth proxy / API gateway already gates access. | `false` |
 | `ALLOW_TESTUSER_AUTOLOGIN` | Dev-only auto-login (debug only, random password). | `false` |
 | `HOST` / `PORT` | Bind address/port for the server. | `0.0.0.0` / `8000` |

--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -123,6 +123,7 @@ Import check: every module below imported successfully via `uv run python -c "im
 | Codey command-injection fix | ✅ | `blueprint_codey.py:933-937` parses with `shlex.split` instead of shell string (commit `2e2ee426` "Fix Command Injection in Codey blueprint") |
 | Sensitive-data redaction | ✅ | `swarm/utils/redact.py`; tests `tests/core/test_redact_sensitive_data.py`, `tests/unit/test_redact*.py` (3 files) pass; marketplace scrubs secrets via `SECRET_PATTERNS` (`marketplace/models.py:20-26`) |
 | API auth (static token / session) | 🟡 | `auth.py:25` `StaticTokenAuthentication`, permission `auth.py:110-135`; `settings.py:40-45` `ENABLE_API_AUTH = bool(SWARM_API_KEY)`. Caveat: when `SWARM_API_KEY` is unset, DRF default permission falls back to `AllowAny` (`settings.py:261-268`) — API is open by default |
+| ChatMessage tenancy + prod security headers | ✅ | `message_views.py` scopes list to `conversation__student=request.user` when `ENABLE_API_AUTH`; token-only → empty qs. Production (`DEBUG=False`): `SECURE_CONTENT_TYPE_NOSNIFF`, `X_FRAME_OPTIONS=DENY`, secure cookies (`SWARM_SECURE_COOKIES`). Browser honesty: `swarm.core.browser_tools` + TROUBLESHOOTING §7 (no fake playwright success). |
 | `SWARM_TEST_MODE` | 🟡 | Works as designed for tests (dummy LLM paths e.g. `blueprint_jeeves.py:276`; `swarm_cli.py:97` installs a bash shim instead of a PyInstaller binary). Caveat: a single env var globally swaps real behavior for canned output — if leaked into prod, responses are fake with no warning |
 
 ---

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -62,6 +62,11 @@ docker compose up -d
 Point any OpenAI client at `http://<host>:8000/v1` with
 `Authorization: Bearer $API_AUTH_TOKEN`.
 
+For multiple clients with separate ownership principals, set
+`API_AUTH_TOKENS=key-a,key-b` (or `SWARM_API_KEYS`) — comma-separated secrets
+accepted alongside the single `API_AUTH_TOKEN` / `SWARM_API_KEY`. Each Bearer
+maps to its own `token:<sha256-prefix>` principal for response ownership.
+
 > **Single worker until a shared queue exists.** Async `/v1/responses` cancel
 > and in-flight limits are **process-local**. Compose/Dockerfile default
 > `SWARM_UVICORN_WORKERS=1`. Setting workers > 1 is refused by default

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -125,6 +125,8 @@ presets, per-request `params`, failover, workdir isolation, native best-of-N).
   --check-auth` on the host.
 - **Server refuses to start** → in production (`DJANGO_DEBUG` not true) you must
   set `DJANGO_SECRET_KEY`, `DJANGO_ALLOWED_HOSTS`, and `API_AUTH_TOKEN`.
+  Production also enables secure cookies + `X-Content-Type-Options` / `X-Frame-Options`
+  (opt out of secure cookies with `SWARM_SECURE_COOKIES=false` for HTTP staging).
 - **401/403** → missing/wrong `Authorization: Bearer $API_AUTH_TOKEN`.
 - **gemini slow / stalls** → the free `oauth-personal` tier throttles the pro
   model heavily; the flash default answers in seconds. Use a paid `GEMINI_API_KEY`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -67,11 +67,12 @@ For multiple clients with separate ownership principals, set
 accepted alongside the single `API_AUTH_TOKEN` / `SWARM_API_KEY`. Each Bearer
 maps to its own `token:<sha256-prefix>` principal for response ownership.
 
-> **Single worker until a shared queue exists.** Async `/v1/responses` cancel
-> and in-flight limits are **process-local**. Compose/Dockerfile default
+> **Single worker preferred for inflight limits.** Async `/v1/responses`
+> inflight limits are **process-local**; cooperative cancel is shared via the
+> filesystem when workers share `SWARM_RESPONSES_DIR`. Compose/Dockerfile default
 > `SWARM_UVICORN_WORKERS=1`. Setting workers > 1 is refused by default
-> (`SWARM_ENFORCE_SINGLE_WORKER=true`); only override if you accept broken
-> cross-worker cancel. Oracle systemd unit already uses `--workers 1`.
+> (`SWARM_ENFORCE_SINGLE_WORKER=true`); only override if you accept per-worker
+> inflight accounting. Oracle systemd unit already uses `--workers 1`.
 
 > **Persist Responses state.** `/v1/responses` is stateful: stored responses (for
 > `previous_response_id` chaining and `GET`/`DELETE`) live under

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -80,4 +80,32 @@ How to proceed:
 
 ---
 
+
+
+## 7. Browser automation / Playwright MCP
+
+Blueprints that declare a ``browser`` capability (e.g. ``whiskeytango_foxtrot``,
+``jeeves``) expect the official **microsoft/playwright-mcp** server
+(``npx -y @playwright/mcp@latest``). Open Swarm auto-provisions it in the tool
+catalog when missing from config, but it still needs Node/npx available on the
+host and a successful MCP process start.
+
+There is **no stub browser that fakes success**. If Playwright MCP is not
+configured or fails to start, tools should report:
+
+```
+browser automation unavailable: no playwright MCP server
+```
+
+(see ``swarm.core.browser_tools.browser_unavailable_error``).
+
+Fix checklist:
+- Ensure Node.js / ``npx`` is on ``PATH`` for the server process.
+- Optionally pin a ``playwright`` entry under ``mcpServers`` in
+  ``swarm_config.json`` (command ``npx``, args ``["-y", "@playwright/mcp@latest"]``).
+- Confirm with ``GET /v1/blueprints/<id>/tools`` that ``satisfied.browser`` is
+  ``playwright`` and that the process can actually spawn ``npx``.
+- First run may download Chromium; allow network or pre-install browsers.
+
+
 **Tip:** Most issues are caused by misconfigured API keys, missing dependencies, or a corrupted config file. Reviewing or resetting your config often resolves stubborn problems.

--- a/src/swarm/apps.py
+++ b/src/swarm/apps.py
@@ -110,7 +110,7 @@ class SwarmConfig(AppConfig):
 
     @staticmethod
     def _check_uvicorn_workers() -> None:
-        """Refuse/warn multi-worker async when serving (process-local cancel)."""
+        """Refuse/warn multi-worker async when serving (process-local inflight)."""
         import sys
 
         argv = " ".join(sys.argv)

--- a/src/swarm/auth.py
+++ b/src/swarm/auth.py
@@ -25,30 +25,35 @@ User = get_user_model()
 # --- Static Token Authentication ---
 class StaticTokenAuthentication(BaseAuthentication):
     """
-    Authenticates requests based on a static API token passed in a header
+    Authenticates requests based on static API token(s) passed in a header
     (Authorization: Bearer <token> or X-API-Key: <token>).
 
-    Returns (AnonymousUser, token) on success. This allows permission classes
-    to check request.auth to see if token authentication succeeded, even though
-    no specific user model is associated with the token.
+    Accepts any token in ``settings.SWARM_API_KEYS`` (or the single
+    ``settings.SWARM_API_KEY`` when the list is empty). On match returns
+    ``(AnonymousUser(), provided_token)`` so ``request.auth`` is the presenting
+    credential and ``request_principal`` can hash that specific token.
     """
     keyword = 'Bearer'
 
     def authenticate(self, request):
         """
-        Attempts to authenticate using a static token.
+        Attempts to authenticate using a static token against all accepted keys.
         """
         logger.debug("[Auth][StaticToken] Attempting static token authentication.")
-        # Retrieve the expected token from settings.
-        expected_token = getattr(settings, 'SWARM_API_KEY', None)
+        # Preferred: multi-key list. Fall back to single SWARM_API_KEY.
+        accepted = list(getattr(settings, 'SWARM_API_KEYS', None) or [])
+        if not accepted:
+            single = getattr(settings, 'SWARM_API_KEY', None)
+            if single:
+                accepted = [single]
 
-        # If no token is configured in settings, this method cannot authenticate.
-        if not expected_token:
+        # If no tokens configured, this method cannot authenticate.
+        if not accepted:
             logger.error(
-                "[Auth][StaticToken] SWARM_API_KEY is not set in Django settings. "
+                "[Auth][StaticToken] SWARM_API_KEY(S) not set in Django settings. "
                 "Cannot use static token auth."
             )
-            return None # Indicate authentication method did not run or failed pre-check
+            return None  # Indicate authentication method did not run or failed pre-check
 
         # Extract the provided token from standard Authorization header or
         # custom X-API-Key header.
@@ -65,19 +70,20 @@ class StaticTokenAuthentication(BaseAuthentication):
         # If no token was found in either header, authentication fails for this method.
         if not provided_token:
             logger.debug("[Auth][StaticToken] No token found in relevant headers.")
-            return None # Indicate authentication method did not find credentials
+            return None  # Indicate authentication method did not find credentials
 
-        # Constant-time compare to mitigate timing attacks on the API token.
-        if hmac.compare_digest(str(provided_token), str(expected_token)):
-            logger.info("[Auth][StaticToken] Static token authentication successful.")
-            # Return AnonymousUser and the token itself as request.auth.
-            # This signals successful authentication via token without linking to
-            # a specific User model.
-            return (AnonymousUser(), provided_token)
-        else:
-            # Token was provided but did not match. Raise AuthenticationFailed.
-            logger.warning("[Auth][StaticToken] Invalid static token provided.")
-            raise exceptions.AuthenticationFailed(_("Invalid API Key."))
+        # Constant-time compare against each accepted token (small N).
+        provided_str = str(provided_token)
+        for expected in accepted:
+            if hmac.compare_digest(provided_str, str(expected)):
+                logger.info("[Auth][StaticToken] Static token authentication successful.")
+                # Return AnonymousUser and the *provided* token as request.auth so
+                # ownership principals differ per credential under multi-key setups.
+                return (AnonymousUser(), provided_token)
+
+        # Token was provided but did not match any accepted key.
+        logger.warning("[Auth][StaticToken] Invalid static token provided.")
+        raise exceptions.AuthenticationFailed(_("Invalid API Key."))
 
 # --- Custom *Synchronous* Session Authentication ---
 class CustomSessionAuthentication(SessionAuthentication):
@@ -152,8 +158,9 @@ def request_principal(request) -> str | None:
 
     - Session user → ``user:<username>``
     - Static API token (request.auth) → ``token:<sha256-prefix>`` of the
-      presenting credential (single configured token ⇒ one principal; multi-key
-      is a future extension)
+      presenting credential. With multi-key auth (``API_AUTH_TOKENS`` /
+      ``SWARM_API_KEYS``), each accepted Bearer maps to a distinct principal
+      because the hash is over the token that authenticated the request.
     - Unauthenticated → ``None``
     """
     import hashlib

--- a/src/swarm/core/blueprint_discovery.py
+++ b/src/swarm/core/blueprint_discovery.py
@@ -42,11 +42,42 @@ class BlueprintLoadError(Exception):
     """Custom exception for errors during blueprint loading."""
     pass
 
+
+def _path_is_under(path: Path, root: Path) -> bool:
+    """Return True if *path* is *root* or a descendant of *root*."""
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except (ValueError, OSError):
+        return False
+
+
+def _should_sandbox_blueprint_dir(blueprint_dir: Path, sandboxed: bool | None) -> bool:
+    """Decide whether to run the AST sandbox before exec_module.
+
+    Explicit ``sandboxed=True/False`` wins.  When *None*, auto-detect the user
+    blueprints directory (community/extra roots pass sandboxed=True from merge).
+    """
+    from swarm.core.blueprint_sandbox import sandbox_enabled
+
+    if not sandbox_enabled():
+        return False
+    if sandboxed is True:
+        return True
+    if sandboxed is False:
+        return False
+    try:
+        from swarm.core.paths import get_user_blueprints_dir
+        return _path_is_under(blueprint_dir, get_user_blueprints_dir())
+    except Exception:
+        return False
+
+
 # This function was defined but not used in the original discover_blueprints.
 # It might be useful if blueprint names from directories need canonicalization.
 # def _get_blueprint_name_from_dir(dir_name: str) -> str:
 #     """Converts directory name (e.g., 'blueprint_my_agent') to blueprint name (e.g., 'my_agent')."""
-def discover_blueprints(blueprint_dir: str, namespace: str | None = None) -> dict[str, DiscoveredBlueprintInfo]:
+def discover_blueprints(blueprint_dir: str, namespace: str | None = None, *, sandboxed: bool | None = None) -> dict[str, DiscoveredBlueprintInfo]:
     """
     Discovers blueprints by looking for Python files within subdirectories
     of the given blueprint directory. Extracts metadata including name, version,
@@ -56,6 +87,10 @@ def discover_blueprints(blueprint_dir: str, namespace: str | None = None) -> dic
 
     Args:
         blueprint_dir: The path to the directory containing blueprint subdirectories.
+        namespace: Optional synthetic module namespace (community packs).
+        sandboxed: When True, run AST safety checks before exec_module.
+            When None (default), auto-enable for the user blueprints dir.
+            Disabled entirely when SWARM_USER_BLUEPRINT_SANDBOX is false.
 
     Returns:
         A dictionary mapping blueprint directory names (as keys) to
@@ -64,6 +99,9 @@ def discover_blueprints(blueprint_dir: str, namespace: str | None = None) -> dic
     logger.info(f"Starting blueprint discovery in directory: {blueprint_dir}")
     blueprints: dict[str, DiscoveredBlueprintInfo] = {}
     base_dir = Path(blueprint_dir).resolve()
+    apply_sandbox = _should_sandbox_blueprint_dir(base_dir, sandboxed)
+    if apply_sandbox:
+        logger.debug("AST sandbox enabled for blueprint discovery in %s", base_dir)
 
     if not base_dir.is_dir():
         logger.error(f"Blueprint directory not found or is not a directory: {base_dir}")
@@ -136,6 +174,25 @@ def discover_blueprints(blueprint_dir: str, namespace: str | None = None) -> dic
             module_spec = importlib.util.spec_from_file_location(module_import_path, py_file_path)
 
             if module_spec and module_spec.loader:
+                if apply_sandbox:
+                    from swarm.core.blueprint_sandbox import assert_safe_blueprint_source
+                    try:
+                        source_text = py_file_path.read_text(encoding="utf-8")
+                        assert_safe_blueprint_source(source_text)
+                    except ValueError as sandbox_err:
+                        logger.warning(
+                            "Skipping unsafe user blueprint %s: %s",
+                            py_file_path,
+                            sandbox_err,
+                        )
+                        continue
+                    except OSError as read_err:
+                        logger.warning(
+                            "Skipping blueprint %s (could not read for sandbox): %s",
+                            py_file_path,
+                            read_err,
+                        )
+                        continue
                 module = importlib.util.module_from_spec(module_spec)
                 # Register module before execution to handle circular imports within blueprint
                 sys.modules[module_import_path] = module
@@ -301,7 +358,7 @@ def merge_community_blueprints(
             continue
         namespace = f"swarm_community_{index}"
         try:
-            found = discover_blueprints(directory)
+            found = discover_blueprints(directory, sandboxed=True)
         except Exception:
             logger.exception("Failed discovering community blueprints in %s", directory)
             continue

--- a/src/swarm/core/blueprint_sandbox.py
+++ b/src/swarm/core/blueprint_sandbox.py
@@ -139,10 +139,10 @@ def _check_node(node: ast.AST) -> None:
         return
 
     if isinstance(node, ast.Name):
-        # Block aliasing / bare references to dangerous builtins.
-        if node.id in ("eval", "exec", "compile", "__import__") and isinstance(
-            node.ctx, (ast.Load, ast.Store)
-        ):
+        # Block aliasing / bare references to dangerous builtins / interpreter state.
+        if node.id in (
+            "eval", "exec", "compile", "__import__", "__builtins__",
+        ) and isinstance(node.ctx, (ast.Load, ast.Store)):
             raise ValueError(
                 f"Banned name {node.id!r} in user blueprint "
                 f"(line {getattr(node, 'lineno', '?')})"
@@ -179,8 +179,8 @@ def _check_call(node: ast.Call) -> None:
             f"(line {getattr(node, 'lineno', '?')})"
         )
 
-    # getattr/setattr/delattr and namespace reflection
-    if name in ("getattr", "setattr", "delattr", "vars", "globals", "locals"):
+    # Namespace reflection (getattr/setattr with constant attrs is common and allowed)
+    if name in ("vars", "globals", "locals"):
         raise ValueError(
             f"Banned reflective call {name!r} in user blueprint "
             f"(line {getattr(node, 'lineno', '?')})"

--- a/src/swarm/core/blueprint_sandbox.py
+++ b/src/swarm/core/blueprint_sandbox.py
@@ -1,0 +1,245 @@
+"""AST-based safety gate for user/community blueprint source.
+
+Bundled blueprints under ``src/swarm/blueprints`` are trusted and skip this
+gate.  Modules discovered from the user blueprints directory (or other extra
+roots) are scanned before ``exec_module`` so obvious escape hatches never run.
+
+Operators can opt out with ``SWARM_USER_BLUEPRINT_SANDBOX=false``.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from typing import Final
+
+# Top-level modules that must never appear in user blueprint imports.
+# Focused on process/network escape and code-loading primitives.
+BANNED_MODULES: Final[frozenset[str]] = frozenset(
+    {
+        "subprocess",
+        "ctypes",
+        "socket",
+        "pickle",
+        "importlib",
+        "multiprocessing",
+        "shutil",
+        "pty",
+        "fcntl",
+        "signal",
+        "code",
+        "codeop",
+    }
+)
+
+# Builtins / free names that must not be called.
+BANNED_CALL_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "eval",
+        "exec",
+        "compile",
+        "__import__",
+        "breakpoint",
+    }
+)
+
+# Attribute names that indicate reflection / dynamic import abuse.
+BANNED_ATTR_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "__import__",
+        "__builtins__",
+        "__loader__",
+        "__spec__",
+        "__subclasses__",
+        "__globals__",
+        "__code__",
+        "__reduce__",
+        "__reduce_ex__",
+    }
+)
+
+# Modes that turn open() into a write/mutate call.
+_WRITE_OPEN_MODES: Final[frozenset[str]] = frozenset(
+    {
+        "w",
+        "a",
+        "x",
+        "w+",
+        "a+",
+        "x+",
+        "wb",
+        "ab",
+        "xb",
+        "w+b",
+        "a+b",
+        "x+b",
+        "wb+",
+        "ab+",
+        "xb+",
+        "wt",
+        "at",
+        "xt",
+        "w+t",
+        "a+t",
+        "x+t",
+    }
+)
+
+
+def sandbox_enabled() -> bool:
+    """Return whether the user-blueprint sandbox gate is active (default on)."""
+    raw = os.getenv("SWARM_USER_BLUEPRINT_SANDBOX", "true")
+    return raw.strip().lower() in ("1", "true", "yes", "y", "t", "on")
+
+
+def assert_safe_blueprint_source(source: str) -> None:
+    """Raise ``ValueError`` if *source* uses banned constructs.
+
+    This is a static AST check — not a full sandbox.  It blocks common
+    escape hatches stronger than a plain substring ban list.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        raise ValueError(f"Blueprint source has invalid syntax: {exc}") from exc
+
+    for node in ast.walk(tree):
+        _check_node(node)
+
+
+def _check_node(node: ast.AST) -> None:
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            _reject_module(alias.name, node)
+        return
+
+    if isinstance(node, ast.ImportFrom):
+        if node.module:
+            _reject_module(node.module, node)
+        for alias in node.names:
+            # ``from . import subprocess`` when module is relative/None
+            root = alias.name.split(".", 1)[0]
+            if root in BANNED_MODULES:
+                raise ValueError(
+                    f"Banned import of {alias.name!r} in user blueprint "
+                    f"(line {getattr(node, 'lineno', '?')})"
+                )
+        return
+
+    if isinstance(node, ast.Call):
+        _check_call(node)
+        return
+
+    if isinstance(node, ast.Attribute):
+        if node.attr in BANNED_ATTR_NAMES:
+            raise ValueError(
+                f"Banned attribute access {node.attr!r} in user blueprint "
+                f"(line {getattr(node, 'lineno', '?')})"
+            )
+        return
+
+    if isinstance(node, ast.Name):
+        # Block aliasing / bare references to dangerous builtins.
+        if node.id in ("eval", "exec", "compile", "__import__") and isinstance(
+            node.ctx, (ast.Load, ast.Store)
+        ):
+            raise ValueError(
+                f"Banned name {node.id!r} in user blueprint "
+                f"(line {getattr(node, 'lineno', '?')})"
+            )
+
+
+def _reject_module(module_name: str, node: ast.AST) -> None:
+    root = (module_name or "").split(".", 1)[0]
+    if root in BANNED_MODULES:
+        raise ValueError(
+            f"Banned import of {root!r} in user blueprint "
+            f"(line {getattr(node, 'lineno', '?')})"
+        )
+
+
+def _call_func_name(node: ast.Call) -> str | None:
+    """Best-effort name of the callable (``eval``, ``os.system``, …)."""
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _check_call(node: ast.Call) -> None:
+    name = _call_func_name(node)
+    if name is None:
+        return
+
+    if name in BANNED_CALL_NAMES:
+        raise ValueError(
+            f"Banned call to {name!r} in user blueprint "
+            f"(line {getattr(node, 'lineno', '?')})"
+        )
+
+    # getattr/setattr/delattr and namespace reflection
+    if name in ("getattr", "setattr", "delattr", "vars", "globals", "locals"):
+        raise ValueError(
+            f"Banned reflective call {name!r} in user blueprint "
+            f"(line {getattr(node, 'lineno', '?')})"
+        )
+
+    if name == "open":
+        _check_open_call(node)
+        return
+
+    # os.system / os.popen / os.exec*
+    if isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name):
+        owner = node.func.value.id
+        attr = node.func.attr
+        if owner == "os" and attr in (
+            "system",
+            "popen",
+            "exec",
+            "execl",
+            "execle",
+            "execlp",
+            "execlpe",
+            "execv",
+            "execve",
+            "execvp",
+            "execvpe",
+            "spawnl",
+            "spawnle",
+            "spawnlp",
+            "spawnlpe",
+            "spawnv",
+            "spawnve",
+            "spawnvp",
+            "spawnvpe",
+            "fork",
+            "forkpty",
+        ):
+            raise ValueError(
+                f"Banned call to os.{attr} in user blueprint "
+                f"(line {getattr(node, 'lineno', '?')})"
+            )
+
+
+def _check_open_call(node: ast.Call) -> None:
+    """Reject ``open(..., 'w')`` / keyword mode= write variants when detectable."""
+    mode: str | None = None
+    if len(node.args) >= 2 and isinstance(node.args[1], ast.Constant) and isinstance(
+        node.args[1].value, str
+    ):
+        mode = node.args[1].value
+    for kw in node.keywords:
+        if kw.arg == "mode" and isinstance(kw.value, ast.Constant) and isinstance(
+            kw.value.value, str
+        ):
+            mode = kw.value.value
+    if mode is None:
+        # open(path) defaults to read; dynamic mode left to runtime policy
+        return
+    if mode in _WRITE_OPEN_MODES or any(c in mode for c in ("w", "a", "x")):
+        raise ValueError(
+            f"Banned open() with write mode {mode!r} in user blueprint "
+            f"(line {getattr(node, 'lineno', '?')})"
+        )

--- a/src/swarm/core/browser_tools.py
+++ b/src/swarm/core/browser_tools.py
@@ -1,0 +1,45 @@
+"""Browser automation honesty helpers.
+
+Open Swarm provisions the official microsoft/playwright-mcp server for blueprints
+that declare a ``browser`` capability (see :mod:`swarm.core.tool_capabilities`).
+There is no built-in stub that fakes successful navigation: when Playwright MCP
+is not running or not reachable, callers should surface a clear structured error
+instead of pretending the page load succeeded.
+
+Usage::
+
+    from swarm.core.browser_tools import browser_unavailable_error, BROWSER_UNAVAILABLE
+
+    if not playwright_mcp_ready:
+        return browser_unavailable_error(detail="npx @playwright/mcp failed to start")
+"""
+from __future__ import annotations
+
+from typing import Any
+
+BROWSER_UNAVAILABLE = "browser automation unavailable: no playwright MCP server"
+
+
+def browser_unavailable_error(detail: str | None = None) -> dict[str, Any]:
+    """Structured error for missing/unreachable Playwright MCP.
+
+    Call sites (tool handlers, blueprint minions, MCP bridges) should return this
+    dict rather than a synthetic success payload when browser automation cannot
+    run.
+    """
+    out: dict[str, Any] = {
+        "ok": False,
+        "error": BROWSER_UNAVAILABLE,
+    }
+    if detail:
+        out["detail"] = detail
+    return out
+
+
+def is_browser_unavailable_payload(payload: Any) -> bool:
+    """True if *payload* looks like a :func:`browser_unavailable_error` result."""
+    return (
+        isinstance(payload, dict)
+        and payload.get("ok") is False
+        and payload.get("error") == BROWSER_UNAVAILABLE
+    )

--- a/src/swarm/core/cancel_registry.py
+++ b/src/swarm/core/cancel_registry.py
@@ -1,0 +1,89 @@
+"""File-backed cancel registry for ``/v1/responses``.
+
+Cooperative cancel flags live under ``{SWARM_RESPONSES_DIR}/cancel/{id}.flag``
+so multiple uvicorn workers that share the same filesystem can cancel each
+other's jobs. A process-local set is kept as a fast path for same-worker
+checks; the filesystem is always written and is the cross-worker source of
+truth.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+from pathlib import Path
+
+from swarm.core.responses_store import _store_dir
+
+# Same charset as responses_store — reject path-traversal / junk ids.
+_ID_RE = re.compile(r"^resp_[A-Za-z0-9_-]{1,128}$")
+
+_local: set[str] = set()
+_local_lock = threading.Lock()
+
+
+def _cancel_dir(base_dir: Path | None = None) -> Path:
+    return (base_dir or _store_dir()) / "cancel"
+
+
+def _flag_path(response_id: str, base_dir: Path | None = None) -> Path | None:
+    if not _ID_RE.match(response_id or ""):
+        return None
+    return _cancel_dir(base_dir) / f"{response_id}.flag"
+
+
+def request_cancel(response_id: str, *, base_dir: Path | None = None) -> bool:
+    """Request cooperative cancel for ``response_id``.
+
+    Writes a flag under the responses store and warms the process-local set.
+    Returns ``False`` if the id is invalid (no file written).
+    """
+    path = _flag_path(response_id, base_dir)
+    if path is None:
+        return False
+    with _local_lock:
+        _local.add(response_id)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Empty flag file; presence alone is the signal.
+        path.write_text("", encoding="utf-8")
+    except OSError:
+        # Local set still marks cancel for this process; peer workers will
+        # miss it until a later successful write (best-effort).
+        pass
+    return True
+
+
+def is_cancel_requested(response_id: str, *, base_dir: Path | None = None) -> bool:
+    """True if cancel was requested (local fast path or shared flag file)."""
+    if not _ID_RE.match(response_id or ""):
+        return False
+    with _local_lock:
+        if response_id in _local:
+            return True
+    path = _flag_path(response_id, base_dir)
+    if path is None:
+        return False
+    try:
+        if path.is_file():
+            with _local_lock:
+                _local.add(response_id)
+            return True
+    except OSError:
+        return False
+    return False
+
+
+def clear_cancel(response_id: str, *, base_dir: Path | None = None) -> None:
+    """Clear cancel flag for ``response_id`` (local + filesystem). Safe no-op on bad ids."""
+    if not _ID_RE.match(response_id or ""):
+        return
+    with _local_lock:
+        _local.discard(response_id)
+    path = _flag_path(response_id, base_dir)
+    if path is None:
+        return
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass

--- a/src/swarm/core/concurrency.py
+++ b/src/swarm/core/concurrency.py
@@ -3,8 +3,10 @@
 Single-instance only — not a multi-worker distributed semaphore. Used to
 reject overload with a client-safe 429 instead of unbounded thread growth.
 
-Until a shared queue exists, async ``/v1/responses`` cancel + inflight are
-**per process**. Prefer a single uvicorn worker (``SWARM_UVICORN_WORKERS=1``).
+Inflight limits remain **per process**. Cooperative ``/v1/responses`` cancel
+is shared across workers via the file-backed cancel registry when they share
+``SWARM_RESPONSES_DIR``. Prefer a single uvicorn worker
+(``SWARM_UVICORN_WORKERS=1``) so inflight accounting stays accurate.
 """
 from __future__ import annotations
 
@@ -24,7 +26,9 @@ def resolved_uvicorn_workers() -> int:
 
     Default 1. When ``SWARM_ENFORCE_SINGLE_WORKER`` is true (default), values
     greater than 1 raise ``ValueError`` so operators cannot silently break
-    cancel/inflight. Set the env to false to allow multi-worker with a warning.
+    process-local inflight limits. Set the env to false to allow multi-worker
+    with a warning. Cancel is filesystem-shared when workers share the
+    responses store dir; inflight remains per process.
     """
     raw = os.getenv("SWARM_UVICORN_WORKERS", "1") or "1"
     try:
@@ -37,8 +41,10 @@ def resolved_uvicorn_workers() -> int:
     )
     if n > 1:
         msg = (
-            f"SWARM_UVICORN_WORKERS={n} > 1: /v1/responses cancel and inflight "
-            "limits are process-local until a shared queue exists. Prefer workers=1."
+            f"SWARM_UVICORN_WORKERS={n} > 1: /v1/responses inflight limits are "
+            "process-local (per worker). Cancel is shared via the filesystem when "
+            "workers share SWARM_RESPONSES_DIR. Prefer workers=1 unless you accept "
+            "per-worker inflight accounting."
         )
         if enforce:
             raise ValueError(msg + " Set SWARM_ENFORCE_SINGLE_WORKER=false to override.")

--- a/src/swarm/management/commands/runserver.py
+++ b/src/swarm/management/commands/runserver.py
@@ -6,7 +6,7 @@ from django.core.management.base import CommandError
 from django.core.management.commands.runserver import Command as RunserverCommand
 from dotenv import load_dotenv
 
-from swarm.utils.env_utils import get_api_auth_token, is_django_debug
+from swarm.utils.env_utils import get_api_auth_token, get_api_auth_tokens, is_django_debug
 
 # Load .env from project root relative to this file's location
 BASE_DIR = Path(__file__).resolve().parent.parent.parent.parent.parent
@@ -64,23 +64,30 @@ class Command(RunserverCommand):
                 )
             settings.ENABLE_API_AUTH = False
             settings.SWARM_API_KEY = None
+            settings.SWARM_API_KEYS = []
             logger.warning(
                 "Swarm API authentication DISABLED via --disable-auth "
                 "(development only). Do NOT use this flag in production."
             )
         else:
-            # Default: authentication ON, keyed by API_AUTH_TOKEN (or SWARM_API_KEY).
-            api_key = get_api_auth_token()
+            # Default: authentication ON, keyed by API_AUTH_TOKEN(S) / SWARM_API_KEY(S).
+            api_keys = get_api_auth_tokens()
+            api_key = api_keys[0] if api_keys else get_api_auth_token()
             if api_key:
                 settings.ENABLE_API_AUTH = True
                 settings.SWARM_API_KEY = api_key
-                logger.info("Swarm API authentication ENABLED (default). API_AUTH_TOKEN found.")
+                settings.SWARM_API_KEYS = list(api_keys) if api_keys else [api_key]
+                logger.info(
+                    "Swarm API authentication ENABLED (default). %d accepted key(s).",
+                    len(settings.SWARM_API_KEYS),
+                )
             else:
                 # No token available. In production settings.py would already have
                 # refused to boot (get_enforced_api_auth_token). In debug mode we
                 # warn loudly instead of silently allowing anonymous access.
                 settings.ENABLE_API_AUTH = False
                 settings.SWARM_API_KEY = None
+                settings.SWARM_API_KEYS = []
                 logger.warning(
                     "API_AUTH_TOKEN not set; Swarm API authentication is INACTIVE "
                     "(allowed only because DJANGO_DEBUG=true). Set API_AUTH_TOKEN "

--- a/src/swarm/mcp/provider.py
+++ b/src/swarm/mcp/provider.py
@@ -163,6 +163,12 @@ class BlueprintMCPProvider:
         started_servers = []
         for server_name in required_servers:
             if server_name not in self._mcp_config:
+                if server_name == "playwright":
+                    from swarm.core.browser_tools import BROWSER_UNAVAILABLE
+                    raise ValueError(
+                        f"{BROWSER_UNAVAILABLE} "
+                        f"(MCP server config 'playwright' not found in swarm_config.json)"
+                    )
                 raise ValueError(f"MCP server config '{server_name}' not found in swarm_config.json")
             server_cfg_dict = self._mcp_config[server_name]
             mcp_config = MCPServerConfig(**server_cfg_dict)
@@ -186,15 +192,15 @@ class BlueprintMCPProvider:
                         if attempt < 2:
                             time.sleep(2 ** attempt)  # Exponential backoff
                         else:
-                            raise RuntimeError(f"Failed to start MCP server '{server_name}' after 3 attempts")
+                            raise self._mcp_start_error(server_name, "exited after 3 attempts")
                 except Exception as e:
                     logger.warning(f"Attempt {attempt + 1} failed for MCP server '{server_name}': {e}")
                     if attempt < 2:
                         time.sleep(2 ** attempt)
                     else:
-                        raise RuntimeError(f"Failed to start MCP server '{server_name}' after 3 attempts: {e}")
+                        raise self._mcp_start_error(server_name, str(e)) from e
             if process is None:
-                raise RuntimeError(f"Failed to start MCP server '{server_name}'")
+                raise self._mcp_start_error(server_name, "process was never created")
             started_servers.append({
                 'name': server_name,
                 'process': process,

--- a/src/swarm/mcp/provider.py
+++ b/src/swarm/mcp/provider.py
@@ -158,6 +158,19 @@ class BlueprintMCPProvider:
         """
         self._executor = fn
 
+    @staticmethod
+    def _mcp_start_error(server_name: str, detail: str) -> RuntimeError:
+        """Build start-failure error; playwright gets a browser-honesty message."""
+        if server_name == "playwright":
+            from swarm.core.browser_tools import browser_unavailable_error
+            return RuntimeError(browser_unavailable_error(detail))
+        base = f"Failed to start MCP server '{server_name}'"
+        if detail:
+            if "after 3 attempts" in detail or detail.startswith("exited"):
+                return RuntimeError(f"{base} after 3 attempts")
+            return RuntimeError(f"{base} after 3 attempts: {detail}")
+        return RuntimeError(base)
+
     def _start_required_mcp_servers(self, required_servers: list[str]) -> list:
         """Start required MCP servers for blueprint execution."""
         started_servers = []
@@ -193,6 +206,8 @@ class BlueprintMCPProvider:
                             time.sleep(2 ** attempt)  # Exponential backoff
                         else:
                             raise self._mcp_start_error(server_name, "exited after 3 attempts")
+                except RuntimeError:
+                    raise
                 except Exception as e:
                     logger.warning(f"Attempt {attempt + 1} failed for MCP server '{server_name}': {e}")
                     if attempt < 2:
@@ -200,7 +215,7 @@ class BlueprintMCPProvider:
                     else:
                         raise self._mcp_start_error(server_name, str(e)) from e
             if process is None:
-                raise self._mcp_start_error(server_name, "process was never created")
+                raise self._mcp_start_error(server_name, "")
             started_servers.append({
                 'name': server_name,
                 'process': process,

--- a/src/swarm/settings.py
+++ b/src/swarm/settings.py
@@ -32,17 +32,23 @@ DEBUG = is_django_debug()
 ALLOWED_HOSTS = get_django_allowed_hosts()
 
 # --- Custom Swarm Settings ---
-# Load the API auth token. In production (DEBUG=False) a missing token raises
+# Load API auth token(s). In production (DEBUG=False) a missing token raises
 # ImproperlyConfigured so the server refuses to start with auth silently disabled.
+# Multi-key: API_AUTH_TOKENS / SWARM_API_KEYS (CSV) merge with singles.
+# get_enforced_api_auth_token returns the primary (first) token or None.
 _raw_api_token = get_enforced_api_auth_token()
+_raw_api_tokens = get_api_auth_tokens()
 
-# *** Only enable API auth if the token is actually set ***
+# *** Only enable API auth if any token is actually set ***
 ENABLE_API_AUTH = bool(_raw_api_token)
-SWARM_API_KEY = _raw_api_token # Assign the loaded token (or None)
+SWARM_API_KEY = _raw_api_token  # primary token for backward compat
+# Full accepted list (primary first). StaticTokenAuthentication compares all.
+SWARM_API_KEYS = list(_raw_api_tokens)
 
 if ENABLE_API_AUTH:
     # Add assertion to satisfy type checkers within this block
     assert SWARM_API_KEY is not None, "SWARM_API_KEY cannot be None when ENABLE_API_AUTH is True"
+    assert SWARM_API_KEYS, "SWARM_API_KEYS cannot be empty when ENABLE_API_AUTH is True"
 
 SWARM_CONFIG_PATH = get_swarm_config_path()
 BLUEPRINT_DIRECTORY = get_blueprint_directory()

--- a/src/swarm/settings.py
+++ b/src/swarm/settings.py
@@ -309,6 +309,26 @@ LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/'
 CSRF_TRUSTED_ORIGINS = get_django_csrf_trusted_origins()
 
+# --- Production security defaults ---
+# Applied when DEBUG is False (production). Tests force DJANGO_DEBUG=true via
+# TESTING, so this block does not affect the suite. Explicit env overrides:
+#   SWARM_SECURE_COOKIES=false  → allow non-HTTPS cookies (HTTP staging)
+#   DJANGO_X_FRAME_OPTIONS      → override frame policy (default DENY)
+# API_AUTH_TOKEN is already required in production via get_enforced_api_auth_token().
+if not DEBUG:
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    X_FRAME_OPTIONS = os.getenv("DJANGO_X_FRAME_OPTIONS", "DENY")
+    # Secure cookies default on in production; opt out with SWARM_SECURE_COOKIES=false.
+    _secure_cookies_env = os.getenv("SWARM_SECURE_COOKIES", "").strip().lower()
+    if _secure_cookies_env in ("false", "0", "no", "n", "off"):
+        _secure_cookies = False
+    else:
+        # true/1/yes/on OR unset → secure cookies when DEBUG is False
+        _secure_cookies = True
+    SESSION_COOKIE_SECURE = _secure_cookies
+    CSRF_COOKIE_SECURE = _secure_cookies
+
+
 # --- ComfyUI Configuration for Avatar Generation ---
 COMFYUI_ENABLED = is_comfyui_enabled()
 COMFYUI_HOST = get_comfyui_host()

--- a/src/swarm/utils/env_utils.py
+++ b/src/swarm/utils/env_utils.py
@@ -126,11 +126,43 @@ def get_stateful_chat_id_path() -> str:
 
 
 # API Tokens and Keys
-def get_api_auth_token() -> str | None:
-    """Get API auth token. If SWARM_ALLOW_NO_AUTH, return None to disable built-in auth."""
+def get_api_auth_tokens() -> list[str]:
+    """All accepted API auth secrets, deduped (order preserved).
+
+    Sources (merged):
+    - singles: ``API_AUTH_TOKEN``, ``SWARM_API_KEY``
+    - multi (comma-separated): ``API_AUTH_TOKENS``, ``SWARM_API_KEYS``
+
+    Returns an empty list when ``SWARM_ALLOW_NO_AUTH`` is truthy (built-in
+    auth intentionally disabled).
+    """
     if os.getenv('SWARM_ALLOW_NO_AUTH', 'false').lower() in ('true', '1', 'yes'):
-        return None
-    return os.getenv('API_AUTH_TOKEN') or os.getenv('SWARM_API_KEY')
+        return []
+    tokens: list[str] = []
+    seen: set[str] = set()
+    for key in ('API_AUTH_TOKEN', 'SWARM_API_KEY'):
+        val = os.getenv(key)
+        if not val:
+            continue
+        t = val.strip()
+        if t and t not in seen:
+            tokens.append(t)
+            seen.add(t)
+    for key in ('API_AUTH_TOKENS', 'SWARM_API_KEYS'):
+        for t in get_csv_env(key):
+            if t not in seen:
+                tokens.append(t)
+                seen.add(t)
+    return tokens
+
+
+def get_api_auth_token() -> str | None:
+    """Primary API auth token (first of :func:`get_api_auth_tokens`).
+
+    If SWARM_ALLOW_NO_AUTH, return None to disable built-in auth.
+    """
+    tokens = get_api_auth_tokens()
+    return tokens[0] if tokens else None
 
 
 def get_openai_api_key() -> str | None:
@@ -378,8 +410,9 @@ def get_enforced_api_auth_token() -> str | None:
         return None
     from django.core.exceptions import ImproperlyConfigured
     raise ImproperlyConfigured(
-        "API_AUTH_TOKEN is required when DJANGO_DEBUG is not enabled. "
-        "Set API_AUTH_TOKEN, or set SWARM_ALLOW_NO_AUTH=true if an external layer gates access."
+        "API_AUTH_TOKEN (or API_AUTH_TOKENS / SWARM_API_KEY / SWARM_API_KEYS) is required "
+        "when DJANGO_DEBUG is not enabled. "
+        "Set a token, or set SWARM_ALLOW_NO_AUTH=true if an external layer gates access."
     )
 
 

--- a/src/swarm/views/agent_creator_views.py
+++ b/src/swarm/views/agent_creator_views.py
@@ -3,6 +3,7 @@ Web views for creating custom agents and teams with Python code validation
 """
 import ast
 import json
+import os
 import subprocess
 import tempfile
 from pathlib import Path
@@ -37,6 +38,28 @@ def _banned_code_error(code: str) -> str | None:
     except ValueError as exc:
         return str(exc)
     return None
+
+
+def _user_blueprint_discovery_enabled() -> bool:
+    """True when operators opted into scanning get_user_blueprints_dir()."""
+    return os.getenv("SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY", "").lower() in (
+        "true", "1", "yes", "y", "t",
+    )
+
+
+def _save_discovery_message() -> str:
+    """Explain runnability of saved blueprints based on discovery flag."""
+    if _user_blueprint_discovery_enabled():
+        return (
+            "User blueprint discovery is enabled "
+            "(SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY); "
+            "the blueprint should appear after a reload."
+        )
+    return (
+        "Saved under the user blueprints directory (write-only until discovery "
+        "is enabled). Set SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY=true to make "
+        "saved blueprints discoverable/runnable."
+    )
 
 
 class BlueprintCodeValidator:
@@ -464,14 +487,16 @@ def save_custom_agent(request):
         if banned:
             return JsonResponse({'success': False, 'error': banned}, status=400)
 
-        # Save to user_blueprints directory (not auto-discovered unless env allows).
-        user_blueprints_dir = Path('user_blueprints')
-        agent_dir = user_blueprints_dir / agent_name.lower().replace(' ', '_')
+        # Save under XDG/user data dir so discovery (when enabled) can find it.
+        blueprint_id = agent_name.lower().replace(' ', '_')
+        user_blueprints_dir = paths.get_user_blueprints_dir()
+        agent_dir = user_blueprints_dir / blueprint_id
         agent_dir.mkdir(parents=True, exist_ok=True)
 
         # Write the blueprint file
-        blueprint_file = agent_dir / f'blueprint_{agent_name.lower().replace(" ", "_")}.py'
+        blueprint_file = agent_dir / f'blueprint_{blueprint_id}.py'
         blueprint_file.write_text(code)
+        abs_path = str(blueprint_file.resolve())
 
         # Create README
         readme_content = f"""# {agent_name}
@@ -483,7 +508,7 @@ Custom agent blueprint created via the Agent Creator.
 
 ## Usage
 ```bash
-swarm-cli launch {agent_name.lower().replace(' ', '_')}
+swarm-cli launch {blueprint_id}
 ```
 """
         readme_file = agent_dir / 'README.md'
@@ -491,8 +516,12 @@ swarm-cli launch {agent_name.lower().replace(' ', '_')}
 
         return JsonResponse({
             'success': True,
-            'message': f'Agent "{agent_name}" saved successfully',
-            'path': str(blueprint_file)
+            'message': (
+                f'Agent "{agent_name}" saved successfully. '
+                f'{_save_discovery_message()}'
+            ),
+            'path': abs_path,
+            'blueprint_id': blueprint_id,
         })
 
     except json.JSONDecodeError:
@@ -531,8 +560,8 @@ def _get_available_agents():
     ]
     agents.extend(builtin_agents)
 
-    # Add user-created agents
-    user_blueprints_dir = Path('user_blueprints')
+    # Add user-created agents from the XDG/user data blueprints dir
+    user_blueprints_dir = paths.get_user_blueprints_dir()
     if user_blueprints_dir.exists():
         for agent_dir in user_blueprints_dir.iterdir():
             if agent_dir.is_dir():
@@ -822,14 +851,18 @@ def save_team_swarm(request):
     if banned:
         return JsonResponse({"success": False, "error": banned}, status=400)
 
-    user_blueprints_dir = Path("user_blueprints")
+    user_blueprints_dir = paths.get_user_blueprints_dir()
     swarm_dir = user_blueprints_dir / blueprint_id
     swarm_dir.mkdir(parents=True, exist_ok=True)
     blueprint_path = swarm_dir / f"blueprint_{blueprint_id}.py"
     if blueprint_path.exists() and not overwrite:
-        return JsonResponse({"success": False, "error": f"Blueprint already exists: {blueprint_path}"}, status=409)
+        return JsonResponse(
+            {"success": False, "error": f"Blueprint already exists: {blueprint_path.resolve()}"},
+            status=409,
+        )
 
     blueprint_path.write_text(code, encoding="utf-8")
+    abs_path = str(blueprint_path.resolve())
 
     readme_path = swarm_dir / "README.md"
     if not readme_path.exists() or overwrite:
@@ -840,7 +873,10 @@ def save_team_swarm(request):
 
     return JsonResponse({
         "success": True,
-        "message": f"Swarm '{name}' saved successfully.",
+        "message": (
+            f"Swarm '{name}' saved successfully. "
+            f"{_save_discovery_message()}"
+        ),
         "blueprint_id": blueprint_id,
-        "path": str(blueprint_path),
+        "path": abs_path,
     })

--- a/src/swarm/views/agent_creator_views.py
+++ b/src/swarm/views/agent_creator_views.py
@@ -20,18 +20,26 @@ from swarm.core import paths
 _BANNED_CODE_SNIPPETS = ("__import__", "subprocess", "os.system", "eval(", "exec(")
 
 
-def _banned_code_error(code: str) -> str | None:
-    """Return an error message if code contains unsandboxed-exec patterns.
-
-    Runs the substring ban list first, then the AST sandbox gate (stronger).
-    """
-    lowered = code.lower()
+def _banned_snippet_error(text: str) -> str | None:
+    """Substring ban for free-text prompts and source (no AST — text need not be Python)."""
+    lowered = text.lower()
     for banned in _BANNED_CODE_SNIPPETS:
         if banned in lowered:
             return (
                 f"Saved blueprints may not contain {banned!r} "
                 "(unsandboxed exec blocked)."
             )
+    return None
+
+
+def _banned_code_error(code: str) -> str | None:
+    """Return an error message if blueprint *source* is unsafe.
+
+    Substring ban list first, then AST sandbox (full Python module only).
+    """
+    snippet = _banned_snippet_error(code)
+    if snippet:
+        return snippet
     try:
         from swarm.core.blueprint_sandbox import assert_safe_blueprint_source
         assert_safe_blueprint_source(code)
@@ -821,7 +829,7 @@ def save_team_swarm(request):
         for field in ("system_prompt", "instructions", "description", "role"):
             val = agent.get(field) or ""
             if isinstance(val, str):
-                banned = _banned_code_error(val)
+                banned = _banned_snippet_error(val)
                 if banned:
                     return JsonResponse({"success": False, "error": banned}, status=400)
         cleaned_agents.append({

--- a/src/swarm/views/agent_creator_views.py
+++ b/src/swarm/views/agent_creator_views.py
@@ -20,7 +20,10 @@ _BANNED_CODE_SNIPPETS = ("__import__", "subprocess", "os.system", "eval(", "exec
 
 
 def _banned_code_error(code: str) -> str | None:
-    """Return an error message if code contains unsandboxed-exec patterns."""
+    """Return an error message if code contains unsandboxed-exec patterns.
+
+    Runs the substring ban list first, then the AST sandbox gate (stronger).
+    """
     lowered = code.lower()
     for banned in _BANNED_CODE_SNIPPETS:
         if banned in lowered:
@@ -28,6 +31,11 @@ def _banned_code_error(code: str) -> str | None:
                 f"Saved blueprints may not contain {banned!r} "
                 "(unsandboxed exec blocked)."
             )
+    try:
+        from swarm.core.blueprint_sandbox import assert_safe_blueprint_source
+        assert_safe_blueprint_source(code)
+    except ValueError as exc:
+        return str(exc)
     return None
 
 

--- a/src/swarm/views/message_views.py
+++ b/src/swarm/views/message_views.py
@@ -1,6 +1,7 @@
 """
 Views related to Chat Messages.
 """
+from django.conf import settings
 from drf_spectacular.utils import extend_schema
 from rest_framework.viewsets import ModelViewSet
 
@@ -10,12 +11,57 @@ from swarm.serializers import ChatMessageSerializer
 
 
 class ChatMessageViewSet(ModelViewSet):
-    """API viewset for managing chat messages."""
-    queryset = ChatMessage.objects.all().order_by('-timestamp')  # Order by timestamp descending
+    """API viewset for managing chat messages.
+
+    Chat is web-session oriented. When ``ENABLE_API_AUTH`` is on, list/retrieve
+    are scoped to the authenticated session user's conversations; token-only
+    (AnonymousUser + static token) and anonymous clients get an empty queryset.
+    """
+
+    queryset = ChatMessage.objects.all().order_by('-timestamp')
     serializer_class = ChatMessageSerializer
 
     def get_permissions(self):
         return [perm() for perm in api_permission_classes()]
+
+    def get_queryset(self):
+        qs = ChatMessage.objects.all().order_by('-timestamp')
+        if not getattr(settings, 'ENABLE_API_AUTH', False):
+            return qs
+        user = getattr(self.request, 'user', None)
+        if user is not None and user.is_authenticated:
+            # Only messages in conversations owned by this session user.
+            # Null-student (legacy) rows are not shared when auth is on.
+            return qs.filter(conversation__student=user)
+        # Token-only or anonymous with auth on: chat is session-oriented.
+        return qs.none()
+
+    def perform_create(self, serializer):
+        """Create a message; stamp conversation.student for session users.
+
+        When auth is on and the requester is a session user, ensure the target
+        conversation is owned by them (set student if still null; refuse if it
+        belongs to someone else). Token-only creates are left alone — the
+        queryset already hides those rows from list/retrieve.
+        """
+        message = serializer.save()
+        if not getattr(settings, 'ENABLE_API_AUTH', False):
+            return
+        user = getattr(self.request, 'user', None)
+        if user is None or not user.is_authenticated:
+            return
+        conversation = message.conversation
+        if conversation.student_id is None:
+            conversation.student = user
+            conversation.save(update_fields=['student'])
+        elif conversation.student_id != user.id:
+            # Should not happen if clients only post to own conversations;
+            # delete the just-created row and surface a permission error.
+            message.delete()
+            from rest_framework.exceptions import PermissionDenied
+            raise PermissionDenied(
+                "Cannot add messages to another user's conversation."
+            )
 
     @extend_schema(summary="List all chat messages")
     def list(self, request, *args, **kwargs):

--- a/src/swarm/views/responses_views.py
+++ b/src/swarm/views/responses_views.py
@@ -43,7 +43,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from swarm.auth import request_principal
-from swarm.core import responses_store
+from swarm.core import cancel_registry, responses_store
 
 from .chat_views import _chunk_is_final, _extract_message_from_chunk
 from .openai_schema import responses_schema
@@ -547,28 +547,23 @@ def _assert_owner_access(request: Request, record: dict[str, Any] | None) -> Non
 
 
 # --- Cancellation registry -------------------------------------------------- #
-# Cooperative cancel: a cancel request adds the id here; the worker checks it
-# between blueprint chunks and stops. A single in-flight CLI call still runs to
-# completion (or its own timeout) — cancellation takes effect at the next chunk
-# boundary, which for multi-step blueprints (fusion/pipeline/planner) is between
-# CLI calls.
-_CANCELLED: set[str] = set()
-_CANCELLED_LOCK = threading.Lock()
+# Cooperative cancel: flags are file-backed under SWARM_RESPONSES_DIR/cancel so
+# multi-worker uvicorn can cancel each other's jobs. A process-local set is a
+# fast path. The worker checks between blueprint chunks; a single in-flight CLI
+# call still runs to completion (or its own timeout) — cancellation takes
+# effect at the next chunk boundary (fusion/pipeline/planner between CLI calls).
 
 
 def _request_cancel(response_id: str) -> None:
-    with _CANCELLED_LOCK:
-        _CANCELLED.add(response_id)
+    cancel_registry.request_cancel(response_id)
 
 
 def _is_cancel_requested(response_id: str) -> bool:
-    with _CANCELLED_LOCK:
-        return response_id in _CANCELLED
+    return cancel_registry.is_cancel_requested(response_id)
 
 
 def _clear_cancel(response_id: str) -> None:
-    with _CANCELLED_LOCK:
-        _CANCELLED.discard(response_id)
+    cancel_registry.clear_cancel(response_id)
 
 
 class _Cancelled(Exception):

--- a/tests/api/test_chat_message_scoping.py
+++ b/tests/api/test_chat_message_scoping.py
@@ -1,0 +1,131 @@
+"""ChatMessageViewSet tenancy: session users only see their own conversations.
+
+When ENABLE_API_AUTH is on:
+- authenticated session users list only messages where conversation.student is them
+- token-only / anonymous authenticated-via-token clients get an empty queryset
+When auth is off, the open list behavior is preserved for local/dev.
+"""
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from swarm.models import ChatConversation, ChatMessage
+from swarm.views.message_views import ChatMessageViewSet
+
+TOKEN = "chat-msg-scope-token-xyz"
+User = get_user_model()
+
+
+def _list_view():
+    return ChatMessageViewSet.as_view({"get": "list"})
+
+
+def _seed_messages():
+    alice = User.objects.create_user(username="scope_alice", password="x")
+    bob = User.objects.create_user(username="scope_bob", password="x")
+    conv_alice = ChatConversation.objects.create(
+        conversation_id="conv-alice-1", student=alice
+    )
+    conv_bob = ChatConversation.objects.create(
+        conversation_id="conv-bob-1", student=bob
+    )
+    conv_legacy = ChatConversation.objects.create(
+        conversation_id="conv-legacy-null", student=None
+    )
+    ChatMessage.objects.create(
+        conversation=conv_alice, sender="user", content="alice-secret"
+    )
+    ChatMessage.objects.create(
+        conversation=conv_bob, sender="user", content="bob-secret"
+    )
+    ChatMessage.objects.create(
+        conversation=conv_legacy, sender="user", content="legacy-orphan"
+    )
+    return alice, bob
+
+
+@pytest.mark.django_db
+class TestChatMessageScoping:
+    def test_session_user_sees_only_own_messages(self):
+        alice, _bob = _seed_messages()
+        factory = APIRequestFactory()
+        request = factory.get("/v1/chat-messages/")
+        force_authenticate(request, user=alice)
+        with override_settings(ENABLE_API_AUTH=True, SWARM_API_KEY=TOKEN):
+            response = _list_view()(request)
+        assert response.status_code == 200
+        contents = [row["content"] for row in response.data]
+        assert "alice-secret" in contents
+        assert "bob-secret" not in contents
+        assert "legacy-orphan" not in contents
+
+    def test_other_session_user_sees_only_theirs(self):
+        _alice, bob = _seed_messages()
+        factory = APIRequestFactory()
+        request = factory.get("/v1/chat-messages/")
+        force_authenticate(request, user=bob)
+        with override_settings(ENABLE_API_AUTH=True, SWARM_API_KEY=TOKEN):
+            response = _list_view()(request)
+        assert response.status_code == 200
+        contents = [row["content"] for row in response.data]
+        assert contents == ["bob-secret"]
+
+    def test_token_only_client_sees_empty_queryset(self):
+        """Static token auth yields AnonymousUser + request.auth — no chat rows."""
+        _seed_messages()
+        factory = APIRequestFactory()
+        request = factory.get(
+            "/v1/chat-messages/",
+            HTTP_AUTHORIZATION=f"Bearer {TOKEN}",
+        )
+        # Run through StaticTokenAuthentication so request.auth is set and
+        # request.user is AnonymousUser (session-less token client).
+        from swarm.auth import StaticTokenAuthentication
+
+        with override_settings(ENABLE_API_AUTH=True, SWARM_API_KEY=TOKEN):
+            user_auth = StaticTokenAuthentication().authenticate(request)
+            assert user_auth is not None
+            request.user, request.auth = user_auth
+            response = _list_view()(request)
+        assert response.status_code == 200
+        assert list(response.data) == []
+
+    def test_unauthenticated_denied_when_auth_on(self):
+        _seed_messages()
+        factory = APIRequestFactory()
+        request = factory.get("/v1/chat-messages/")
+        with override_settings(ENABLE_API_AUTH=True, SWARM_API_KEY=TOKEN):
+            response = _list_view()(request)
+        assert response.status_code in (401, 403)
+
+    def test_open_list_when_auth_off(self):
+        _seed_messages()
+        factory = APIRequestFactory()
+        request = factory.get("/v1/chat-messages/")
+        with override_settings(ENABLE_API_AUTH=False, SWARM_API_KEY=None):
+            response = _list_view()(request)
+        assert response.status_code == 200
+        contents = {row["content"] for row in response.data}
+        assert {"alice-secret", "bob-secret", "legacy-orphan"} <= contents
+
+    def test_create_stamps_student_on_null_conversation(self):
+        alice = User.objects.create_user(username="create_alice", password="x")
+        conv = ChatConversation.objects.create(
+            conversation_id="conv-stamp-me", student=None
+        )
+        factory = APIRequestFactory()
+        request = factory.post(
+            "/v1/chat-messages/",
+            {"conversation": conv.conversation_id, "sender": "user", "content": "hi"},
+            format="json",
+        )
+        force_authenticate(request, user=alice)
+        view = ChatMessageViewSet.as_view({"post": "create"})
+        with override_settings(ENABLE_API_AUTH=True, SWARM_API_KEY=TOKEN):
+            response = view(request)
+        assert response.status_code == 201, getattr(response, "data", response.content)
+        conv.refresh_from_db()
+        assert conv.student_id == alice.id

--- a/tests/core/test_cancel_registry.py
+++ b/tests/core/test_cancel_registry.py
@@ -1,0 +1,55 @@
+"""Unit tests for the file-backed cancel registry (cross-worker shared cancel)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from swarm.core import cancel_registry
+
+
+def test_request_then_is_cancel_requested(tmp_path: Path) -> None:
+    rid = "resp_cancel_ok1"
+    assert cancel_registry.request_cancel(rid, base_dir=tmp_path) is True
+    assert cancel_registry.is_cancel_requested(rid, base_dir=tmp_path) is True
+    flag = tmp_path / "cancel" / f"{rid}.flag"
+    assert flag.is_file()
+
+
+def test_clear_then_false(tmp_path: Path) -> None:
+    rid = "resp_cancel_clear1"
+    cancel_registry.request_cancel(rid, base_dir=tmp_path)
+    assert cancel_registry.is_cancel_requested(rid, base_dir=tmp_path) is True
+    cancel_registry.clear_cancel(rid, base_dir=tmp_path)
+    assert cancel_registry.is_cancel_requested(rid, base_dir=tmp_path) is False
+    assert not (tmp_path / "cancel" / f"{rid}.flag").exists()
+
+
+def test_invalid_response_ids_rejected_safely(tmp_path: Path) -> None:
+    for bad in ("", "../escape", "resp_../x", "secret", "resp_", "not_resp_id"):
+        assert cancel_registry.request_cancel(bad, base_dir=tmp_path) is False
+        assert cancel_registry.is_cancel_requested(bad, base_dir=tmp_path) is False
+        cancel_registry.clear_cancel(bad, base_dir=tmp_path)  # no-op, no raise
+    # Nothing written under store (or only an empty cancel dir is ok if mkdir raced — expect none)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_filesystem_visible_without_local_cache(tmp_path: Path) -> None:
+    """Simulate another worker: flag on disk, empty process-local set."""
+    rid = "resp_cross_worker1"
+    flag = tmp_path / "cancel" / f"{rid}.flag"
+    flag.parent.mkdir(parents=True, exist_ok=True)
+    flag.write_text("", encoding="utf-8")
+    with cancel_registry._local_lock:
+        cancel_registry._local.discard(rid)
+    assert cancel_registry.is_cancel_requested(rid, base_dir=tmp_path) is True
+
+
+def test_honors_swarm_responses_dir(monkeypatch, tmp_path: Path) -> None:
+    target = tmp_path / "shared"
+    monkeypatch.setenv("SWARM_RESPONSES_DIR", str(target))
+    rid = "resp_env_cancel1"
+    assert cancel_registry.request_cancel(rid) is True
+    assert (target / "cancel" / f"{rid}.flag").is_file()
+    assert cancel_registry.is_cancel_requested(rid) is True
+    cancel_registry.clear_cancel(rid)
+    assert not (target / "cancel" / f"{rid}.flag").exists()

--- a/tests/unit/test_auth_hardening.py
+++ b/tests/unit/test_auth_hardening.py
@@ -44,6 +44,8 @@ class TestGetApiAuthToken:
     def test_returns_none_when_unset(self, monkeypatch):
         monkeypatch.delenv("API_AUTH_TOKEN", raising=False)
         monkeypatch.delenv("SWARM_API_KEY", raising=False)
+        monkeypatch.delenv("API_AUTH_TOKENS", raising=False)
+        monkeypatch.delenv("SWARM_API_KEYS", raising=False)
         assert env_utils.get_api_auth_token() is None
 
 
@@ -56,6 +58,8 @@ class TestGetEnforcedApiAuthToken:
     def test_debug_mode_allows_missing_token_with_warning(self, monkeypatch):
         monkeypatch.delenv("API_AUTH_TOKEN", raising=False)
         monkeypatch.delenv("SWARM_API_KEY", raising=False)
+        monkeypatch.delenv("API_AUTH_TOKENS", raising=False)
+        monkeypatch.delenv("SWARM_API_KEYS", raising=False)
         monkeypatch.setenv("DJANGO_DEBUG", "true")
         monkeypatch.setattr(env_utils, "_api_auth_disabled_warning_emitted", False)
         with patch.object(env_utils._logger, "warning") as mock_warning:
@@ -66,6 +70,8 @@ class TestGetEnforcedApiAuthToken:
     def test_debug_warning_only_emitted_once(self, monkeypatch):
         monkeypatch.delenv("API_AUTH_TOKEN", raising=False)
         monkeypatch.delenv("SWARM_API_KEY", raising=False)
+        monkeypatch.delenv("API_AUTH_TOKENS", raising=False)
+        monkeypatch.delenv("SWARM_API_KEYS", raising=False)
         monkeypatch.setenv("DJANGO_DEBUG", "true")
         monkeypatch.setattr(env_utils, "_api_auth_disabled_warning_emitted", False)
         with patch.object(env_utils._logger, "warning") as mock_warning:
@@ -76,6 +82,8 @@ class TestGetEnforcedApiAuthToken:
     def test_production_refuses_without_token(self, monkeypatch):
         monkeypatch.delenv("API_AUTH_TOKEN", raising=False)
         monkeypatch.delenv("SWARM_API_KEY", raising=False)
+        monkeypatch.delenv("API_AUTH_TOKENS", raising=False)
+        monkeypatch.delenv("SWARM_API_KEYS", raising=False)
         monkeypatch.setenv("DJANGO_DEBUG", "false")
         with pytest.raises(ImproperlyConfigured, match="API_AUTH_TOKEN"):
             env_utils.get_enforced_api_auth_token()
@@ -139,6 +147,8 @@ def _settings_import_env(**overrides):
         # override variables that are already present in the environment).
         "API_AUTH_TOKEN": "",
         "SWARM_API_KEY": "",
+        "API_AUTH_TOKENS": "",
+        "SWARM_API_KEYS": "",
         "DJANGO_SECRET_KEY": "test-secret-key-for-subprocess",
         "DJANGO_ALLOWED_HOSTS": "example.com",
         "DJANGO_DEBUG": "false",
@@ -265,9 +275,12 @@ def restore_auth_settings():
     from django.conf import settings
     orig_enable = getattr(settings, "ENABLE_API_AUTH", None)
     orig_key = getattr(settings, "SWARM_API_KEY", None)
+    orig_keys = getattr(settings, "SWARM_API_KEYS", None)
     yield
     settings.ENABLE_API_AUTH = orig_enable
     settings.SWARM_API_KEY = orig_key
+    if orig_keys is not None:
+        settings.SWARM_API_KEYS = orig_keys
 
 
 @pytest.mark.usefixtures("restore_auth_settings")
@@ -311,6 +324,8 @@ class TestRunserverCommand:
         monkeypatch.setenv("DJANGO_DEBUG", "true")
         monkeypatch.delenv("API_AUTH_TOKEN", raising=False)
         monkeypatch.delenv("SWARM_API_KEY", raising=False)
+        monkeypatch.delenv("API_AUTH_TOKENS", raising=False)
+        monkeypatch.delenv("SWARM_API_KEYS", raising=False)
         mock_super = self._handle()
         assert mock_super.called
         assert settings.ENABLE_API_AUTH is False

--- a/tests/unit/test_blueprint_sandbox.py
+++ b/tests/unit/test_blueprint_sandbox.py
@@ -79,9 +79,15 @@ class TestAssertSafeBlueprintSource:
         with pytest.raises(ValueError, match=r"os\.system"):
             assert_safe_blueprint_source("import os\nos.system('id')\n")
 
-    def test_getattr_fails(self):
-        with pytest.raises(ValueError, match=r"getattr"):
+    def test_builtins_name_fails(self):
+        with pytest.raises(ValueError, match=r"__builtins__"):
             assert_safe_blueprint_source("getattr(__builtins__, 'eval')\n")
+
+    def test_getattr_constant_attr_allowed(self):
+        # Common pattern in generated team blueprints.
+        assert_safe_blueprint_source(
+            "result = object()\ncontent = getattr(result, 'final_output', str(result))\n"
+        )
 
     def test_allowed_imports_pass(self):
         src = """

--- a/tests/unit/test_blueprint_sandbox.py
+++ b/tests/unit/test_blueprint_sandbox.py
@@ -1,0 +1,175 @@
+"""Unit tests for the user-blueprint AST sandbox gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from swarm.core.blueprint_sandbox import (
+    assert_safe_blueprint_source,
+    sandbox_enabled,
+)
+
+
+SAFE_MINIMAL_BLUEPRINT = '''\
+from __future__ import annotations
+
+from typing import Any, AsyncGenerator
+
+from swarm.core.blueprint_base import BlueprintBase
+
+
+class SafeAgent(BlueprintBase):
+    metadata = {
+        "name": "safe_agent",
+        "description": "minimal safe blueprint",
+        "version": "0.0.1",
+    }
+
+    async def run(self, messages, stream: bool = False) -> AsyncGenerator:
+        yield {"role": "assistant", "content": "ok"}
+'''
+
+
+class TestAssertSafeBlueprintSource:
+    def test_safe_minimal_blueprint_passes(self):
+        assert_safe_blueprint_source(SAFE_MINIMAL_BLUEPRINT)  # no raise
+
+    def test_exec_call_fails(self):
+        src = SAFE_MINIMAL_BLUEPRINT + "\nexec('print(1)')\n"
+        with pytest.raises(ValueError, match=r"exec"):
+            assert_safe_blueprint_source(src)
+
+    def test_eval_call_fails(self):
+        src = "x = eval('1+1')\n"
+        with pytest.raises(ValueError, match=r"eval"):
+            assert_safe_blueprint_source(src)
+
+    def test_import_subprocess_fails(self):
+        src = "import subprocess\n"
+        with pytest.raises(ValueError, match=r"subprocess"):
+            assert_safe_blueprint_source(src)
+
+    def test_from_import_ctypes_fails(self):
+        src = "from ctypes import CDLL\n"
+        with pytest.raises(ValueError, match=r"ctypes"):
+            assert_safe_blueprint_source(src)
+
+    def test_import_pickle_fails(self):
+        with pytest.raises(ValueError, match=r"pickle"):
+            assert_safe_blueprint_source("import pickle\n")
+
+    def test_importlib_fails(self):
+        with pytest.raises(ValueError, match=r"importlib"):
+            assert_safe_blueprint_source("import importlib\n")
+
+    def test_dunder_import_fails(self):
+        with pytest.raises(ValueError, match=r"__import__"):
+            assert_safe_blueprint_source("__import__('os')\n")
+
+    def test_open_write_mode_fails(self):
+        with pytest.raises(ValueError, match=r"open"):
+            assert_safe_blueprint_source("open('/tmp/x', 'w')\n")
+
+    def test_open_read_mode_ok(self):
+        assert_safe_blueprint_source("f = open('/tmp/x', 'r')\n")
+
+    def test_os_system_fails(self):
+        with pytest.raises(ValueError, match=r"os\.system"):
+            assert_safe_blueprint_source("import os\nos.system('id')\n")
+
+    def test_getattr_fails(self):
+        with pytest.raises(ValueError, match=r"getattr"):
+            assert_safe_blueprint_source("getattr(__builtins__, 'eval')\n")
+
+    def test_allowed_imports_pass(self):
+        src = """
+import asyncio
+from pathlib import Path
+from typing import Any
+from swarm.core.blueprint_base import BlueprintBase
+"""
+        assert_safe_blueprint_source(src)
+
+    def test_syntax_error_raises_value_error(self):
+        with pytest.raises(ValueError, match=r"syntax"):
+            assert_safe_blueprint_source("def (\n")
+
+
+class TestSandboxEnabledEnv:
+    def test_default_true(self, monkeypatch):
+        monkeypatch.delenv("SWARM_USER_BLUEPRINT_SANDBOX", raising=False)
+        assert sandbox_enabled() is True
+
+    def test_false_opt_out(self, monkeypatch):
+        monkeypatch.setenv("SWARM_USER_BLUEPRINT_SANDBOX", "false")
+        assert sandbox_enabled() is False
+
+    def test_true_explicit(self, monkeypatch):
+        monkeypatch.setenv("SWARM_USER_BLUEPRINT_SANDBOX", "1")
+        assert sandbox_enabled() is True
+
+
+class TestDiscoverySkipsUnsafe:
+    def test_discover_skips_unsafe_user_blueprint(self, tmp_path, monkeypatch):
+        """Unsafe source under a sandboxed root is skipped, not exec'd."""
+        from swarm.core import blueprint_discovery as bd
+
+        monkeypatch.setenv("SWARM_USER_BLUEPRINT_SANDBOX", "true")
+
+        bp_dir = tmp_path / "evil_bp"
+        bp_dir.mkdir()
+        (bp_dir / "evil_bp.py").write_text(
+            "import subprocess\n"
+            "from swarm.core.blueprint_base import BlueprintBase\n"
+            "class Evil(BlueprintBase):\n"
+            "    metadata = {'name': 'evil_bp'}\n"
+            "    async def run(self, messages, **kw):\n"
+            "        yield {}\n",
+            encoding="utf-8",
+        )
+
+        found = bd.discover_blueprints(str(tmp_path), sandboxed=True)
+        assert "evil_bp" not in found
+        assert found == {}
+
+    def test_discover_loads_safe_when_sandboxed(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SWARM_USER_BLUEPRINT_SANDBOX", "true")
+        from swarm.core import blueprint_discovery as bd
+
+        bp_dir = tmp_path / "safe_bp"
+        bp_dir.mkdir()
+        (bp_dir / "safe_bp.py").write_text(SAFE_MINIMAL_BLUEPRINT, encoding="utf-8")
+
+        found = bd.discover_blueprints(str(tmp_path), sandboxed=True)
+        assert "safe_bp" in found
+        assert found["safe_bp"]["metadata"].get("name") in ("safe_agent", "safe_bp")
+
+    def test_sandbox_opt_out_loads_banned_import(self, tmp_path, monkeypatch):
+        """With SWARM_USER_BLUEPRINT_SANDBOX=false, AST gate is skipped.
+
+        The module still must be valid Python that imports successfully; we
+        use a banned-import module that does not call the import at class
+        body in a failing way — import subprocess succeeds if the package
+        exists.  We only assert the sandbox does not *skip* the file.
+        """
+        monkeypatch.setenv("SWARM_USER_BLUEPRINT_SANDBOX", "false")
+        from swarm.core import blueprint_discovery as bd
+
+        bp_dir = tmp_path / "sub_bp"
+        bp_dir.mkdir()
+        (bp_dir / "sub_bp.py").write_text(
+            "import subprocess  # would be banned when sandbox on\n"
+            "from swarm.core.blueprint_base import BlueprintBase\n"
+            "class SubBP(BlueprintBase):\n"
+            "    metadata = {'name': 'sub_bp'}\n"
+            "    async def run(self, messages, **kw):\n"
+            "        if False:\n"
+            "            yield {}\n",
+            encoding="utf-8",
+        )
+
+        found = bd.discover_blueprints(str(tmp_path), sandboxed=True)
+        # sandboxed=True is overridden by env opt-out via sandbox_enabled()
+        assert "sub_bp" in found

--- a/tests/unit/test_browser_tools.py
+++ b/tests/unit/test_browser_tools.py
@@ -1,0 +1,26 @@
+"""Browser automation honesty helpers."""
+from swarm.core.browser_tools import (
+    BROWSER_UNAVAILABLE,
+    browser_unavailable_error,
+    is_browser_unavailable_payload,
+)
+
+
+def test_browser_unavailable_error_shape():
+    err = browser_unavailable_error()
+    assert err["ok"] is False
+    assert err["error"] == BROWSER_UNAVAILABLE
+    assert "detail" not in err
+    assert BROWSER_UNAVAILABLE == "browser automation unavailable: no playwright MCP server"
+
+
+def test_browser_unavailable_error_with_detail():
+    err = browser_unavailable_error(detail="npx not found")
+    assert err["detail"] == "npx not found"
+    assert is_browser_unavailable_payload(err)
+
+
+def test_is_browser_unavailable_rejects_success_shaped():
+    assert not is_browser_unavailable_payload({"ok": True, "content": "done"})
+    assert not is_browser_unavailable_payload(None)
+    assert not is_browser_unavailable_payload("browser automation unavailable: no playwright MCP server")

--- a/tests/unit/test_creator_save_path.py
+++ b/tests/unit/test_creator_save_path.py
@@ -1,0 +1,164 @@
+"""Creator save path: user blueprints land under get_user_blueprints_dir() (XDG)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+
+
+VALID_AGENT_CODE = '''
+from collections.abc import AsyncGenerator
+from typing import Any
+from swarm.core.blueprint_base import BlueprintBase
+
+class MyTestAgent(BlueprintBase):
+    metadata = {
+        "name": "My Test Agent",
+        "description": "unit test agent",
+        "version": "1.0.0",
+    }
+
+    async def run(self, messages: list[dict[str, Any]], **kwargs: Any) -> AsyncGenerator[dict[str, Any], None]:
+        yield {"messages": [{"role": "assistant", "content": "ok"}]}
+'''
+
+
+def _login_client():
+    User = get_user_model()
+    User.objects.create_user(username="creator_save", password="cpass")
+    client = Client()
+    assert client.login(username="creator_save", password="cpass")
+    return client
+
+
+@pytest.mark.django_db
+class TestCreatorSavePath:
+    def test_save_custom_agent_writes_under_user_blueprints_dir(
+        self, tmp_path, monkeypatch
+    ):
+        """save_custom_agent must write under SWARM_USER_DATA_DIR/blueprints, not cwd."""
+        data_dir = tmp_path / "swarm_data"
+        monkeypatch.setenv("SWARM_USER_DATA_DIR", str(data_dir))
+        monkeypatch.delenv("SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY", raising=False)
+
+        # Isolate cwd so a relative user_blueprints/ write would be detectable
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+
+        from swarm.core.paths import get_user_blueprints_dir
+
+        expected_root = get_user_blueprints_dir()
+        assert expected_root == data_dir / "blueprints"
+
+        client = _login_client()
+        resp = client.post(
+            "/agent-creator/save/",
+            data=json.dumps({
+                "name": "My Test Agent",
+                "code": VALID_AGENT_CODE,
+                "description": "unit test",
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200, resp.content
+        body = resp.json()
+        assert body.get("success") is True
+        assert body.get("blueprint_id") == "my_test_agent"
+
+        saved = Path(body["path"])
+        assert saved.is_absolute()
+        assert saved.exists()
+        assert expected_root in saved.parents or saved.parent == expected_root / "my_test_agent"
+        assert str(saved).startswith(str(expected_root.resolve()))
+        assert saved.name == "blueprint_my_test_agent.py"
+        assert saved.read_text() == VALID_AGENT_CODE
+
+        # Must NOT write only under cwd/user_blueprints
+        cwd_only = cwd / "user_blueprints" / "my_test_agent" / "blueprint_my_test_agent.py"
+        assert not cwd_only.exists()
+
+        # Discovery-off guidance
+        msg = body.get("message", "")
+        assert "SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY" in msg
+        assert "true" in msg.lower() or "write-only" in msg.lower()
+
+    def test_save_custom_agent_discovery_on_message(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SWARM_USER_DATA_DIR", str(tmp_path / "data"))
+        monkeypatch.setenv("SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY", "true")
+        monkeypatch.chdir(tmp_path)
+
+        client = _login_client()
+        resp = client.post(
+            "/agent-creator/save/",
+            data=json.dumps({
+                "name": "Enabled Agent",
+                "code": VALID_AGENT_CODE.replace("My Test Agent", "Enabled Agent"),
+                "description": "d",
+            }),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body.get("success") is True
+        assert "discovery is enabled" in body.get("message", "").lower()
+        assert body["blueprint_id"] == "enabled_agent"
+        assert Path(body["path"]).exists()
+
+    def test_save_team_swarm_writes_under_user_blueprints_dir(
+        self, tmp_path, monkeypatch
+    ):
+        data_dir = tmp_path / "swarm_data"
+        monkeypatch.setenv("SWARM_USER_DATA_DIR", str(data_dir))
+        monkeypatch.delenv("SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY", raising=False)
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+
+        from swarm.core.paths import get_user_blueprints_dir
+
+        expected_root = get_user_blueprints_dir()
+        client = _login_client()
+        payload = {
+            "name": "Alpha Team",
+            "description": "two-bot team for path test",
+            "agents": [
+                {"name": "bot_a", "system_prompt": "You are bot a."},
+                {"name": "bot_b", "system_prompt": "You are bot b."},
+            ],
+        }
+        resp = client.post(
+            "/team-creator/save/",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200, resp.content
+        body = resp.json()
+        assert body.get("success") is True
+        assert body.get("blueprint_id") == "alpha-team"
+
+        saved = Path(body["path"])
+        assert saved.is_absolute()
+        assert saved.exists()
+        assert str(saved).startswith(str(expected_root.resolve()))
+        assert not (cwd / "user_blueprints" / "alpha-team").exists()
+        assert "SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY" in body.get("message", "")
+
+    def test_get_available_agents_scans_user_blueprints_dir(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("SWARM_USER_DATA_DIR", str(tmp_path / "data"))
+        from swarm.core.paths import get_user_blueprints_dir
+        from swarm.views.agent_creator_views import _get_available_agents
+
+        root = get_user_blueprints_dir()
+        custom = root / "my_saved_agent"
+        custom.mkdir(parents=True)
+        (custom / "blueprint_my_saved_agent.py").write_text("# stub\n")
+
+        names = {a["name"] for a in _get_available_agents()}
+        assert "my_saved_agent" in names
+        assert "codey" in names  # builtin still present

--- a/tests/unit/test_multi_token_auth.py
+++ b/tests/unit/test_multi_token_auth.py
@@ -1,0 +1,194 @@
+"""Multi-token API auth: multiple Bearer secrets → distinct ownership principals."""
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from django.test import override_settings
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.test import APIRequestFactory
+
+from swarm.auth import StaticTokenAuthentication, request_principal
+from swarm.utils import env_utils
+
+
+TOKEN_A = "multi-token-alpha-secret"
+TOKEN_B = "multi-token-beta-secret"
+TOKEN_SINGLE = "single-token-gamma-secret"
+
+
+def _token_principal(token: str) -> str:
+    digest = hashlib.sha256(token.encode("utf-8")).hexdigest()[:24]
+    return f"token:{digest}"
+
+
+# =============================================================================
+# env_utils: get_api_auth_tokens merge + dedupe
+# =============================================================================
+
+
+class TestGetApiAuthTokens:
+    def test_merges_single_and_multi(self, monkeypatch):
+        monkeypatch.delenv("SWARM_ALLOW_NO_AUTH", raising=False)
+        monkeypatch.setenv("API_AUTH_TOKEN", "primary")
+        monkeypatch.setenv("SWARM_API_KEY", "legacy")
+        monkeypatch.setenv("API_AUTH_TOKENS", "extra1,extra2")
+        monkeypatch.delenv("SWARM_API_KEYS", raising=False)
+        assert env_utils.get_api_auth_tokens() == [
+            "primary",
+            "legacy",
+            "extra1",
+            "extra2",
+        ]
+
+    def test_dedupes_overlap(self, monkeypatch):
+        monkeypatch.delenv("SWARM_ALLOW_NO_AUTH", raising=False)
+        monkeypatch.setenv("API_AUTH_TOKEN", "same")
+        monkeypatch.setenv("SWARM_API_KEY", "same")
+        monkeypatch.setenv("API_AUTH_TOKENS", "same,other")
+        monkeypatch.delenv("SWARM_API_KEYS", raising=False)
+        assert env_utils.get_api_auth_tokens() == ["same", "other"]
+
+    def test_multi_only(self, monkeypatch):
+        monkeypatch.delenv("SWARM_ALLOW_NO_AUTH", raising=False)
+        monkeypatch.delenv("API_AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("SWARM_API_KEY", raising=False)
+        monkeypatch.setenv("SWARM_API_KEYS", "a,b")
+        monkeypatch.delenv("API_AUTH_TOKENS", raising=False)
+        assert env_utils.get_api_auth_tokens() == ["a", "b"]
+        assert env_utils.get_api_auth_token() == "a"
+
+    def test_allow_no_auth_returns_empty(self, monkeypatch):
+        monkeypatch.setenv("SWARM_ALLOW_NO_AUTH", "true")
+        monkeypatch.setenv("API_AUTH_TOKEN", "tok")
+        monkeypatch.setenv("API_AUTH_TOKENS", "a,b")
+        assert env_utils.get_api_auth_tokens() == []
+        assert env_utils.get_api_auth_token() is None
+
+    def test_empty_when_unset(self, monkeypatch):
+        monkeypatch.delenv("SWARM_ALLOW_NO_AUTH", raising=False)
+        for key in (
+            "API_AUTH_TOKEN",
+            "SWARM_API_KEY",
+            "API_AUTH_TOKENS",
+            "SWARM_API_KEYS",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        assert env_utils.get_api_auth_tokens() == []
+
+
+# =============================================================================
+# StaticTokenAuthentication multi-key
+# =============================================================================
+
+
+class TestStaticTokenMultiKey:
+    def test_both_tokens_authenticate(self):
+        factory = APIRequestFactory()
+        auth = StaticTokenAuthentication()
+        with override_settings(
+            ENABLE_API_AUTH=True,
+            SWARM_API_KEY=TOKEN_A,
+            SWARM_API_KEYS=[TOKEN_A, TOKEN_B],
+        ):
+            for tok in (TOKEN_A, TOKEN_B):
+                req = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {tok}")
+                pair = auth.authenticate(req)
+                assert pair is not None
+                user, provided = pair
+                assert provided == tok
+                assert not user.is_authenticated  # AnonymousUser
+
+    def test_invalid_token_fails(self):
+        factory = APIRequestFactory()
+        auth = StaticTokenAuthentication()
+        with override_settings(
+            ENABLE_API_AUTH=True,
+            SWARM_API_KEY=TOKEN_A,
+            SWARM_API_KEYS=[TOKEN_A, TOKEN_B],
+        ):
+            req = factory.get("/", HTTP_AUTHORIZATION="Bearer not-a-valid-key")
+            with pytest.raises(AuthenticationFailed):
+                auth.authenticate(req)
+
+    def test_single_token_still_works(self):
+        factory = APIRequestFactory()
+        auth = StaticTokenAuthentication()
+        with override_settings(
+            ENABLE_API_AUTH=True,
+            SWARM_API_KEY=TOKEN_SINGLE,
+            SWARM_API_KEYS=[TOKEN_SINGLE],
+        ):
+            req = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {TOKEN_SINGLE}")
+            pair = auth.authenticate(req)
+            assert pair is not None
+            assert pair[1] == TOKEN_SINGLE
+
+    def test_fallback_to_swarm_api_key_when_keys_empty(self):
+        """Backward compat: only SWARM_API_KEY set (no SWARM_API_KEYS list)."""
+        factory = APIRequestFactory()
+        auth = StaticTokenAuthentication()
+        with override_settings(
+            ENABLE_API_AUTH=True,
+            SWARM_API_KEY=TOKEN_SINGLE,
+            SWARM_API_KEYS=[],
+        ):
+            req = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {TOKEN_SINGLE}")
+            pair = auth.authenticate(req)
+            assert pair is not None
+            assert pair[1] == TOKEN_SINGLE
+
+    def test_x_api_key_header(self):
+        factory = APIRequestFactory()
+        auth = StaticTokenAuthentication()
+        with override_settings(
+            ENABLE_API_AUTH=True,
+            SWARM_API_KEY=TOKEN_A,
+            SWARM_API_KEYS=[TOKEN_A, TOKEN_B],
+        ):
+            req = factory.get("/", HTTP_X_API_KEY=TOKEN_B)
+            pair = auth.authenticate(req)
+            assert pair is not None
+            assert pair[1] == TOKEN_B
+
+
+# =============================================================================
+# request_principal differs per presenting token
+# =============================================================================
+
+
+class TestRequestPrincipalMultiKey:
+    def test_principals_differ_for_a_vs_b(self):
+        factory = APIRequestFactory()
+        auth = StaticTokenAuthentication()
+        with override_settings(
+            ENABLE_API_AUTH=True,
+            SWARM_API_KEY=TOKEN_A,
+            SWARM_API_KEYS=[TOKEN_A, TOKEN_B],
+        ):
+            principals = []
+            for tok in (TOKEN_A, TOKEN_B):
+                req = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {tok}")
+                pair = auth.authenticate(req)
+                assert pair is not None
+                req.user, req.auth = pair
+                p = request_principal(req)
+                principals.append(p)
+                assert p == _token_principal(tok)
+
+            assert principals[0] != principals[1]
+            assert principals[0].startswith("token:")
+            assert principals[1].startswith("token:")
+
+    def test_single_token_principal(self):
+        factory = APIRequestFactory()
+        auth = StaticTokenAuthentication()
+        with override_settings(
+            ENABLE_API_AUTH=True,
+            SWARM_API_KEY=TOKEN_SINGLE,
+            SWARM_API_KEYS=[TOKEN_SINGLE],
+        ):
+            req = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {TOKEN_SINGLE}")
+            pair = auth.authenticate(req)
+            req.user, req.auth = pair
+            assert request_principal(req) == _token_principal(TOKEN_SINGLE)

--- a/tests/unit/test_production_security_defaults.py
+++ b/tests/unit/test_production_security_defaults.py
@@ -1,0 +1,64 @@
+"""Production security header / cookie defaults when DEBUG is False.
+
+These assert the *logic* used in settings.py (replicated here) so we do not
+need to re-import settings under a flipped DEBUG (which is sticky under pytest).
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+
+def _apply_prod_secure_defaults(debug: bool, env: dict[str, str] | None = None) -> dict:
+    """Mirror of the settings.py production security block."""
+    out: dict = {}
+    env = env or {}
+    if not debug:
+        out["SECURE_CONTENT_TYPE_NOSNIFF"] = True
+        out["X_FRAME_OPTIONS"] = env.get("DJANGO_X_FRAME_OPTIONS", "DENY")
+        secure_env = env.get("SWARM_SECURE_COOKIES", "").strip().lower()
+        if secure_env in ("false", "0", "no", "n", "off"):
+            secure = False
+        else:
+            secure = True
+        out["SESSION_COOKIE_SECURE"] = secure
+        out["CSRF_COOKIE_SECURE"] = secure
+    return out
+
+
+class TestProductionSecurityDefaults:
+    def test_debug_true_sets_nothing(self):
+        assert _apply_prod_secure_defaults(debug=True) == {}
+
+    def test_production_sets_headers_and_secure_cookies(self):
+        out = _apply_prod_secure_defaults(debug=False, env={})
+        assert out["SECURE_CONTENT_TYPE_NOSNIFF"] is True
+        assert out["X_FRAME_OPTIONS"] == "DENY"
+        assert out["SESSION_COOKIE_SECURE"] is True
+        assert out["CSRF_COOKIE_SECURE"] is True
+
+    def test_secure_cookies_opt_out(self):
+        out = _apply_prod_secure_defaults(
+            debug=False, env={"SWARM_SECURE_COOKIES": "false"}
+        )
+        assert out["SESSION_COOKIE_SECURE"] is False
+        assert out["CSRF_COOKIE_SECURE"] is False
+
+    def test_x_frame_options_override(self):
+        out = _apply_prod_secure_defaults(
+            debug=False, env={"DJANGO_X_FRAME_OPTIONS": "SAMEORIGIN"}
+        )
+        assert out["X_FRAME_OPTIONS"] == "SAMEORIGIN"
+
+    def test_live_settings_under_pytest_are_debug(self):
+        """TESTING forces DEBUG; production block must not have flipped cookies."""
+        from django.conf import settings
+
+        # Under pytest, DEBUG is True so secure-cookie production defaults
+        # should not be forced on (session cookies work over http://testserver).
+        assert settings.DEBUG is True or getattr(settings, "TESTING", False)
+        # If DEBUG is somehow False, the block would set secure cookies — but
+        # the default test path keeps DEBUG True.
+        if settings.DEBUG:
+            # Production-only attrs may be unset or False under DEBUG.
+            assert getattr(settings, "SESSION_COOKIE_SECURE", False) in (False, True)


### PR DESCRIPTION
# Summary

Closes the five remaining outstanding structural items from the production-readiness campaign: multi-token API principals, filesystem-shared cancel across workers, AST sandbox for user blueprint discovery, creator save→XDG create→run path, and chat scoping / production secure defaults (plus browser honesty helper).

## Problem it solves

Post-#261 outstanding list:
1. Single shared API token principal  
2. Process-local cancel (multi-worker blind spot)  
3. Creator ban-list ≠ sandbox when discovery is on  
4. Web create→run wrote to cwd `user_blueprints/` not discovery path  
5. Public-facing gaps (chat row leak, missing prod cookie/headers defaults, browser MCP honesty)

## How it works

1. **Multi-token** — `API_AUTH_TOKENS` / `SWARM_API_KEYS` CSV merged with single token; each Bearer → distinct `token:<sha256>` principal.  
2. **Cancel registry** — flag files under `{SWARM_RESPONSES_DIR}/cancel/`; multi-worker cancel when store is shared; inflight remains process-local.  
3. **Sandbox** — AST gate before `exec_module` on user roots (`SWARM_USER_BLUEPRINT_SANDBOX` default true); creator save also gates full source.  
4. **Create→run** — saves to `get_user_blueprints_dir()`; discovery messaging; team creator lists XDG agents.  
5. **Public slice** — ChatMessage queryset scoped to session user when auth on; production `SECURE_*` / secure cookies; playwright-missing returns clear error.

## Measured impact

- Combined targeted suite: **89 passed**  
- No new runtime dependencies

## Test coverage

- `test_multi_token_auth`, `test_cancel_registry`, `test_blueprint_sandbox`, `test_creator_save_path`, `test_chat_message_scoping`, `test_production_security_defaults`, `test_browser_tools` + prior P0 suites

## Risks / follow-ups

- Sandbox is static AST, not a full OS sandbox — still opt-in discovery  
- Inflight limits still per-worker if multi-worker override  
- Full OAuth/mTLS public multi-tenant still not in scope  
- Issue #55 Finish Setup UI not found as discrete code path in this repo snapshot  
- Rollback: revert this PR

## Build footprint

None.