### PR TITLE
fix(webui): drop duplicate apiPatch, threadKey, openAgentEditor (closes #471)

### DIFF
--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -74,7 +74,6 @@ import { fetchTeamRosters, teamHideId, type TeamRoster } from '../lib/teamRoster
 import {
   AGENT_SETTINGS_CHANGED_EVENT,
   loadLocalNewChatPerTask,
-  openAgentEditor,
 } from '../lib/agentSettings'
 import { activeTaskSessionCount } from '../lib/agentChat'
 import { openSearchPalette } from './SearchPalette'

--- a/webui/frontend/src/lib/api.ts
+++ b/webui/frontend/src/lib/api.ts
@@ -157,20 +157,6 @@ export async function apiPost<T>(path: string, body: unknown): Promise<T> {
   return (await response.json()) as T
 }
 
-export async function apiPatch<T>(path: string, body: unknown): Promise<T> {
-  const response = await fetch(path, {
-    method: 'PATCH',
-    headers: buildHeaders(true),
-    body: JSON.stringify(body),
-  })
-
-  if (!response.ok) {
-    await throwApiError(path, response)
-  }
-
-  return (await response.json()) as T
-}
-
 export async function apiDelete(path: string): Promise<void> {
   const response = await fetch(path, {
     method: 'DELETE',

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -28,6 +28,7 @@ import { fetchBlueprints, fetchCliAgents, fetchRemotes } from '../lib/api'
 import {
   agentIdFromBlueprint,
   compactAgentThread,
+  conversationIdForAgent,
   conversationIdForTask,
   fetchAgentThread,
   type ConversationSummary,
@@ -117,13 +118,6 @@ const ChatPage = () => {
   const [newChatPerTask, setNewChatPerTask] = useState(() =>
     teamFromUrl ? false : loadLocalNewChatPerTask(defaultBlueprintId(searchParams.get('blueprint'))),
   )
-  const threadKey = teamFromUrl
-    ? teamThreadId(teamFromUrl)
-    : sessionFromUrl
-      ? `${selectedBlueprint}::${sessionFromUrl}`
-      : newChatPerTask
-        ? `${selectedBlueprint}::task`
-        : selectedBlueprint
   const [threads, setThreads] = useState<Record<string, ChatMessage[]>>({})
   const [summariesByThread, setSummariesByThread] = useState<
     Record<string, ConversationSummary[]>
@@ -275,6 +269,7 @@ const ChatPage = () => {
       return
     }
 
+    const agent = agentIdFromBlueprint(selectedBlueprint)
     const fresh = !sessionFromUrl && newChatPerTask
     const nextId = fresh
       ? conversationIdForTask(agent, { newChatPerTask: true })


### PR DESCRIPTION
# Summary
Removes merge leftovers from #415 so the SPA builds again: one `apiPatch`, one `threadKey`, one `openAgentEditor` import. Hydrate effect now imports `conversationIdForAgent` and defines `agent` in that scope.

## Problem it solves
Issue #471. `main` at `0001241c` (REQ-65 #415) fails `npm run build` with duplicated `apiPatch`, `threadKey`, and `openAgentEditor`. Live `:8001` is stuck on the last good SPA (#404).

## How it works
- `api.ts`: drop the second identical `apiPatch`.
- `AgentSidebar.tsx`: keep `openAgentEditor` from `./AgentEditor` (same event App listens for); still import settings helpers from `agentSettings`.
- `ChatPage.tsx`: keep the `conversationId` thread key (new-chat-per-task); import `conversationIdForAgent`; bind `agent` inside the hydrate effect.

## Measured impact
`npm run build` on this branch: success in 287ms (`index--iMzWNvt.js` 532.74 kB). Before: rolldown `PARSE_ERROR` (3 errors).

## Test coverage
- Vite production build
- `vitest` ChatPage: 34 passed / 3 failed that already exist on #415 (identity button, combobox query, remotes fetch) — not caused by this dedupe
- Repro: `npm run build` on `main` @ `0001241c` fails; this branch succeeds

## Risks / follow-ups
`AgentSidebar.test.tsx` on #415 still has a parse error (separate leftover). New-chat-per-task runtime still needs a live ping. Rollback is revert of this three-file diff.

## Build footprint
None.