### PR TITLE
docs: GitHub-safe Developer mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,78 @@ Feature-flag variables for experimental subsystems (`ENABLE_MCP_SERVER`, `ENABLE
 
 ---
 
+## Developer
+
+Runtime maps from the code. GitHub-safe Mermaid: short plain labels, no HTML, no markdown links in nodes. Dates are from git tags and the commits that added each surface.
+
+### Gateway vs workers
+
+The API process is the gateway: `swarm.core.swarm_api` starts uvicorn on `swarm.asgi:application`. Default is one uvicorn worker (`SWARM_UVICORN_WORKERS=1`; `swarm.core.concurrency.resolved_uvicorn_workers` refuses more unless `SWARM_ENFORCE_SINGLE_WORKER` is false). Inflight slots for async work are process-local (`SWARM_MAX_INFLIGHT`). Long `/v1/responses` jobs run in a daemon thread (`_spawn_worker` in `swarm.views.responses_views`), not extra uvicorn workers. The blueprint then calls host CLI adapters or REST/LLM profiles.
+
+```mermaid
+block-beta
+columns 3
+  Client["Client"]:3
+  Gateway["API gateway"]:3
+  Chat["Chat view"] Resp["Responses view"] Store["File store"]
+  Worker["Daemon worker"]:3
+  CLI["CLI adapters"] Blueprint["Blueprint run"] LLM["REST LLM"]
+```
+
+### Request sequence
+
+`POST /v1/responses` (`ResponsesView.post` in `swarm.views.responses_views`): authenticate, resolve the blueprint from `model`, persist a queued record (`swarm.core.responses_store`), spawn the daemon worker, then return 200 if the wait window hits completion or 202 to poll. `GET /v1/responses/{id}` reads the store. Chat `background:true` reuses the same worker (`ChatCompletionsView._handle_background_chat`).
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Gateway
+    participant Store
+    participant Worker
+    participant Blueprint
+
+    Client->>Gateway: POST /v1/responses
+    Gateway->>Gateway: auth and load blueprint
+    Gateway->>Store: save queued record
+    Gateway->>Worker: spawn daemon thread
+    alt wait is zero
+        Gateway-->>Client: 202 queued handle
+    else wait window
+        Gateway-->>Client: 200 done or 202 poll
+    end
+    Worker->>Store: set in_progress
+    Worker->>Blueprint: run messages
+    Blueprint-->>Worker: output
+    Worker->>Store: completed or failed
+    Client->>Gateway: GET /v1/responses/id
+    Gateway->>Store: load record
+    Store-->>Gateway: status and output
+    Gateway-->>Client: JSON body
+```
+
+### History
+
+Real dates only (git). The changelog `0.1.0` row dated 2024-01-01 is not a tag and is omitted.
+
+```mermaid
+gantt
+    title Open Swarm git history
+    dateFormat YYYY-MM-DD
+    axisFormat %Y-%m
+    section Start
+    Initial commit           :milestone, 2024-12-21, 0d
+    Django REST API          :2024-12-26, 2025-01-04
+    section Releases
+    Tag 0.0.1                :milestone, 2026-02-20, 0d
+    React Web UI             :milestone, 2026-04-04, 0d
+    v0.3 MoA                 :2026-06-11, 2026-06-12
+    v0.4 CLI fusion          :2026-06-16, 2026-06-17
+    v0.5 responses           :2026-06-18, 2026-06-19
+    section Later
+    Worker gates             :milestone, 2026-07-22, 0d
+    ADR-001 Django UI        :2026-08-18, 2026-08-24
+```
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -240,16 +240,32 @@ Runtime maps from the code. GitHub-safe Mermaid: short plain labels, no HTML, no
 
 ### Gateway vs workers
 
-The API process is the gateway: `swarm.core.swarm_api` starts uvicorn on `swarm.asgi:application`. Default is one uvicorn worker (`SWARM_UVICORN_WORKERS=1`; `swarm.core.concurrency.resolved_uvicorn_workers` refuses more unless `SWARM_ENFORCE_SINGLE_WORKER` is false). Inflight slots for async work are process-local (`SWARM_MAX_INFLIGHT`). Long `/v1/responses` jobs run in a daemon thread (`_spawn_worker` in `swarm.views.responses_views`), not extra uvicorn workers. The blueprint then calls host CLI adapters or REST/LLM profiles.
+Block view below uses flowchart subgraphs (GitHub Mermaid; `block-beta` is not reliable there). The API process is the gateway: `swarm.core.swarm_api` starts uvicorn on `swarm.asgi:application`. Default is one uvicorn worker (`SWARM_UVICORN_WORKERS=1`; `swarm.core.concurrency.resolved_uvicorn_workers` refuses more unless `SWARM_ENFORCE_SINGLE_WORKER` is false). Inflight slots for async work are process-local (`SWARM_MAX_INFLIGHT`). Long `/v1/responses` jobs run in a daemon thread (`_spawn_worker` in `swarm.views.responses_views`), not extra uvicorn workers. The blueprint then calls host CLI adapters or REST/LLM profiles.
 
 ```mermaid
-block-beta
-columns 3
-  Client["Client"]:3
-  Gateway["API gateway"]:3
-  Chat["Chat view"] Resp["Responses view"] Store["File store"]
-  Worker["Daemon worker"]:3
-  CLI["CLI adapters"] Blueprint["Blueprint run"] LLM["REST LLM"]
+flowchart TB
+  subgraph clients [Clients]
+    C[Client]
+  end
+  subgraph gateway [API gateway]
+    CH[Chat view]
+    RV[Responses view]
+    ST[File store]
+  end
+  subgraph workers [Workers]
+    DW[Daemon worker]
+    BP[Blueprint run]
+    CLI[CLI adapters]
+    LLM[REST LLM]
+  end
+  C --> CH
+  C --> RV
+  RV --> ST
+  RV --> DW
+  CH --> BP
+  DW --> BP
+  BP --> CLI
+  BP --> LLM
 ```
 
 ### Request sequence
@@ -260,26 +276,26 @@ columns 3
 sequenceDiagram
     participant Client
     participant Gateway
-    participant Store
+    participant FileStore
     participant Worker
     participant Blueprint
 
     Client->>Gateway: POST /v1/responses
     Gateway->>Gateway: auth and load blueprint
-    Gateway->>Store: save queued record
+    Gateway->>FileStore: save queued record
     Gateway->>Worker: spawn daemon thread
     alt wait is zero
         Gateway-->>Client: 202 queued handle
     else wait window
         Gateway-->>Client: 200 done or 202 poll
     end
-    Worker->>Store: set in_progress
+    Worker->>FileStore: set in_progress
     Worker->>Blueprint: run messages
     Blueprint-->>Worker: output
-    Worker->>Store: completed or failed
+    Worker->>FileStore: completed or failed
     Client->>Gateway: GET /v1/responses/id
-    Gateway->>Store: load record
-    Store-->>Gateway: status and output
+    Gateway->>FileStore: load record
+    FileStore-->>Gateway: status and output
     Gateway-->>Client: JSON body
 ```
 
@@ -306,6 +322,19 @@ gantt
     ADR-001 Django UI        :2026-08-18, 2026-08-24
 ```
 
+| Date | What | Evidence |
+|---|---|---|
+| 2024-12-21 | Initial commit | git root commit |
+| 2024-12-26 | Django REST API | commit `c3a092c4` |
+| 2026-02-20 | Tag 0.0.1 | git tag |
+| 2026-04-04 | React Web UI | commit `9077902b` |
+| 2026-06-11 | v0.3.0 MoA | tag `v0.3.0` |
+| 2026-06-16 | CLI fusion | commit `976cbd49` |
+| 2026-06-18 | `/v1/responses` | commit `50492380` |
+| 2026-06-19 | v0.5.4 | tag `v0.5.4` |
+| 2026-07-22 | Worker gates | commit `ff014180` |
+| 2026-08-18 | ADR-001 | commit `3d870d62` |
+
 ## Development
 
 ```bash
@@ -329,6 +358,7 @@ Documentation map:
 * [docs/SKILLS_AND_CONSENSUS_WALKTHROUGH.md](./docs/SKILLS_AND_CONSENSUS_WALKTHROUGH.md) — illustrated end-to-end walkthrough of skills + 3-CLI consensus, with real terminal captures.
 * [docs/MOA.md](./docs/MOA.md) — Mixture of Agents consensus and consensus→team path.
 * [docs/SCREENSHOTS.md](./docs/SCREENSHOTS.md) — screenshot capture registry; regenerate with `scripts/capture_user_journey.py`.
+* [Developer](#developer) — gateway vs workers, `/v1/responses` sequence, git-dated history.
 * [DEVELOPMENT.md](./DEVELOPMENT.md) — tech stack and internal architecture; [ROADMAP.md](./ROADMAP.md) — honest feature status.
 * [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) — common issues (CLI/blueprint not found, API errors, the production `ImproperlyConfigured` startup crash) and fixes.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Developer` section to `README.md` with three GitHub-safe Mermaid diagrams that document **this repo’s actual runtime**, not a generic architecture sketch.

## Diagrams

1. **Block — gateway vs workers**  
   Flowchart with subgraphs (GitHub Mermaid; `block-beta` is not reliable there). Uvicorn/Django API process (`swarm.core.swarm_api` → `swarm.asgi`) is the gateway (default `SWARM_UVICORN_WORKERS=1`). Long `/v1/responses` work runs in a daemon thread (`_spawn_worker` in `swarm.views.responses_views`). Blueprints then call CLI adapters or REST/LLM profiles. File store is `swarm.core.responses_store`, not a database.

2. **Sequence — `POST /v1/responses`**  
   Auth → load blueprint from `model` → persist a queued record → spawn worker → 200 if the wait window hits completion, else 202. Poll via `GET /v1/responses/{id}`. Chat `background:true` reuses the same worker (`ChatCompletionsView._handle_background_chat`).

3. **Gantt — real git history**  
   Dates from tags and the commits that added each surface. The changelog `0.1.0` / 2024-01-01 row is not a tag and is omitted. A date table sits under the chart so the real dates stay readable if the gantt axis compresses.

## Constraints

- Docs only (`README.md`). No systemd, Neon, or runtime config changes.
- GitHub Mermaid rules: no HTML in labels, no markdown links in nodes, short plain labels, real dates only.
- No secrets.

## Verification

All three diagrams render with `@mermaid-js/mermaid-cli` 11.4.0. Static scan: no HTML tags and no markdown links inside the mermaid fences.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f0cf7a2-da7e-4772-9d64-0cbc8ea9d811?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f0cf7a2-da7e-4772-9d64-0cbc8ea9d811&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

