### PR TITLE
fix(webui): one disconnect toast, clear on WS reconnect (REQ-112)

### DIFF
--- a/webui/frontend/src/components/DaisyUI/Toast.tsx
+++ b/webui/frontend/src/components/DaisyUI/Toast.tsx
@@ -1,10 +1,13 @@
-import { createContext, useContext, useState, useEffect, useRef, ReactNode } from 'react';
+import { createContext, useCallback, useContext, useState, useEffect, useRef, ReactNode } from 'react';
 import { CheckCircle2, AlertTriangle, AlertCircle, Info, X } from 'lucide-react';
 
 /**
  * Toast types
  */
 export type ToastType = 'success' | 'error' | 'warning' | 'info';
+
+/** Chat websocket drop / handshake failure / auth-gate outage (REQ-112). */
+export const TOAST_KIND_WS_DISCONNECT = 'ws-disconnect';
 
 /**
  * Toast interface
@@ -16,6 +19,8 @@ export interface Toast {
   message: ReactNode;
   duration?: number;
   position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
+  /** When set, addToast replaces any existing toast with the same kind. */
+  kind?: string;
 }
 
 /**
@@ -25,6 +30,7 @@ interface ToastContextType {
   toasts: Toast[];
   addToast: (toast: Omit<Toast, 'id'>) => void;
   removeToast: (id: string) => void;
+  dismissByKind: (kind: string) => void;
   success: (title: string, message: ReactNode, duration?: number) => void;
   error: (title: string, message: ReactNode, duration?: number) => void;
   warning: (title: string, message: ReactNode, duration?: number) => void;
@@ -42,35 +48,47 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
   // Monotonic counter avoids same-millisecond id collisions (duplicate keys).
   const toastIdRef = useRef(0);
 
-  const addToast = (toast: Omit<Toast, 'id'>) => {
-    toastIdRef.current += 1;
-    const id = `toast-${Date.now()}-${toastIdRef.current}`;
-    const newToast = { ...toast, id };
-    setToasts(prev => [...prev, newToast]);
-  };
+  const addToast = useCallback((toast: Omit<Toast, 'id'>) => {
+    setToasts(prev => {
+      if (toast.kind) {
+        const others = prev.filter(existing => existing.kind !== toast.kind);
+        const existing = prev.find(candidate => candidate.kind === toast.kind);
+        if (existing) {
+          return [...others, { ...existing, ...toast }];
+        }
+      }
+      toastIdRef.current += 1;
+      const id = `toast-${Date.now()}-${toastIdRef.current}`;
+      return [...prev, { ...toast, id }];
+    });
+  }, []);
 
-  const removeToast = (id: string) => {
+  const removeToast = useCallback((id: string) => {
     setToasts(prev => prev.filter(toast => toast.id !== id));
-  };
+  }, []);
 
-  const success = (title: string, message: ReactNode, duration = 5000) => {
+  const dismissByKind = useCallback((kind: string) => {
+    setToasts(prev => prev.filter(toast => toast.kind !== kind));
+  }, []);
+
+  const success = useCallback((title: string, message: ReactNode, duration = 5000) => {
     addToast({ type: 'success', title, message, duration, position: 'top-right' });
-  };
+  }, [addToast]);
 
-  const error = (title: string, message: ReactNode, duration = 5000) => {
+  const error = useCallback((title: string, message: ReactNode, duration = 5000) => {
     addToast({ type: 'error', title, message, duration, position: 'top-right' });
-  };
+  }, [addToast]);
 
-  const warning = (title: string, message: ReactNode, duration = 5000) => {
+  const warning = useCallback((title: string, message: ReactNode, duration = 5000) => {
     addToast({ type: 'warning', title, message, duration, position: 'top-right' });
-  };
+  }, [addToast]);
 
-  const info = (title: string, message: ReactNode, duration = 5000) => {
+  const info = useCallback((title: string, message: ReactNode, duration = 5000) => {
     addToast({ type: 'info', title, message, duration, position: 'top-right' });
-  };
+  }, [addToast]);
 
   return (
-    <ToastContext.Provider value={{ toasts, addToast, removeToast, success, error, warning, info }}>
+    <ToastContext.Provider value={{ toasts, addToast, removeToast, dismissByKind, success, error, warning, info }}>
       {children}
       <ToastContainer toasts={toasts} removeToast={removeToast} />
     </ToastContext.Provider>
@@ -153,6 +171,7 @@ const ToastItem = ({ toast, removeToast }: ToastItemProps) => {
       role="status"
       aria-live={live}
       aria-atomic="true"
+      data-toast-kind={toast.kind}
     >
       <div className="flex items-start gap-3">
         <div className="mt-1">

--- a/webui/frontend/src/components/DaisyUI/__tests__/Toast.test.tsx
+++ b/webui/frontend/src/components/DaisyUI/__tests__/Toast.test.tsx
@@ -1,0 +1,125 @@
+import { useEffect } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ToastProvider, TOAST_KIND_WS_DISCONNECT, useToast } from '../Toast'
+
+function ToastProbe() {
+  const { addToast, dismissByKind } = useToast()
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          addToast({
+            kind: TOAST_KIND_WS_DISCONNECT,
+            type: 'error',
+            title: 'Chat disconnected',
+            message: 'The chat websocket closed.',
+          })
+        }
+      >
+        fire-disconnect
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          addToast({
+            kind: TOAST_KIND_WS_DISCONNECT,
+            type: 'error',
+            title: 'Chat websocket unreachable',
+            message: 'ASGI is not serving /ws/.',
+          })
+        }
+      >
+        fire-unreachable
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          addToast({
+            type: 'info',
+            title: 'Copied',
+            message: 'Message copied.',
+          })
+        }
+      >
+        fire-copy
+      </button>
+      <button type="button" onClick={() => dismissByKind(TOAST_KIND_WS_DISCONNECT)}>
+        dismiss-disconnect
+      </button>
+    </div>
+  )
+}
+
+function disconnectToasts() {
+  return document.querySelectorAll(`[data-toast-kind="${TOAST_KIND_WS_DISCONNECT}"]`)
+}
+
+describe('Toast kind dedupe (REQ-112 #489)', () => {
+  it('keeps at most one disconnect toast and updates it instead of stacking', () => {
+    render(
+      <ToastProvider>
+        <ToastProbe />
+      </ToastProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'fire-disconnect' }))
+    fireEvent.click(screen.getByRole('button', { name: 'fire-disconnect' }))
+    fireEvent.click(screen.getByRole('button', { name: 'fire-unreachable' }))
+
+    expect(disconnectToasts()).toHaveLength(1)
+    expect(screen.getByText('Chat websocket unreachable')).toBeInTheDocument()
+    expect(screen.queryByText('Chat disconnected')).not.toBeInTheDocument()
+  })
+
+  it('dismisses only disconnect-kind toasts, leaving unrelated ones', () => {
+    render(
+      <ToastProvider>
+        <ToastProbe />
+      </ToastProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'fire-disconnect' }))
+    fireEvent.click(screen.getByRole('button', { name: 'fire-copy' }))
+    expect(screen.getByText('Chat disconnected')).toBeInTheDocument()
+    expect(screen.getByText('Copied')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'dismiss-disconnect' }))
+
+    expect(disconnectToasts()).toHaveLength(0)
+    expect(screen.queryByText('Chat disconnected')).not.toBeInTheDocument()
+    expect(screen.getByText('Copied')).toBeInTheDocument()
+    expect(screen.getByText('Message copied.')).toBeInTheDocument()
+  })
+
+  it('does not stack when a consumer remounts and fires the same kind again', () => {
+    function FireOnMount() {
+      const { addToast } = useToast()
+      useEffect(() => {
+        addToast({
+          kind: TOAST_KIND_WS_DISCONNECT,
+          type: 'error',
+          title: 'Chat disconnected',
+          message: 'The chat websocket closed.',
+        })
+      }, [addToast])
+      return null
+    }
+
+    const { rerender } = render(
+      <ToastProvider>
+        <FireOnMount key="first" />
+      </ToastProvider>,
+    )
+    expect(disconnectToasts()).toHaveLength(1)
+
+    rerender(
+      <ToastProvider>
+        <FireOnMount key="second" />
+      </ToastProvider>,
+    )
+    expect(disconnectToasts()).toHaveLength(1)
+    expect(screen.getAllByText('Chat disconnected')).toHaveLength(1)
+  })
+})

--- a/webui/frontend/src/components/DaisyUI/index.ts
+++ b/webui/frontend/src/components/DaisyUI/index.ts
@@ -21,8 +21,10 @@ export {
   useSuccessToast,
   useErrorToast,
   useWarningToast,
-  useInfoToast
+  useInfoToast,
+  TOAST_KIND_WS_DISCONNECT,
 } from './Toast';
+export type { Toast, ToastType } from './Toast';
 
 // Loading & Skeleton Components
 export { 

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -11,7 +11,7 @@ import { useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { Layers, Mic, PanelLeft, Plus, Settings } from 'lucide-react'
 import AgentAvatar from '../components/AgentAvatar'
-import { useToast } from '../components/DaisyUI'
+import { TOAST_KIND_WS_DISCONNECT, useToast } from '../components/DaisyUI'
 import ThemeToggle from '../components/ThemeToggle'
 import { OPEN_SETTINGS_EVENT, openSettingsSheet } from '../components/SettingsSheet'
 import {
@@ -127,7 +127,7 @@ export {
 
 const ChatPage = () => {
   const [searchParams, setSearchParams] = useSearchParams()
-  const { addToast } = useToast()
+  const { addToast, dismissByKind } = useToast()
   const { narrow, railOpen, openRail } = useRailChrome()
   const teamFromUrl = searchParams.get('team') ?? ''
   const remoteFromUrl = searchParams.get('remote') ?? ''
@@ -208,7 +208,6 @@ const ChatPage = () => {
   const backoffAttemptRef = useRef(0)
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const intentionalCloseRef = useRef(false)
-  const toastedOutageRef = useRef(false)
   const streamStartedAtRef = useRef<number | null>(null)
   const lastUserTextRef = useRef('')
   /** Last hydrated agent or team thread; used to clear bubbles only on switch. */
