### PR TITLE
fix(webui): drop leftover conflict marker in api.ts (closes #454)

### DIFF
--- a/tests/unit/test_no_git_conflict_markers.py
+++ b/tests/unit/test_no_git_conflict_markers.py
@@ -1,0 +1,12 @@
+"""Lock: shipped source must not contain leftover git conflict markers (#454)."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MARKERS = ("<<<<<<< ", ">>>>>>> ", "=======",)
+
+
+def test_spa_api_ts_has_no_conflict_markers():
+    text = (ROOT / "webui/frontend/src/lib/api.ts").read_text(encoding="utf-8")
+    for marker in MARKERS:
+        assert marker not in text, f"leftover {marker!r} in webui/frontend/src/lib/api.ts"

--- a/webui/frontend/src/lib/api.ts
+++ b/webui/frontend/src/lib/api.ts
@@ -238,7 +238,6 @@ export interface SupportContext {
 
 export function fetchSupportContext(): Promise<SupportContext> {
   return apiGet<SupportContext>('/v1/support/context/')
->>>>>>> origin/main
 }
 
 /** GET /v1/models/ (OpenAI-style model list) */


### PR DESCRIPTION
# Summary
Removes a leftover `>>>>>>> origin/main` line that #401 committed into `webui/frontend/src/lib/api.ts`. Vite production build works again. Adds a unit lock so that marker cannot return in this file.

## Problem it solves
Issue #454. `main` at `ccc1b33e` (REQ-60 #401) cannot `npm run build`: rolldown reports `Unexpected token` at `fetchSupportContext`. Live `:8001` cannot ship the header avatar until this line is gone.

## How it works
Delete the stray marker after `return apiGet<SupportContext>('/v1/support/context/')`. `tests/unit/test_no_git_conflict_markers.py` reads `api.ts` and fails if `<<<<<<< `, `>>>>>>> `, or `=======` reappear.

## Measured impact
`npm run build` on this branch: success in 294ms (`index-DBTjVblq.js` 516.45 kB). `pytest tests/unit/test_no_git_conflict_markers.py`: 1 passed in 0.33s.

## Test coverage
- `tests/unit/test_no_git_conflict_markers.py` — new lock
- Vite production build on the fixed tree
- Repro: `rg '^>>>>>>> origin/main' webui/frontend/src/lib/api.ts` is empty after the change

## Risks / follow-ups
Only this one marker existed on `main`. Rollback is revert of the one-line deletion. Other agents merging `api.ts` must not reintroduce conflict markers.

## Build footprint
None — no dependency, image, or service changes. One 12-line test file.