### PR TITLE
fix(webui): restore dropOnSelf and dedupe api.ts (closes #490)

### DIFF
--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -597,6 +597,12 @@ export default function AgentSidebar({
     finishDrag()
   }
 
+  const dropOnSelf = (event: ReactDragEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    finishDrag()
+  }
+
   const beginRowDrag = (event: ReactDragEvent, agent: { id: string; name: string }) => {
     writeAgentDragPayload(event.dataTransfer, agent)
     beginRailDrag(agent.id)

--- a/webui/frontend/src/lib/api.ts
+++ b/webui/frontend/src/lib/api.ts
@@ -157,20 +157,6 @@ export async function apiPost<T>(path: string, body: unknown): Promise<T> {
   return (await response.json()) as T
 }
 
-export async function apiPatch<T>(path: string, body: unknown): Promise<T> {
-  const response = await fetch(path, {
-    method: 'PATCH',
-    headers: buildHeaders(true),
-    body: JSON.stringify(body),
-  })
-
-  if (!response.ok) {
-    await throwApiError(path, response)
-  }
-
-  return (await response.json()) as T
-}
-
 export async function apiDelete(path: string): Promise<void> {
   const response = await fetch(path, {
     method: 'DELETE',
@@ -180,20 +166,6 @@ export async function apiDelete(path: string): Promise<void> {
   if (!response.ok) {
     await throwApiError(path, response)
   }
-}
-
-export async function apiPatch<T>(path: string, body: unknown): Promise<T> {
-  const response = await fetch(path, {
-    method: 'PATCH',
-    headers: buildHeaders(true),
-    body: JSON.stringify(body),
-  })
-
-  if (!response.ok) {
-    await throwApiError(path, response)
-  }
-
-  return (await response.json()) as T
 }
 
 // ---------------------------------------------------------------------------
@@ -826,16 +798,8 @@ export interface RemoteOperateResult {
   gap?: string
 }
 
-export function fetchRemotes(): Promise<RemotesListResponse> {
-  return apiGet<RemotesListResponse>('/v1/remotes/')
-}
-
 export function addRemote(body: AddRemoteRequest): Promise<RemoteConnection> {
   return apiPost<RemoteConnection>('/v1/remotes/', body)
-}
-
-export function deleteRemote(remoteId: string): Promise<void> {
-  return apiDelete(`/v1/remotes/${encodeURIComponent(remoteId)}/`)
 }
 
 export function probeRemoteHealth(remoteId: string): Promise<RemoteHealthResult> {


### PR DESCRIPTION
# Summary
Restores `dropOnSelf` for remote rail rows and removes duplicate `apiPatch` / `fetchRemotes` / `deleteRemote` exports so the SPA builds and Chat lists CLI agents again.

## Problem it solves
Issue #490. Chat crashed with `dropOnSelf is not defined`. `main` after #414/#411 also fails `npm run build` on duplicated remotes helpers. Live `:8001` was patched locally so the rail is visible; this lands the same fix on `main`.

## How it works
- `dropOnSelf`: preventDefault, stopPropagation, `finishDrag()`.
- Keep one typed `apiPatch`, one `fetchRemotes`, one `deleteRemote`. Leave `createRemote` and `addRemote` (both POST `/v1/remotes/`).

## Measured impact
`npm run build` succeeds. Live Playwright after the local patch: Support then grok_agent, agy_agent, opencode_agent, pi_agent.

## Test coverage
- Vite production build
- Live `/chat` after local dist rebuild: four CLI hrefs, no console errors

## Risks / follow-ups
`AgentSidebar.test.tsx` still fails to parse (#415 leftover). Rollback is revert of these two files.

## Build footprint
None.