### PR TITLE
fix(db): merge 0012_chatattachment with 0013_conversationsummary (closes #500)

### DIFF
--- a/src/swarm/migrations/0014_merge_chatattachment_summary.py
+++ b/src/swarm/migrations/0014_merge_chatattachment_summary.py
@@ -1,0 +1,13 @@
+# Merge #359 0012_chatattachment with 0012_herdragent → 0013_conversationsummary.
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("swarm", "0012_chatattachment"),
+        ("swarm", "0013_conversationsummary"),
+    ]
+
+    operations = []


### PR DESCRIPTION
# Summary
Adds empty `0014_merge_chatattachment_summary` depending on `0012_chatattachment` and `0013_conversationsummary` so Django has a single leaf.

## Problem it solves
Issue #500. After #359, `migrate swarm` fails with conflicting leaf nodes. Composer attachments cannot persist.

## How it works
Standard Django merge: no operations, two dependencies.

## Measured impact
`migrate swarm` can apply `0012_chatattachment` on a DB that already has herdr + summaries.

## Test coverage
Repro: `showmigrations swarm` listed both 0012_chatattachment (unapplied) and 0013 (applied); `migrate` raised CommandError. After this file, graph has one leaf.

## Risks / follow-ups
Do not add another 0012. Rollback is delete this merge file (graph splits again).

## Build footprint
None.