@@ -612,7 +611,6 @@ const ChatPage = () => {
 
   const reconnect = useCallback(() => {
     backoffAttemptRef.current = 0
-    toastedOutageRef.current = false
     if (reconnectTimerRef.current) {
       clearTimeout(reconnectTimerRef.current)
       reconnectTimerRef.current = null
@@ -622,12 +620,10 @@ const ChatPage = () => {
 
   useEffect(() => {
     if (status === 'open') {
-      toastedOutageRef.current = false
+      dismissByKind(TOAST_KIND_WS_DISCONNECT)
       return
     }
     if (status !== 'failed' && status !== 'closed') return
-    if (toastedOutageRef.current) return
-    toastedOutageRef.current = true
     const title = authRejected
       ? 'Chat unavailable — sign in required'
       : status === 'failed'
@@ -639,6 +635,7 @@ const ChatPage = () => {
         ? 'ASGI is not serving /ws/ or Origin does not match ALLOWED_HOSTS.'
         : 'The chat websocket closed. Message history is kept.'
     addToast({
+      kind: TOAST_KIND_WS_DISCONNECT,
       type: 'error',
       title,
       message: (
@@ -656,7 +653,7 @@ const ChatPage = () => {
       ),
       position: 'bottom-right',
     })
-  }, [status, authRejected, signInHref, addToast, reconnect])
+  }, [status, authRejected, signInHref, addToast, dismissByKind, reconnect])
 
   const canSend = status === 'open' && input.trim().length > 0
 

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, act, fireEvent, within } from '@testing-librar
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Link, MemoryRouter, Route, Routes, useSearchParams } from 'react-router-dom'
 import ChatPage, { chatLoginHref, chatLoginNext } from '../ChatPage'
-import { ToastProvider } from '../../components/DaisyUI'
+import { ToastProvider, TOAST_KIND_WS_DISCONNECT } from '../../components/DaisyUI'
 import AgentAvatar, { DEFAULT_AGENT_AVATAR_SRC } from '../../components/AgentAvatar'
 import { resetConversationThreads } from '../../lib/chatMeter'
 import { AVATAR_THEME_STORAGE_KEY, saveAvatarTheme } from '../../lib/avatarTheme'
@@ -228,6 +228,117 @@ describe('ChatPage Unavailable / Sign-in CTA + connection status', () => {
 
     fireEvent.keyDown(composer, { key: 'Escape' })
     expect(composer).toHaveValue('')
+  })
+})
+
+describe('ChatPage disconnect toasts (REQ-112 #489)', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [] }),
+      } as Response),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    resetConversationThreads()
+  })
+
+  function disconnectToasts() {
+    return document.querySelectorAll(`[data-toast-kind="${TOAST_KIND_WS_DISCONNECT}"]`)
+  }
+
+  it('shows at most one disconnect toast, clears it on reconnect, and keeps unrelated toasts', async () => {
+    renderChat()
+
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+    await act(async () => {
+      MockWebSocket.instances[0]?.close()
+    })
+
+    expect(await screen.findByText('Chat disconnected')).toBeInTheDocument()
+    expect(disconnectToasts()).toHaveLength(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Voice input' }))
+    expect(await screen.findByText(/Speech recognition is not available/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Reconnect/i }))
+    await waitFor(() => {
+      expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(2)
+    })
+    await act(async () => {
+      MockWebSocket.instances[MockWebSocket.instances.length - 1]?.failBeforeOpen()
+    })
+
+    expect(await screen.findByText('Chat websocket unreachable')).toBeInTheDocument()
+    expect(disconnectToasts()).toHaveLength(1)
+    expect(screen.queryByText('Chat disconnected')).not.toBeInTheDocument()
+    expect(screen.getByText(/Speech recognition is not available/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Reconnect/i }))
+    await waitFor(() => {
+      expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(3)
+    })
+    await act(async () => {
+      MockWebSocket.instances[MockWebSocket.instances.length - 1]?.open()
+    })
+
+    await waitFor(() => {
+      expect(disconnectToasts()).toHaveLength(0)
+    })
+    expect(screen.queryByText('Chat disconnected')).not.toBeInTheDocument()
+    expect(screen.queryByText('Chat websocket unreachable')).not.toBeInTheDocument()
+    expect(screen.getByText(/Speech recognition is not available/i)).toBeInTheDocument()
+  })
+
+  it('does not stack disconnect toasts when ChatPage remounts while the socket is down', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const { rerender } = render(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/chat']}>
+            <ChatPage key="one" />
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    await act(async () => {
+      MockWebSocket.instances[0]?.failBeforeOpen()
+    })
+    expect(await screen.findByText('Chat websocket unreachable')).toBeInTheDocument()
+    expect(disconnectToasts()).toHaveLength(1)
+
+    rerender(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/chat']}>
+            <ChatPage key="two" />
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(2)
+    })
+    await act(async () => {
+      MockWebSocket.instances[MockWebSocket.instances.length - 1]?.failBeforeOpen()
+    })
+
+    expect(disconnectToasts()).toHaveLength(1)
+    expect(screen.getAllByText('Chat websocket unreachable')).toHaveLength(1)
   })
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #489 (REQ-112).

