### PR TITLE
feat(cli): persist CLI session ids and resume them (REQ-52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **REQ-52 CLI session resume:** Catalog CLIs (grok / claude / gemini / codex / opencode) document how they name a session. Swarm stores that id on the chat thread (`cli_sessions`) and the next send includes `--resume` / `--session` / `exec resume` so the CLI restores its own context. Missing or expired ids start a new session (honest bubble-less line; never a fake “restored”). Fixture-CLI tests; no secrets in stored records. Distinct from Django/API conversation ids and OS `start_new_session`.
 - **REQ-37 nested conversation compact:** Composer `+` menu Compact summarises the backlog into a Django/sqlite `ConversationSummary` (`span`, `parent_summary_id`, `body`). Raw JSON + `ChatMessage` rows stay. Later compacts nest. UI renders bordered `.chat-summary` blocks. Model context walks the summary tree. No Neon.
 - **REQ-25 hover-edit on role agents:** Rail rows for the example roles (support, gate, skeptic) reveal a focusable edit icon on hover. Enter/click opens a DaisyUI `modal-end` Settings sheet scrolled to the Blueprint editor, which shows that agent's Python (`highlightPython` / `os-code-python`). Live `blueprint_support.py` / `tool_gate` / `skeptic` files are linked when `/v1/blueprints/<id>/source` lists them. Does not open the Teams drop-zone and does not rewrite role runtime.
 

--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -151,6 +151,7 @@ one-shot, API-addressable subagents. See `docs/CLI_FUSION.md`.
 | Auth autodiscovery | ✅ | `CliAgentConfig.auth_check` + `discover_auth()` + `--check-auth` (PR 3) |
 | Full-capability panelists + workdir isolation | ✅ | Yolo-flag example adapters; `cli_fusion.isolate_workdir` git-worktree/temp-dir isolation (PR 4); isolation tests incl. real-git end-to-end |
 | Built-in adapter catalog + `--suggest` | ✅ | `src/swarm/core/cli_catalog.py`; `swarm-cli cli-agents --suggest`; `tests/core/test_cli_catalog.py` (PR 5) |
+| CLI session resume (REQ-52) | ✅ | Per-CLI `--resume` / `--session` / `exec resume` in `cli_catalog.SESSION`; id stored on the chat thread (`cli_sessions`); honest new-session line; `tests/core/test_cli_sessions.py`, fixture two-turn resume in `tests/blueprints/test_cli_agent.py` |
 | Non-interactive smoke probe + `--smoke` | ✅ | `CliAdapter.smoke_check()` / `smoke_check_all()`; classifies ok/hang/error/not_installed (PR 6) |
 | End-to-end API coverage | ✅ | `tests/api/test_cli_fusion_api.py`: real panel→synthesize and `params` selection over `/v1/chat/completions` (PR 7) |
 

--- a/docs/CLI_FUSION.md
+++ b/docs/CLI_FUSION.md
@@ -121,6 +121,9 @@ string.
 | `mode` | str | Free-text label documenting safety posture (`"readonly"`, `"write"`). Advisory. |
 | `auth_check` | list[str] | Optional argv probe for `swarm-cli cli-agents --check-auth`. Exit 0 ⇒ authenticated. Should be cheap and not consume quota (capped at 30s). |
 | `consensus` | bool \| list[str] \| dict | Designate this agent as a **consensus agent** — calling it runs a panel, not a single call. `true` ⇒ all available CLIs; a list ⇒ a preferred whitelist (falls back to all-available if it matches nothing); `{"panel":[…],"judge":"…"}` ⇒ explicit. See [Consensus modes](BLUEPRINT_LIBRARY.md#consensus-modes-a-second-axis--partly-built-partly-roadmap). |
+| `resume_argv` | list[str] \| null | Extra argv inserted when a stored CLI session id exists. Use `{session_id}`. `null` uses the catalog policy for this name; `[]` means this CLI cannot resume. |
+| `resume_insert` | int \| null | Index in argv at which `resume_argv` is inserted (catalog default `1`; `codex` uses `2` so it becomes `codex exec resume <id>`). |
+| `session_id_paths` | list[str] \| null | JSON dotted paths to capture a session id from stdout (e.g. `.session_id`). |
 
 > ⚠️ **Exact flags and JSON shapes vary by CLI version.** The snippets below are
 > starting points — run the CLI's `--help` and confirm its non-interactive flag,
@@ -145,6 +148,31 @@ get a panelist that actually *does work*, pin down two flags from its `--help`:
 | `gemini` | `-p` | `--yolo` | `-o json` → `json:.response` |
 | `codex` | `exec` | `--dangerously-bypass-approvals-and-sandbox` (or `--full-auto`) | text |
 | `opencode` | `run` | (none needed — `run` acts without an approval gate) | text |
+
+### CLI session resume (REQ-52)
+
+Catalog CLIs **own** their sessions. Open Swarm stores each CLI session id next
+to the chat thread (`cli_sessions` on the per-agent JSON record) and, on the
+next send to that CLI, inserts the resume argv so the CLI restores its own
+context. This is not a Django/API conversation id and not OS
+`start_new_session` (process-group kill). First-turn catalog cmds stay one-shot;
+resume argv is added only when a stored id exists. Missing or expired ids start
+a new session; we store the new id. If a CLI cannot resume, the UI says we
+started a new session — never a fake “restored”.
+
+| CLI | Resume argv (when an id is stored) | How the id is named | Capture |
+|---|---|---|---|
+| `grok` | `--resume {session_id}` (`-r`) | UUID. `--session-id` / `-s` names a **new** session | JSON `sessionId` / `session_id` |
+| `claude` | `--resume {session_id}` (`-r`) | UUID. `--session-id` names a **new** session | JSON `session_id` (sibling of `result`) |
+| `gemini` | `--resume {session_id}` (`-r`) | UUID. `--session-id` starts a **new** session | JSON `session_id` / `sessionId` when present |
+| `codex` | `codex exec resume {session_id} …` (subcommand) | UUID / thread id | JSON `thread_id` when `--json`; default catalog parse is text |
+| `opencode` | `--session {session_id}` (`-s`) | `ses_…`. `--continue` is last-cwd, not thread-scoped | JSON when the CLI emits it; default parse is text |
+
+`antigravity` is not in the catalog. If wired later, headless resume is
+`agy -p --conversation <id>` (JSON often includes `conversation_id`).
+
+Per-adapter config can override `resume_argv`, `resume_insert`, and
+`session_id_paths`. An empty `resume_argv` means the CLI cannot resume.
 
 ### Example adapters
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -37,6 +37,10 @@ Wrapping installed agentic CLIs (`grok` / `claude` / `gemini` / …) behind the 
 
 A stateful `/v1/responses` record (and related conversation/delegation data) owned by an operator or API-token principal. The Django **Session Explorer** at `/sessions/` is a read-only observability UI over those records — not a chat composer.
 
+## CLI session
+
+An id **owned by an agentic CLI** (`--resume` / `--session` / `exec resume` / id file). Open Swarm stores it next to the chat thread (`cli_sessions`) and passes it back so the CLI restores its own context (REQ-52). Not a Django `conversation_id`, not a `/v1/responses` Session, and not OS `start_new_session` (process-group kill). Remotes keep the remote’s session.
+
 ## Herdr member (`kind=herdr`)
 
 A persisted connection to a [Herdr](https://herdr.dev/) pane/agent that Open Swarm drives via the official `herdr` CLI (not a socket protocol). Empty `remote` means localhost (unix sockets, typically `~/.config/herdr/`). Optional `remote` becomes `herdr --remote <user@host>`. **Not** Hermes, OMB, or Rakazo. Docs: [HERDR.md](./HERDR.md).

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -58,6 +58,7 @@ In-flight PRs sit on their own branches. This tree does not include their code.
 | [REQ-24](./REQ-24.md) | Drag any agent incl. roles into Hidden drop zone | in flight |
 | [REQ-26](./REQ-26.md) | First load hide gate and skeptic | in flight |
 | [REQ-37](./REQ-37.md) | Nested conversation compact / summaries | in flight (#350) |
+| [REQ-52](./REQ-52.md) | Persist CLI session ids and resume them | in flight (#369) |
 
 REQ-22 (debt audits) and earlier REQ-5 / REQ-6 chrome/avatar work are **not**
 filed here — they were not in this backlog slice.

--- a/docs/requirements/REQ-52.md
+++ b/docs/requirements/REQ-52.md
@@ -1,0 +1,38 @@
+# REQ-52 — Persist CLI session ids and resume them
+
+**Status:** in flight (GitHub #369)
+
+## Intent
+
+CLI tools own their sessions. Open Swarm tracks each CLI **session id** so when
+the user comes back to that CLI agent, we pass the id back and the CLI restores
+context. (API threads we own and persist ourselves; remotes are the remote’s
+session.)
+
+## Success
+
+1. For each catalogued CLI (grok, claude, gemini, codex, opencode; antigravity
+   if already wired): document how that CLI names a session (`--session` /
+   `--resume` / id file). Swarm stores that id next to the chat thread.
+2. Resume: the next send to that CLI agent includes the stored id so the CLI
+   restores its own context. Missing/expired id starts a new session and we
+   store the new id.
+3. Honest UI: if a CLI cannot resume, no fake “restored” — show we started a
+   new session (bubble-less line is OK; related to #362).
+4. Tests: fixture CLI that echoes `--resume ID`; second turn passes the stored
+   id. No secrets in stored records.
+
+## Constraints
+
+- Distinct from #366 (API edit).
+- No live preview. No secrets. GitHub PR only (`Fixes` #369).
+- Do not confuse with Django/API conversation ids or OS `start_new_session`.
+- Keep catalog one-shot flags for first turn; add resume argv only when a
+  stored id exists.
+
+## Owner
+
+- CoS transcribes
+- cloud implements
+- engineer GitHub-merge after skeptic
+- live preview `10.0.0.30:8001` — guest dirty only (not this PR)

--- a/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
+++ b/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
@@ -18,6 +18,14 @@ from typing import Any, ClassVar
 
 from swarm.blueprints.common import cli_fusion_support as support
 from swarm.core.blueprint_base import BlueprintBase
+from swarm.core.cli_adapter import CliAdapter, CliResult
+from swarm.core.cli_sessions import (
+    clear_cli_session,
+    get_cli_session,
+    is_resume_failure,
+    put_cli_session,
+    resolve_thread,
+)
 from swarm.core.consensus import run_consensus
 
 logger = logging.getLogger(__name__)
@@ -47,6 +55,92 @@ class CliAgentBlueprint(BlueprintBase):
     def set_params(self, params: dict[str, Any] | None) -> None:
         """Capture per-request params forwarded by the API view."""
         self._params = dict(params or {})
+
+    def _thread_ref(self, params: dict[str, Any]) -> tuple[str, str] | None:
+        return resolve_thread(params, default_agent=self.blueprint_id)
+
+    def _stored_session(self, params: dict[str, Any], cli_name: str) -> str | None:
+        ref = self._thread_ref(params)
+        if ref is None:
+            return None
+        return get_cli_session(ref[0], ref[1], cli_name)
+
+    def _remember_session(
+        self, params: dict[str, Any], cli_name: str, session_id: str | None
+    ) -> None:
+        ref = self._thread_ref(params)
+        if ref is None:
+            return
+        put_cli_session(
+            ref[0],
+            ref[1],
+            cli_name,
+            session_id,
+            conversation_id=str(params.get("conversation_id") or ""),
+        )
+
+    def _forget_session(self, params: dict[str, Any], cli_name: str) -> None:
+        ref = self._thread_ref(params)
+        if ref is None:
+            return
+        clear_cli_session(
+            ref[0],
+            ref[1],
+            cli_name,
+            conversation_id=str(params.get("conversation_id") or ""),
+        )
+
+    def _turn_prompt(
+        self,
+        messages: list[dict[str, Any]],
+        full_prompt: str,
+        params: dict[str, Any],
+        workdir: str | None,
+        *,
+        resume: bool,
+    ) -> str:
+        if not resume:
+            return full_prompt
+        latest = support.latest_user_prompt(messages)
+        if not latest:
+            return full_prompt
+        prompt, _applied = support.apply_skill_to_prompt(latest, params, workdir=workdir)
+        return prompt
+
+    async def _invoke_cli(
+        self,
+        adapter: CliAdapter,
+        messages: list[dict[str, Any]],
+        full_prompt: str,
+        params: dict[str, Any],
+        workdir: str | None,
+    ) -> tuple[CliResult, bool]:
+        """Run one CLI, replaying a stored session id when the CLI can resume.
+
+        Returns ``(result, resumed)``. ``resumed`` is True only when a stored
+        id was passed and the run succeeded without falling back to a new session.
+        """
+        stored = self._stored_session(params, adapter.name)
+        can_resume = bool(stored and adapter.can_resume())
+        prompt = self._turn_prompt(
+            messages, full_prompt, params, workdir, resume=can_resume
+        )
+        result = await adapter.run(
+            prompt, workdir=workdir, session_id=stored if can_resume else None
+        )
+        resumed = can_resume and result.ok
+        if can_resume and not result.ok and is_resume_failure(result):
+            self._forget_session(params, adapter.name)
+            prompt = self._turn_prompt(
+                messages, full_prompt, params, workdir, resume=False
+            )
+            result = await adapter.run(prompt, workdir=workdir, session_id=None)
+            resumed = False
+        if result.session_id:
+            self._remember_session(params, adapter.name, result.session_id)
+        elif resumed and stored:
+            self._remember_session(params, adapter.name, stored)
+        return result, resumed
 
     async def run(self, messages: list[dict[str, Any]], **kwargs) -> Any:
         # Snapshot params once before any await: the API view may reuse a cached
@@ -161,12 +255,39 @@ class CliAgentBlueprint(BlueprintBase):
             if target is not None and (registry.get(target).config.parse or "text") == "text":
                 adapter = registry.get(target)
                 yield support.progress_chunk(f"_Streaming CLI agent `{target}`…_")
+                stored = self._stored_session(params, adapter.name)
+                can_resume = bool(stored and adapter.can_resume())
+                turn_prompt = self._turn_prompt(
+                    messages, prompt, params, workdir, resume=can_resume
+                )
                 result = None
-                async for chunk in adapter.stream_run(prompt, workdir=workdir):
+                async for chunk in adapter.stream_run(
+                    turn_prompt,
+                    workdir=workdir,
+                    session_id=stored if can_resume else None,
+                ):
                     if chunk.final:
                         result = chunk.result
                     elif chunk.delta:
                         yield support.message_chunk(chunk.delta)  # incremental delta
+                resumed = can_resume and result is not None and result.ok
+                if result is not None and can_resume and not result.ok and is_resume_failure(result):
+                    self._forget_session(params, adapter.name)
+                    turn_prompt = self._turn_prompt(
+                        messages, prompt, params, workdir, resume=False
+                    )
+                    result = None
+                    async for chunk in adapter.stream_run(turn_prompt, workdir=workdir):
+                        if chunk.final:
+                            result = chunk.result
+                        elif chunk.delta:
+                            yield support.message_chunk(chunk.delta)
+                    resumed = False
+                if result is not None and result.session_id:
+                    self._remember_session(params, adapter.name, result.session_id)
+                elif resumed and stored:
+                    self._remember_session(params, adapter.name, stored)
+                yield support.session_notice_chunk(adapter.name, resumed=resumed)
                 if result is None or not result.ok:
                     err = (result.error if result else None) or "unknown error"
                     yield support.message_chunk(support.format_cli_error(adapter, err), final=True)
@@ -184,7 +305,10 @@ class CliAgentBlueprint(BlueprintBase):
                 yield support.progress_chunk(f"_Skipping `{name}` (not installed); failing over…_")
                 continue
             yield support.progress_chunk(f"_Running CLI agent `{name}`…_")
-            result = await adapter.run(prompt, workdir=workdir)
+            result, resumed = await self._invoke_cli(
+                adapter, messages, prompt, params, workdir
+            )
+            yield support.session_notice_chunk(adapter.name, resumed=resumed)
             if result.ok:
                 if result.parse_error:
                     logger.warning("CLI %s parse issue: %s", name, result.parse_error)

--- a/src/swarm/blueprints/common/cli_fusion_support.py
+++ b/src/swarm/blueprints/common/cli_fusion_support.py
@@ -57,6 +57,19 @@ def resolve_workdir(
     return str(resolve_confined_workdir(raw, create=create))
 
 
+def latest_user_prompt(messages: list[dict[str, Any]]) -> str:
+    """The newest user turn — used when a CLI session is being resumed."""
+    for message in reversed(messages or []):
+        if not isinstance(message, dict):
+            continue
+        if (message.get("role") or "user") != "user":
+            continue
+        text = str(message.get("content") or "").strip()
+        if text:
+            return text
+    return ""
+
+
 def render_prompt(messages: list[dict[str, Any]]) -> str:
     """Flatten an OpenAI-style message list into a single prompt string.
 
@@ -378,6 +391,8 @@ def backend_meta(backends: list[str], judge: str | None = None) -> dict[str, Any
 
 #: Chunk ``type`` for fusion progress side-channel events.
 PROGRESS_TYPE = "fusion_progress"
+#: Honest CLI session line (new vs resumed). Not a chat bubble.
+SESSION_NOTICE_TYPE = "cli_session_notice"
 
 
 def progress_chunk(content: str) -> dict:
@@ -389,6 +404,18 @@ def progress_chunk(content: str) -> dict:
     by inspecting ``chunk["type"] == PROGRESS_TYPE``.
     """
     return {"type": PROGRESS_TYPE, "content": content}
+
+
+def session_notice_chunk(cli_name: str, *, resumed: bool) -> dict:
+    """Bubble-less session line. ``resumed`` only when the stored id was used."""
+    from swarm.core.cli_sessions import session_notice_text
+
+    return {
+        "type": SESSION_NOTICE_TYPE,
+        "content": session_notice_text(cli_name, resumed=resumed),
+        "resumed": resumed,
+        "session_notice": True,
+    }
 
 
 def format_cli_error(adapter: CliAdapter, error: str) -> str:

--- a/src/swarm/consumers.py
+++ b/src/swarm/consumers.py
@@ -87,6 +87,15 @@ async def _compacted_context(conversation_id, messages):
         return list(messages or [])
 
 
+def _status_line_html(text: str) -> str:
+    """Bubble-less transcript line (CLI session notice; related to #362)."""
+    return (
+        '<div id="message-list" hx-swap-oob="beforeend">'
+        f'<div class="chat-status-line os-chat-status">{escape(text)}</div>'
+        "</div>"
+    )
+
+
 def _oob_append_html(contents_div_id: str, text: str) -> str:
     """HTMX OOB append chunk with HTML-escaped body text.
 
@@ -212,7 +221,7 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
         if params and params.get("team"):
             await self.respond_with_team_stub(params, message_text, contents_div_id)
         elif blueprint_id:
-            await self.respond_with_blueprint(blueprint_id, contents_div_id)
+            await self.respond_with_blueprint(blueprint_id, contents_div_id, params=params)
         else:
             await self.respond_with_default_model(contents_div_id)
 
@@ -233,7 +242,7 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
         )
         await self.send(text_data=final_html)
 
-    async def respond_with_blueprint(self, blueprint_id, contents_div_id):
+    async def respond_with_blueprint(self, blueprint_id, contents_div_id, params=None):
         """Generate the assistant reply by running a discovered blueprint."""
         # In test mode, skip slow blueprint instantiation and return canned output.
         if os.environ.get("SWARM_TEST_MODE"):
@@ -280,6 +289,26 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
             )
             return
 
+        thread_params = {
+            "conversation_id": getattr(self, "conversation_id", ""),
+            "agent": blueprint_id,
+            "agent_id": blueprint_id,
+        }
+        if getattr(self.user, "is_authenticated", False):
+            try:
+                from swarm.core import chat_store
+
+                thread_params["user_key"] = chat_store.user_key_for(self.user)
+            except Exception:
+                logger.exception("Could not resolve chat user_key for CLI session")
+        if isinstance(params, dict):
+            thread_params.update(params)
+        if hasattr(blueprint_instance, "set_params") and callable(blueprint_instance.set_params):
+            existing = getattr(blueprint_instance, "_params", None)
+            if not isinstance(existing, dict):
+                existing = {}
+            blueprint_instance.set_params({**existing, **thread_params})
+
         final_message = None
         try:
             model_messages = await _compacted_context(
@@ -287,6 +316,12 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
                 self.messages,
             )
             async for chunk in blueprint_instance.run(model_messages):
+                if isinstance(chunk, dict) and chunk.get("type") == "cli_session_notice":
+                    notice = str(chunk.get("content") or "").strip()
+                    if notice:
+                        await self.send(text_data=_status_line_html(notice))
+                        self.messages.append({"role": "status", "content": notice})
+                    continue
                 message = _extract_message_from_chunk(chunk)
                 if message is None:
                     continue

--- a/src/swarm/core/chat_compact.py
+++ b/src/swarm/core/chat_compact.py
@@ -179,6 +179,8 @@ def build_model_context(
             out.append({"role": "system", "content": f"[Conversation summary]\n{tree}"})
             continue
         role = item.get("role") or "user"
+        if str(role) == "status":
+            continue  # bubble-less session/status lines are not model context
         role_s = "assistant" if str(role) == "assistant" else "user"
         if str(role) == "system":
             role_s = "system"
@@ -195,6 +197,7 @@ def context_for_conversation(
         return [
             {"role": (m.get("role") or "user"), "content": m.get("content") or ""}
             for m in (messages or [])
+            if (m.get("role") or "user") != "status"
         ]
     try:
         rows = list(
@@ -204,6 +207,7 @@ def context_for_conversation(
         return [
             {"role": (m.get("role") or "user"), "content": m.get("content") or ""}
             for m in (messages or [])
+            if (m.get("role") or "user") != "status"
         ]
     return build_model_context(messages, rows)
 

--- a/src/swarm/core/chat_store.py
+++ b/src/swarm/core/chat_store.py
@@ -188,7 +188,13 @@ def _normalize_messages(raw: Any) -> list[dict[str, str]]:
             content = item.get("text") or ""
         if not isinstance(content, str):
             content = str(content)
-        role_s = "assistant" if str(role) == "assistant" else "user"
+        role_raw = str(role)
+        if role_raw == "assistant":
+            role_s = "assistant"
+        elif role_raw == "status":
+            role_s = "status"
+        else:
+            role_s = "user"
         msg = {"role": role_s, "content": content}
         ts = item.get("ts") or item.get("timestamp")
         if isinstance(ts, str) and ts:
@@ -212,6 +218,7 @@ def empty_record(
         "created_at": now,
         "updated_at": now,
         "messages": [],
+        "cli_sessions": {},
     }
 
 
@@ -221,6 +228,7 @@ def save(
     messages: list[dict[str, Any]],
     *,
     conversation_id: str = "",
+    cli_sessions: dict[str, Any] | None = None,
     base_dir: Path | None = None,
 ) -> Path | None:
     """Write (or replace) the active thread. Returns the path, or None if ids are unsafe."""
@@ -234,6 +242,11 @@ def save(
         return None
     existing = _read_json(path) if path.is_file() else None
     created = (existing or {}).get("created_at") or _iso()
+    sessions = (
+        normalize_cli_sessions(cli_sessions)
+        if cli_sessions is not None
+        else normalize_cli_sessions((existing or {}).get("cli_sessions"))
+    )
     record = {
         "schema": SCHEMA,
         "agent_id": agent,
@@ -242,6 +255,7 @@ def save(
         "created_at": created,
         "updated_at": _iso(),
         "messages": _normalize_messages(messages),
+        "cli_sessions": sessions,
     }
     _atomic_write(path, record)
     return path
@@ -261,7 +275,23 @@ def load(
     if record is None:
         return None
     record["messages"] = _normalize_messages(record.get("messages"))
+    record["cli_sessions"] = normalize_cli_sessions(record.get("cli_sessions"))
     return record
+
+
+def normalize_cli_sessions(raw: Any) -> dict[str, str]:
+    """``{cli_name: session_id}`` with unsafe keys/values dropped (no secrets)."""
+    from swarm.core.cli_sessions import sanitize_cli_session_id
+
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, str] = {}
+    for key, value in raw.items():
+        cli = normalize_agent_id(str(key))
+        sid = sanitize_cli_session_id(value)
+        if cli and sid:
+            out[cli] = sid
+    return out
 
 
 def archive(

--- a/src/swarm/core/cli_adapter.py
+++ b/src/swarm/core/cli_adapter.py
@@ -1,18 +1,22 @@
 """CLI agent adapter layer.
 
 Turns an external, interactive agentic CLI (``claude``, ``gemini``, ``codex``,
-``opencode`` ...) into a one-shot, awaitable subagent that takes a prompt and
-returns text. This is the building block the CLI-fusion blueprints compose:
-each panelist is a :class:`CliAdapter` driven entirely by configuration.
+``opencode`` ...) into an awaitable subagent that takes a prompt and returns
+text. First turn is one-shot; a stored CLI session id (not an OS process
+session, not a Django conversation id) can be replayed via ``resume_argv``.
+This is the building block the CLI-fusion blueprints compose: each panelist
+is a :class:`CliAdapter` driven entirely by configuration.
 
 Design notes
 ------------
 * **No shell.** The command is an argv list executed directly
   (``asyncio.create_subprocess_exec``); the prompt is passed as a discrete
   argument or on stdin, so there is no shell-injection surface.
-* **Lifecycle.** Every launch runs in its own process *session*
+* **Lifecycle.** Every launch runs in its own OS process *group*
   (``start_new_session=True``) so a hung or runaway agent — and any children it
-  spawned — can be killed as a group on timeout, ``aclose``, or cancel.
+  spawned — can be killed as a group on timeout, ``aclose``, or cancel. That
+  flag is not a CLI conversation session. CLI session ids (``--resume`` /
+  ``--session``) are tracked separately on the chat thread (REQ-52).
 * **Config-driven.** Adapters are described as plain dicts (see
   :meth:`CliAdapter.from_config`) so adding a new CLI is a config edit, not code.
 """
@@ -36,6 +40,8 @@ logger = logging.getLogger(__name__)
 # Sentinel substituted in argv / cwd / env templates.
 PROMPT_TOKEN = "{prompt}"
 WORKDIR_TOKEN = "{workdir}"
+# Injected into resume_argv when a stored CLI session id is replayed.
+SESSION_TOKEN = "{session_id}"
 
 DEFAULT_TIMEOUT = 180.0
 # Grace period between SIGTERM and SIGKILL when reaping a timed-out agent.
@@ -104,6 +110,17 @@ class CliAgentConfig:
         Informational label describing the safety posture (e.g. ``"readonly"``,
         ``"write"``). Not enforced here — it documents intent and is surfaced in
         results/logs.
+    resume_argv:
+        Extra argv pieces inserted when a stored CLI session id is replayed.
+        Use ``{session_id}`` for the id. ``None`` (default) falls back to the
+        catalog policy for ``name``. An empty list means this CLI cannot resume.
+        Distinct from OS ``start_new_session=True`` (process-group kill).
+    resume_insert:
+        Index in the token-substituted argv at which ``resume_argv`` is inserted.
+        ``None`` uses the catalog (default ``1`` — after the executable).
+    session_id_paths:
+        JSON dotted paths to try when capturing a session id from stdout
+        (e.g. ``.session_id``). ``None`` uses the catalog plus common defaults.
     """
 
     name: str
@@ -121,6 +138,9 @@ class CliAgentConfig:
     # a preferred whitelist (falls back to all-available if none match); a dict
     # ``{"panel": [...], "judge": "<cli>"}`` => explicit. None (default) => normal.
     consensus: bool | list[str] | dict[str, Any] | None = None
+    resume_argv: list[str] | None = None
+    resume_insert: int | None = None
+    session_id_paths: list[str] | None = None
 
     def __post_init__(self) -> None:
         if not self.cmd:
@@ -143,6 +163,26 @@ class CliAgentConfig:
             raise CliAdapterError(
                 f"CLI adapter '{self.name}': auth_check must be a non-empty list of strings"
             )
+        if self.resume_argv is not None and (
+            not isinstance(self.resume_argv, list)
+            or not all(isinstance(p, str) for p in self.resume_argv)
+        ):
+            raise CliAdapterError(
+                f"CLI adapter '{self.name}': resume_argv must be a list of strings"
+            )
+        if self.resume_insert is not None and (
+            not isinstance(self.resume_insert, int) or self.resume_insert < 0
+        ):
+            raise CliAdapterError(
+                f"CLI adapter '{self.name}': resume_insert must be an int >= 0"
+            )
+        if self.session_id_paths is not None and (
+            not isinstance(self.session_id_paths, list)
+            or not all(isinstance(p, str) for p in self.session_id_paths)
+        ):
+            raise CliAdapterError(
+                f"CLI adapter '{self.name}': session_id_paths must be a list of strings"
+            )
 
 
 @dataclass
@@ -158,6 +198,7 @@ class CliResult:
     parse_error: str | None = None
     error: str | None = None
     stderr: str = ""
+    session_id: str | None = None
 
 
 @dataclass
@@ -246,8 +287,37 @@ class CliAdapter:
             mode=raw.get("mode", "default"),
             auth_check=raw.get("auth_check"),
             consensus=raw.get("consensus"),
+            resume_argv=raw.get("resume_argv"),
+            resume_insert=raw.get("resume_insert"),
+            session_id_paths=raw.get("session_id_paths"),
         )
         return cls(cfg)
+
+    def session_policy(self) -> dict[str, Any]:
+        """Resolved resume policy: config override, else catalog by name."""
+        from swarm.core.cli_catalog import session_policy as catalog_policy
+
+        catalog = catalog_policy(self.name) or {}
+        resume_argv = self.config.resume_argv
+        if resume_argv is None:
+            resume_argv = catalog.get("resume_argv")
+        insert = self.config.resume_insert
+        if insert is None:
+            insert = catalog.get("resume_insert", 1)
+        paths = self.config.session_id_paths
+        if paths is None:
+            paths = list(catalog.get("session_id_paths") or [])
+        return {
+            "resume_argv": list(resume_argv) if resume_argv else [],
+            "resume_insert": int(insert) if insert is not None else 1,
+            "session_id_paths": list(paths),
+            "can_resume": bool(resume_argv),
+            "notes": catalog.get("notes") or "",
+        }
+
+    def can_resume(self) -> bool:
+        """True when this adapter knows how to replay a stored CLI session id."""
+        return bool(self.session_policy()["can_resume"])
 
     def is_available(self) -> bool:
         """True when the CLI executable is resolvable on PATH (or absolute)."""
@@ -257,37 +327,57 @@ class CliAdapter:
         return shutil.which(exe) is not None
 
     def _build_invocation(
-        self, prompt: str, workdir: str
+        self, prompt: str, workdir: str, session_id: str | None = None
     ) -> tuple[list[str], bytes | None]:
-        """Return (argv, stdin_bytes) for the given prompt."""
+        """Return (argv, stdin_bytes) for the given prompt.
+
+        First-turn catalog cmds stay one-shot. Resume argv is inserted only
+        when ``session_id`` is set and this CLI has a resume policy.
+        """
         argv = [_apply_tokens(part, prompt, workdir) for part in self.config.cmd]
+        if session_id:
+            policy = self.session_policy()
+            extra = [
+                part.replace(SESSION_TOKEN, session_id) for part in policy["resume_argv"]
+            ]
+            if extra:
+                insert = min(int(policy["resume_insert"]), len(argv))
+                argv = argv[:insert] + extra + argv[insert:]
         stdin_bytes: bytes | None = None
         if self.config.prompt_mode == "stdin":
             stdin_bytes = prompt.encode("utf-8")
         return argv, stdin_bytes
 
-    def _parse_output(self, stdout: str) -> tuple[str, str | None]:
-        """Return (text, parse_error). parse_error is None on success."""
+    def _extract_session_id(self, stdout: str) -> str | None:
+        """Capture a CLI session id from JSON/JSONL stdout when present."""
+        from swarm.core.cli_sessions import extract_session_id
+
+        return extract_session_id(stdout, self.session_policy()["session_id_paths"])
+
+    def _parse_output(self, stdout: str) -> tuple[str, str | None, str | None]:
+        """Return (text, parse_error, session_id). parse_error is None on success."""
+        session_id = self._extract_session_id(stdout)
         spec = self.config.parse or "text"
         if spec == "text":
-            return stdout.strip(), None
+            return stdout.strip(), None, session_id
         if spec.startswith("json"):
             dotpath = spec[len("json"):].lstrip(":")
             try:
                 data = json.loads(stdout)
             except json.JSONDecodeError as exc:
-                return stdout.strip(), f"invalid JSON: {exc}"
+                return stdout.strip(), f"invalid JSON: {exc}", session_id
             if not dotpath:
                 return (
                     data if isinstance(data, str) else json.dumps(data),
                     None,
+                    session_id,
                 )
             try:
                 value = _extract_json_path(data, dotpath)
             except (KeyError, IndexError, TypeError, ValueError) as exc:
-                return stdout.strip(), f"json path '{dotpath}' not found: {exc}"
-            return (value if isinstance(value, str) else json.dumps(value)), None
-        return stdout.strip(), f"unknown parse spec {spec!r}"
+                return stdout.strip(), f"json path '{dotpath}' not found: {exc}", session_id
+            return (value if isinstance(value, str) else json.dumps(value)), None, session_id
+        return stdout.strip(), f"unknown parse spec {spec!r}", session_id
 
     async def run(
         self,
@@ -295,6 +385,7 @@ class CliAdapter:
         *,
         workdir: str | None = None,
         extra_env: dict[str, str] | None = None,
+        session_id: str | None = None,
     ) -> CliResult:
         """Launch the CLI, await its answer, and parse the result.
 
@@ -305,7 +396,9 @@ class CliAdapter:
         result (``stream_run`` always emits exactly one ``final`` chunk).
         """
         result: CliResult | None = None
-        async for chunk in self.stream_run(prompt, workdir=workdir, extra_env=extra_env):
+        async for chunk in self.stream_run(
+            prompt, workdir=workdir, extra_env=extra_env, session_id=session_id
+        ):
             if chunk.final:
                 result = chunk.result
         assert result is not None  # stream_run guarantees a terminal chunk
@@ -317,6 +410,7 @@ class CliAdapter:
         *,
         workdir: str | None = None,
         extra_env: dict[str, str] | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[CliStreamChunk]:
         """Like :meth:`run`, but yield stdout incrementally as it arrives.
 
@@ -334,7 +428,9 @@ class CliAdapter:
             if cfg.cwd
             else (workdir or os.getcwd())
         )
-        argv, stdin_bytes = self._build_invocation(prompt, effective_workdir)
+        argv, stdin_bytes = self._build_invocation(
+            prompt, effective_workdir, session_id=session_id
+        )
         env = self._build_env(prompt, effective_workdir, extra_env)
 
         if not self.is_available():
@@ -428,6 +524,8 @@ class CliAdapter:
             duration = time.monotonic() - start
             stdout = "".join(out_parts)
 
+            captured_session = self._extract_session_id(stdout)
+
             if timed_out:
                 await self._terminate(proc)
                 stderr_task.cancel()
@@ -442,6 +540,7 @@ class CliAdapter:
                         name=cfg.name, ok=False, text=stdout.strip(), returncode=proc.returncode,
                         duration=duration, timed_out=True, stderr=stderr.strip(),
                         error=f"timed out after {cfg.timeout}s",
+                        session_id=captured_session,
                     ),
                 )
                 return
@@ -460,16 +559,18 @@ class CliAdapter:
                         name=cfg.name, ok=False, text=stdout.strip(), returncode=proc.returncode,
                         duration=duration, stderr=stderr.strip(),
                         error=f"exited {proc.returncode}: {stderr.strip()[:500]}",
+                        session_id=captured_session,
                     ),
                 )
                 return
 
-            text, parse_error = self._parse_output(stdout)
+            text, parse_error, parsed_session = self._parse_output(stdout)
             yield CliStreamChunk(
                 final=True,
                 result=CliResult(
                     name=cfg.name, ok=True, text=text, returncode=0, duration=duration,
                     parse_error=parse_error, stderr=stderr.strip(),
+                    session_id=parsed_session or captured_session,
                 ),
             )
         finally:

--- a/src/swarm/core/cli_catalog.py
+++ b/src/swarm/core/cli_catalog.py
@@ -87,6 +87,65 @@ NATIVE_CONSENSUS: dict[str, list[str]] = {
 }
 
 
+# How each catalogued CLI names and resumes a session. First-turn ``cmd`` stays
+# one-shot; Swarm inserts ``resume_argv`` only when a stored id exists.
+# ``{session_id}`` is replaced with the stored id. Distinct from Django/API
+# conversation ids and from OS ``start_new_session`` (process-group kill).
+#
+# antigravity is **not** in CATALOG (not wired). If it is added later, headless
+# resume is ``agy -p --conversation <id>`` (JSON often includes conversation_id).
+SESSION: dict[str, dict[str, Any]] = {
+    "grok": {
+        "resume_argv": ["--resume", "{session_id}"],
+        "resume_insert": 1,
+        "session_id_paths": [".sessionId", ".session_id"],
+        "notes": (
+            "grok -p --resume <uuid> (also -r). --session-id / -s names a NEW "
+            "session; do not use it to resume. JSON often includes sessionId."
+        ),
+    },
+    "claude": {
+        "resume_argv": ["--resume", "{session_id}"],
+        "resume_insert": 1,
+        "session_id_paths": [".session_id"],
+        "notes": (
+            "claude -p --resume <uuid> (also -r). JSON result includes session_id "
+            "even when parse is json:.result. A resume may mint a new session_id; "
+            "store the latest. --session-id names a new session, not a resume."
+        ),
+    },
+    "gemini": {
+        "resume_argv": ["--resume", "{session_id}"],
+        "resume_insert": 1,
+        "session_id_paths": [".session_id", ".sessionId"],
+        "notes": (
+            "gemini -p --resume <uuid> (also -r). --session-id starts a NEW "
+            "session and conflicts with --resume. Capture id from JSON when present."
+        ),
+    },
+    "codex": {
+        "resume_argv": ["resume", "{session_id}"],
+        "resume_insert": 2,  # after `codex exec` → `codex exec resume <id> …`
+        "session_id_paths": [".thread_id", ".session_id"],
+        "notes": (
+            "codex exec resume <SESSION_ID> <prompt> (subcommand, not a --flag). "
+            "Default catalog parse is text; thread_id appears when --json is used. "
+            "Interactive `codex resume` is a TUI — do not use it here."
+        ),
+    },
+    "opencode": {
+        "resume_argv": ["--session", "{session_id}"],
+        "resume_insert": 1,
+        "session_id_paths": [".session", ".sessionID", ".id"],
+        "notes": (
+            "opencode run --session <id> (also -s). --continue/-c is last-session "
+            "in the cwd, not thread-scoped — do not use it. Capture id when the "
+            "CLI emits JSON; the default catalog parse is text."
+        ),
+    },
+}
+
+
 # Default capability traits (0..1) per known CLI for inference-profile matching
 # (see swarm.core.inference_profile). These are sensible starting points the
 # USER is expected to tune for their own plans/models via a per-agent ``traits``
@@ -203,6 +262,12 @@ def with_model(name: str, model: str, *, timeout: int | None = None) -> dict[str
     if timeout is not None:
         entry["timeout"] = timeout
     return entry
+
+
+def session_policy(name: str) -> dict[str, Any] | None:
+    """How ``name`` names and resumes a CLI session, or None if undocumented."""
+    entry = SESSION.get(name)
+    return _deepcopy(entry) if entry is not None else None
 
 
 def catalog_names() -> list[str]:

--- a/src/swarm/core/cli_sessions.py
+++ b/src/swarm/core/cli_sessions.py
@@ -1,0 +1,216 @@
+"""CLI session ids — owned by the CLI, tracked next to the chat thread.
+
+API / Django conversation ids are Swarm-owned. Remote harnesses keep the
+remote's session. This module stores only the **CLI's** session id so the
+next send can pass ``--resume`` / ``--session`` / ``exec resume`` and the
+CLI restores its own context.
+
+Ids are persisted on the per-agent chat JSON record (``cli_sessions``),
+keyed by CLI name. Nothing here stores secrets, API keys, or env dumps.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from swarm.core import chat_store
+from swarm.core.cli_adapter import CliResult
+
+SESSION_TOKEN = "{session_id}"
+
+# Id-shaped tokens only. Reject assignments, whitespace, and common secret prefixes.
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_SECRET_PREFIX = re.compile(
+    r"^(?i:sk-|gsk_|xai-|AIza|ghp_|github_pat_|xox[baprs]-|Bearer )"
+)
+
+# Default JSON paths tried after any per-CLI list (Claude often uses session_id
+# even when parse is json:.result).
+DEFAULT_SESSION_ID_PATHS = (
+    ".session_id",
+    ".sessionId",
+    ".thread_id",
+    ".conversation_id",
+    ".session.id",
+    ".session",
+)
+
+_RESUME_FAILURE_NEEDLES = (
+    "no conversation",
+    "conversation found",
+    "session not found",
+    "unknown session",
+    "invalid session",
+    "expired session",
+    "cannot resume",
+    "failed to resume",
+    "no such session",
+    "unable to resume",
+    "resume failed",
+)
+
+
+def sanitize_cli_session_id(raw: Any) -> str | None:
+    """Return a storeable CLI session id, or None if it looks unsafe / secret."""
+    if raw is None:
+        return None
+    if isinstance(raw, bool) or isinstance(raw, (dict, list)):
+        return None
+    text = str(raw).strip()
+    if not text or len(text) > 128:
+        return None
+    if any(ch in text for ch in ("=", " ", "\n", "\t", "/", "\\")):
+        return None
+    if _SECRET_PREFIX.match(text):
+        return None
+    if not _SESSION_ID_RE.match(text):
+        return None
+    return text
+
+
+def _iter_json_blobs(stdout: str):
+    text = (stdout or "").strip()
+    if not text:
+        return
+    try:
+        yield json.loads(text)
+        return
+    except json.JSONDecodeError:
+        pass
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+
+def extract_session_id(stdout: str, paths: list[str] | None = None) -> str | None:
+    """Best-effort session id from JSON or JSONL stdout. Last match wins."""
+    from swarm.core.cli_adapter import _extract_json_path
+
+    ordered: list[str] = []
+    for path in list(paths or []) + list(DEFAULT_SESSION_ID_PATHS):
+        if path and path not in ordered:
+            ordered.append(path)
+    found: str | None = None
+    for blob in _iter_json_blobs(stdout):
+        if not isinstance(blob, dict):
+            continue
+        for path in ordered:
+            try:
+                value = _extract_json_path(blob, path)
+            except (KeyError, IndexError, TypeError, ValueError):
+                continue
+            sid = sanitize_cli_session_id(value)
+            if sid:
+                found = sid
+    return found
+
+
+def is_resume_failure(result: CliResult) -> bool:
+    """True when a resumed CLI run looks like a missing/expired session."""
+    if result.ok:
+        return False
+    blob = f"{result.error or ''} {result.stderr or ''} {result.text or ''}".lower()
+    return any(needle in blob for needle in _RESUME_FAILURE_NEEDLES)
+
+
+def resolve_thread(
+    params: dict[str, Any] | None, *, default_agent: str
+) -> tuple[str, str] | None:
+    """``(user_key, agent_id)`` for the chat thread, or None if unknown.
+
+    Prefer the websocket identity (``user_key`` + ``agent``). API callers can
+    pass ``conversation_id`` / ``thread`` and we persist under ``_api``.
+    """
+    params = params or {}
+    user_key = str(params.get("user_key") or "").strip()
+    agent = str(
+        params.get("agent") or params.get("agent_id") or default_agent or ""
+    ).strip()
+    conversation_id = str(
+        params.get("conversation_id") or params.get("thread") or ""
+    ).strip()
+    if user_key and agent:
+        return user_key, chat_store.normalize_agent_id(agent)
+    if conversation_id:
+        return "_api", chat_store.normalize_agent_id(conversation_id)
+    return None
+
+
+def get_cli_session(
+    user_key: str,
+    agent_id: str,
+    cli_name: str,
+    *,
+    base_dir: Path | None = None,
+) -> str | None:
+    """Stored CLI session id for this chat thread + CLI, or None."""
+    record = chat_store.load(user_key, agent_id, base_dir=base_dir)
+    if not record:
+        return None
+    sessions = chat_store.normalize_cli_sessions(record.get("cli_sessions"))
+    return sessions.get(chat_store.normalize_agent_id(cli_name))
+
+
+def put_cli_session(
+    user_key: str,
+    agent_id: str,
+    cli_name: str,
+    session_id: str | None,
+    *,
+    conversation_id: str = "",
+    base_dir: Path | None = None,
+) -> str | None:
+    """Write or clear one CLI session id on the thread. Returns the stored id."""
+    sid = sanitize_cli_session_id(session_id)
+    record = chat_store.load(user_key, agent_id, base_dir=base_dir)
+    messages = (record or {}).get("messages") or []
+    sessions = chat_store.normalize_cli_sessions((record or {}).get("cli_sessions"))
+    key = chat_store.normalize_agent_id(cli_name)
+    if sid:
+        sessions[key] = sid
+    else:
+        sessions.pop(key, None)
+    chat_store.save(
+        user_key,
+        agent_id,
+        messages,
+        conversation_id=conversation_id
+        or (record or {}).get("conversation_id")
+        or "",
+        cli_sessions=sessions,
+        base_dir=base_dir,
+    )
+    return sid
+
+
+def clear_cli_session(
+    user_key: str,
+    agent_id: str,
+    cli_name: str,
+    *,
+    conversation_id: str = "",
+    base_dir: Path | None = None,
+) -> None:
+    put_cli_session(
+        user_key,
+        agent_id,
+        cli_name,
+        None,
+        conversation_id=conversation_id,
+        base_dir=base_dir,
+    )
+
+
+def session_notice_text(cli_name: str, *, resumed: bool) -> str:
+    """Honest user-facing line. Never claims restore unless we actually resumed."""
+    if resumed:
+        return f"Resumed {cli_name} session."
+    return f"Started a new {cli_name} session."

--- a/tests/blueprints/test_cli_agent.py
+++ b/tests/blueprints/test_cli_agent.py
@@ -50,6 +50,20 @@ def test_render_prompt_single():
     assert support.render_prompt([{"role": "user", "content": "hi"}]) == "hi"
 
 
+def test_latest_user_prompt_skips_status_and_assistant():
+    assert (
+        support.latest_user_prompt(
+            [
+                {"role": "user", "content": "first"},
+                {"role": "assistant", "content": "ok"},
+                {"role": "status", "content": "Started a new echo session."},
+                {"role": "user", "content": "second"},
+            ]
+        )
+        == "second"
+    )
+
+
 def test_render_prompt_multiturn_transcript():
     out = support.render_prompt(
         [
@@ -249,6 +263,116 @@ async def test_blueprint_reports_cli_failure():
     bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
     chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
     assert "failed" in _final_content(chunks)
+
+
+def _session_notices(chunks):
+    return [
+        c["content"]
+        for c in chunks
+        if isinstance(c, dict) and c.get("type") == "cli_session_notice"
+    ]
+
+
+async def test_second_turn_passes_stored_resume_id(tmp_path, monkeypatch):
+    """Fixture CLI echoes --resume ID; turn two must pass the stored id."""
+    monkeypatch.setenv("SWARM_CHAT_DIR", str(tmp_path))
+    script = tmp_path / "fixture_cli.py"
+    script.write_text(
+        "import json, sys\n"
+        "args = sys.argv[1:]\n"
+        "resume = None\n"
+        "if '--resume' in args:\n"
+        "    resume = args[args.index('--resume') + 1]\n"
+        "prompt = args[-1] if args else ''\n"
+        "print(json.dumps({\n"
+        "    'result': f'resume={resume} prompt={prompt}',\n"
+        "    'session_id': resume or 'sid-1',\n"
+        "}))\n"
+    )
+    cfg = {
+        "cli_agents": {
+            "echo": {
+                "cmd": [PY, str(script), "{prompt}"],
+                "parse": "json:.result",
+                "resume_argv": ["--resume", "{session_id}"],
+                "resume_insert": 2,
+                "session_id_paths": [".session_id"],
+            }
+        },
+        "cli_fusion": {"default_cli": "echo"},
+    }
+    thread = {"user_key": "u1", "agent": "cli_agent", "conversation_id": "t-echo"}
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    bp.set_params({**thread, "cli": "echo", "failover": False})
+    first = await _collect(bp.run([{"role": "user", "content": "hello"}]))
+    assert _final_content(first) == "resume=None prompt=hello"
+    assert _session_notices(first) == ["Started a new echo session."]
+    assert "restored" not in " ".join(_session_notices(first)).lower()
+
+    from swarm.core.cli_sessions import get_cli_session
+
+    assert get_cli_session("u1", "cli_agent", "echo") == "sid-1"
+
+    bp.set_params({**thread, "cli": "echo", "failover": False})
+    second = await _collect(
+        bp.run(
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "resume=None prompt=hello"},
+                {"role": "user", "content": "again"},
+            ]
+        )
+    )
+    assert _final_content(second) == "resume=sid-1 prompt=again"
+    assert _session_notices(second) == ["Resumed echo session."]
+
+
+async def test_missing_session_starts_new_and_is_honest(tmp_path, monkeypatch):
+    monkeypatch.setenv("SWARM_CHAT_DIR", str(tmp_path))
+    script = tmp_path / "expire_cli.py"
+    script.write_text(
+        "import json, sys\n"
+        "args = sys.argv[1:]\n"
+        "if '--resume' in args:\n"
+        "    sys.stderr.write('No conversation found with session ID\\n')\n"
+        "    sys.exit(2)\n"
+        "print(json.dumps({'result': 'fresh', 'session_id': 'sid-new'}))\n"
+    )
+    cfg = {
+        "cli_agents": {
+            "echo": {
+                "cmd": [PY, str(script), "{prompt}"],
+                "parse": "json:.result",
+                "resume_argv": ["--resume", "{session_id}"],
+                "resume_insert": 2,
+            }
+        },
+        "cli_fusion": {"default_cli": "echo"},
+    }
+    from swarm.core.cli_sessions import put_cli_session
+
+    put_cli_session("u1", "cli_agent", "echo", "sid-expired")
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    bp.set_params(
+        {"user_key": "u1", "agent": "cli_agent", "cli": "echo", "failover": False}
+    )
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+    assert _final_content(chunks) == "fresh"
+    assert _session_notices(chunks) == ["Started a new echo session."]
+    assert "restored" not in " ".join(_session_notices(chunks)).lower()
+    from swarm.core.cli_sessions import get_cli_session
+
+    assert get_cli_session("u1", "cli_agent", "echo") == "sid-new"
+
+
+async def test_cli_without_resume_never_claims_restore(tmp_path, monkeypatch):
+    monkeypatch.setenv("SWARM_CHAT_DIR", str(tmp_path))
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=_echo_config())
+    bp.set_params({"user_key": "u1", "agent": "cli_agent", "cli": "echo", "failover": False})
+    chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
+    assert _final_content(chunks) == "ECHO: ping"
+    assert _session_notices(chunks) == ["Started a new echo session."]
+    assert all("Resumed" not in n and "restored" not in n.lower() for n in _session_notices(chunks))
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/core/test_chat_store.py
+++ b/tests/core/test_chat_store.py
@@ -22,6 +22,34 @@ def test_save_load_roundtrip(tmp_path):
     assert [m["content"] for m in loaded["messages"]] == ["hi", "hello"]
 
 
+def test_save_preserves_status_messages_and_cli_sessions(tmp_path):
+    path = chat_store.save(
+        "u1",
+        "cli_agent",
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "status", "content": "Started a new echo session."},
+            {"role": "assistant", "content": "hello"},
+        ],
+        conversation_id="agt-1-cli",
+        cli_sessions={"echo": "sid-1"},
+        base_dir=tmp_path,
+    )
+    assert path is not None
+    loaded = chat_store.load("u1", "cli_agent", base_dir=tmp_path)
+    assert [m["role"] for m in loaded["messages"]] == ["user", "status", "assistant"]
+    assert loaded["cli_sessions"] == {"echo": "sid-1"}
+    chat_store.save(
+        "u1",
+        "cli_agent",
+        loaded["messages"] + [{"role": "user", "content": "again"}],
+        base_dir=tmp_path,
+    )
+    again = chat_store.load("u1", "cli_agent", base_dir=tmp_path)
+    assert again["cli_sessions"] == {"echo": "sid-1"}
+    assert again["cli_sessions"].get("echo") != "sk-secret"
+
+
 def test_normalize_and_default_agent():
     assert chat_store.normalize_agent_id(None) == "_default"
     assert chat_store.normalize_agent_id("  ") == "_default"

--- a/tests/core/test_cli_adapter.py
+++ b/tests/core/test_cli_adapter.py
@@ -96,6 +96,49 @@ async def test_json_parse_dotpath():
     assert res.parse_error is None
 
 
+async def test_json_parse_captures_sibling_session_id():
+    code = (
+        "import json,sys; "
+        "print(json.dumps({'result': 'answer', 'session_id': 'sess-42'}))"
+    )
+    adapter = CliAdapter.from_config(
+        "claude", {"cmd": [PY, "-c", code, "{prompt}"], "parse": "json:.result"}
+    )
+    res = await adapter.run("Q")
+    assert res.ok is True
+    assert res.text == "answer"
+    assert res.session_id == "sess-42"
+
+
+async def test_resume_argv_injected_only_when_id_given(tmp_path):
+    script = tmp_path / "echo_resume.py"
+    script.write_text(
+        "import json,sys\n"
+        "args=sys.argv[1:]\n"
+        "resume=None\n"
+        "if '--resume' in args:\n"
+        "    resume=args[args.index('--resume')+1]\n"
+        "print(json.dumps({'result': 'ok', 'session_id': resume or 'sid-new', "
+        "'argv': args}))\n"
+    )
+    raw = {
+        "cmd": [PY, str(script), "{prompt}"],
+        "parse": "json:.result",
+        "resume_argv": ["--resume", "{session_id}"],
+        "resume_insert": 2,
+        "session_id_paths": [".session_id"],
+    }
+    adapter = CliAdapter.from_config("echo", raw)
+    first = await adapter.run("hello")
+    assert first.ok and first.session_id == "sid-new"
+    argv = adapter._build_invocation("hello", ".", session_id=None)[0]
+    assert "--resume" not in argv
+    resumed = adapter._build_invocation("next", ".", session_id="sid-new")[0]
+    assert resumed[2:4] == ["--resume", "sid-new"]
+    second = await adapter.run("next", session_id="sid-new")
+    assert second.ok and second.session_id == "sid-new"
+
+
 async def test_json_parse_nested_list_index():
     code = (
         "import json; "

--- a/tests/core/test_cli_catalog.py
+++ b/tests/core/test_cli_catalog.py
@@ -12,6 +12,25 @@ def test_catalog_names_are_sorted_and_known():
     assert {"claude", "gemini", "codex", "opencode"} <= set(names)
 
 
+def test_every_catalog_cli_documents_session_resume():
+    for name in cli_catalog.catalog_names():
+        policy = cli_catalog.session_policy(name)
+        assert policy is not None, f"{name} missing SESSION policy"
+        assert policy.get("resume_argv"), f"{name} has no resume_argv"
+        assert "{session_id}" in " ".join(policy["resume_argv"])
+        assert policy.get("notes")
+    assert cli_catalog.session_policy("antigravity") is None
+    grok = cli_catalog.session_policy("grok")
+    assert grok["resume_argv"] == ["--resume", "{session_id}"]
+    claude = cli_catalog.session_policy("claude")
+    assert ".session_id" in claude["session_id_paths"]
+    codex = cli_catalog.session_policy("codex")
+    assert codex["resume_argv"] == ["resume", "{session_id}"]
+    assert codex["resume_insert"] == 2
+    opencode = cli_catalog.session_policy("opencode")
+    assert opencode["resume_argv"] == ["--session", "{session_id}"]
+
+
 def test_every_catalog_entry_is_a_valid_adapter_config():
     # The catalog must never ship a config the adapter layer would reject.
     for name in cli_catalog.catalog_names():

--- a/tests/core/test_cli_sessions.py
+++ b/tests/core/test_cli_sessions.py
@@ -1,0 +1,104 @@
+"""CLI session id capture, sanitization, and per-thread persistence (REQ-52)."""
+
+from __future__ import annotations
+
+from swarm.core import chat_store
+from swarm.core.cli_adapter import CliResult
+from swarm.core.cli_sessions import (
+    extract_session_id,
+    get_cli_session,
+    is_resume_failure,
+    put_cli_session,
+    resolve_thread,
+    sanitize_cli_session_id,
+    session_notice_text,
+)
+
+
+def test_sanitize_keeps_id_shaped_tokens():
+    assert sanitize_cli_session_id("8075bc20-afc5-439f-b281-1376e5785784")
+    assert sanitize_cli_session_id("ses_2132323b6ffeuRlYHhPcU8DaZ6")
+    assert sanitize_cli_session_id("thread.started-1")
+
+
+def test_sanitize_rejects_secrets_and_assignments():
+    assert sanitize_cli_session_id("sk-live-secret-key") is None
+    assert sanitize_cli_session_id("gsk_abc123") is None
+    assert sanitize_cli_session_id("ANTHROPIC_API_KEY=secret") is None
+    assert sanitize_cli_session_id("Bearer tok") is None
+    assert sanitize_cli_session_id({"token": "x"}) is None
+    assert sanitize_cli_session_id("id with spaces") is None
+    assert sanitize_cli_session_id("../etc/passwd") is None
+
+
+def test_extract_session_id_from_claude_shaped_json():
+    raw = '{"type":"result","result":"hello","session_id":"aaa-bbb-ccc"}'
+    assert extract_session_id(raw, [".session_id"]) == "aaa-bbb-ccc"
+
+
+def test_extract_session_id_from_jsonl_last_wins():
+    raw = (
+        '{"type":"thread.started","thread_id":"old-id"}\n'
+        '{"type":"result","session_id":"new-id"}\n'
+    )
+    assert extract_session_id(raw) == "new-id"
+
+
+def test_extract_ignores_secret_looking_json():
+    raw = '{"session_id":"sk-please-do-not-store"}'
+    assert extract_session_id(raw) is None
+
+
+def test_put_and_get_are_per_thread_and_cli(tmp_path):
+    put_cli_session("u1", "cli_agent", "claude", "sid-claude", base_dir=tmp_path)
+    put_cli_session("u1", "cli_agent", "grok", "sid-grok", base_dir=tmp_path)
+    put_cli_session("u1", "other", "claude", "sid-other", base_dir=tmp_path)
+    assert get_cli_session("u1", "cli_agent", "claude", base_dir=tmp_path) == "sid-claude"
+    assert get_cli_session("u1", "cli_agent", "grok", base_dir=tmp_path) == "sid-grok"
+    assert get_cli_session("u1", "other", "claude", base_dir=tmp_path) == "sid-other"
+    record = chat_store.load("u1", "cli_agent", base_dir=tmp_path)
+    assert record["cli_sessions"] == {"claude": "sid-claude", "grok": "sid-grok"}
+    assert "sk-" not in str(record)
+
+
+def test_put_rejects_secrets(tmp_path):
+    assert put_cli_session("u1", "cli_agent", "claude", "sk-secret", base_dir=tmp_path) is None
+    assert get_cli_session("u1", "cli_agent", "claude", base_dir=tmp_path) is None
+
+
+def test_message_save_preserves_cli_sessions(tmp_path):
+    put_cli_session("u1", "cli_agent", "echo", "sid-1", base_dir=tmp_path)
+    chat_store.save(
+        "u1",
+        "cli_agent",
+        [{"role": "user", "content": "hi"}],
+        base_dir=tmp_path,
+    )
+    assert get_cli_session("u1", "cli_agent", "echo", base_dir=tmp_path) == "sid-1"
+
+
+def test_resolve_thread_prefers_user_and_agent():
+    assert resolve_thread(
+        {"user_key": "u9", "agent": "cli_agent", "conversation_id": "other"},
+        default_agent="cli_agent",
+    ) == ("u9", "cli_agent")
+    assert resolve_thread({"conversation_id": "conv-1"}, default_agent="cli_agent") == (
+        "_api",
+        "conv-1",
+    )
+    assert resolve_thread({}, default_agent="cli_agent") is None
+
+
+def test_resume_failure_detects_missing_session():
+    miss = CliResult(name="c", ok=False, text="", error="No conversation found with session ID")
+    ok = CliResult(name="c", ok=True, text="hi")
+    other = CliResult(name="c", ok=False, text="", error="model overloaded")
+    assert is_resume_failure(miss) is True
+    assert is_resume_failure(ok) is False
+    assert is_resume_failure(other) is False
+
+
+def test_session_notice_is_honest():
+    assert "Restored" not in session_notice_text("claude", resumed=False)
+    assert session_notice_text("claude", resumed=False) == "Started a new claude session."
+    assert session_notice_text("claude", resumed=True) == "Resumed claude session."

--- a/tests/e2e_visual/test_golden_journey.py
+++ b/tests/e2e_visual/test_golden_journey.py
@@ -42,12 +42,23 @@ def test_landing_page_is_styled(page, live_server_url):
         "the built CSS is not applying"
     )
 
-    btn = page.locator(".btn-primary").first
+    # `/` is ChatPage (`/?blueprint=support`). SettingsSheet keeps a hidden
+    # `.btn-primary` ("Save retention"), so `.btn-primary`.first is never
+    # visible. Use a visible DaisyUI `.btn` plus the themed composer fill.
+    btn = page.locator("button.btn").locator("visible=true").first
     btn.wait_for(state="visible", timeout=10_000)
-    bg = _computed(page, btn, "backgroundColor")
+    pad = _computed(page, btn, "paddingLeft")
+    assert pad not in ("0px", "0"), (
+        f"visible .btn padding-left is {pad!r}; DaisyUI button styles "
+        "are missing from the bundle"
+    )
+
+    composer = page.locator(".os-composer").first
+    composer.wait_for(state="visible", timeout=10_000)
+    bg = _computed(page, composer, "backgroundColor")
     assert bg not in TRANSPARENT, (
-        ".btn-primary has a transparent background; DaisyUI component "
-        "styles are missing from the bundle"
+        ".os-composer has a transparent background; theme / DaisyUI "
+        "tokens are missing from the bundle"
     )
 
     # The empty-CSS guard: fetch every stylesheet the page links and demand
@@ -82,11 +93,13 @@ def test_login_with_throwaway_superuser(browser, live_server_url, auth_state):
 
 
 def test_chat_websocket_connects(page, live_server_url):
-    """The Connected badge only renders after ws.onopen fires, so this also
-    guards the ASGI/daphne websocket wiring."""
+    """Composer enables only after ws.onopen (REQ-8: healthy WS is silent;
+    do not wait on a standing Connected badge)."""
     page.goto(live_server_url + "/chat", wait_until="domcontentloaded")
-    badge = page.get_by_text("Connected", exact=True)
-    badge.wait_for(state="visible", timeout=20_000)
+    page.get_by_label("Connection status").wait_for(state="attached", timeout=20_000)
+    page.locator('[aria-label="Chat message"]:not([disabled])').wait_for(
+        state="visible", timeout=20_000
+    )
 
 
 def test_blueprint_cards_have_borders(page, live_server_url):

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -502,6 +502,41 @@ class TestBlueprintSelection:
                 }
 
     @pytest.mark.asyncio
+    async def test_blueprint_session_notice_is_bubbleless_status(self, consumer, monkeypatch):
+        """REQ-52: CLI session notice is a status line, not an assistant bubble."""
+        monkeypatch.delenv("SWARM_TEST_MODE", raising=False)
+        consumer.messages = [{"role": "user", "content": "Hello"}]
+
+        async def fake_run(messages, **kwargs):
+            yield {
+                "type": "cli_session_notice",
+                "content": "Started a new echo session.",
+                "resumed": False,
+            }
+            yield {"messages": [{"role": "assistant", "content": "ok"}]}
+
+        instance = MagicMock()
+        instance.run = fake_run
+        instance._params = {}
+
+        with patch("swarm.views.utils.get_blueprint_instance", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = instance
+            with patch.object(consumer, "send", new_callable=AsyncMock) as mock_send:
+                await consumer.respond_with_blueprint("cli_agent", "message-response-cli")
+
+                frames = [
+                    call.kwargs.get("text_data") or call.args[0]
+                    for call in mock_send.await_args_list
+                ]
+                assert any("chat-status-line" in frame for frame in frames)
+                assert any("Started a new echo session." in frame for frame in frames)
+                assert "Restored" not in "".join(frames)
+                assert {"role": "status", "content": "Started a new echo session."} in consumer.messages
+                instance.set_params.assert_called()
+                passed = instance.set_params.call_args[0][0]
+                assert passed.get("agent") == "cli_agent"
+
+    @pytest.mark.asyncio
     async def test_blueprint_run_uses_compacted_context(self, consumer, monkeypatch):
         """REQ-37: blueprint.run sees the summary tree, not covered raw turns."""
         monkeypatch.delenv("SWARM_TEST_MODE", raising=False)

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -465,6 +465,17 @@ html[data-theme="light"] #root {
   background: color-mix(in srgb, var(--color-base-300) 55%, transparent);
 }
 
+.os-chat-status {
+  display: block;
+  margin: 0.45rem auto;
+  max-width: 36rem;
+  padding: 0;
+  text-align: center;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  color: color-mix(in srgb, var(--color-base-content) 45%, transparent);
+}
+
 .chat-summary {
   border: 1px solid color-mix(in srgb, var(--color-base-content) 28%, transparent);
   border-left-width: 3px;

--- a/webui/frontend/src/lib/__tests__/agentChat.test.ts
+++ b/webui/frontend/src/lib/__tests__/agentChat.test.ts
@@ -46,6 +46,7 @@ describe('fetchAgentThread', () => {
           conversation_id: 'agt-1-jeeves',
           messages: [
             { role: 'user', content: 'hi' },
+            { role: 'status', content: 'Started a new grok session.' },
             { role: 'assistant', content: 'hello' },
           ],
         }),
@@ -54,6 +55,7 @@ describe('fetchAgentThread', () => {
     const thread = await fetchAgentThread('jeeves')
     expect(thread.messages).toEqual([
       { role: 'user', content: 'hi' },
+      { role: 'status', content: 'Started a new grok session.' },
       { role: 'assistant', content: 'hello' },
     ])
     expect(thread.conversation_id).toBe('agt-1-jeeves')

--- a/webui/frontend/src/lib/__tests__/chatWs.test.ts
+++ b/webui/frontend/src/lib/__tests__/chatWs.test.ts
@@ -60,6 +60,15 @@ describe('parseChatWsMessage', () => {
     expect(parseChatWsMessage(raw)).toEqual({ kind: 'user_echo', text: 'hi there' })
   })
 
+  it('parses a bubble-less status line', () => {
+    const raw =
+      '<div id="message-list" hx-swap-oob="beforeend"><div class="chat-status-line os-chat-status">Started a new grok session.</div></div>'
+    expect(parseChatWsMessage(raw)).toEqual({
+      kind: 'status',
+      text: 'Started a new grok session.',
+    })
+  })
+
   it('parses an assistant-start append', () => {
     const raw =
       '<div id="message-list" hx-swap-oob="beforeend"><div id="message-response-abc123" class="assistant-message"></div></div>'

--- a/webui/frontend/src/lib/agentChat.ts
+++ b/webui/frontend/src/lib/agentChat.ts
@@ -32,7 +32,7 @@ export function conversationIdForAgent(agentId: string): string {
 }
 
 export interface AgentThreadMessage {
-  role: 'user' | 'assistant'
+  role: 'user' | 'assistant' | 'status'
   content: string
 }
 
@@ -53,7 +53,7 @@ function isThreadMessage(value: unknown): value is AgentThreadMessage {
   if (!value || typeof value !== 'object') return false
   const row = value as { role?: unknown; content?: unknown }
   return (
-    (row.role === 'user' || row.role === 'assistant') &&
+    (row.role === 'user' || row.role === 'assistant' || row.role === 'status') &&
     typeof row.content === 'string'
   )
 }

--- a/webui/frontend/src/lib/chatCompact.ts
+++ b/webui/frontend/src/lib/chatCompact.ts
@@ -12,7 +12,7 @@ export interface ConversationSummary {
 
 export interface ChatBubble {
   key: string
-  role: 'user' | 'assistant'
+  role: 'user' | 'assistant' | 'status'
   text: string
   streaming: boolean
 }

--- a/webui/frontend/src/lib/chatWs.ts
+++ b/webui/frontend/src/lib/chatWs.ts
@@ -31,6 +31,7 @@ export type ChatWsEvent =
   | { kind: 'assistant_start'; id: string }
   | { kind: 'assistant_chunk'; id: string; text: string }
   | { kind: 'assistant_final'; id: string; text: string }
+  | { kind: 'status'; text: string }
   | { kind: 'unknown'; raw: string }
 
 const OOB_CHUNK_PREFIX = 'beforeend:#'
@@ -99,6 +100,9 @@ export function parseChatWsMessage(raw: string): ChatWsEvent {
     const child = root.firstElementChild
     if (child?.classList.contains('user-message')) {
       return { kind: 'user_echo', text: (child.textContent ?? '').trim() }
+    }
+    if (child?.classList.contains('chat-status-line')) {
+      return { kind: 'status', text: (child.textContent ?? '').trim() }
     }
     if (child?.id.startsWith(ASSISTANT_ID_PREFIX)) {
       return { kind: 'assistant_start', id: child.id }

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -71,7 +71,7 @@ type ConnectionStatus = 'connecting' | 'open' | 'closed' | 'failed'
 interface ChatMessage {
   /** Stable key; for assistant messages this is the server-issued container id. */
   key: string
-  role: 'user' | 'assistant'
+  role: 'user' | 'assistant' | 'status'
   text: string
   /** True while the assistant message is still streaming. */
   streaming: boolean
@@ -270,6 +270,17 @@ const ChatPage = () => {
             next = current.map((m) =>
               m.key === event.id ? { ...m, text: event.text, streaming: false } : m,
             )
+            break
+          case 'status':
+            next = [
+              ...current,
+              {
+                key: `status-${current.length}-${Date.now()}`,
+                role: 'status',
+                text: event.text,
+                streaming: false,
+              },
+            ]
             break
         }
         return { ...prev, [threadKey]: next }
@@ -627,6 +638,13 @@ const ChatPage = () => {
               )
             }
             const message = item.message
+            if (message.role === 'status') {
+              return (
+                <p key={message.key} className="os-chat-status" data-role="status">
+                  {message.text}
+                </p>
+              )
+            }
             const isLast = idx === displayItems.length - 1
             const retryEnabled =
               SHOW_MESSAGE_ACTIONS &&

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -513,6 +513,51 @@ describe('ChatPage per-agent persistence (no retention chrome)', () => {
     expect(screen.queryByText(/Disk used/i)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /archive/i })).not.toBeInTheDocument()
   })
+
+  it('renders a CLI session notice without a chat-start/chat-end bubble', async () => {
+    MockWebSocket.instances = []
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/chat/thread/')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              agent_id: 'cli_agent',
+              conversation_id: 'agt-1-cli',
+              messages: [
+                { role: 'user', content: 'hello' },
+                { role: 'status', content: 'Started a new grok session.' },
+                { role: 'assistant', content: 'hi' },
+              ],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: [{ id: 'cli_agent', name: 'CLI Agent', description: 'CLI' }],
+          }),
+        } as Response
+      }),
+    )
+
+    renderChat('/chat?blueprint=cli_agent')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+
+    const notice = await screen.findByText('Started a new grok session.')
+    expect(notice).toHaveAttribute('data-role', 'status')
+    expect(notice.closest('.chat-start')).toBeNull()
+    expect(notice.closest('.chat-end')).toBeNull()
+    expect(notice.closest('.chat-bubble')).toBeNull()
+  })
 })
 
 describe('ChatPage Grok composer and per-agent threads', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #369

## Intent

CLI tools own their sessions. Open Swarm now tracks each catalogued CLI **session id** next to the chat thread and, on the next send to that CLI agent, passes the id back so the CLI restores its own context.

This is distinct from Django/API conversation ids (we persist those ourselves), remote harness sessions (the remote’s session), and OS `start_new_session` (process-group kill). Distinct from #366 (API edit).

## What changed

- Catalog documents per-CLI resume (`--resume` / `--session` / `codex exec resume`). `antigravity` is not wired; noted for later.
- First-turn catalog cmds stay one-shot. Resume argv is inserted only when a stored id exists.
- Session ids are captured from CLI JSON when present (Claude `session_id` even with `json:.result`) and stored on the thread as `cli_sessions` (no secrets).
- Missing/expired ids start a new session; we store the new id.
- Honest UI: bubble-less status line — “Started a new {cli} session.” or “Resumed {cli} session.” Never a fake “restored”.
- Tests use a fixture CLI that echoes `--resume ID`.

## Testing

- Fixture CLI two-turn resume (second turn passes the stored id)
- Expired-id retry starts a new session and is honest
- Secret-shaped values are not stored
- Frontend status line is not a `chat-start` / `chat-end` bubble
- Golden-journey locators updated for the current chat SPA: visible DaisyUI `.btn` + composer fill (not hidden Settings `.btn-primary`); enabled composer instead of a standing Connected badge (REQ-8). Local run: 5 passed, 1 skipped.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-191be0be-725b-4de0-95bb-7b3e9437a4f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-191be0be-725b-4de0-95bb-7b3e9437a4f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

