### PR TITLE
fix(deploy): RestartPreventExitStatus=78 so systemd actually honors the exit-78 fail-fast

### DIFF
--- a/deploy/oracle/open-swarm-oracle.service
+++ b/deploy/oracle/open-swarm-oracle.service
@@ -25,6 +25,11 @@ Environment=API_AUTH_TOKEN=CHANGE_ME_GENERATE_A_TOKEN
 ExecStart=/home/YOURUSER/open-swarm/.venv/bin/uvicorn swarm.asgi:application --host 127.0.0.1 --port 8001 --workers 1
 Restart=always
 RestartSec=3
+# Exit 78 (EX_CONFIG) is the DB health check's fail-fast for permanent config
+# errors (e.g. Neon quota exhausted). Restart=always restarts on EVERY exit
+# code, so without this directive systemd would crash-loop anyway. With it,
+# an exit 78 leaves the service stopped until the config is fixed.
+RestartPreventExitStatus=78
 
 [Install]
 WantedBy=default.target

--- a/docs/RUNBOOK_NEON_QUOTA_CRASH_LOOP.md
+++ b/docs/RUNBOOK_NEON_QUOTA_CRASH_LOOP.md
@@ -99,6 +99,18 @@ Edit `~/.config/systemd/user/open-swarm-oracle.service`:
 
 Only do this if you intentionally want to use Neon and have upgraded your plan to remove compute limits. Otherwise, prefer Option A or B.
 
+**In all options**, also add this to the `[Service]` section of
+`~/.config/systemd/user/open-swarm-oracle.service` (already present in the
+repo template `deploy/oracle/open-swarm-oracle.service`):
+
+```
+RestartPreventExitStatus=78
+```
+
+Without it, `Restart=always` restarts the service on every exit code —
+including the health check's fail-fast exit 78 — and the crash-loop continues.
+With it, an exit 78 stops the service until you fix the configuration.
+
 ### Step 4: Apply Changes and Restart
 
 ```bash
@@ -136,13 +148,14 @@ This PR introduces a **pre-startup database health check** that prevents crash-l
 1. **Health check runs before Django starts**: The check happens in `swarm.utils.db_health.enforce_database_health_on_startup()`
 2. **Detects quota-exceeded errors**: Looks for Neon-specific error indicators like "quota", "compute time", "suspended"
 3. **Fails fast with clear error**: Exits with code 78 (EX_CONFIG) and prints actionable remediation steps
-4. **Prevents systemd restart churn**: Exit code 78 signals a configuration error, not a transient failure
+4. **Prevents systemd restart churn — only together with `RestartPreventExitStatus=78`**: The exit code alone does NOT stop the loop. `Restart=always` restarts the service on *every* exit code, including 78. The unit file must set `RestartPreventExitStatus=78` (now included in `deploy/oracle/open-swarm-oracle.service`) so systemd leaves the service stopped after a config-error exit instead of restarting it
 
 ### Files Changed
 
 - **`src/swarm/utils/db_health.py`**: New module with health check logic
 - **`src/swarm/asgi.py`**: Calls health check before `get_asgi_application()`
 - **`src/manage.py`**: Calls health check for server commands (runserver, daphne, etc.)
+- **`deploy/oracle/open-swarm-oracle.service`**: Adds `RestartPreventExitStatus=78` so systemd does not restart the service after a fail-fast exit 78 (required — `Restart=always` restarts on all exit codes otherwise)
 - **`docker-compose.postgres.yml`**: New compose file for local Postgres setup
 
 ### Environment Variables
@@ -217,7 +230,7 @@ journalctl --user -u open-swarm-oracle.service | grep "DATABASE HEALTH CHECK FAI
 ## Related Documentation
 
 - **Neon Postgres compute limits**: https://neon.tech/docs/introduction/plans#compute-time
-- **systemd Restart behavior**: `man systemd.service` (see `Restart=` and `RestartSec=`)
+- **systemd Restart behavior**: `man systemd.service` (see `Restart=`, `RestartSec=`, and `RestartPreventExitStatus=`)
 - **Django database configuration**: https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 - **dj-database-url**: https://github.com/jazzband/dj-database-url
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Honesty finding on [PR #295](https://github.com/matthewhand/open-swarm/pull/295): the DB health check fails fast with exit 78 (EX_CONFIG) on a Neon quota error, but the unit still has plain `Restart=always`. systemd's `Restart=always` restarts the service on **every** exit code, including 78, so the fail-fast alone does not stop the crash-loop. The runbook's claim that "exit code 78 ... prevents systemd restart churn" was not true as written.

## Fix

- `deploy/oracle/open-swarm-oracle.service`: add `RestartPreventExitStatus=78` (with a comment explaining why), so an exit 78 leaves the service stopped until the configuration is fixed. Transient failures (other exit codes) still restart as before.
- `docs/RUNBOOK_NEON_QUOTA_CRASH_LOOP.md`: correct the "prevents restart churn" claim to state the directive is required, add the unit file to the Files Changed list, tell operators to add the directive to the deployed user unit in all remediation options, and reference `RestartPreventExitStatus=` in the systemd docs pointer.

## Scope

- Stacked on `cursor/fix-neon-quota-crash-loop-d671` (PR #295), since the runbook only exists on that branch. The diff is 2 files, +20/−2.
- No Neon resume, no Fly secrets changes, no other deploy changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1860a4f-f63f-4443-b040-687d1e2671d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1860a4f-f63f-4443-b040-687d1e2671d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