## Intent
Reconnect means we’re fine — don’t leave stale disconnect toasts on screen. At most one disconnect/WS-down toast; dismiss all disconnect-related toasts on successful websocket reconnect. Do not wipe unrelated toasts.

## Success
1. Disconnect / connection-lost / WS-down toasts dismiss automatically when the SPA websocket reconnects.
2. Other toasts (errors, copy, notifications) are not wiped.
3. If multiple disconnect toasts were stacked, one reconnect clears all of them.
4. Show-time dedupe: a further disconnect while one is visible updates the existing toast (does not stack).
5. Tests cover fire → reconnect → gone, unrelated toast survives, remount does not stack. DaisyUI 5 / React 18. No live host. No secrets.

## Approach
- Tag outage toasts with `TOAST_KIND_WS_DISCONNECT` on the existing DaisyUI toast bus.
- `addToast` replaces any existing toast of the same `kind` (show-time dedupe; collapses already-stacked same-kind toasts).
- `dismissByKind` on websocket `open` clears only that kind.
- ChatPage remount / StrictMode / flicker no longer stacks because the bus is the source of truth (not a per-mount ref).

## Constraints
- Small focused PR. GitHub-only. No Neon. No live host. Own-diff CI only.

## Verification
- `npx vitest run src/components/DaisyUI/__tests__/Toast.test.tsx src/pages/__tests__/ChatPage.test.tsx -t "REQ-112"` → 5 passed.
- The six other `ChatPage.test.tsx` failures (avatar heading, remotes OpenMousBot, `chat-status`, CLI combobox) are already red on `origin/main`; not in this diff.
- Ignore pre-existing main pytest red.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5988d6b-1d0b-4bce-aeca-f3af4dc49090?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5988d6b-1d0b-4bce-aeca-f3af4dc49090&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

