### PR TITLE
fix: honor LiteLLM proxy and master key in OpenAI clients

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -7,7 +7,9 @@ app = 'open-swarm'
 primary_region = 'syd'
 
 [build]
-  image = 'mhand79/open-swarm'
+  # Build from local Dockerfile so LiteLLM base_url / master-key client fixes ship.
+  # (Previously pinned to prebuilt mhand79/open-swarm:latest which lagged the repo.)
+  dockerfile = 'Dockerfile'
 
 [env]
   PORT = '8000'

--- a/src/swarm/blueprints/geese/blueprint_geese.py
+++ b/src/swarm/blueprints/geese/blueprint_geese.py
@@ -129,9 +129,10 @@ class GeeseBlueprint(BlueprintBase):
         agent_assignments = kwargs.pop("agent_mcp_assignments", {})
         super().__init__(blueprint_id, config=config, **kwargs)
         from agents import Agent
-        # --- Setup OpenAI LLM Model ---
-        openai_api_key = os.environ.get("OPENAI_API_KEY")
-        openai_client = AsyncOpenAI(api_key=openai_api_key) if openai_api_key else None
+        # --- Setup OpenAI / LiteLLM model ---
+        from swarm.utils.env_utils import openai_client_kwargs
+        client_kwargs = openai_client_kwargs()
+        openai_client = AsyncOpenAI(**client_kwargs) if client_kwargs.get("api_key") else None
         llm_model_name = kwargs.get("llm_model", "o4-mini")
         llm_model = OpenAIChatCompletionsModel(model=llm_model_name, openai_client=openai_client)
         # --- Create Agent instances and corresponding Tools ---

--- a/src/swarm/blueprints/suggestion/blueprint_suggestion.py
+++ b/src/swarm/blueprints/suggestion/blueprint_suggestion.py
@@ -285,12 +285,15 @@ class SuggestionBlueprint(BlueprintBase):
             import os
 
             from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
-            api_key = os.environ.get("OPENAI_API_KEY")
-            if not api_key:
-                raise ValueError("No OPENAI_API_KEY found and config not loaded")
-            logger.warning(f"Config not available, using fallback OpenAI model for {profile_name}")
+            from swarm.utils.env_utils import openai_client_kwargs
+            client_kwargs = openai_client_kwargs()
+            if not client_kwargs.get("api_key"):
+                raise ValueError("No OPENAI_API_KEY / LITELLM_* key found and config not loaded")
+            logger.warning(
+                f"Config not available, using fallback OpenAI/LiteLLM model for {profile_name}"
+            )
             from openai import AsyncOpenAI
-            client = AsyncOpenAI(api_key=api_key)
+            client = AsyncOpenAI(**client_kwargs)
             model_instance = OpenAIChatCompletionsModel(model="gpt-4o-mini", openai_client=client)
             self._model_instance_cache[profile_name] = model_instance
             return model_instance

--- a/src/swarm/blueprints/zeus/blueprint_zeus.py
+++ b/src/swarm/blueprints/zeus/blueprint_zeus.py
@@ -189,9 +189,9 @@ class ZeusCoordinatorBlueprint(BlueprintBase):
         from agents import Agent
         from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
         from openai import AsyncOpenAI
+        from swarm.utils.env_utils import openai_client_kwargs
         model_name = (self.config.get('llm_profile', 'default') if hasattr(self, 'config') and self.config else 'default')
