### PR TITLE
fix(webui): define dragging in team rail rows (closes #486)

### DIFF
--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -835,6 +835,7 @@ export default function AgentSidebar({
     const active = selectedTeamId === team.id
     const sessions = sessionsForTeam(team)
     const stacked = selectStackedFaces(stackFacesForTeam(team))
+    const dragging = draggingId === hideId
     const dropping = dropTargetId === hideId
     return (
       <Link


### PR DESCRIPTION
# Summary
Declares `dragging` in `renderTeamLink` so team rows can apply the drag class without crashing Chat.

## Problem it solves
Issue #486. After #484, Chat still shows “Something went wrong”: `ReferenceError: dragging is not defined`. The CLI rail (`grok_agent`, `agy_agent`, `opencode_agent`, `pi_agent`) does not list.

## How it works
`const dragging = draggingId === hideId` next to the existing `dropping` binding in `renderTeamLink`.

## Measured impact
`npm run build` succeeds. Live `/chat` currently error-boundaries; this should restore the Agent list nav.

## Test coverage
- Vite production build
- Repro: `/chat` on `3d1106b2` → “dragging is not defined”
- Live Playwright after merge (rail hrefs)

## Risks / follow-ups
`AgentSidebar.test.tsx` still fails to parse (leftover from #415). Rollback is revert of one line.

## Build footprint
None.