### PR TITLE
docs: file open-swarm REQ backlog under docs/requirements

### DIFF
--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -1,0 +1,62 @@
+# Open Swarm REQ backlog
+
+> **This is docs-only.** These pages transcribe the tracked REQ backlog. They
+> do not implement features, do not enable Neon, and do not resume oracle.
+
+One markdown file per REQ (REQ-18/25 is one combined page). Do not invent
+extra REQs here — only items already tracked in the product chat.
+
+## Template
+
+Every REQ page uses this shape:
+
+| Section | What it holds |
+|---|---|
+| **Status** | PR number / merged / in flight |
+| **Intent** | Why this exists |
+| **Success** | What “done” looks like |
+| **Constraints** | What must not happen |
+| **Owner** | Who does what |
+
+## Owner (same on every REQ)
+
+- **CoS** transcribes
+- **cloud** implements
+- **engineer** GitHub-merge after skeptic
+- **live preview** `10.0.0.30:8001` — guest dirty only
+
+## Honesty (read before acting)
+
+| Claim | Reality on this starting tree (`91dabd64`) |
+|---|---|
+| Teams | **Live today are LLM-profile aliases** (`/teams/` + `/v1/teams` + `teams.json`). Not a multi-agent roster. Intended composition is a later REQ. |
+| Grok-Bot chrome | **Not on `:8001` yet.** REQ-5 dark chrome ≠ the left-rail Bot product (REQ-16). |
+| Neon / oracle | **Off.** Do not enable Neon. Do not resume oracle. |
+
+In-flight PRs sit on their own branches. This tree does not include their code.
+
+## Index
+
+| REQ | Title | Status |
+|---|---|---|
+| [REQ-7](./REQ-7.md) | Support agent (pill, threads, question cards) | PR 313 — in flight |
+| [REQ-8](./REQ-8.md) | UX tighten (theme icon, unlabeled dropdowns, toast, hide popup) | PR 312 — in flight |
+| [REQ-9](./REQ-9.md) | gate + skeptic roles as-tool | PR 314 — in flight |
+| [REQ-10](./REQ-10.md) | Favourites tile grid (left rail, not top chrome) | PR 311 — in flight (wrong place) |
+| [REQ-11](./REQ-11.md) | Remotes Hermes / OMB / Rakazo | PR 318 — in flight |
+| [REQ-12](./REQ-12.md) | Harness-of-harnesses docs | PR 315 — in flight |
+| [REQ-13](./REQ-13.md) | Mock inference fast + >60s | PR 317 — in flight |
+| [REQ-14](./REQ-14.md) | Chat JSON persist + Settings retention | PR 319 **merged** `4d554ea5` |
+| [REQ-15](./REQ-15.md) | CLI dropdown lists CLIs | PR 316 — in flight |
+| [REQ-16](./REQ-16.md) | Grok-Bot left rail chrome | PR 322 — in flight |
+| [REQ-17](./REQ-17.md) | Search command palette | inside PR 322 — in flight |
+| [REQ-18/25](./REQ-18-25.md) | Support Socratic+MCQ (into 313); hover-edit role → blueprint Python | absorbed / in flight |
+| [REQ-19](./REQ-19.md) | DaisyUI settings sheet `modal-end` + Menu + Join | PR 320 — in flight |
+| [REQ-20](./REQ-20.md) | Teams composition roster DnD (not LLM aliases) | PR 323 — in flight |
+| [REQ-21](./REQ-21.md) | Herdr client localhost default + optional `--remote` | in flight |
+| [REQ-23](./REQ-23.md) | Teams in sidepane + send-to-all dropdown | in flight |
+| [REQ-24](./REQ-24.md) | Drag any agent incl. roles into Hidden drop zone | in flight |
+| [REQ-26](./REQ-26.md) | First load hide gate and skeptic | in flight |
+
+REQ-22 (debt audits) and earlier REQ-5 / REQ-6 chrome/avatar work are **not**
+filed here — they were not in this backlog slice.

