### PR TITLE
ci: HOLD-skip visual-regression (REQ-89) during smash flush

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -14,9 +14,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   golden-journey:
+    # HOLD (REQ-89 #446): skipped during merge-smash flush — screenshots/tour lock stale.
+    # Re-enable after smash / PNG recapture. Do not delete this workflow.
+    # Agents: ignore this job; own-diff CI only (pytest still required).
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #446

## Feasibility (REQ-89 / #446)

**Intent:** `main` CI is either green, or the jobs that are known-stale are **explicitly skipped/HOLD** with a documented reason, so a new PR is only red for **its own diff**.

**Success:**
1. On current `main`, a no-op or docs-only PR is not red for golden-journey / tour PNG lockfile / other pre-existing fails. Either those jobs pass, or they are skip/continue-on-error **named HOLD** with a pointer to this Issue.
2. A PR that actually breaks unit/frontend still fails those jobs.
3. Document in CONTRIBUTING or workflow comments: do not fan agents at a HOLD job. Own-diff CI only.
4. Tests: workflow YAML or job `if:` makes the HOLD visible. No live host. No secrets. Recapture is a follow-on.

**Constraints:** After the merge smash, not during it (Matthew 2026-09-04: do the HOLD **now** during the PR flush). Distinct from #417/#418, #352. Do not fold into 344. No Neon. No guessed hosts. Do not delete the workflow. Pytest stays required.

HOLD path is enough for Success item 1 skip option. Pytest remains the real gate.

## Change

Tiny workflow-only edit to `.github/workflows/visual-regression.yml`:

- Job-level `if: false` so `golden-journey` does **not** run (and does not fail) on `push`/`pull_request` to `main`.
- HOLD comment pointing at REQ-89 / #446: screenshots/tour lock stale; re-enable after smash / PNG recapture.
- Agents: ignore this job; own-diff CI only (pytest still required).
- `workflow_dispatch` added so the file stays invokable after the HOLD is flipped; job remains skipped while `if: false` is in place.
- Workflow file kept. `python-pytest.yml` not touched. No product code. No secrets. No Neon.

## Verification

On this PR, GitHub already evaluated the HOLD:

- **Visual Regression / golden-journey: skipped** (not failed) — https://github.com/matthewhand/open-swarm/actions/runs/33821783112
- Python Tests frontend + 3.10/3.11/3.12 still queued/running (gate not weakened).
- Local check: YAML parses; `if: false` on `golden-journey`; `python-pytest.yml` identical to `origin/main`.

## Re-enable

Remove `if: false` (and the HOLD comment) after smash / screenshot recapture (`docs/debt/qa-wave2-screenshots-tour.md`). Do not delete this workflow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cc82a8b-237e-4122-899e-8b404c79eb81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cc82a8b-237e-4122-899e-8b404c79eb81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

