### PR TITLE
chore(env): add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,13 @@
+{
+  "name": "Open Swarm",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh",
+  "start": "export PATH=\"$HOME/.local/bin:$PATH\" && DJANGO_DEBUG=true DJANGO_DB_NAME=/tmp/db.sqlite3 uv run python manage.py migrate --noinput",
+  "terminals": [
+    {
+      "name": "swarm-api",
+      "command": "export PATH=\"$HOME/.local/bin:$PATH\" && DJANGO_DEBUG=true ENABLE_WEBUI=true DJANGO_DB_NAME=/tmp/db.sqlite3 HOST=0.0.0.0 PORT=8000 uv run swarm-api --port 8000 --reload"
+    }
+  ],
+  "ports": [8000]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for Open Swarm.
+# Runs after the repository is checked out. Safe to run repeatedly.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo /workspace)"
+
+# 1. Install uv (Python package/venv manager) if it is not already present.
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+export PATH="$HOME/.local/bin:$PATH"
+
+# 2. Create .venv and install the project plus all extras from the committed
+#    uv.lock (dev, test, memory, docs). Deterministic and idempotent.
+uv sync --all-extras
+
+# 3. Build the optional React SPA (webui/frontend/dist) so `/` serves the
+#    dashboard + /chat. Django falls back to server-rendered templates if the
+#    build is absent, so a Node failure here is non-fatal for backend work.
+if command -v npm >/dev/null 2>&1; then
+  ./scripts/build_frontend.sh || echo "WARN: frontend build failed; Django template UI will be used."
+else
+  echo "WARN: npm not found; skipping SPA build (Django template UI will be used)."
+fi
+
+echo "Open Swarm install complete."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cursor Cloud Agent development environment for Open Swarm so future agents boot into a ready-to-use dev setup: a Python venv with all extras, a built React SPA, and a live OpenAI-compatible API server.

This is a **repository-managed** environment (committed `.cursor/environment.json`), so it becomes active automatically when this PR merges — no dashboard save needed.

## What's included

- `.cursor/environment.json` — declares the environment:
  - `install`: runs `.cursor/install.sh`
  - `start`: applies Django migrations (idempotent, per boot)
  - `terminals`: launches the `swarm-api` ASGI server on port `8000` with `--reload`
  - `ports`: exposes `8000`
- `.cursor/install.sh` — idempotent bootstrap: installs `uv` (if missing), runs `uv sync --all-extras` from the committed `uv.lock`, and builds the optional React SPA (`webui/frontend/dist`). Node/SPA failures are non-fatal (Django falls back to its template UI).

The server runs with `DJANGO_DEBUG=true` and `ENABLE_WEBUI=true` so it boots keyless for local development; add `OPENAI_API_KEY` (and optionally `API_AUTH_TOKEN`) via secrets for real LLM calls and enforced API auth.

## Validation (on the VM)

- `uv sync --all-extras` from `uv.lock`
- `uv run python manage.py check` → no issues (debug mode)
- Full keyless suite: **2143 passed, 8 skipped** (`SWARM_TEST_MODE=1`); the single intermittent failure (`test_stewie.py::test_unknown_llm_profile_warns_then_falls_back`) is a pre-existing test-isolation flake — it passes in isolation and is unrelated to the environment
- `swarm-cli list` + `swarm-cli launch suggestion` (deterministic test-mode output)
- API end to end: `/v1/models`, `/v1/chat/completions`, `/v1/responses` return valid OpenAI-compatible responses; auth returns `403` without a token
- Web UI: React SPA served at `/`, `/chat` → `200`, Swagger UI at `/api/schema/swagger-ui/` → `200`
- `install.sh` run twice → idempotent

## Validation (prebuilt environment build)

- Triggered a draft environment build from this branch + the working snapshot → **SUCCEEDED**; build logs show a clean checkout, `uv sync --all-extras` (191 packages, `open-swarm` built), and the vite frontend build.
- Booted a **fresh Cloud Agent** from that exact build → **7/7 checks passed**: toolchain (`uv 0.12.6`, Python 3.12.3, Node 22), `.venv` present, deps import (`django 4.2.18`), `webui/frontend/dist/index.html` present, `manage.py check` clean, `swarm-cli launch suggestion` OK, and the live API returned `200` for `/v1/models`, `/`, and a valid `chat.completion` for `/v1/chat/completions`.

## Demo

Live OpenAI-compatible chat completion executed through the Swagger UI (200 response):

[swagger_chat_completion_200.mp4](https://cursor.com/agents/bc-65fc5f83-f995-4926-9242-6586021d50fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswagger_chat_completion_200.mp4)

React SPA dashboard served at `/`, reporting the API as reachable (46 blueprints / 46 models):

[Open Swarm dashboard](https://cursor.com/agents/bc-65fc5f83-f995-4926-9242-6586021d50fe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65fc5f83-f995-4926-9242-6586021d50fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65fc5f83-f995-4926-9242-6586021d50fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