--- a/docs/requirements/REQ-10.md
+++ b/docs/requirements/REQ-10.md
@@ -1,0 +1,30 @@
+# REQ-10 — Favourites tile grid (left rail, not top chrome)
+
+**Status:** PR [311](https://github.com/matthewhand/open-swarm/pull/311) — in flight (**wrong place**)
+
+## Intent
+
+An unlabeled favourite / pin **tile grid** so operators can keep a short set of
+agents one click away. Pin is a copy, not a move.
+
+## Success
+
+- Unlabeled compact tiles. No “Favourites” heading. No hide-all.
+- Drag an AGENTS row onto the grid → tile. Persist `localStorage.swarm_pinned_agents`. Duplicate drops are no-ops. Remove control on each tile.
+- Clicking a tile opens that agent’s chat (`/chat?blueprint=<id>`).
+- **Placement:** left rail, under Search (see REQ-16). Native HTML5 drag. No `@dnd-kit`.
+
+## Constraints
+
+- **PR 311 put the grid in top chrome.** That is the wrong place. Do not land 311 as the product location.
+- Correct home is the Grok-Bot **left rail** (PR 322 / REQ-16). Treat 311 as a misplaced attempt, not the target layout.
+- Sidepane list stays unchanged — pin is a shortcut.
+- No Neon. No oracle. Docs-only on this PR — do not implement here.
+- Grok chrome is **not on `:8001` yet**.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-11.md
+++ b/docs/requirements/REQ-11.md
@@ -1,0 +1,34 @@
+# REQ-11 — Remotes Hermes / OMB / Rakazo
+
+**Status:** PR [318](https://github.com/matthewhand/open-swarm/pull/318) — in flight
+
+## Intent
+
+Open Swarm as a harness **for** Hermes, OpenMausBot (OMB), and Rakazo. Those
+remotes are Team *members* you place into a roster so they can see and talk via
+openai-agents handoff / `as_tool`.
+
+## Success
+
+| Remote | Host | Default | Auth |
+|---|---|---|---|
+| hermes | ubuntu-gtx | `http://10.0.0.36:8642` (UI `:9119` is chrome, not the operate API) | `HERMES_API_KEY` |
+| omb | Windows2 | `http://10.0.0.32:8802` | `OMB_API_KEY` |
+| rakazo | Windows2 | API `http://10.0.0.32:3100`, UI `:5173` | `RAKAZO_API_KEY` and/or session cookie |
+
+- `swarm-cli remotes` set / place / unplace / health. REST `/v1/remotes/<id>/` + `/v1/agent-team/`.
+- Health is one TCP + one HTTP, no retries, no crash-loop. DOWN is a report. 401/403 on a live port is UP.
+- Persist refuses Fly open-litellm URLs. LAN LLM for *this* swarm: `http://10.0.0.30:8000/v1`.
+
+## Constraints
+
+- This is **not** Django `/teams/` + `/v1/teams/` (those are **LLM-profile aliases** — live today). Prefer **Profiles** in new copy. URLs stay `/teams/` (documented collision).
+- Do not claim remotes work on this starting tree. Chat has no Remote selector here.
+- No Neon. No oracle. Docs-only on this PR — do not implement here.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-12.md
+++ b/docs/requirements/REQ-12.md
@@ -1,0 +1,37 @@
+# REQ-12 — Harness-of-harnesses docs
+
+**Status:** PR [315](https://github.com/matthewhand/open-swarm/pull/315) — in flight
+
+## Intent
+
+Direction write: Open Swarm is turning from *an* agent harness into a
+**harness for other harnesses** (Hermes, OMB, Rakazo). Composition is
+openai-agents **handoff / `as_tool`**, not extra concurrent Grok / Rakazo / OMB
+seats.
+
+## Success
+
+Honesty table lands in VISION / GLOSSARY / README pointers:
+
+| Surface | Honesty |
+|---|---|
+| Running today | API, blueprints, CLI fusion / MoA, Django + SPA `/` + `/chat`, REQ-5 dark chrome |
+| **Teams** | **Live:** LLM-profile alias registry. **Intended:** wire API / CLI / remote so they can see and talk. Admin does not do inter-agent talk. |
+| Grok-Bot-like UI | **Not live.** Dark chrome ≠ Bot product. Not on `:8001` yet. |
+| Support / gate / skeptic | In flight (not on `main` / this starting tree). |
+| Remotes (REQ-11) | Not landed. Do not claim remotes work. |
+
+Differentiator: coordinator invokes another harness as a tool / handoff.
+
+## Constraints
+
+- Docs only (this REQ and this filing PR). Not the generic audit in #297.
+- Does not enable Neon / oracle.
+- Does not implement remotes, Support, gate, skeptic, or the intended Team graph.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-13.md
+++ b/docs/requirements/REQ-13.md
@@ -1,0 +1,28 @@
+# REQ-13 — Mock inference fast + >60s
+
+**Status:** PR [317](https://github.com/matthewhand/open-swarm/pull/317) — in flight
+
+## Intent
+
+TDD for the SPA chat **Send** path with **MOCK inference** — prove both a fast
+reply and a >60s reply without live LiteLLM / Qwen / Fly.
+
+## Success
+
+1. User types a message, clicks **Send**, the conversation log shows a canned assistant reply.
+2. **FAST** mock: reply well under 60s (wall clock from Send, e.g. under 2s).
+3. **SLOW** mock: assistant frames scheduled at **61s**. Playwright `page.clock` fast-forwards — still no reply at 59s, reply appears after +2s. No false timeout, no stuck Send, no silent drop.
+4. Tests fail if mock strings never render.
+
+## Constraints
+
+- No live LiteLLM / Qwen / Fly. No oracle / Neon. No Grok-Bot chrome. No Hide-all.
+- After REQ-8 (PR 312) removes standing Connected, FAST/SLOW waits must target composer-ready / enabled Send / conversation log — **not** a Connected badge. Do not reintroduce Connected.
+- Docs-only on this PR — do not implement here.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-14.md
+++ b/docs/requirements/REQ-14.md
@@ -1,0 +1,29 @@
+# REQ-14 — Chat JSON persist + Settings retention
+
+**Status:** PR [319](https://github.com/matthewhand/open-swarm/pull/319) **merged** `4d554ea5`
+
+## Intent
+
+Each agent chat thread persists so switching agents or reloading Chat restores
+that agent’s context. Retention lives on **Settings only** — not in Grok-Bot
+Chat chrome.
+
+## Success
+
+- Source of truth is **JSON on disk** (`$SWARM_CHAT_DIR/active/<user>/<agent>.json`; trash beside it). Django DB remains a consumer mirror.
+- Reload / agent switch restores that agent’s thread. Default max age **90** days (`SWARM_CHAT_MAX_AGE_DAYS`); `0` disables auto-archive. Auto-archive moves to trash; empty trash is a **manual** Settings action.
+- Settings-only: counts, disk use, per-chat Move to trash / Restore, Move all / Empty trash.
+- Chat chrome unchanged aside from silent restore — no history sidebar, no archive/delete controls in chat.
+
+## Constraints
+
+- Not markdown session logs (`SessionLogger` stays unused by SPA Chat).
+- Grok chrome is **not on `:8001` yet** — do not put retention UI there.
+- No Neon. No oracle. **This filing PR is docs-only** (319 already merged; do not re-implement).
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-15.md
+++ b/docs/requirements/REQ-15.md
@@ -1,0 +1,29 @@
+# REQ-15 — CLI dropdown lists CLIs
+
+**Status:** PR [316](https://github.com/matthewhand/open-swarm/pull/316) — in flight
+
+## Intent
+
+When the selected agent / mode is a CLI agent, the Chat dropdown must list
+**available CLIs**, not the full blueprint catalog. (Grok CLI can already
+answer; the dropdown still listed blueprints.)
+
+## Success
+
+- CLI-agent context: selected / `?blueprint=` is `cli_agent` or any `cli_*` slug, or `?mode=cli` / `?cli=<name>`.
+- Dropdown prefers host-exposed CLIs (`installed` ∪ `configured` from `GET /v1/cli-agents/`), then falls back to the static catalog.
+- Selecting a CLI sends `{"message", "blueprint": "cli_agent", "params": {"cli": "grok"}}` (or the chosen name). Consumer forwards `params`.
+- In CLI context the dropdown is **unlabeled** (REQ-8) and ends with **Manage Cli** → `/settings/`. Blueprint-mode chats still list `/v1/blueprints`.
+
+## Constraints
+
+- Not piled onto 313. Not a Grok-Bot chrome rewrite.
+- Builder SPA stays deleted (ADR-001).
+- No Neon. No oracle. Docs-only on this PR — do not implement here.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-16.md
+++ b/docs/requirements/REQ-16.md
@@ -1,0 +1,29 @@
+# REQ-16 — Grok-Bot left rail chrome
+
+**Status:** PR [322](https://github.com/matthewhand/open-swarm/pull/322) — in flight
+
+## Intent
+
+Grok-Bot **product chrome**: left rail + selected-agent main pane. Not piled
+onto PRs 309–315 (those are other layouts). Favourites live in the **left rail
+under Search**, not in top chrome like #311.
+
+## Success
+
+**Left rail (top → bottom):** Search (opens palette — REQ-17) → unlabeled favourite tile grid → conversation list with **Support first / highlighted** → Hidden via end-of-list `N hidden` popup (Unhide only, no Hide-all) → Plugins → editable hostname.
+
+**Main pane:** selected agent’s chat only. No Home / Chat / Blueprints / Teams / Settings top nav. Header = agent name + icon tools (theme is sun/moon, not Light). Composer pill: `[+] [ Message … ] [mic]`. `+` reaches Django Blueprints / Teams / Settings. Footer is laconic. Errors toast. No standing Connected. Switching agents opens a unique websocket thread.
+
+## Constraints
+
+- No `@dnd-kit`, no shadcn migration.
+- No `SWARM_ALLOW_ANONYMOUS` / guest auth. No oracle / Neon.
+- **Honesty:** Grok chrome is **not on `:8001` yet.** REQ-5 dark chrome ≠ this Bot product.
+- Docs-only on this filing PR — do not implement here.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-17.md
+++ b/docs/requirements/REQ-17.md
@@ -1,0 +1,30 @@
+# REQ-17 — Search command palette
+
+**Status:** inside PR [322](https://github.com/matthewhand/open-swarm/pull/322) — in flight
+
+## Intent
+
+Search in the left rail is a **command palette overlay**, not an in-place
+filter of the AGENTS dump.
+
+## Success
+
+- Focus/click Search opens a dark overlay with large rounded corners.
+- Magnifying glass + placeholder exactly `Search`.
+- Tabs: All (pill) · Messages · Bots · Groups · Files · Links · Routines · Actions.
+- Rows: icon + name + one-line desc + ⌃N. First row highlighted; arrows + Enter; Esc / click-outside close.
+- Does **not** filter the 50-row AGENTS list in place.
+
+## Constraints
+
+- Ships inside REQ-16 / PR 322 — do not open a separate Search PR.
+- Existing experimental `CommandPalette` is not the product unless 322 adopts it.
+- No Neon. No oracle. Grok chrome **not on `:8001` yet**.
+- Docs-only on this filing PR — do not implement here.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-18-25.md
+++ b/docs/requirements/REQ-18-25.md
@@ -1,0 +1,31 @@
+# REQ-18 / REQ-25 — Support Socratic+MCQ; hover-edit role → blueprint Python
+
+**Status:** REQ-18 **absorbed into PR 313** (REQ-7). REQ-25 hover-edit role → blueprint Python — in flight
+
+## Intent
+
+**REQ-18:** Support helps configure tools and prompts for *other* agents via
+Socratic, one-question-at-a-time **MCQ cards**. That UX is the question-card
+work already specified on REQ-7 — do not fork it.
+
+**REQ-25:** Hover-edit of an agent **role** writes through to the blueprint
+**Python** (role seat in source / `AGENT_SPECS`), not a cosmetic UI-only flag.
+
+## Success
+
+- REQ-18: ` ```question ` fences render question cards (MCQ chips + last open-string) in Support / any agent thread. Tracked and implemented on [313](https://github.com/matthewhand/open-swarm/pull/313). Close 18 as absorbed when 313 lands.
+- REQ-25: hovering a role (support / gate / skeptic / default) and changing it updates the blueprint Python that defines that seat. Reload / rediscovery shows the new role. Not a `localStorage`-only badge.
+
+## Constraints
+
+- Do not open a second Support Socratic PR. Do not invent extra Support chrome.
+- Role edit is a seat change (REQ-9), not another Grok / OMB / Rakazo worker.
+- Teams live today are **LLM-profile aliases** — role hover-edit is blueprint Python, not `/teams/` JSON.
+- No Neon. No oracle. Docs-only on this filing PR — do not implement here.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-19.md
+++ b/docs/requirements/REQ-19.md
@@ -1,0 +1,30 @@
+# REQ-19 — DaisyUI settings sheet `modal-end` + Menu + Join
+
+**Status:** PR [320](https://github.com/matthewhand/open-swarm/pull/320) — in flight
+
+## Intent
+
+Settings opens as a DaisyUI **popup over SPA chat** instead of a top-nav eject
+to the Django dashboard.
+
+## Success
+
+- Gear (`Open settings`) opens a right-docked `<dialog class="modal modal-end">` over `/` and `/chat`. Esc and backdrop close.
+- Inner nav is DaisyUI **`menu`** + `menu-dropdown` (e.g. Remotes: Hermes / OMB / Rakazo placeholders).
+- Segmented controls use DaisyUI **`join`** (e.g. Retention: Count | Disk | Archive | Trash).
+- Settings is **not** in the desktop top-nav text links or the mobile dock. Django `/settings/` remains the operator dump.
+- Narrow viewports stack the menu above the pane so Retention / Hostname stay usable.
+
+## Constraints
+
+- React 18 + Tailwind 4 + DaisyUI 5 only. No Drawer, no Join-as-section-nav, no `btn-group`.
+- Guest auth / Neon / oracle untouched.
+- Teams live today are LLM aliases; remotes in the sheet may be placeholders until REQ-11 lands.
+- Docs-only on this filing PR — do not implement here.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-20.md
+++ b/docs/requirements/REQ-20.md
@@ -1,0 +1,30 @@
+# REQ-20 — Teams composition roster DnD (not LLM aliases)
+
+**Status:** PR [323](https://github.com/matthewhand/open-swarm/pull/323) — in flight
+
+## Intent
+
+**Teams** is the composition abstraction: a drag-drop roster of API / CLI /
+remote members that can see and talk via handoff / `as_tool`. This is **not**
+the Django `/teams/` LLM-alias admin.
+
+## Success
+
+- First-launch two panes: left = drop zone (“drop agents here”); right = available agents (API / CLI / remote), HTML5-draggable. Context-menu Add/Remove. No `@dnd-kit`.
+- Member chips: name, kind badge (`API` | `CLI` | `remote`), optional role (`support` | `gate` | `skeptic` | `default`).
+- Per-team wires: `handoff` and `as_tool` toggles (default on). Persist a roster contract that is **not** `teams.json`.
+- Django Team Launcher / Admin / Swarm Creator stay aliases.
+
+## Constraints
+
+- **Honesty:** Teams live today **are** LLM-profile aliases (`/teams/` + `/v1/teams` + `teams.json`). Do not rewrite that admin in this REQ. Do not call aliases a multi-agent builder.
+- No SPA Teams tab / Grok chrome in the 323 slice unless later REQs say so.
+- No Neon / oracle, no guest auth, no `.30` deploy from cloud.
+- Docs-only on this filing PR — do not implement here.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-21.md
+++ b/docs/requirements/REQ-21.md
@@ -1,0 +1,27 @@
+# REQ-21 — Herdr client localhost default + optional `--remote`
+
+**Status:** in flight (no PR number in this backlog slice)
+
+## Intent
+
+The **Herdr** client talks to this swarm by default on **localhost**. Reaching
+a non-local swarm is opt-in via `--remote`, not the implicit default.
+
+## Success
+
+- Default target is localhost (local Open Swarm / Herdr loopback). No LAN or Fly URL unless asked.
+- Optional `--remote` (or equivalent) points at a remote base URL when the operator wants it.
+- Missing / failed remote is a report, not a crash-loop or silent fallback to a cloud host.
+
+## Constraints
+
+- Do not enable Neon. Do not resume oracle.
+- Do not bake `10.0.0.30` or Fly open-litellm as the Herdr default.
+- Docs-only on this filing PR — do not implement here.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-23.md
+++ b/docs/requirements/REQ-23.md
@@ -1,0 +1,28 @@
+# REQ-23 — Teams in sidepane + send-to-all dropdown
+
+**Status:** in flight (no PR number in this backlog slice)
+
+## Intent
+
+Composition **Teams** (REQ-20) show up in the AGENTS / conversation sidepane,
+with a control to **send to all** members — not only the selected seat.
+
+## Success
+
+- Teams appear in the sidepane as first-class rows (roster teams, not `/teams/` LLM aliases).
+- A dropdown (or equivalent unlabeled select, REQ-8) offers send-to-all vs a single member.
+- Send-to-all fans the same user turn to the roster; per-member threads stay isolated (REQ-7).
+
+## Constraints
+
+- **Honesty:** Teams live today are **LLM-profile aliases**. This REQ is the composition roster, not more alias chrome on `/teams/`.
+- Grok chrome is **not on `:8001` yet** — sidepane placement follows REQ-16 when that lands.
+- No extra concurrent Grok / OMB / Rakazo seats; composition stays handoff / `as_tool`.
+- No Neon. No oracle. Docs-only on this filing PR — do not implement here.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-24.md
+++ b/docs/requirements/REQ-24.md
@@ -1,0 +1,28 @@
+# REQ-24 — Drag any agent incl. roles into Hidden drop zone
+
+**Status:** in flight (no PR number in this backlog slice)
+
+## Intent
+
+Hide is a **drop zone**, not only a context-menu. Any agent — including
+**role** seats (support / gate / skeptic / default) — can be dragged there.
+
+## Success
+
+- Drag any AGENTS / conversation row onto a Hidden drop zone → that id joins `localStorage.swarm_hidden_agents`.
+- Role-badged rows (REQ-9) are eligible. Support can be hidden if the user does it (first-load default is REQ-26).
+- Unhide remains per-row from the `N hidden` popup (REQ-8). **No Hide-all.**
+- Pin / favourite (REQ-10) is a copy; hide does not have to unpin unless the implementer proves that is clearer.
+
+## Constraints
+
+- Native HTML5 drag. No `@dnd-kit`.
+- Do not hide-all. Do not re-seed hide on every load (REQ-26).
+- No Neon. No oracle. Docs-only on this filing PR — do not implement here.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-26.md
+++ b/docs/requirements/REQ-26.md
@@ -1,0 +1,28 @@
+# REQ-26 — First load hide gate and skeptic
+
+**Status:** in flight (no PR number in this backlog slice)
+
+## Intent
+
+On a **first** visit, **gate** and **skeptic** are hidden from the sidepane so
+the roster is not noisy. **Support stays visible.** If the user has already
+customized hide/unhide, do **not** re-seed.
+
+## Success
+
+- Fresh `localStorage` (no `swarm_hidden_agents` yet): seed hide for gate + skeptic (and `tool_gate` if present). Support remains listed and highlighted when REQ-16/7 apply.
+- If `swarm_hidden_agents` already exists — including an empty list the user chose — **do not re-seed**. User customization wins.
+- Unhide from the `N hidden` popup (REQ-8 / REQ-24) is enough to bring gate/skeptic back.
+
+## Constraints
+
+- Do not hide Support on first load.
+- Do not hide-all. Do not rewrite role wiring (REQ-9).
+- No Neon. No oracle. Docs-only on this filing PR — do not implement here.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-7.md
+++ b/docs/requirements/REQ-7.md
@@ -1,0 +1,28 @@
+# REQ-7 — Support agent (pill, threads, question cards)
+
+**Status:** PR [313](https://github.com/matthewhand/open-swarm/pull/313) — in flight
+
+## Intent
+
+A first-class **Support** seat that talks *about* the other agents. Welcome
+intel is a one-way system pill (not a transcript dump). Each agent keeps its
+own chat thread. Configuration help is question cards, not a wall of prose.
+
+## Success
+
+- Default Support chat is quiet; one **System → Support** pill expands compressed intel (agents, inference, gate/skeptic). Visible chips: **New team**, **Set inference**, **Write blueprint**. Support cannot reply to the pill.
+- Support chat ≠ hybrid_team chat ≠ skeptic chat — messages do not leak. Switching away and back restores that agent’s thread. Default `/chat` opens Support. Header name/avatar match the selected agent.
+- Any agent can emit a ` ```question ` fence. Chat renders a **question card**: multiple-choice chips plus a last open-string. Cards are user-answerable.
+
+## Constraints
+
+- Role looks (support / gate / skeptic) stay seats, not extra Grok / OMB / Rakazo workers.
+- No auth skip. No Neon. No oracle. Docs-only on this PR — do not implement here.
+- Socratic + MCQ (REQ-18) is absorbed into 313; do not open a second Support UX PR.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-8.md
+++ b/docs/requirements/REQ-8.md
@@ -1,0 +1,30 @@
+# REQ-8 — UX tighten (theme icon, unlabeled dropdowns, toast, hide popup)
+
+**Status:** PR [312](https://github.com/matthewhand/open-swarm/pull/312) — in flight
+
+## Intent
+
+Tighten chat / sidepane chrome so healthy UI is quiet and controls are
+icon-first. Not a new product surface.
+
+## Success
+
+- Theme toggle is a sun/moon **icon**, not a Light/Dark text button. Accessible name stays “Switch to light/dark theme”.
+- Chat dropdowns have **no field labels**. Last item is `Manage Blueprints` → `/blueprint-library/`.
+- Healthy connection is **silent**. Failures **toast**. No standing Connected badge.
+- Composer footer is a compact tokens-in-context meter plus a live “who / how long” line while streaming.
+- **No Hide-all.** When agents are hidden, the AGENTS list ends with `N hidden`; click opens a popup with Unhide per row. Persist `localStorage.swarm_hidden_agents`.
+
+## Constraints
+
+- Does not change OMB, LiteLLM, API auth, `SWARM_ALLOW_ANONYMOUS`, or default blueprints.
+- Does not add Hide-all or a Support agent (that is REQ-7).
+- After 312, tests must not wait on a Connected badge (REQ-13 follow-up).
+- No Neon. No oracle. Docs-only on this PR — do not implement here.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only

--- a/docs/requirements/REQ-9.md
+++ b/docs/requirements/REQ-9.md
@@ -1,0 +1,37 @@
+# REQ-9 — gate + skeptic roles as-tool
+
+**Status:** PR [314](https://github.com/matthewhand/open-swarm/pull/314) — in flight
+
+## Intent
+
+Agents get first-class **roles** so they look different in the AGENTS sidepane,
+and one agent’s output can feed another’s input via openai-agents **`as_tool` /
+handoff** — not extra concurrent Grok / OMB / Rakazo seats.
+
+## Success
+
+| Role | Sidepane | Runtime |
+|---|---|---|
+| `default` | no badge | ordinary worker |
+| `support` | teal | Support seat (REQ-7). Talks about the others. |
+| `gate` (`tool_gate`) | amber | Classifies a **pending tool call** as dangerous or not (YES/NO). |
+| `skeptic` | violet | Reviews the **original prompt** + output. |
+
+- **Default-open gate.** If no `gate` / `tool_gate` is on the roster, every tool call is approved and the user is never elicited.
+- **Skeptic is a bounded retry, not a nag.** Failure hands findings back (max 2). Success stops.
+- Team Creator writes `AGENT_SPECS[].role` plus `gate_agent` / `skeptic_agent`. `GET /v1/blueprints/` includes role metadata so the sidepane can highlight seats.
+
+## Constraints
+
+- Roles are **seats, not models**. Assigning gate/skeptic does not add another worker.
+- Composition is openai-agents handoff / `as_tool` only.
+- Support UX (pill / threads / cards) is REQ-7, not this PR.
+- First-load hide of gate/skeptic is REQ-26 — do not re-seed hide here.
+- No Neon. No oracle. Docs-only on this PR — do not implement here.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` guest dirty only


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**This is docs-only.** It files the tracked open-swarm REQ backlog as short markdown pages. It does **not** implement features. It does **not** enable Neon. Oracle stays off.

Branched from starting_ref `91dabd64` (REQ-5 dark chrome).

## What

`docs/requirements/README.md` — one file per REQ; template **Intent / Success / Constraints / Owner**.

Owner on every page: CoS transcribes; cloud implements; engineer GitHub-merge after skeptic; live preview `10.0.0.30:8001` guest dirty only.

One short file per REQ already tracked (no extras; REQ-18/25 combined):

| REQ | Status |
|---|---|
| 7 Support agent (pill, threads, question cards) | PR 313 — in flight |
| 8 UX tighten | PR 312 — in flight |
| 9 gate + skeptic as-tool | PR 314 — in flight |
| 10 favourites tile grid (left rail, not top chrome) | PR 311 — in flight, **wrong place** |
| 11 remotes Hermes/OMB/Rakazo | PR 318 — in flight |
| 12 harness-of-harnesses docs | PR 315 — in flight |
| 13 mock inference fast + >60s | PR 317 — in flight |
| 14 chat JSON persist + Settings retention | PR 319 **merged** `4d554ea5` |
| 15 CLI dropdown lists CLIs | PR 316 — in flight |
| 16 Grok-Bot left rail chrome | PR 322 — in flight |
| 17 Search command palette | inside 322 |
| 18/25 Socratic+MCQ absorbed into 313; hover-edit role → blueprint Python | absorbed / in flight |
| 19 DaisyUI settings sheet `modal-end` + Menu + Join | PR 320 — in flight |
| 20 Teams composition roster DnD (not LLM aliases) | PR 323 — in flight |
| 21 Herdr client localhost default + optional `--remote` | in flight |
| 23 Teams in sidepane + send-to-all dropdown | in flight |
| 24 drag any agent incl. roles into Hidden drop zone | in flight |
| 26 first load hide gate and skeptic (Support stays visible; do not re-seed if customized) | in flight |

## Honesty (quoted in the README)

- Teams live today are **LLM-profile aliases**.
- Grok chrome is **not on `:8001` yet**.
- Neon / oracle are **off**. Do not enable Neon.

REQ-22 debt audits and REQ-5/6 chrome/avatar work are not filed here.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97770f3c-53fc-426d-8b80-29b6f60f0319?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97770f3c-53fc-426d-8b80-29b6f60f0319&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

