### PR TITLE
feat(webui): REQ-94 favourites — large avatar + name, 2-up, move not copy

### DIFF
--- a/src/swarm/static/css/rest_mode_style.css
+++ b/src/swarm/static/css/rest_mode_style.css
@@ -446,11 +446,10 @@ html[data-os-theme="light"] {
   min-height: 56px;
 }
 .os-agent-pin-grid {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.4rem;
-  min-height: 2.75rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  min-height: 4.75rem;
   padding: 0.4rem 0.75rem 0.55rem;
   border-top: 1px solid var(--os-border);
   background: #101010;
@@ -463,9 +462,10 @@ html[data-os-theme="light"] .os-agent-pin-grid {
   outline-offset: -3px;
 }
 .os-agent-tile {
-  display: inline-flex;
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  max-width: 11rem;
+  min-width: 0;
   border: 1px solid var(--os-border);
   border-radius: 0.65rem;
   background: var(--os-panel);
@@ -474,18 +474,21 @@ html[data-os-theme="light"] .os-agent-pin-grid {
   border-color: var(--os-accent);
 }
 .os-agent-tile__link {
-  display: inline-flex;
+  display: flex;
   min-width: 0;
+  flex-direction: column;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.28rem 0.35rem 0.28rem 0.5rem;
+  gap: 0.3rem;
+  padding: 0.45rem 0.35rem 0.4rem;
   color: var(--os-text-strong);
   text-decoration: none;
 }
-.os-agent-tile__link .os-agent-dot {
+.os-agent-tile__link .os-agent-dot,
+.os-agent-tile__avatar {
   margin-top: 0;
-  width: 0.55rem;
-  height: 0.55rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
 }
 .os-agent-tile__name {
   overflow: hidden;

--- a/src/swarm/static/js/agent_pin_grid.js
+++ b/src/swarm/static/js/agent_pin_grid.js
@@ -1,6 +1,6 @@
 /**
  * Unlabeled chrome pin grid — drop target for AGENTS sidepane rows.
- * Persist pins in localStorage.swarm_pinned_agents (copy/pin, not a move).
+ * Persist pins in localStorage.swarm_pinned_agents (REQ-94: move, not a copy).
  */
 (function agentPinGrid() {
   var STORAGE_KEY = "swarm_pinned_agents";
@@ -100,7 +100,7 @@
       if (selected === pin.id) link.setAttribute("aria-current", "page");
 
       var dot = document.createElement("span");
-      dot.className = "os-agent-dot";
+      dot.className = "os-agent-dot os-agent-tile__avatar";
       dot.setAttribute("data-mark", markIndex(pin.id));
       dot.setAttribute("aria-hidden", "true");
 
@@ -134,7 +134,7 @@
 
     grid.addEventListener("dragover", function (event) {
       event.preventDefault();
-      if (event.dataTransfer) event.dataTransfer.dropEffect = "copy";
+      if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
       grid.classList.add("is-over");
     });
     grid.addEventListener("dragleave", function (event) {

--- a/src/swarm/static/js/agent_sidebar.js
+++ b/src/swarm/static/js/agent_sidebar.js
@@ -4,6 +4,7 @@
  */
 (function agentSidebar() {
   var STORAGE_KEY = "swarm_hidden_agents";
+  var PINNED_KEY = "swarm_pinned_agents";
   var MARK_COUNT = 6;
 
   var DEFAULT_HIDDEN = ["gate", "tool_gate", "skeptic"];
@@ -28,6 +29,23 @@
       name === "safety" ||
       name === "skeptic"
     );
+  }
+
+  function loadPinnedIds() {
+    try {
+      var raw = localStorage.getItem(PINNED_KEY);
+      if (!raw) return [];
+      var parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      var ids = [];
+      parsed.forEach(function (item) {
+        var id = typeof item === "string" ? item : item && item.id;
+        if (typeof id === "string" && id.length && ids.indexOf(id) === -1) ids.push(id);
+      });
+      return ids;
+    } catch (err) {
+      return [];
+    }
   }
 
   function loadHidden() {
@@ -367,8 +385,9 @@
       var hiddenTeams = teams.filter(function (team) {
         return hiddenIds.indexOf(teamHideId(team.id)) !== -1 && matchesFilter(team, q);
       });
+      var pinnedIds = loadPinnedIds();
       var visible = sortRoles(agents.filter(function (agent) {
-        return hiddenIds.indexOf(agent.id) === -1 && matchesFilter(agent, q);
+        return hiddenIds.indexOf(agent.id) === -1 && pinnedIds.indexOf(agent.id) === -1 && matchesFilter(agent, q);
       }));
       var hidden = sortRoles(agents.filter(function (agent) {
         return hiddenIds.indexOf(agent.id) !== -1 && matchesFilter(agent, q);

--- a/tests/unit/test_req10_pin_grid.py
+++ b/tests/unit/test_req10_pin_grid.py
@@ -18,13 +18,11 @@ def test_base_shell_has_unlabeled_pin_grid_not_favourites_heading():
     assert "Favorites" not in html
 
 
-def test_sidebar_rows_are_html5_draggable_copy_not_move():
+def test_sidebar_excludes_pinned_ids_from_the_list():
     js = SIDEBAR_JS.read_text(encoding="utf-8")
-    assert "draggable" in js
-    assert "application/x-swarm-agent" in js
-    assert "effectAllowed" in js
-    assert "copy" in js
-    assert "__osAgentDrag" in js
+    assert "swarm_pinned_agents" in js
+    assert "pinnedIds" in js
+    assert "loadPinnedIds" in js
 
 
 def test_pin_grid_js_persists_and_can_remove_one():

--- a/tests/unit/test_req94_fav_grid.py
+++ b/tests/unit/test_req94_fav_grid.py
@@ -1,0 +1,49 @@
+"""REQ-94 favourite grid: 2-up named large tiles, move not copy."""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SPA_CSS = REPO / "webui/frontend/src/index.css"
+SPA_SIDEBAR = REPO / "webui/frontend/src/components/AgentSidebar.tsx"
+SPA_PINS = REPO / "webui/frontend/src/lib/pinnedAgents.ts"
+DJANGO_CSS = REPO / "src/swarm/static/css/rest_mode_style.css"
+DJANGO_PIN_JS = REPO / "src/swarm/static/js/agent_pin_grid.js"
+DJANGO_SIDEBAR_JS = REPO / "src/swarm/static/js/agent_sidebar.js"
+
+
+def test_spa_fav_grid_is_two_up_named_large_avatar():
+    css = SPA_CSS.read_text(encoding="utf-8")
+    sidebar = SPA_SIDEBAR.read_text(encoding="utf-8")
+    assert "grid-template-columns: repeat(2, minmax(0, 1fr))" in css
+    assert "repeat(4," not in css.split(".os-fav-grid")[1].split(".os-fav-grid--active")[0]
+    assert ".os-fav-tile__name" in css
+    assert 'data-fav-layout="2-up"' in sidebar
+    assert 'size="lg"' in sidebar
+    assert "os-fav-tile__name" in sidebar
+    assert "Favourites" not in sidebar
+    assert "Favorites" not in sidebar
+
+
+def test_spa_pin_is_a_move_out_of_the_rail_list():
+    pins = SPA_PINS.read_text(encoding="utf-8")
+    sidebar = SPA_SIDEBAR.read_text(encoding="utf-8")
+    assert "excludePinnedFromList" in pins
+    assert "excludePinnedFromList" in sidebar
+    assert "move, not a copy" in pins
+    assert "swarm_pinned_agents" in pins
+    assert 'dropEffect = \'move\'' in sidebar or 'dropEffect = "move"' in sidebar
+
+
+def test_django_mirror_matches_two_up_named_large_tiles():
+    css = DJANGO_CSS.read_text(encoding="utf-8")
+    js = DJANGO_PIN_JS.read_text(encoding="utf-8")
+    sidebar = DJANGO_SIDEBAR_JS.read_text(encoding="utf-8")
+    assert "grid-template-columns: repeat(2, minmax(0, 1fr))" in css
+    assert ".os-agent-tile__name" in css
+    assert "os-agent-tile__avatar" in css
+    assert "os-agent-tile__avatar" in js
+    assert 'dropEffect = "move"' in js
+    assert "swarm_pinned_agents" in sidebar
+    assert "pinnedIds" in sidebar
+    assert "Favourites" not in css
+    assert "Favourites" not in js

--- a/webui/frontend/e2e/req72-merged-chrome.spec.ts
+++ b/webui/frontend/e2e/req72-merged-chrome.spec.ts
@@ -239,10 +239,12 @@ test('REQ-5c #322: pin persists across reload; Unpin clears the grid', async ({ 
 
   await page.reload()
   await expect(page.getByLabel('Pinned agents').getByRole('link', { name: 'Codey' })).toBeVisible()
+  await expect(list.getByRole('link', { name: /Codey/ })).toHaveCount(0)
 
-  await list.getByRole('link', { name: /Codey/ }).click({ button: 'right' })
+  await page.getByLabel('Pinned agents').getByRole('link', { name: 'Codey' }).click({ button: 'right' })
   await page.getByRole('menuitem', { name: /^Unpin$/i }).click()
   await expect(page.getByLabel('Pinned agents').getByRole('link', { name: 'Codey' })).toHaveCount(0)
+  await expect(list.getByRole('link', { name: /Codey/ })).toBeVisible()
 })
 
 test('REQ-28 #345: CoS badge and nested team rows render in the rail', async ({ page }) => {

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -55,6 +55,7 @@ import {
 } from '../lib/settingsPrefs'
 import {
   endAgentDrag,
+  excludePinnedFromList,
   loadPinnedAgents,
   parseAgentDragPayload,
   pinAgent,
@@ -405,8 +406,11 @@ export default function AgentSidebar({
       id: agent.id,
       agent,
     }))
-    return [...supportRows, ...cliRows, ...teamRows, ...remoteRows, ...otherRows]
-  }, [supportAgents, cliAgents, visibleRootTeams, visibleRemotes, otherAgents])
+    return excludePinnedFromList(
+      [...supportRows, ...cliRows, ...teamRows, ...remoteRows, ...otherRows],
+      pins,
+    )
+  }, [supportAgents, cliAgents, visibleRootTeams, visibleRemotes, otherAgents, pins])
   const orderedRows = useMemo(
     () => applyRailOrder(catalogRows, railOrder),
     [catalogRows, railOrder],
@@ -1088,10 +1092,12 @@ export default function AgentSidebar({
         <div
           className={`os-fav-grid ${dropActive ? 'os-fav-grid--active' : ''}`}
           aria-label="Pinned agents"
+          data-fav-layout="2-up"
+          data-testid="agent-fav-grid"
           onDragOver={(event) => {
             event.preventDefault()
             try {
-              event.dataTransfer.dropEffect = 'copy'
+              event.dataTransfer.dropEffect = 'move'
             } catch {
               /* synthetic events may omit dataTransfer */
             }
@@ -1101,7 +1107,19 @@ export default function AgentSidebar({
           onDrop={dropPin}
         >
           {visiblePins.map((pin) => {
+            const live = agents.find((agent) => agent.id === pin.id)
+            const pinName = live ? agentLabel(live) : pin.name || pin.id
             const pinClass = `os-fav-tile ${draggingId === pin.id ? 'os-fav-tile--dragging' : ''}`
+            const pinFace = (
+              <>
+                <AgentAvatar
+                  src={live?.avatar_path}
+                  size="lg"
+                  className="os-fav-tile__avatar"
+                />
+                <span className="os-fav-tile__name">{pinName}</span>
+              </>
+            )
             const pinHandlers = {
               draggable: true as const,
               onDragStart: (event: ReactDragEvent) => beginRowDrag(event, pin),
@@ -1111,7 +1129,7 @@ export default function AgentSidebar({
                 event.preventDefault()
                 setMenu({
                   agentId: pin.id,
-                  agentName: pin.name,
+                  agentName: pinName,
                   hidden: resolvedHiddenIds.includes(pin.id),
                   pinned: true,
                   x: event.clientX,
@@ -1125,15 +1143,12 @@ export default function AgentSidebar({
                   key={pin.id}
                   href="/teams/#herdr-members"
                   className={pinClass}
-                  title={pin.name}
-                  aria-label={pin.name}
+                  title={pinName}
+                  aria-label={pinName}
                   data-agent-id={pin.id}
                   {...pinHandlers}
                 >
-                  <AgentAvatar
-                    src={agents.find((agent) => agent.id === pin.id)?.avatar_path}
-                    size="sm"
-                  />
+                  {pinFace}
                 </a>
               )
             }
@@ -1142,15 +1157,12 @@ export default function AgentSidebar({
                 key={pin.id}
                 to={`/chat?blueprint=${encodeURIComponent(pin.id)}`}
                 className={pinClass}
-                title={pin.name}
-                aria-label={pin.name}
+                title={pinName}
+                aria-label={pinName}
                 data-agent-id={pin.id}
                 {...pinHandlers}
               >
-                <AgentAvatar
-                  src={agents.find((agent) => agent.id === pin.id)?.avatar_path}
-                  size="sm"
-                />
+                {pinFace}
               </Link>
             )
           })}

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -343,8 +343,11 @@ describe('AgentSidebar Grok rail', () => {
     fireEvent.click(await screen.findByRole('menuitem', { name: /^Pin$/i }))
 
     const grid = screen.getByLabelText('Pinned agents')
-    expect(within(grid).getByRole('link', { name: 'Codey' })).toBeInTheDocument()
-    expect(within(list).getByRole('link', { name: /Codey/ })).toBeInTheDocument()
+    const tile = within(grid).getByRole('link', { name: 'Codey' })
+    expect(tile).toBeInTheDocument()
+    expect(tile.querySelector('.os-agent-avatar--lg')).toBeTruthy()
+    expect(tile.querySelector('.os-fav-tile__name')).toHaveTextContent('Codey')
+    expect(within(list).queryByRole('link', { name: /Codey/ })).not.toBeInTheDocument()
     expect(JSON.parse(localStorage.getItem(PINNED_AGENTS_STORAGE_KEY) || '[]')).toEqual([
       { id: 'codey', name: 'Codey' },
     ])
@@ -450,9 +453,11 @@ describe('AgentSidebar Grok rail', () => {
     fireEvent.contextMenu(codey)
     fireEvent.click(await screen.findByRole('menuitem', { name: /^Pin$/i }))
     const grid = screen.getByLabelText('Pinned agents')
-    expect(within(grid).getByRole('link', { name: 'Codey' })).toBeInTheDocument()
+    const tile = within(grid).getByRole('link', { name: 'Codey' })
+    expect(tile).toBeInTheDocument()
+    expect(within(list).queryByRole('link', { name: /Codey/ })).not.toBeInTheDocument()
 
-    dragTo(codey, screen.getByRole('region', { name: 'Hidden' }))
+    dragTo(tile, screen.getByRole('region', { name: 'Hidden' }))
 
     await waitFor(() => {
       expect(within(list).queryByRole('link', { name: /Codey/ })).not.toBeInTheDocument()
@@ -560,6 +565,7 @@ describe('AgentSidebar Grok rail', () => {
     const grid = screen.getByLabelText('Pinned agents')
     expect(within(grid).getByRole('link', { name: 'Codey' })).toBeInTheDocument()
     expect(within(grid).getAllByRole('link')).toHaveLength(1)
+    expect(within(list).queryByRole('link', { name: /Codey/ })).not.toBeInTheDocument()
   })
 
   it('moves a just-completed fixture to index 0 when bump is on', async () => {
@@ -914,6 +920,63 @@ describe('AgentSidebar teams', () => {
   })
 })
 
+describe('AgentSidebar favourites grid (REQ-94)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.stubGlobal('fetch', mockFetch())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    localStorage.clear()
+  })
+
+  it('drops a row onto the 2-up grid as a named large avatar and removes it from the list', async () => {
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const codey = await within(list).findByRole('link', { name: /Codey/ })
+    const stewie = within(list).getByRole('link', { name: /Stewie/ })
+    const grid = screen.getByTestId('agent-fav-grid')
+    expect(grid).toHaveAttribute('data-fav-layout', '2-up')
+    expect(screen.queryByText(/Favourites/i)).not.toBeInTheDocument()
+
+    dragTo(codey, grid)
+    const first = await within(grid).findByRole('link', { name: 'Codey' })
+    expect(first.querySelector('.os-agent-avatar--lg')).toBeTruthy()
+    expect(first.querySelector('.os-fav-tile__name')).toHaveTextContent('Codey')
+    expect(within(list).queryByRole('link', { name: /Codey/ })).not.toBeInTheDocument()
+
+    dragTo(stewie, grid)
+    const tiles = within(grid).getAllByRole('link')
+    expect(tiles.map((link) => link.getAttribute('aria-label'))).toEqual(['Codey', 'Stewie'])
+    expect(tiles[1].querySelector('.os-fav-tile__name')).toHaveTextContent('Stewie')
+    expect(within(list).queryByRole('link', { name: /Stewie/ })).not.toBeInTheDocument()
+    expect(JSON.parse(localStorage.getItem(PINNED_AGENTS_STORAGE_KEY) || '[]')).toEqual([
+      { id: 'codey', name: 'Codey' },
+      { id: 'stewie', name: 'Stewie' },
+    ])
+  })
+
+  it('keeps named tiles and list exclusion after remount', async () => {
+    localStorage.setItem(
+      PINNED_AGENTS_STORAGE_KEY,
+      JSON.stringify([
+        { id: 'codey', name: 'Codey' },
+        { id: 'stewie', name: 'Stewie' },
+      ]),
+    )
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const grid = screen.getByTestId('agent-fav-grid')
+    const tiles = await within(grid).findAllByRole('link')
+    expect(tiles.map((link) => link.getAttribute('aria-label'))).toEqual(['Codey', 'Stewie'])
+    expect(tiles[0].querySelector('.os-agent-avatar--lg')).toBeTruthy()
+    expect(tiles[0].querySelector('.os-fav-tile__name')).toHaveTextContent('Codey')
+    expect(within(list).queryByRole('link', { name: /Codey/ })).not.toBeInTheDocument()
+    expect(within(list).queryByRole('link', { name: /Stewie/ })).not.toBeInTheDocument()
+  })
+})
+
 describe('AgentSidebar pin unpin + plugins (REQ-5c #322)', () => {
   beforeEach(() => {
     localStorage.clear()
@@ -932,13 +995,16 @@ describe('AgentSidebar pin unpin + plugins (REQ-5c #322)', () => {
     fireEvent.contextMenu(codey)
     fireEvent.click(await screen.findByRole('menuitem', { name: /^Pin$/i }))
     const grid = screen.getByLabelText('Pinned agents')
-    expect(within(grid).getByRole('link', { name: 'Codey' })).toBeInTheDocument()
+    const tile = within(grid).getByRole('link', { name: 'Codey' })
+    expect(tile).toBeInTheDocument()
+    expect(within(list).queryByRole('link', { name: /Codey/ })).not.toBeInTheDocument()
 
-    fireEvent.contextMenu(codey)
+    fireEvent.contextMenu(tile)
     fireEvent.click(await screen.findByRole('menuitem', { name: /^Unpin$/i }))
     await waitFor(() => {
       expect(within(grid).queryByRole('link', { name: 'Codey' })).not.toBeInTheDocument()
     })
+    expect(within(list).getByRole('link', { name: /Codey/ })).toBeInTheDocument()
     expect(JSON.parse(localStorage.getItem(PINNED_AGENTS_STORAGE_KEY) || '[]')).toEqual([])
   })
 

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -287,9 +287,9 @@ html[data-theme="light"] #root {
     animation: none;
   }
 }
-.os-fav-tile .os-blob-avatar--sm {
-  width: 1.85rem;
-  height: 1.85rem;
+.os-fav-tile .os-agent-avatar--lg {
+  width: 3rem;
+  height: 3rem;
 }
 .os-agent-row .os-blob-avatar {
   margin-top: 0;
@@ -319,11 +319,11 @@ html[data-theme="light"] #root {
 
 .os-fav-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.4rem;
-  min-height: 2.6rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  min-height: 4.75rem;
   margin: 0 0.75rem 0.5rem;
-  padding: 0.35rem;
+  padding: 0.4rem;
   border-radius: 0.75rem;
   border: 1px dashed color-mix(in srgb, var(--color-base-content) 12%, transparent);
 }
@@ -333,14 +333,28 @@ html[data-theme="light"] #root {
 }
 .os-fav-tile {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 2.15rem;
+  gap: 0.3rem;
+  min-height: 4.5rem;
+  height: auto;
+  padding: 0.45rem 0.3rem 0.4rem;
   border-radius: 0.65rem;
   background: color-mix(in srgb, var(--color-base-content) 6%, transparent);
 }
 .os-fav-tile:hover {
   background: color-mix(in srgb, var(--color-base-content) 12%, transparent);
+}
+.os-fav-tile__name {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.7rem;
+  font-weight: 650;
+  line-height: 1.2;
+  text-align: center;
 }
 
 .os-agent-row {

--- a/webui/frontend/src/lib/__tests__/pinnedAgents.test.ts
+++ b/webui/frontend/src/lib/__tests__/pinnedAgents.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   PINNED_AGENTS_STORAGE_KEY,
+  excludePinnedFromList,
   loadPinnedAgents,
   pinAgent,
   unpinAgent,
@@ -23,5 +24,16 @@ describe('pinnedAgents persistence', () => {
     const pinned = pinAgent({ id: 'stewie', name: 'Stewie' }, [{ id: 'codey', name: 'Codey' }])
     expect(unpinAgent('codey', pinned)).toEqual([{ id: 'stewie', name: 'Stewie' }])
     expect(loadPinnedAgents()).toEqual([{ id: 'stewie', name: 'Stewie' }])
+  })
+
+  it('drops favourited ids from the rail list (move, not copy)', () => {
+    const rows = [{ id: 'codey' }, { id: 'stewie' }, { id: 'support' }]
+    const pins = pinAgent({ id: 'codey', name: 'Codey' }, [])
+    expect(excludePinnedFromList(rows, pins).map((row) => row.id)).toEqual(['stewie', 'support'])
+    expect(excludePinnedFromList(rows, unpinAgent('codey', pins)).map((row) => row.id)).toEqual([
+      'codey',
+      'stewie',
+      'support',
+    ])
   })
 })

--- a/webui/frontend/src/lib/pinnedAgents.ts
+++ b/webui/frontend/src/lib/pinnedAgents.ts
@@ -1,8 +1,10 @@
 /**
  * Persist pinned favourite tiles (drag-from-conversation-list).
  *
- * Pin is a copy, not a move: the conversation row stays in the rail.
- * IDs live in localStorage so a reload keeps the unlabeled tile grid.
+ * REQ-94: pin is a move, not a copy. The rail list excludes these ids so
+ * an agent is never listed in both the favourite grid and the rows below.
+ * Unpin restores the row (rail order is unchanged). IDs live in
+ * localStorage so a reload keeps the unlabeled tile grid and the exclusion.
  */
 
 export const PINNED_AGENTS_STORAGE_KEY = 'swarm_pinned_agents'
@@ -94,6 +96,21 @@ export function unpinAgent(id: string, current: PinnedAgent[]): PinnedAgent[] {
   const next = current.filter((item) => item.id !== id)
   savePinnedAgents(next)
   return next
+}
+
+/** Ids currently sitting in the favourite grid (hidden pins stay in storage). */
+export function pinnedAgentIds(pins: PinnedAgent[]): Set<string> {
+  return new Set(pins.map((pin) => pin.id))
+}
+
+/** Drop favourited ids from the AGENTS/rail list so pin is a move, not a copy. */
+export function excludePinnedFromList<T extends { id: string }>(
+  items: T[],
+  pins: PinnedAgent[],
+): T[] {
+  if (!pins.length) return items
+  const ids = pinnedAgentIds(pins)
+  return items.filter((item) => !ids.has(item.id))
 }
 
 export function writeAgentDragPayload(dataTransfer: DataTransfer, agent: PinnedAgent): void {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Favourites are the primary place for pinned agents — big enough to scan by face + name, two-up, and not duplicated in the AGENTS/rail list underneath.

## Success

1. Each favourite is a **large avatar** with the **agent name underneath** (not icon-only compact tiles).
2. Grid is **2 columns**; extra pins wrap to new rows and the block grows vertically.
3. **Move, not copy:** dropping into favourites removes that id from the list below. Unpin restores the row (rail order unchanged). Same agent id is never listed in both places.
4. Persist via existing `swarm_pinned_agents`; reload keeps the set and the list exclusion.
5. Click still opens that agent’s chat. Native HTML5 DnD. DaisyUI 5 / React 18. No new DnD library.
6. Retargets REQ-10 / PR #311 copy + compact tiles. SPA is source of truth. Existing Django pin mirror gets the same 2-up + name + list-exclusion rules (no new Django chrome).

## Constraints

- Distinct from #368 / #435 / #347. No “Favourites” heading added.
- GitHub-only. No Neon. No secrets. Own-diff CI only.
- Does **not** change navbar Edit/Computer, search popup, or disconnect toasts.

## Tests

- Vitest REQ-94 / pin cases: drop → named large-avatar tile; second pin wraps; dropped id absent from list; unpin restores; remount keeps both. **10 passed**.
- Pytest file contracts for SPA + Django 2-up / move (`test_req94_fav_grid.py` + retargeted REQ-10). **7 passed**.

Fixes #451

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4368d890-671f-4aac-90d5-0f0b76641350?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4368d890-671f-4aac-90d5-0f0b76641350&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

