### PR TITLE
fix(cursor): named swarm-api port for Cloud Agents

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -9,5 +9,10 @@
       "command": "export PATH=\"$HOME/.local/bin:$PATH\" && DJANGO_DEBUG=true ENABLE_WEBUI=true DJANGO_DB_NAME=/tmp/db.sqlite3 HOST=0.0.0.0 PORT=8000 uv run swarm-api --port 8000 --reload"
     }
   ],
-  "ports": [8000]
+  "ports": [
+    {
+      "name": "swarm-api",
+      "port": 8000
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Change `.cursor/environment.json` `ports` from `[8000]` to `[{"name": "swarm-api", "port": 8000}]` so Cloud Agents can launch from main.