-        api_key = os.environ.get('OPENAI_API_KEY', 'sk-test')
-        openai_client = AsyncOpenAI(api_key=api_key)
+        openai_client = AsyncOpenAI(**openai_client_kwargs())
         model_instance = OpenAIChatCompletionsModel(model=model_name, openai_client=openai_client)
 
         pantheon_names = [

--- a/src/swarm/consumers.py
+++ b/src/swarm/consumers.py
@@ -268,16 +268,15 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
             _self_mod.AsyncOpenAI = _cls
 
         # Mirror blueprint_base.configure_openai_client_from_env / LITELLM_* patterns.
-        base_url = os.environ.get("LITELLM_BASE_URL") or os.environ.get("OPENAI_BASE_URL")
-        api_key = os.environ.get("LITELLM_API_KEY") or os.environ.get("OPENAI_API_KEY")
+        from swarm.utils.env_utils import get_llm_base_url, openai_client_kwargs
+
+        base_url = get_llm_base_url()
+        client_kwargs = openai_client_kwargs()
         model = (
             os.environ.get("LITELLM_MODEL")
             or os.environ.get("OPENAI_MODEL")
             or os.environ.get("DEFAULT_LLM")
         )
-        client_kwargs = {"api_key": api_key}
-        if base_url:
-            client_kwargs["base_url"] = base_url
         client = _cls(**client_kwargs)
 
         if base_url:
@@ -290,7 +289,7 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
 
         def _enforce_litellm_only(client):
             """Reject openai.com fallback when a custom LiteLLM gateway is configured."""
-            expected = os.environ.get("LITELLM_BASE_URL") or os.environ.get("OPENAI_BASE_URL")
+            expected = get_llm_base_url()
             if not expected:
                 return
             actual = str(getattr(client, "base_url", "") or "")

--- a/src/swarm/core/blueprint_base.py
+++ b/src/swarm/core/blueprint_base.py
@@ -125,18 +125,30 @@ def configure_openai_client_from_env():
     """
     Framework-level function: Always instantiate and set the default OpenAI client.
     Prints out the config being used for debug.
+
+    Uses LiteLLM proxy when ``LITELLM_BASE_URL`` / ``OPENAI_BASE_URL`` is set
+    (required for load balancing + accounting).
     """
-    import os
-    base_url = os.environ.get("LITELLM_BASE_URL") or os.environ.get("OPENAI_BASE_URL")
-    api_key = os.environ.get("LITELLM_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    from swarm.utils.env_utils import get_llm_base_url, openai_client_kwargs
+
+    kwargs = openai_client_kwargs()
+    base_url = kwargs.get("base_url") or get_llm_base_url()
+    api_key = kwargs.get("api_key")
     if _should_debug():
-        _debug_print(f"[DEBUG] Using OpenAI client config: base_url={base_url}, api_key={'set' if api_key else 'NOT SET'}")
+        _debug_print(
+            f"[DEBUG] Using OpenAI client config: base_url={base_url}, api_key={'set' if api_key else 'NOT SET'}"
+        )
     if base_url and api_key:
-        client = AsyncOpenAI(base_url=base_url, api_key=api_key)
+        client = AsyncOpenAI(**kwargs)
         set_default_openai_client(client)
-        _framework_print(f"[FRAMEWORK] Set default OpenAI client: base_url={base_url}, api_key={'set' if api_key else 'NOT SET'}")
+        _framework_print(
+            f"[FRAMEWORK] Set default OpenAI client: base_url={base_url}, api_key={'set' if api_key else 'NOT SET'}"
+        )
     else:
-        _framework_print("[FRAMEWORK] WARNING: base_url or api_key missing, OpenAI client not set!")
+        _framework_print(
+            "[FRAMEWORK] WARNING: base_url or api_key missing, OpenAI client not set! "
+            "Set OPENAI_BASE_URL/LITELLM_BASE_URL to the LiteLLM proxy."
+        )
 
 configure_openai_client_from_env()
 

--- a/src/swarm/utils/env_utils.py
+++ b/src/swarm/utils/env_utils.py
@@ -205,6 +205,36 @@ def get_litellm_base_url() -> str | None:
     return os.getenv('LITELLM_BASE_URL')
 
 
+def get_llm_base_url() -> str | None:
+    """Prefer LiteLLM proxy URL, then OPENAI_BASE_URL."""
+    return get_litellm_base_url() or get_openai_base_url()
+
+
+def get_llm_api_key() -> str | None:
+    """Client key for the proxy (master key), then a raw OpenAI key."""
+    return (
+        os.getenv("LITELLM_API_KEY")
+        or os.getenv("LITELLM_MASTER_KEY")
+        or os.getenv("OPENAI_API_KEY")
+    )
+
+
+def openai_client_kwargs() -> dict:
+    """Kwargs for ``AsyncOpenAI`` / ``OpenAI`` that honor the LiteLLM proxy.
+
+    Clients must send the master key to ``LITELLM_BASE_URL`` /
+    ``OPENAI_BASE_URL``. Raw ``sk-proj-`` keys belong only on the proxy.
+    """
+    kwargs: dict = {}
+    api_key = get_llm_api_key()
+    base_url = get_llm_base_url()
+    if api_key:
+        kwargs["api_key"] = api_key
+    if base_url:
+        kwargs["base_url"] = base_url
+    return kwargs
+
+
 def get_default_llm() -> str | None:
     """Get default LLM."""
     return os.getenv('DEFAULT_LLM')

--- a/tests/utils/test_env_utils.py
+++ b/tests/utils/test_env_utils.py
@@ -10,9 +10,12 @@ from swarm.utils.env_utils import (
     get_django_allowed_hosts,
     get_django_csrf_trusted_origins,
     get_django_secret_key,
+    get_llm_api_key,
+    get_llm_base_url,
     get_swarm_config_path,
     get_swarm_log_level,
     is_truthy,
+    openai_client_kwargs,
 )
 
 
@@ -135,3 +138,39 @@ def test_build_mcp_stdio_env_empty_server_env_is_essentials_only():
         env = build_mcp_stdio_env(None)
     assert env == {"PATH": "/bin"}
     assert "OPENAI_API_KEY" not in env
+
+
+def test_openai_client_kwargs_prefers_litellm_proxy():
+    env = {
+        "LITELLM_BASE_URL": "https://open-litellm.example/v1",
+        "LITELLM_MASTER_KEY": "sk-master",
+        "OPENAI_API_KEY": "sk-proj-raw",
+        "OPENAI_BASE_URL": "https://api.openai.com/v1",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        assert get_llm_base_url() == "https://open-litellm.example/v1"
+        assert get_llm_api_key() == "sk-master"
+        assert openai_client_kwargs() == {
+            "api_key": "sk-master",
+            "base_url": "https://open-litellm.example/v1",
+        }
+
+
+def test_openai_client_kwargs_litellm_api_key_beats_master_key():
+    env = {
+        "LITELLM_API_KEY": "sk-litellm",
+        "LITELLM_MASTER_KEY": "sk-master",
+        "LITELLM_BASE_URL": "http://127.0.0.1:4000/v1",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        assert openai_client_kwargs() == {
+            "api_key": "sk-litellm",
+            "base_url": "http://127.0.0.1:4000/v1",
+        }
+
+
+def test_openai_client_kwargs_empty_when_unset():
+    with patch.dict(os.environ, {}, clear=True):
+        assert openai_client_kwargs() == {}
+        assert get_llm_api_key() is None
+        assert get_llm_base_url() is None


### PR DESCRIPTION
## What
Stop constructing `AsyncOpenAI(api_key=OPENAI_API_KEY)` with no `base_url`. Clients should talk to `LITELLM_BASE_URL` with `LITELLM_API_KEY` / `LITELLM_MASTER_KEY`.

## Why
Geese, Zeus, suggestion fallback, and a few other paths ignored the proxy and sent a raw project key to `api.openai.com`. Accounting and load-balancing on LiteLLM never saw that traffic. `fly.toml` was also pinned to a lagging prebuilt image, so even the framework-level proxy client would not ship.

## How
- `openai_client_kwargs()` / `get_llm_api_key()` / `get_llm_base_url()` in `env_utils`
- used from `configure_openai_client_from_env`, websocket `respond_with_default_model`, geese, suggestion, zeus
- `fly.toml` builds from the local `Dockerfile`

Existing `TestRespondWithDefaultModelLiteLLM` still passes.

Independent of the XDG dotenv PR.