### PR TITLE
fix(config): load secrets from XDG ~/.config/swarm/.env first

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -3,14 +3,18 @@
 import os
 import sys
 from pathlib import Path
-from dotenv import load_dotenv
 
 def main():
     # Define the base directory
     BASE_DIR = Path(__file__).resolve().parent
 
-    # Load environment variables from .env file
-    load_dotenv(dotenv_path=BASE_DIR / '.env')
+    # XDG ~/.config/swarm/.env (primary) + checkout .env (fallback)
+    try:
+        from swarm.utils.dotenv_load import load_swarm_dotenv
+        load_swarm_dotenv(project_root=BASE_DIR)
+    except Exception:
+        from dotenv import load_dotenv
+        load_dotenv(dotenv_path=BASE_DIR / '.env')
 
     """Run administrative tasks."""
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'swarm.settings')

--- a/src/manage.py
+++ b/src/manage.py
@@ -4,15 +4,18 @@ import os
 import sys
 from pathlib import Path
 
-from dotenv import load_dotenv
-
-
 def main():
     # Define the base directory
     base_dir = Path(__file__).resolve().parent
 
-    # Load environment variables from .env file
-    load_dotenv(dotenv_path=base_dir / '.env')
+    # XDG ~/.config/swarm/.env (primary) + checkout .env (fallback)
+    try:
+        # src/manage.py → project root is parent of src/
+        from swarm.utils.dotenv_load import load_swarm_dotenv
+        load_swarm_dotenv(project_root=base_dir.parent)
+    except Exception:
+        from dotenv import load_dotenv
+        load_dotenv(dotenv_path=base_dir.parent / '.env')
 
     """Run administrative tasks."""
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'swarm.settings')

--- a/src/swarm/core/config_loader.py
+++ b/src/swarm/core/config_loader.py
@@ -4,8 +4,6 @@ import os
 from pathlib import Path
 from typing import Any
 
