### PR TITLE
fix(webui): dedupe api.ts remotes helpers so Vite builds (closes #493)

### DIFF
--- a/webui/frontend/src/lib/api.ts
+++ b/webui/frontend/src/lib/api.ts
@@ -157,20 +157,6 @@ export async function apiPost<T>(path: string, body: unknown): Promise<T> {
   return (await response.json()) as T
 }
 
-export async function apiPatch<T>(path: string, body: unknown): Promise<T> {
-  const response = await fetch(path, {
-    method: 'PATCH',
-    headers: buildHeaders(true),
-    body: JSON.stringify(body),
-  })
-
-  if (!response.ok) {
-    await throwApiError(path, response)
-  }
-
-  return (await response.json()) as T
-}
-
 export async function apiDelete(path: string): Promise<void> {
   const response = await fetch(path, {
     method: 'DELETE',
@@ -485,13 +471,11 @@ export function probeRemoteHealth(remoteId: string): Promise<RemoteHealthResult>
 
 export function operateRemote(
   remoteId: string,
-  op: 'list' | 'send',
-  prompt = '',
-  target = '',
+  body: { op: 'list' | 'send'; prompt?: string; target?: string },
 ): Promise<RemoteOperateResult> {
   return apiPost<RemoteOperateResult>(
     `/v1/remotes/${encodeURIComponent(remoteId)}/operate/`,
-    { op, prompt, target },
+    body,
   )
 }
 
@@ -589,10 +573,6 @@ export interface CreateRemoteRequest {
   api_key?: string
   ui_url?: string
   cookie?: string
-}
-
-export function fetchRemotes(): Promise<RemotesListResponse> {
-  return apiGet<RemotesListResponse>('/v1/remotes/')
 }
 
 export function createRemote(remote: CreateRemoteRequest): Promise<RemoteConnection> {
@@ -907,27 +887,6 @@ export interface RemoteOperateResult {
   http_status?: number | null
   data?: unknown
   gap?: string
-}
-
-export function addRemote(body: AddRemoteRequest): Promise<RemoteConnection> {
-  return apiPost<RemoteConnection>('/v1/remotes/', body)
-}
-
-export function probeRemoteHealth(remoteId: string): Promise<RemoteHealthResult> {
-  return apiPost<RemoteHealthResult>(
-    `/v1/remotes/${encodeURIComponent(remoteId)}/health/`,
-    {},
-  )
-}
-
-export function operateRemote(
-  remoteId: string,
-  body: { op: 'list' | 'send'; prompt?: string; target?: string },
-): Promise<RemoteOperateResult> {
-  return apiPost<RemoteOperateResult>(
-    `/v1/remotes/${encodeURIComponent(remoteId)}/operate/`,
-    body,
-  )
 }
 
 /** GET /v1/blueprints/<id>/tools — a blueprint's capability requirements


### PR DESCRIPTION
# Summary
Removes duplicate `apiPatch`, `fetchRemotes`, `addRemote`, `probeRemoteHealth`, and `operateRemote` exports left by #406 so the SPA builds.

## Problem it solves
Issue #493. `main` at `25e9af69` fails `npm run build`. Live `:8001` still serves the last good bundle and lists the four CLI agents.

## How it works
Keep one typed helper of each. `operateRemote(id, { op, prompt, target })` matches `RemotesSettings.tsx`. `createRemote` / `deleteRemote` stay.

## Measured impact
`npm run build` succeeds (~289ms). Before: five rolldown `PARSE_ERROR`s.

## Test coverage
- Vite production build
- Callers: `RemotesSettings.tsx` uses body-form `operateRemote` / `addRemote`

## Risks / follow-ups
Further remotes PRs must not paste a second copy of these helpers. Rollback is revert of `api.ts`.

## Build footprint
None.