### PR TITLE
fix: restore REQ-49 API message edit persist and Chat UI

### DIFF
--- a/src/swarm/consumers.py
+++ b/src/swarm/consumers.py
@@ -240,6 +240,19 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
             await self.resolve_tool_decision(text_data_json)
             return
 
+        if text_data_json.get("type") == "status":
+            status_text = text_data_json.get("text")
+            if not isinstance(status_text, str) or not status_text.strip():
+                return
+            agent = text_data_json.get("agent")
+            if isinstance(agent, str) and agent.strip():
+                self.active_agent = agent.strip()
+            self.messages.append({"role": "status", "content": status_text})
+            conversation_id = getattr(self, "conversation_id", None)
+            if conversation_id:
+                await self.save_conversation(conversation_id, self.messages)
+            return
+
         if "edit" in text_data_json:
             await self.apply_message_edit(text_data_json.get("edit"))
             return

--- a/src/swarm/consumers.py
+++ b/src/swarm/consumers.py
@@ -212,7 +212,7 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
         # land before the close is applied. Refuse unauthenticated receives
         # (do not append to transcript or invoke blueprints / LLM).
         if not getattr(self.user, "is_authenticated", False):
-            if swarm_allow_anonymous(client_ip_from_scope(self.scope)):
+            if swarm_allow_anonymous(client_ip_from_scope(getattr(self, "scope", None))):
                 self.user = await database_sync_to_async(get_or_create_preview_user)()
             else:
                 await self.close(
@@ -238,6 +238,10 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
 
         if text_data_json.get("type") == "tool_decision":
             await self.resolve_tool_decision(text_data_json)
+            return
+
+        if "edit" in text_data_json:
+            await self.apply_message_edit(text_data_json.get("edit"))
             return
 
         try:
@@ -650,6 +654,37 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
         )
         await client.close()
         await self.send(text_data=final_message)
+
+    async def apply_message_edit(self, edit):
+        """Replace one transcript turn and persist it (REQ-49)."""
+        from swarm.core.agent_kind import can_edit_agent_messages
+
+        agent = getattr(self, "active_agent", None) or getattr(self, "default_blueprint", None)
+        if not can_edit_agent_messages(agent):
+            logger.info("Ignoring message edit on non-API agent %s", agent)
+            return
+        if not isinstance(edit, dict):
+            logger.warning("Ignoring malformed chat edit frame: %.200r", edit)
+            return
+        index = edit.get("index")
+        content = edit.get("content")
+        if type(index) is not int or not isinstance(content, str):
+            logger.warning("Ignoring malformed chat edit frame: %.200r", edit)
+            return
+        if index < 0 or index >= len(self.messages):
+            logger.warning(
+                "Ignoring chat edit index %s (transcript length %s)",
+                index,
+                len(self.messages),
+            )
+            return
+        current = dict(self.messages[index])
+        current["content"] = content
+        current["edited"] = True
+        self.messages[index] = current
+        conversation_id = getattr(self, "conversation_id", None)
+        if conversation_id:
+            await self.save_conversation(conversation_id, self.messages)
 
     @database_sync_to_async
     def fetch_conversation(self, conversation_id):

--- a/src/swarm/core/chat_store.py
+++ b/src/swarm/core/chat_store.py
@@ -202,10 +202,10 @@ def _read_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _normalize_messages(raw: Any) -> list[dict[str, str]]:
+def _normalize_messages(raw: Any) -> list[dict[str, Any]]:
     if not isinstance(raw, list):
         return []
-    out: list[dict[str, str]] = []
+    out: list[dict[str, Any]] = []
     for item in raw:
         if not isinstance(item, dict):
             continue
@@ -222,10 +222,12 @@ def _normalize_messages(raw: Any) -> list[dict[str, str]]:
             role_s = "status"
         else:
             role_s = "user"
-        msg = {"role": role_s, "content": content}
+        msg: dict[str, Any] = {"role": role_s, "content": content}
         ts = item.get("ts") or item.get("timestamp")
         if isinstance(ts, str) and ts:
             msg["ts"] = ts
