### PR TITLE
fix(webui): restore threadKey so Chat and the CLI rail render (closes #483)

### DIFF
--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -146,6 +146,15 @@ const ChatPage = () => {
             ),
           }),
   )
+  const threadKey = teamFromUrl
+    ? teamThreadId(teamFromUrl)
+    : remoteFromUrl
+      ? `remote-${remoteFromUrl}${sessionFromUrl ? `-${sessionFromUrl}` : ''}`
+      : sessionFromUrl
+        ? `${selectedBlueprint}::${sessionFromUrl}`
+        : newChatPerTask
+          ? conversationId
+          : selectedBlueprint
 
   const messages = useMemo(() => threads[threadKey] ?? [], [threads, threadKey])
   const summaries = useMemo(


### PR DESCRIPTION
# Summary
Declares `threadKey` on ChatPage so team / remote / session / new-chat-per-task / agent threads resolve. Chat and the left rail render again.

## Problem it solves
Issue #483. After #413, Chat throws `ReferenceError: threadKey is not defined`. The AGENTS rail never mounts, so `grok_agent`, `agy_agent`, `opencode_agent`, and `pi_agent` are gone. Live `:8001` currently white-screens `/chat`.

## How it works
One `const threadKey` after `conversationId` state: team id, `remote-<id>[-session]`, `blueprint::session`, `conversationId` when new-chat-per-task, else the blueprint id.

## Measured impact
`npm run build` succeeds (539.76 kB JS on the previous #482 tree; this is a one-binding add). Playwright on broken main: 0 rail links. After this, rail hrefs should return.

## Test coverage
- Vite production build
- Repro: load `/chat` on `e4964b3b` → console `threadKey is not defined`, no Agent list nav
- Follow-up live Playwright on `:8001` after merge

## Risks / follow-ups
`AgentSidebar.test.tsx` still has a parse error from #415. Rollback is revert of this one binding.

## Build footprint
None.