-from dotenv import load_dotenv
-
 from .paths import (  # Import XDG path functions
     get_project_root_dir,
     get_swarm_config_file,
@@ -212,19 +210,22 @@ def create_default_config(config_path: Path):
         raise
 
 def load_environment():
-    """Loads environment variables from a `.env` file located at the project root."""
-    project_root = get_project_root_dir() # Use XDG utility to find project root
-    dotenv_path = project_root / ".env"
-    logger.debug(f"Checking for .env file at: {dotenv_path}")
+    """Load XDG ``~/.config/swarm/.env`` (primary) then project-root ``.env``."""
+    from swarm.utils.dotenv_load import load_swarm_dotenv
+
+    project_root = get_project_root_dir()
     try:
-        if dotenv_path.is_file():
-            loaded = load_dotenv(dotenv_path=dotenv_path, override=True)
-            if loaded:
-                logger.debug(f".env file Loaded/Overridden at: {dotenv_path}")
+        loaded = load_swarm_dotenv(project_root=project_root)
+        if loaded:
+            logger.debug("dotenv loaded from: %s", ", ".join(loaded))
         else:
-            logger.debug(f"No .env file found at {dotenv_path}.")
+            logger.debug("No dotenv files found (XDG or project root).")
     except Exception as e:
-        logger.error(f"Error loading .env file '{dotenv_path}': {e}", exc_info=logger.level <= logging.DEBUG)
+        logger.error(
+            "Error loading dotenv files: %s",
+            e,
+            exc_info=logger.level <= logging.DEBUG,
+        )
 
 def load_full_configuration(
     blueprint_class_name: str,

--- a/src/swarm/management/commands/runserver.py
+++ b/src/swarm/management/commands/runserver.py
@@ -4,25 +4,17 @@ from pathlib import Path
 from django.conf import settings
 from django.core.management.base import CommandError
 from django.core.management.commands.runserver import Command as RunserverCommand
-from dotenv import load_dotenv
 
+from swarm.utils.dotenv_load import load_swarm_dotenv
 from swarm.utils.env_utils import (
     get_api_auth_token,
     get_api_auth_tokens,
     is_django_debug,
 )
 
-# Load .env from project root relative to this file's location
-BASE_DIR = Path(__file__).resolve().parent.parent.parent.parent.parent
-# Check if .env exists before trying to load
-dotenv_path = BASE_DIR / '.env'
-if dotenv_path.is_file():
-    load_dotenv(dotenv_path=dotenv_path)
-else:
-    # Optionally log if .env is missing, but don't require it
-    # logger = logging.getLogger(__name__) # Get logger if needed here
-    # logger.debug(".env file not found in project root, relying solely on environment variables.")
-    pass
+# Project root: …/management/commands → parents[4] == repo root when under src/swarm/
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+load_swarm_dotenv(project_root=_PROJECT_ROOT)
 
 
 logger = logging.getLogger(__name__) # Get logger for command messages

--- a/src/swarm/settings.py
+++ b/src/swarm/settings.py
@@ -6,15 +6,13 @@ import os
 import sys
 from pathlib import Path
 
-from dotenv import load_dotenv
-
 BASE_DIR = Path(__file__).resolve().parent.parent # Points to src/
 
 from swarm.utils.env_utils import *
+from swarm.utils.dotenv_load import load_swarm_dotenv
 
-# --- Load .env file ---
-dotenv_path = BASE_DIR.parent / '.env'
-load_dotenv(dotenv_path=dotenv_path)
+# --- Load .env: XDG ~/.config/swarm/.env (primary) + project .env (fallback) ---
+load_swarm_dotenv(project_root=BASE_DIR.parent)
 # ---
 
 # Secure-by-default: DJANGO_DEBUG defaults to False, and production

--- a/src/swarm/utils/dotenv_load.py
+++ b/src/swarm/utils/dotenv_load.py
@@ -1,0 +1,58 @@
+"""Unified dotenv loading for Open Swarm.
+
+Precedence:
+  1. Process env already set at call time (systemd ``Environment=`` /
+     ``EnvironmentFile=``, shell exports) — never overwritten.
+  2. ``~/.config/swarm/.env`` (or ``$XDG_CONFIG_HOME/swarm/.env``) — primary
+     operator secrets; wins over project checkout ``.env``.
+  3. Project-root ``.env`` — dev fallback for keys not in (1) or (2).
+
+Call ``load_swarm_dotenv()`` early from manage.py, settings, wsgi, and CLI.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dotenv import dotenv_values, load_dotenv
+
+
+def xdg_swarm_env_path() -> Path:
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".config"
+    return base / "swarm" / ".env"
+
+
+def project_env_path(project_root: Path | None = None) -> Path:
+    if project_root is not None:
+        return Path(project_root) / ".env"
+    here = Path(__file__).resolve()
+    # src/swarm/utils/dotenv_load.py → parents[3] == repo root
+    return here.parents[3] / ".env"
+
+
+def load_swarm_dotenv(project_root: Path | None = None) -> list[str]:
+    """Load project then XDG dotenv with unit/shell env winning.
+
+    Returns a list of human-readable status strings for diagnostics.
+    """
+    loaded: list[str] = []
+    preexisting = set(os.environ.keys())
+
+    proj = project_env_path(project_root)
+    if proj.is_file():
+        load_dotenv(dotenv_path=proj, override=False)
+        loaded.append(str(proj.resolve()))
+
+    xdg = xdg_swarm_env_path()
+    if xdg.is_file():
+        applied = 0
+        for key, value in (dotenv_values(xdg) or {}).items():
+            if value is None or key in preexisting:
+                continue
+            # XDG wins over project-only keys; never stomps unit/shell.
+            os.environ[key] = value
+            applied += 1
+        loaded.append(f"{xdg.resolve()} (+{applied} keys)")
+
+    return loaded

--- a/src/swarm/wsgi.py
+++ b/src/swarm/wsgi.py
@@ -4,13 +4,14 @@ import os
 from pathlib import Path
 
 from django.core.wsgi import get_wsgi_application
-from dotenv import load_dotenv
 
-# Define the base directory
+# Define the base directory (src/)
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-# Load environment variables from .env file
-load_dotenv(dotenv_path=BASE_DIR / '.env')
+# XDG ~/.config/swarm/.env (primary) + project .env (fallback)
+from swarm.utils.dotenv_load import load_swarm_dotenv
+
+load_swarm_dotenv(project_root=BASE_DIR.parent)
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'swarm.settings')
 

--- a/tests/core/test_config_loader.py
+++ b/tests/core/test_config_loader.py
@@ -97,7 +97,9 @@ class TestLoadEnvironment:
                 f.write(env_content)
 
             with patch('src.swarm.core.config_loader.get_project_root_dir', return_value=temp_path):
-                with patch.dict(os.environ, {}, clear=True):
+                xdg = temp_path / "xdg"
+                xdg.mkdir()
+                with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(xdg)}, clear=True):
                     load_environment()
 
                     # Should have loaded the variables
@@ -106,9 +108,13 @@ class TestLoadEnvironment:
 
     def test_load_environment_no_dotenv_file(self):
         """Test loading environment when no .env file exists."""
-        with patch('src.swarm.core.config_loader.get_project_root_dir', return_value=Path('/nonexistent')):
-            # Should not raise an exception
-            load_environment()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            xdg = Path(temp_dir) / "xdg"
+            xdg.mkdir()
+            with patch('src.swarm.core.config_loader.get_project_root_dir', return_value=Path('/nonexistent')):
+                with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(xdg)}, clear=False):
+                    # Should not raise an exception
+                    load_environment()
 
     def test_load_environment_invalid_dotenv_file(self):
         """Test loading environment with invalid .env file."""
@@ -118,8 +124,13 @@ class TestLoadEnvironment:
 
         try:
             with patch('src.swarm.core.config_loader.get_project_root_dir', return_value=dotenv_path.parent):
-                # Should handle invalid lines gracefully
-                load_environment()
+                with patch.dict(
+                    os.environ,
+                    {"XDG_CONFIG_HOME": str(dotenv_path.parent / "xdg-empty")},
+                    clear=False,
+                ):
+                    # Should handle invalid lines gracefully
+                    load_environment()
         finally:
             os.unlink(dotenv_path)
 

--- a/tests/utils/test_dotenv_load.py
+++ b/tests/utils/test_dotenv_load.py
@@ -1,0 +1,52 @@
+"""XDG-first dotenv loading (unit/shell env wins, then XDG, then checkout)."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from swarm.utils.dotenv_load import load_swarm_dotenv, xdg_swarm_env_path
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def test_xdg_wins_over_project_env(tmp_path: Path):
+    project = tmp_path / "project"
+    xdg = tmp_path / "xdg"
+    _write(project / ".env", "SHARED=from-project\nONLY_PROJECT=p\n")
+    _write(xdg / "swarm" / ".env", "SHARED=from-xdg\nONLY_XDG=x\n")
+
+    with patch.dict(
+        os.environ,
+        {"XDG_CONFIG_HOME": str(xdg), "PREEXISTING": "keep-me"},
+        clear=True,
+    ):
+        loaded = load_swarm_dotenv(project_root=project)
+        assert os.environ["PREEXISTING"] == "keep-me"
+        assert os.environ["SHARED"] == "from-xdg"
+        assert os.environ["ONLY_PROJECT"] == "p"
+        assert os.environ["ONLY_XDG"] == "x"
+        assert any("swarm" in item and "+2 keys" in item for item in loaded)
+
+
+def test_process_env_not_overwritten_by_xdg(tmp_path: Path):
+    project = tmp_path / "project"
+    xdg = tmp_path / "xdg"
+    _write(project / ".env", "TOKEN=from-project\n")
+    _write(xdg / "swarm" / ".env", "TOKEN=from-xdg\n")
+
+    with patch.dict(
+        os.environ,
+        {"XDG_CONFIG_HOME": str(xdg), "TOKEN": "from-systemd"},
+        clear=True,
+    ):
+        load_swarm_dotenv(project_root=project)
+        assert os.environ["TOKEN"] == "from-systemd"
+
+
+def test_xdg_swarm_env_path_uses_xdg_config_home(tmp_path: Path):
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path)}, clear=False):
+        assert xdg_swarm_env_path() == tmp_path / "swarm" / ".env"


### PR DESCRIPTION
## What
Load operator secrets from `~/.config/swarm/.env` (or `$XDG_CONFIG_HOME/swarm/.env`) **before** the checkout `.env`, and never overwrite process env already set by systemd/`EnvironmentFile=`/shell.

## Why
This host (and the oracle unit) keeps secrets in XDG. Several entry points only called `load_dotenv(project/.env)`, and `config_loader.load_environment()` used `override=True`, so checkout `.env` could clobber the unit token and LiteLLM master key.

## How
New `swarm.utils.dotenv_load.load_swarm_dotenv()`:

1. process env (untouched)
2. XDG `.env` (wins over checkout-only keys)
3. project-root `.env` (dev fallback)

Wired from `manage.py`, `src/manage.py`, `settings.py`, `wsgi.py`, `runserver`, and `load_environment()`.

## Tests
- `tests/utils/test_dotenv_load.py` — XDG vs project vs systemd precedence
- `tests/core/test_config_loader.py::TestLoadEnvironment` — hermetic `XDG_CONFIG_HOME`

Independent of the LiteLLM client PR.