+        if item.get("edited") is True or item.get("edited") == "true":
+            msg["edited"] = True
         out.append(msg)
     return out
 
@@ -252,6 +254,7 @@ def empty_record(
 def save(
     user_key: str,
     agent_id: str,
+    messages: list[dict[str, Any]] | None = None,
     *,
     conversation_id: str = "",
     session_id: str = "",
@@ -282,7 +285,9 @@ def save(
         "session_id": session_id or (existing or {}).get("session_id") or "",
         "created_at": created,
         "updated_at": _iso(),
-        "messages": _normalize_messages(messages),
+        "messages": _normalize_messages(
+            messages if messages is not None else (existing or {}).get("messages")
+        ),
         "cli_sessions": sessions,
     }
     _atomic_write(path, record)

--- a/src/swarm/views/chat_persist_views.py
+++ b/src/swarm/views/chat_persist_views.py
@@ -82,6 +82,9 @@ def _public_messages(messages) -> list[dict]:
             "role": item.get("role", "user"),
             "content": item.get("content", ""),
         }
+        ts = item.get("ts") or item.get("timestamp")
+        if isinstance(ts, str) and ts:
+            row["ts"] = ts
         if item.get("edited"):
             row["edited"] = True
         out.append(row)

--- a/src/swarm/views/chat_persist_views.py
+++ b/src/swarm/views/chat_persist_views.py
@@ -16,13 +16,14 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
 
 from swarm.core import chat_store
+from swarm.core.agent_kind import can_edit_agent_messages, classify_agent_kind
 from swarm.core.chat_compact import (
     CompactError,
     compact_backlog,
     list_summaries,
     summary_to_dict,
 )
-from swarm.models import ChatConversation
+from swarm.models import ChatConversation, ChatMessage
 
 logger = logging.getLogger(__name__)
 
@@ -74,18 +75,76 @@ def _summaries_for(*conversation_ids: str) -> tuple[str, list[dict]]:
     return (seen[0] if seen else ""), []
 
 
+def _public_messages(messages) -> list[dict]:
+    out: list[dict] = []
+    for item in messages or []:
+        row = {
+            "role": item.get("role", "user"),
+            "content": item.get("content", ""),
+        }
+        if item.get("edited"):
+            row["edited"] = True
+        out.append(row)
+    return out
+
+
+def _sync_django_and_memory(user, messages, conversation_ids: list[str]) -> None:
+    from swarm.consumers import IN_MEMORY_CONVERSATIONS, _conversation_cache_key
+
+    seen: set[str] = set()
+    for cid in conversation_ids:
+        if not cid or cid in seen:
+            continue
+        seen.add(cid)
+        chat, created = ChatConversation.objects.get_or_create(
+            conversation_id=cid,
+            defaults={"student": user},
+        )
+        if not created and chat.student_id is not None and chat.student_id != user.pk:
+            continue
+        if chat.student_id is None:
+            chat.student = user
+            chat.save(update_fields=["student"])
+        ChatMessage.objects.filter(conversation=chat).delete()
+        ChatMessage.objects.bulk_create(
+            [
+                ChatMessage(
+                    conversation=chat,
+                    sender=item.get("role", "user"),
+                    content=item.get("content", ""),
+                )
+                for item in messages
+            ]
+        )
+        mem_rows: list[dict] = []
+        for item in messages:
+            row = {
+                "role": item.get("role", "user"),
+                "content": item.get("content", ""),
+            }
+            if item.get("edited"):
+                row["edited"] = True
+            mem_rows.append(row)
+        IN_MEMORY_CONVERSATIONS[_conversation_cache_key(user, cid)] = mem_rows
+
+
 @login_required
 @ensure_csrf_cookie
-@require_http_methods(["GET"])
+@require_http_methods(["GET", "PATCH"])
 def chat_thread(request):
-    """Return the persisted transcript for one agent (JSON store, DB fallback)."""
+    """Hydrate (GET) or edit (PATCH) the persisted transcript for one agent."""
     from swarm.core.agent_settings import is_new_chat_per_task
     from swarm.core.session_policy import list_active_task_sessions
 
-    agent = chat_store.normalize_agent_id(request.GET.get("agent"))
+    agent_raw = request.GET.get("agent")
+    agent = chat_store.normalize_agent_id(agent_raw)
     user_key = _user_key(request.user)
     conversation_id = chat_store.conversation_id_for(request.user, agent)
     requested_cid = (request.GET.get("conversation_id") or "").strip()
+    if request.method == "PATCH":
+        body = _json_body(request)
+        if isinstance(body.get("conversation_id"), str) and body["conversation_id"].strip():
+            requested_cid = body["conversation_id"].strip()
     fresh_task = is_new_chat_per_task(agent)
     if fresh_task:
         record = chat_store.load(
@@ -128,19 +187,59 @@ def chat_thread(request):
             request.user, agent
         )
     sessions = list_active_task_sessions(user_key, agent) if fresh_task else []
-    return JsonResponse(
-        {
-            "agent_id": agent,
-            "conversation_id": conversation_id,
-            "new_chat_per_task": fresh_task,
-            "active_sessions": sessions,
-            "messages": [
-                {"role": m.get("role", "user"), "content": m.get("content", "")}
-                for m in (messages or [])
-            ],
-            "summaries": summaries if not (fresh_task and not requested_cid) else [],
-        }
+    kind = classify_agent_kind(agent_raw or agent)
+    payload = {
+        "agent_id": agent,
+        "conversation_id": conversation_id,
+        "kind": kind,
+        "editable": kind == "api",
+        "new_chat_per_task": fresh_task,
+        "active_sessions": sessions,
+        "messages": _public_messages(messages),
+        "summaries": summaries if not (fresh_task and not requested_cid) else [],
+    }
+    if request.method == "GET":
+        return JsonResponse(payload)
+
+    if not can_edit_agent_messages(agent_raw or agent):
+        return JsonResponse(
+            {"error": "Edits are only allowed on API-agent threads."},
+            status=403,
+        )
+    body = _json_body(request)
+    index = body.get("index")
+    content = body.get("content")
+    if type(index) is not int:
+        return JsonResponse({"error": "index must be an integer."}, status=400)
+    if not isinstance(content, str):
+        return JsonResponse({"error": "content must be a string."}, status=400)
+    current_messages = list(messages or [])
+    if index < 0 or index >= len(current_messages):
+        return JsonResponse({"error": "No message at that index."}, status=404)
+    updated = dict(current_messages[index])
+    updated["content"] = content
+    updated["edited"] = True
+    current_messages[index] = updated
+    try:
+        chat_store.save(
+            user_key,
+            agent,
+            current_messages,
+            conversation_id=conversation_id,
+        )
+    except OSError:
+        logger.exception("Failed to persist edited chat JSON for %s/%s", user_key, agent)
+        return JsonResponse(
+            {"error": "Could not persist the edit. See server logs."},
+            status=500,
+        )
+    _sync_django_and_memory(
+        request.user,
+        current_messages,
+        [conversation_id, chat_store.conversation_id_for(request.user, agent)],
     )
+    payload["messages"] = _public_messages(current_messages)
+    return JsonResponse(payload)
 
 
 @login_required

--- a/tests/core/test_chat_store.py
+++ b/tests/core/test_chat_store.py
@@ -47,6 +47,19 @@ def test_save_load_roundtrip(tmp_path):
     assert [m["content"] for m in loaded["messages"]] == ["hi", "hello"]
 
 
+def test_save_preserves_edited_flag(tmp_path):
+    chat_store.save(
+        "u1",
+        "jeeves",
+        [{"role": "user", "content": "engineered", "edited": True}],
+        conversation_id="agt-1-jeeves",
+        base_dir=tmp_path,
+    )
+    loaded = chat_store.load("u1", "jeeves", base_dir=tmp_path)
+    assert loaded["messages"][0]["content"] == "engineered"
+    assert loaded["messages"][0]["edited"] is True
+
+
 def test_save_preserves_status_messages_and_cli_sessions(tmp_path):
     path = chat_store.save(
         "u1",

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -462,6 +462,62 @@ class TestReceive:
         assert future.result() == "allow"
         assert consumer.messages == []
 
+    @pytest.mark.asyncio
+    async def test_edit_frame_updates_transcript_used_by_next_turn(self, consumer):
+        """REQ-49: saved edit is what the next send includes."""
+        consumer.messages = [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+        ]
+        consumer.conversation_id = "test-conv-123"
+        consumer.default_blueprint = "jeeves"
+        consumer.active_agent = "jeeves"
+
+        with patch.object(consumer, "save_conversation", new_callable=AsyncMock) as mock_save:
+            await consumer.receive(
+                json.dumps({"edit": {"index": 0, "content": "engineered question"}})
+            )
+            mock_save.assert_called_once_with("test-conv-123", consumer.messages)
+        assert consumer.messages[0]["content"] == "engineered question"
+        assert consumer.messages[0]["edited"] is True
+
+        captured = {}
+
+        async def fake_respond(blueprint_id, contents_div_id, params=None):
+            captured["messages"] = [dict(m) for m in consumer.messages]
+            captured["blueprint"] = blueprint_id
+            captured["params"] = params
+
+        with patch("swarm.consumers.render_to_string", return_value="<div/>"):
+            with patch.object(consumer, "send", new_callable=AsyncMock):
+                with patch.object(consumer, "respond_with_blueprint", side_effect=fake_respond):
+                    await consumer.receive(
+                        json.dumps({"message": "follow up", "blueprint": "jeeves"})
+                    )
+
+        assert captured["blueprint"] == "jeeves"
+        assert captured["messages"][0]["content"] == "engineered question"
+        assert captured["messages"][-1]["content"] == "follow up"
+
+    @pytest.mark.asyncio
+    async def test_edit_frame_ignored_for_cli_and_remote(self, consumer):
+        consumer.messages = [{"role": "user", "content": "stay"}]
+        consumer.conversation_id = "test-conv-123"
+        consumer.default_blueprint = "cli:grok"
+        consumer.active_agent = "cli:grok"
+
+        with patch.object(consumer, "save_conversation", new_callable=AsyncMock) as mock_save:
+            await consumer.receive(json.dumps({"edit": {"index": 0, "content": "nope"}}))
+            mock_save.assert_not_called()
+        assert consumer.messages[0]["content"] == "stay"
+
+        consumer.default_blueprint = "remote:acp"
+        consumer.active_agent = "remote:acp"
+        with patch.object(consumer, "save_conversation", new_callable=AsyncMock) as mock_save:
+            await consumer.receive(json.dumps({"edit": {"index": 0, "content": "nope"}}))
+            mock_save.assert_not_called()
+        assert consumer.messages[0]["content"] == "stay"
+
 
 # =============================================================================
 # Blueprint Selection Tests

--- a/webui/frontend/src/components/ChatMessageBubble.tsx
+++ b/webui/frontend/src/components/ChatMessageBubble.tsx
@@ -1,4 +1,12 @@
-import { memo, useEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from 'react'
+import {
+  memo,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactNode,
+} from 'react'
 import { Pencil } from 'lucide-react'
 import { Textarea, LoadingDots } from './DaisyUI'
 import { renderSafeMarkdown } from '../lib/markdown'
@@ -14,6 +22,7 @@ export interface ChatMessageBubbleProps {
   onStartEdit: () => void
   onCancelEdit: () => void
   onSaveEdit: (text: string) => void
+  children?: ReactNode
 }
 
 function selectionIsActive(): boolean {
@@ -67,6 +76,7 @@ export function ChatMessageBubble({
   onStartEdit,
   onCancelEdit,
   onSaveEdit,
+  children,
 }: ChatMessageBubbleProps) {
   const [draft, setDraft] = useState(text)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
@@ -147,6 +157,7 @@ export function ChatMessageBubble({
           onClick={handleBubbleClick}
         >
           <ChatBubbleBody text={text} streaming={streaming} />
+          {children}
         </div>
       )}
       {canEdit && !streaming && !editing ? (

--- a/webui/frontend/src/lib/agentChat.ts
+++ b/webui/frontend/src/lib/agentChat.ts
@@ -1,4 +1,5 @@
-import { apiGet, apiPost } from './api'
+import { apiGet, apiPatch, apiPost, ensureCsrfCookie } from './api'
+import { classifyAgentKind, type AgentKind } from './agentKind'
 import {
   isConversationSummary,
   type ConversationSummary,
@@ -93,6 +94,7 @@ export function conversationIdForTask(
 export interface AgentThreadMessage {
   role: 'user' | 'assistant' | 'status'
   content: string
+  edited?: boolean
 }
 
 export interface AgentThread {
@@ -100,6 +102,8 @@ export interface AgentThread {
   conversation_id: string
   messages: AgentThreadMessage[]
   summaries: ConversationSummary[]
+  kind?: AgentKind
+  editable?: boolean
 }
 
 export interface CompactResult {
@@ -110,11 +114,15 @@ export interface CompactResult {
 
 function isThreadMessage(value: unknown): value is AgentThreadMessage {
   if (!value || typeof value !== 'object') return false
-  const row = value as { role?: unknown; content?: unknown }
-  return (
-    (row.role === 'user' || row.role === 'assistant' || row.role === 'status') &&
-    typeof row.content === 'string'
-  )
+  const row = value as { role?: unknown; content?: unknown; edited?: unknown }
+  if (
+    !(row.role === 'user' || row.role === 'assistant' || row.role === 'status') ||
+    typeof row.content !== 'string'
+  ) {
+    return false
+  }
+  if (row.edited !== undefined && row.edited !== true) return false
+  return true
 }
 
 function parseSummaries(value: unknown): ConversationSummary[] {
@@ -136,6 +144,7 @@ export async function fetchAgentThread(
     const messages = Array.isArray(data?.messages)
       ? data.messages.filter(isThreadMessage)
       : []
+    const kind = classifyAgentKind(agent, data?.kind)
     return {
       agent_id: typeof data?.agent_id === 'string' ? data.agent_id : agent,
       conversation_id:
@@ -144,14 +153,53 @@ export async function fetchAgentThread(
           : conversationId,
       messages,
       summaries: parseSummaries(data?.summaries),
+      kind,
+      editable: data?.editable === true || (data?.editable !== false && kind === 'api'),
     }
   } catch {
+    const kind = classifyAgentKind(agent)
     return {
       agent_id: agent,
       conversation_id: conversationId,
       messages: [],
       summaries: [],
+      kind,
+      editable: kind === 'api',
     }
+  }
+}
+
+export interface PatchAgentMessageRequest {
+  index: number
+  content: string
+  conversation_id?: string
+}
+
+/** PATCH /chat/thread/?agent= — persist one edited turn (API agents only). */
+export async function patchAgentMessage(
+  agentId: string,
+  body: PatchAgentMessageRequest,
+): Promise<AgentThread> {
+  const agent = agentIdFromBlueprint(agentId)
+  await ensureCsrfCookie()
+  const data = await apiPatch<AgentThread>(
+    `/chat/thread/?agent=${encodeURIComponent(agent)}`,
+    body,
+  )
+  const messages = Array.isArray(data?.messages)
+    ? data.messages.filter(isThreadMessage)
+    : []
+  const kind = classifyAgentKind(agent, data?.kind)
+  return {
+    agent_id: typeof data?.agent_id === 'string' ? data.agent_id : agent,
+    conversation_id:
+      typeof data?.conversation_id === 'string' && data.conversation_id
+        ? data.conversation_id
+        : conversationIdForAgent(agent),
+    messages,
+    summaries: parseSummaries(data?.summaries),
+    kind,
+    editable: data?.editable === true || (data?.editable !== false && kind === 'api'),
   }
 }
 

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -1,5 +1,4 @@
 import {
-  memo,
   useCallback,
   useEffect,
   useMemo,
@@ -12,7 +11,7 @@ import { useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { Layers, Mic, PanelLeft, Plus, Settings } from 'lucide-react'
 import AgentAvatar from '../components/AgentAvatar'
-import { LoadingDots, useToast } from '../components/DaisyUI'
+import { useToast } from '../components/DaisyUI'
 import ThemeToggle from '../components/ThemeToggle'
 import { OPEN_SETTINGS_EVENT, openSettingsSheet } from '../components/SettingsSheet'
 import {
@@ -24,6 +23,7 @@ import {
 import { useRailChrome } from '../components/RailChrome'
 import { ComputerControlStub } from '../components/ComputerControlStub'
 import { RemoteSelect } from '../components/RemoteSelect'
+import { ChatMessageBubble } from '../components/ChatMessageBubble'
 import { fetchBlueprints, fetchCliAgents, fetchRemotes } from '../lib/api'
 import {
   agentIdFromBlueprint,
@@ -31,14 +31,17 @@ import {
   conversationIdForAgent,
   conversationIdForTask,
   fetchAgentThread,
+  patchAgentMessage,
   type ConversationSummary,
 } from '../lib/agentChat'
+import { canEditAgentMessages, classifyAgentKind, type AgentKind } from '../lib/agentKind'
 import {
   buildDisplayItems,
   contextTextsForMeter,
   summariesById,
 } from '../lib/chatCompact'
 import {
+  buildChatWsEditFrame,
   buildChatWsFrame,
   buildChatWsUrl,
   buildToolDecisionFrame,
@@ -78,7 +81,6 @@ import {
   formatElapsed,
   formatTokenCount,
 } from '../lib/chatMeter'
-import { renderSafeMarkdown } from '../lib/markdown'
 import { isExperimentalEnabled } from '../experimental/flags'
 import { ChatMessageActions } from '../experimental/ChatMessageActions'
 import { agentRole, exampleRoleAgents, isChiefOfStaff, isExampleRole } from '../lib/agentRoles'
@@ -102,6 +104,7 @@ interface ChatMessage {
   /** True while the assistant message is still streaming. */
   streaming: boolean
   tools?: ToolCallState[]
+  edited?: boolean
 }
 
 /** Post-login return path for the Django session gate (rooted, same-origin). */
@@ -145,6 +148,15 @@ const ChatPage = () => {
   const [authRejected, setAuthRejected] = useState(false)
   const [nowMs, setNowMs] = useState(() => Date.now())
   const [plusOpen, setPlusOpen] = useState(false)
+  const [editingKey, setEditingKey] = useState<string | null>(null)
+  const [agentKind, setAgentKind] = useState<AgentKind>(() =>
+    classifyAgentKind(searchParams.get('remote') ? `remote:${searchParams.get('remote')}` : searchParams.get('blueprint')),
+  )
+  const [messagesEditable, setMessagesEditable] = useState(() =>
+    canEditAgentMessages(searchParams.get('blueprint')) &&
+    !searchParams.get('team') &&
+    !searchParams.get('remote'),
+  )
   const [, setEditsTick] = useState(0)
   const [selectedRemoteId, setSelectedRemoteId] = useState('')
   const [conversationId, setConversationId] = useState(() =>
@@ -291,6 +303,9 @@ const ChatPage = () => {
         lastHydratedAgentRef.current !== null && lastHydratedAgentRef.current !== key
       lastHydratedAgentRef.current = key
       setConversationId(key)
+      setEditingKey(null)
+      setAgentKind('api')
+      setMessagesEditable(false)
       userKeyCounterRef.current = 0
       if (switched) {
         setThreads((prev) => ({ ...prev, [key]: [] }))
@@ -304,6 +319,9 @@ const ChatPage = () => {
         lastHydratedAgentRef.current !== null && lastHydratedAgentRef.current !== key
       lastHydratedAgentRef.current = key
       setConversationId(key)
+      setEditingKey(null)
+      setAgentKind('remote')
+      setMessagesEditable(false)
       userKeyCounterRef.current = 0
       if (switched) {
         setThreads((prev) => ({ ...prev, [key]: [] }))
@@ -327,6 +345,9 @@ const ChatPage = () => {
       lastHydratedAgentRef.current !== hydrateKey
     lastHydratedAgentRef.current = hydrateKey
     setConversationId(nextId)
+    setEditingKey(null)
+    setAgentKind(classifyAgentKind(selectedBlueprint))
+    setMessagesEditable(canEditAgentMessages(selectedBlueprint) && !selectedCli)
     userKeyCounterRef.current = 0
     if (switched) {
       setThreads((prev) => ({ ...prev, [threadKey]: [] }))
@@ -340,6 +361,12 @@ const ChatPage = () => {
     ;(async () => {
       const thread = await fetchAgentThread(agent, sessionFromUrl || undefined)
       if (cancelled) return
+      setAgentKind(thread.kind ?? classifyAgentKind(selectedBlueprint))
+      setMessagesEditable(
+        !teamFromUrl &&
+          !remoteFromUrl &&
+          (thread.editable ?? canEditAgentMessages(selectedBlueprint, thread.kind)),
+      )
       setSummariesByThread((prev) => ({
         ...prev,
         [threadKey]: thread.summaries,
@@ -352,13 +379,14 @@ const ChatPage = () => {
           role: message.role,
           text: message.content,
           streaming: false,
+          edited: message.edited === true,
         })),
       }))
     })()
     return () => {
       cancelled = true
     }
-  }, [selectedBlueprint, sessionFromUrl, teamFromUrl, remoteFromUrl, newChatPerTask, threadKey])
+  }, [selectedBlueprint, sessionFromUrl, teamFromUrl, remoteFromUrl, newChatPerTask, threadKey, selectedCli])
 
   const attachToolToThread = useCallback(
     (tool: ToolCallState) => {
@@ -669,6 +697,41 @@ const ChatPage = () => {
     ],
   )
 
+  const saveEditedMessage = useCallback(
+    async (index: number, nextText: string) => {
+      if (!messagesEditable) return
+      const current = threads[threadKey] ?? []
+      const target = current[index]
+      if (!target || target.streaming) return
+      setThreads((prev) => {
+        const list = prev[threadKey] ?? []
+        if (!list[index]) return prev
+        const next = list.slice()
+        next[index] = { ...next[index], text: nextText, edited: true }
+        return { ...prev, [threadKey]: next }
+      })
+      setEditingKey(null)
+      const ws = wsRef.current
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(buildChatWsEditFrame(index, nextText))
+      }
+      try {
+        await patchAgentMessage(agentIdFromBlueprint(selectedBlueprint), {
+          index,
+          content: nextText,
+          conversation_id: conversationIdRef.current,
+        })
+      } catch {
+        addToast({
+          type: 'error',
+          title: 'Could not save edit',
+          message: 'The message was updated in this view, but persist failed.',
+        })
+      }
+    },
+    [addToast, messagesEditable, selectedBlueprint, threadKey, threads],
+  )
+
   const handleSend = (event: FormEvent) => {
     event.preventDefault()
     sendText(input)
@@ -909,6 +972,8 @@ const ChatPage = () => {
         aria-live="polite"
         role="log"
         aria-label="Conversation"
+        data-agent-kind={remoteFromUrl ? 'remote' : selectedCli ? 'cli' : agentKind}
+        data-messages-editable={messagesEditable && !selectedCli ? 'true' : 'false'}
         tabIndex={0}
         onScroll={(e) => {
           const el = e.currentTarget
@@ -945,22 +1010,28 @@ const ChatPage = () => {
               message.role === 'assistant' &&
               !message.streaming &&
               lastUserTextRef.current.length > 0
+            const messageIndex = messages.findIndex((row) => row.key === message.key)
+            const canEditThis =
+              messagesEditable &&
+              !selectedCli &&
+              !message.streaming &&
+              (message.role === 'user' || message.role === 'assistant')
             return (
-              <div
-                key={message.key}
-                className={`chat ${message.role === 'user' ? 'chat-end' : 'chat-start'}`}
-              >
-                <div className="chat-header text-xs opacity-60">
-                  {message.role === 'user' ? 'You' : selectedAgentName}
-                </div>
-                <div
-                  className={`chat-bubble ${
-                    message.role === 'user'
-                      ? 'bg-neutral text-neutral-content'
-                      : 'bg-base-200 text-base-content'
-                  }`}
+              <div key={message.key}>
+                <ChatMessageBubble
+                  role={message.role}
+                  agentName={selectedAgentName}
+                  text={message.text}
+                  streaming={message.streaming}
+                  edited={message.edited}
+                  canEdit={canEditThis}
+                  editing={editingKey === message.key}
+                  onStartEdit={() => setEditingKey(message.key)}
+                  onCancelEdit={() => setEditingKey(null)}
+                  onSaveEdit={(next) => {
+                    if (messageIndex >= 0) void saveEditedMessage(messageIndex, next)
+                  }}
                 >
-                  <ChatBubbleBody text={message.text} streaming={message.streaming} />
                   {(message.tools ?? []).map((tool) => (
                     <ToolCallPopup
                       key={tool.id}
@@ -982,7 +1053,7 @@ const ChatPage = () => {
                       }}
                     />
                   ))}
-                </div>
+                </ChatMessageBubble>
                 {SHOW_MESSAGE_ACTIONS && message.role === 'assistant' && !message.streaming && (
                   <ChatMessageActions
                     text={message.text}
@@ -1112,31 +1183,5 @@ function SummaryBlock({
     </div>
   )
 }
-
-const ChatBubbleBody = memo(
-  function ChatBubbleBody({
-    text,
-    streaming,
-  }: {
-    text: string
-    streaming: boolean
-  }) {
-    if (text.length === 0) {
-      return streaming ? (
-        <LoadingDots size="sm" />
-      ) : (
-        <span className="opacity-60">(empty response)</span>
-      )
-    }
-    return (
-      <div
-        data-testid="chat-md"
-        className="chat-md break-words [&_p]:my-1 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:bg-base-300/40 [&_pre]:p-2 [&_code]:text-sm [&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-1 [&_ol]:list-decimal [&_ol]:pl-5 [&_a]:underline"
-        dangerouslySetInnerHTML={{ __html: renderSafeMarkdown(text) }}
-      />
-    )
-  },
-  (prev, next) => prev.text === next.text && prev.streaming === next.streaming,
-)
 
 export default ChatPage


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## REQ-49 — Engineer context by editing API messages

> Matthew, 2026-09-04.
>
> - **Intent:** On **API** agents, the user can edit any message (user or assistant) so they can engineer the context in-place. **CLI** and **remote** sessions are owned outside Open Swarm, so edit is not offered there.
> - **Success:**
>   1. API-agent threads: hover reveals an edit control on each bubble, **or** clicking the bubble enters edit mode. User and assistant messages both. Save writes the new text into the persisted thread and that is what later turns see.
>   2. CLI and remote threads: **no** edit button, **no** click-to-edit. (Those sessions are managed outside swarm.)
>   3. After edit: bubble-less status is **not** required; the edited bubble is the source of truth. Optional small “edited” hint is OK if cheap.
>   4. Tests: API fixture chat shows edit on user+assistant; CLI/remote fixtures do not; saved edit is what the next send includes.
> - **Constraints:** React 18 + Vite + Tailwind 4 + DaisyUI 5. Chat stays the main view (#364). Distinct from #344. `Fixes` this issue. No live preview checkout. No secrets.

#391 merged kind helpers, `ChatMessageBubble`, and the REQ-49 tests, but not persist or Chat wiring. `chat_store.save()` on main also dropped its `messages` argument while callers still pass one.

This PR restores:

- `PATCH /chat/thread/?agent=` for API threads (403 for CLI/remote)
- Websocket `{"edit": {"index", "content"}}` updates the live transcript used by the next turn
- ChatPage hover/click edit on API bubbles only; chat stays mounted
- `chat_store.save(user_key, agent_id, messages, …)` plus an optional `edited` hint
- GET `/chat/thread/` keeps stored `ts`; `type=status` frames append without invoking the model

Refs #366. Completes the work started in #391.

Fixes #366

### Verification

- `uv run pytest` on agent_kind, chat_store, chat_retention, consumers, chat_compact, cli_sessions, session_policy: **124 passed**
- Vitest REQ-49 ChatPage fixtures (API edit+save+next send, click-to-edit, CLI/remote no edit) + agentKind: **7 passed**
- `./scripts/build_frontend.sh`: **success**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-563bd2e4-ef6b-4fdb-94f3-6359a5eed782?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-563bd2e4-ef6b-4fdb-94f3-6359a5eed782&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

