### PR TITLE
fix(deploy): RestartPreventExitStatus=78 in oracle unit + corrected Neon quota runbook

### DIFF
--- a/deploy/oracle/open-swarm-oracle.service
+++ b/deploy/oracle/open-swarm-oracle.service
@@ -25,6 +25,12 @@ Environment=API_AUTH_TOKEN=CHANGE_ME_GENERATE_A_TOKEN
 ExecStart=/home/YOURUSER/open-swarm/.venv/bin/uvicorn swarm.asgi:application --host 127.0.0.1 --port 8001 --workers 1
 Restart=always
 RestartSec=3
+# The app exits 78 (EX_CONFIG) when the configured database is permanently
+# unusable (e.g. a quota-exhausted Neon Postgres in DATABASE_URL). Restart=always
+# restarts on ANY exit status — clean or not — so without this exemption systemd
+# crash-loops forever on a failure no restart can fix. With it, an exit-78 leaves
+# the unit stopped (state: failed) for an operator to fix the config.
+RestartPreventExitStatus=78
 
 [Install]
 WantedBy=default.target

--- a/docs/RUNBOOK_NEON_QUOTA_CRASH_LOOP.md
+++ b/docs/RUNBOOK_NEON_QUOTA_CRASH_LOOP.md
@@ -1,0 +1,117 @@
+# Runbook: Crash-Loop on Neon Postgres Quota Exhaustion
+
+## Incident summary
+
+- **Service**: `open-swarm-oracle.service` (systemd *user* unit; see
+  [`deploy/oracle/open-swarm-oracle.service`](../deploy/oracle/open-swarm-oracle.service))
+- **Symptom**: service crash-looping (tens of thousands of restarts), high
+  CPU/IO from restart churn, gateway unavailable.
+- **Root cause**: `DATABASE_URL` pointed at a Neon Postgres instance whose
+  compute quota was exhausted. Every startup failed at DB connection; with
+  `Restart=always` + `RestartSec=3`, systemd restarted the process forever.
+- **Current host state**: the unit has been **stopped and disabled** on the
+  affected host. Do not assume it is running when following this runbook.
+
+## The fix, and a correction to an earlier draft of this runbook
+
+PR [#295](https://github.com/matthewhand/open-swarm/pull/295) adds a
+pre-startup database health check that fails fast with **exit code 78**
+(`EX_CONFIG`) when the database is permanently unusable (e.g. Neon quota
+exhausted).
+
+An earlier draft of this runbook claimed that exiting 78 by itself "prevents
+systemd restart churn" because it "signals a configuration error, not a
+transient failure". **That is incorrect.** systemd's `Restart=always` restarts
+the service on *any* exit — clean or unclean, regardless of exit code (see
+`man systemd.service`, `Restart=`). An exit code only suppresses restarts if
+the unit explicitly exempts it.
+
+The unit therefore now carries:
+
+```ini
+Restart=always
+RestartSec=3
+RestartPreventExitStatus=78
+```
+
+With `RestartPreventExitStatus=78`, an exit-78 leaves the unit stopped in the
+`failed` state for an operator to fix the configuration, while all other
+crashes (transient network blips, OOM kills, etc.) are still restarted as
+before. Both halves are required: the fail-fast (exit 78) *and* the unit
+exemption. Neither alone stops the loop.
+
+## Remediation
+
+Run everything below as the user owning the unit.
+
+### 1. Ensure the unit is not looping
+
+The unit on the affected host is already stopped; these commands are
+idempotent and safe to re-run:
+
+```bash
+systemctl --user stop open-swarm-oracle.service
+systemctl --user disable open-swarm-oracle.service
+systemctl --user reset-failed open-swarm-oracle.service   # clear failed state / restart counter
+```
+
+### 2. Do NOT resume the Neon instance
+
+Resuming or upgrading Neon compute is **not** the remediation for this
+deployment, and no Fly.io secrets should be changed as part of this incident.
+The database backend is fixed in the unit's environment instead.
+
+### 3. Point the service at a usable database
+
+Edit `~/.config/systemd/user/open-swarm-oracle.service`:
+
+- **SQLite (default, recommended here)**: remove any
+  `Environment=DATABASE_URL=...` line and keep
+  `Environment=DJANGO_DB_NAME=/home/YOURUSER/.local/share/swarm/db.sqlite3`.
+- **Other Postgres**: set `DATABASE_URL` to an instance that is not
+  quota-limited.
+
+### 4. Add the restart exemption
+
+Ensure the `[Service]` section contains `RestartPreventExitStatus=78`
+(present in the repo copy of the unit — re-copy from
+`deploy/oracle/open-swarm-oracle.service` or add the line by hand).
+
+### 5. Reload, migrate, start, verify
+
+```bash
+systemctl --user daemon-reload
+
+# if the database changed, run migrations first:
+cd ~/open-swarm && source .venv/bin/activate && cd src && python manage.py migrate
+
+systemctl --user enable --now open-swarm-oracle.service
+systemctl --user status open-swarm-oracle.service
+curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8001/v1/models   # expect 200
+```
+
+## Verifying the loop protection
+
+- Validate the unit parses:
+
+  ```bash
+  systemd-analyze verify --user ~/.config/systemd/user/open-swarm-oracle.service
+  ```
+
+- Watch the restart counter; it should stay flat once healthy:
+
+  ```bash
+  systemctl --user show open-swarm-oracle.service -p NRestarts
+  ```
+
+- If the service exits 78 again (bad DB config), systemd now leaves it in the
+  `failed` state instead of restarting it. `systemctl --user status` will show
+  `status=78` and no restart activity; fix the configuration, then
+  `systemctl --user reset-failed` and start it again.
+
+## References
+
+- `man systemd.service` — `Restart=`, `RestartPreventExitStatus=`
+- `sysexits.h` — `EX_CONFIG` (78): configuration error
+- Neon compute limits: https://neon.tech/docs/introduction/plans
+- Deployment runbook: [`docs/ORACLE_DEPLOY.md`](./ORACLE_DEPLOY.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

PR #295 adds a pre-startup DB health check that fails fast with exit code 78 (`EX_CONFIG`) when `DATABASE_URL` points at a quota-exhausted Neon Postgres. But `deploy/oracle/open-swarm-oracle.service` uses `Restart=always`, and systemd restarts on **any** exit status regardless of exit code (`man systemd.service`, `Restart=`). So the fail-fast alone does not stop the crash-loop — systemd keeps restarting every `RestartSec=3`.

#295's runbook draft claimed exit 78 "prevents systemd restart churn" by itself; that claim is incorrect.

## Changes (unit + runbook only)

- **`deploy/oracle/open-swarm-oracle.service`**: add `RestartPreventExitStatus=78` so an exit-78 leaves the unit stopped in the `failed` state for an operator, while transient crashes are still restarted as before.
- **`docs/RUNBOOK_NEON_QUOTA_CRASH_LOOP.md`**: corrected runbook explaining that both halves are required (the exit-78 fail-fast *and* the unit exemption), with remediation and verification steps. Explicitly notes: do not resume Neon compute, do not change Fly secrets, and the host unit is already stopped/disabled.

Out of scope, deliberately: no changes to #295 (not merged), no Neon resume, no Fly secret changes, no application code.

## Verification

`systemd-analyze verify` (systemd 255) on the unit:

- As-is: the only diagnostic is the expected placeholder path (`/home/YOURUSER/...` not executable); no unknown-key warnings, so `RestartPreventExitStatus=78` parses.
- With placeholders substituted for real paths: clean pass, exit 0.

Note the host unit is stopped; nothing was verified against a live service.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-347f7726-6e22-4fdb-bfa1-af0de0fdc09f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-347f7726-6e22-4fdb-bfa1-af0de0fdc09f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

