### PR TITLE
fix(webui): restore rail ul and parseStartedAt (closes #480)

### DIFF
--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -1157,6 +1157,7 @@ export default function AgentSidebar({
           ) : visibleCount === 0 ? (
             <p className="px-2 py-3 text-sm text-base-content/45">No agents yet.</p>
           ) : (
+            <ul className="space-y-0.5">
               {orderedRows.map((row, index) => (
                 <li key={row.id} data-rail-id={row.id} data-rail-index={index}>
                   {row.kind === 'team'

--- a/webui/frontend/src/lib/__tests__/avatarStack.test.ts
+++ b/webui/frontend/src/lib/__tests__/avatarStack.test.ts
@@ -3,6 +3,7 @@ import {
   STACK_FACE_LIMIT,
   STACK_PULSE_MS,
   isAvatarStack,
+  parseStartedAt,
   selectStackedFaces,
   stackAnimationDelayMs,
   type StackFace,
@@ -34,5 +35,11 @@ describe('avatarStack', () => {
     expect(isAvatarStack(1, 0)).toBe(false)
     expect(isAvatarStack(2, 0)).toBe(true)
     expect(isAvatarStack(1, 1)).toBe(true)
+  })
+
+  it('parses startedAt from a number, ISO string, or fallback index', () => {
+    expect(parseStartedAt(1500, 9)).toBe(1500)
+    expect(parseStartedAt('2020-01-01T00:00:00.000Z', 9)).toBe(Date.parse('2020-01-01T00:00:00.000Z'))
+    expect(parseStartedAt(undefined, 4)).toBe(4)
   })
 })

--- a/webui/frontend/src/lib/avatarStack.ts
+++ b/webui/frontend/src/lib/avatarStack.ts
@@ -51,6 +51,18 @@ export function earliestStartedAt(faces: ReadonlyArray<{ startedAt: number }>): 
   return faces.reduce((min, face) => Math.min(min, face.startedAt), faces[0]!.startedAt)
 }
 
+/** Epoch ms from a number, ISO/date string, or a stable fallback index. */
+export function parseStartedAt(value: unknown, fallbackIndex = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Date.parse(value)
+    if (Number.isFinite(parsed)) return parsed
+    const asNum = Number(value)
+    if (Number.isFinite(asNum)) return asNum
+  }
+  return fallbackIndex
+}
+
 /**
  * Most recent `maxFaces` by `startedAt`, plus remainder.
  * Callers that need a different order (e.g. running-first) should pass


### PR DESCRIPTION
# Summary
Restores the missing `<ul className="space-y-0.5">` around `orderedRows` in `AgentSidebar.tsx` and exports `parseStartedAt` from `avatarStack.ts` so REQ-68 remotes/teams stacks can build.

## Problem it solves
Issue #480. `main` at `41671f2b` (#413) fails `npm run build`: JSX parse error at `orderedRows.map`, then missing export `parseStartedAt`. Live `:8001` is still on #474.

## How it works
- Wrap `orderedRows.map` in `<ul className="space-y-0.5">` as before #413.
- Export `parseStartedAt(value, fallbackIndex)` (number, ISO string, or index).
- Unit lock in `avatarStack.test.ts`.

## Measured impact
`npm run build` on this branch: success in 328ms (`index-BfhcIY--.js` 539.76 kB). Before: rolldown parse + missing export.

## Test coverage
- Vite production build
- `avatarStack.test.ts`, `sessionPicker.test.ts`, `remotesCatalog.test.ts`: 9 passed
- `AgentSidebar.test.tsx` still fails to parse at line 719 (leftover from #415, not this JSX). Follow-up.

## Risks / follow-ups
Fix the AgentSidebar test file parse error separately. Rollback is revert of these three files.

## Build footprint
None.