### PR TITLE
fix(webui): drag favourite back to list + reorder grid (REQ-139)

### DIFF
--- a/tests/unit/test_req94_fav_grid.py
+++ b/tests/unit/test_req94_fav_grid.py
@@ -17,9 +17,15 @@ def test_spa_fav_grid_is_two_up_named_large_avatar():
     assert "grid-template-columns: repeat(2, minmax(0, 1fr))" in css
     assert "repeat(4," not in css.split(".os-fav-grid")[1].split(".os-fav-grid--active")[0]
     assert ".os-fav-tile__name" in css
+    assert ".os-fav-tile__badge" in css
+    tile_block = css.split(".os-fav-tile {")[1].split("}")[0]
+    assert "background: transparent" in tile_block
+    assert ".os-fav-tile--active" in css
     assert 'data-fav-layout="2-up"' in sidebar
     assert 'size="lg"' in sidebar
     assert "os-fav-tile__name" in sidebar
+    assert "os-fav-tile__badge" in sidebar
+    assert "os-fav-tile--active" in sidebar
     assert "Favourites" not in sidebar
     assert "Favorites" not in sidebar
 

--- a/tests/unit/test_req94_fav_grid.py
+++ b/tests/unit/test_req94_fav_grid.py
@@ -31,6 +31,10 @@ def test_spa_pin_is_a_move_out_of_the_rail_list():
     assert "excludePinnedFromList" in sidebar
     assert "move, not a copy" in pins
     assert "swarm_pinned_agents" in pins
+    assert "movePinnedAgent" in pins
+    assert "dropUnfavourite" in sidebar
+    assert "dropPinReorder" in sidebar
+    assert "agent-list-drop" in sidebar
     assert 'dropEffect = \'move\'' in sidebar or 'dropEffect = "move"' in sidebar
 
 

--- a/tests/unit/test_req94_fav_grid.py
+++ b/tests/unit/test_req94_fav_grid.py
@@ -21,11 +21,16 @@ def test_spa_fav_grid_is_two_up_named_large_avatar():
     tile_block = css.split(".os-fav-tile {")[1].split("}")[0]
     assert "background: transparent" in tile_block
     assert ".os-fav-tile--active" in css
+    assert ".os-fav-grid--bare" in css
+    assert ".os-fav-grid__hint" in css
     assert 'data-fav-layout="2-up"' in sidebar
     assert 'size="lg"' in sidebar
     assert "os-fav-tile__name" in sidebar
     assert "os-fav-tile__badge" in sidebar
     assert "os-fav-tile--active" in sidebar
+    assert "os-fav-grid--bare" in sidebar
+    assert "fav-empty-hint" in sidebar
+    assert "loadOrSeedPinnedAgents" in sidebar
     assert "Favourites" not in sidebar
     assert "Favorites" not in sidebar
 
@@ -38,6 +43,8 @@ def test_spa_pin_is_a_move_out_of_the_rail_list():
     assert "move, not a copy" in pins
     assert "swarm_pinned_agents" in pins
     assert "movePinnedAgent" in pins
+    assert "loadOrSeedPinnedAgents" in pins
+    assert "DEFAULT_PINNED_SUPPORT" in pins
     assert "dropUnfavourite" in sidebar
     assert "dropPinReorder" in sidebar
     assert "agent-list-drop" in sidebar

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -57,6 +57,7 @@ import {
   endAgentDrag,
   excludePinnedFromList,
   loadPinnedAgents,
+  movePinnedAgent,
   parseAgentDragPayload,
   pinAgent,
   type PinnedAgent,
@@ -213,6 +214,7 @@ export default function AgentSidebar({
   const [menu, setMenu] = useState<ContextMenuState | null>(null)
   const [settingsTick, setSettingsTick] = useState(0)
   const [dropActive, setDropActive] = useState(false)
+  const [listDropActive, setListDropActive] = useState(false)
   const [hideDropActive, setHideDropActive] = useState(false)
   const [draggingId, setDraggingId] = useState<string | null>(null)
   const [picker, setPicker] = useState<PickerState | null>(null)
@@ -514,9 +516,13 @@ export default function AgentSidebar({
     setDraggingId(null)
     setDropTargetId(null)
     setDropActive(false)
+    setListDropActive(false)
     setHideDropActive(false)
     hideDropDepth.current = 0
   }
+
+  const isPinnedId = (id: string | null | undefined) =>
+    Boolean(id && pins.some((pin) => pin.id === id))
 
   /**
    * Hide wins: the id leaves the conversation list and the favourite pin grid.
@@ -559,7 +565,46 @@ export default function AgentSidebar({
     setDropActive(false)
     finishDrag()
     if (!payload) return
-    setPins((current) => pinAgent(payload, current))
+    // Already-pinned drops on empty grid space are a no-op; tile drops reorder.
+    setPins((current) =>
+      current.some((pin) => pin.id === payload.id) ? current : pinAgent(payload, current),
+    )
+  }
+
+  const dropPinReorder = (event: ReactDragEvent, beforeId: string) => {
+    event.preventDefault()
+    event.stopPropagation()
+    const payload = parseAgentDragPayload(event.dataTransfer)
+    finishDrag()
+    if (!payload?.id || payload.id === beforeId) return
+    setPins((current) => {
+      if (current.some((pin) => pin.id === payload.id)) {
+        return movePinnedAgent(payload.id, beforeId, current)
+      }
+      return pinAgent(payload, current)
+    })
+  }
+
+  const dropUnfavourite = (event: ReactDragEvent) => {
+    event.preventDefault()
+    const payload = parseAgentDragPayload(event.dataTransfer)
+    finishDrag()
+    if (!payload?.id) return
+    setPins((current) =>
+      current.some((pin) => pin.id === payload.id) ? unpinAgent(payload.id, current) : current,
+    )
+  }
+
+  const allowListUnfavourite = (event: ReactDragEvent) => {
+    const fromId = peekRailDrag() || parseAgentDragPayload(event.dataTransfer)?.id
+    if (!isPinnedId(fromId)) return
+    event.preventDefault()
+    try {
+      event.dataTransfer.dropEffect = 'move'
+    } catch {
+      /* synthetic events may omit dataTransfer */
+    }
+    setListDropActive(true)
   }
 
   const dropHide = (event: ReactDragEvent) => {
@@ -596,7 +641,11 @@ export default function AgentSidebar({
     event.stopPropagation()
     const fromId = peekRailDrag() || parseAgentDragPayload(event.dataTransfer)?.id
     if (fromId && fromId !== targetId) {
-      reorderBefore(fromId, targetId)
+      if (isPinnedId(fromId)) {
+        setPins((current) => unpinAgent(fromId, current))
+      } else {
+        reorderBefore(fromId, targetId)
+      }
     }
     finishDrag()
   }
@@ -604,6 +653,10 @@ export default function AgentSidebar({
   const dropOnSelf = (event: ReactDragEvent) => {
     event.preventDefault()
     event.stopPropagation()
+    const fromId = peekRailDrag() || parseAgentDragPayload(event.dataTransfer)?.id
+    if (isPinnedId(fromId)) {
+      setPins((current) => unpinAgent(fromId!, current))
+    }
     finishDrag()
   }
 
@@ -947,6 +1000,11 @@ export default function AgentSidebar({
         onDragStart={(event) => beginRowDrag(event, { id: hideId, name })}
         onDragEnd={finishDrag}
         onDragOver={(event) => {
+          const fromId = peekRailDrag() || parseAgentDragPayload(event.dataTransfer)?.id
+          if (isPinnedId(fromId)) {
+            allowRowDrop(event, hideId)
+            return
+          }
           try {
             event.dataTransfer.dropEffect = 'none'
           } catch {
@@ -1109,7 +1167,9 @@ export default function AgentSidebar({
           {visiblePins.map((pin) => {
             const live = agents.find((agent) => agent.id === pin.id)
             const pinName = live ? agentLabel(live) : pin.name || pin.id
-            const pinClass = `os-fav-tile ${draggingId === pin.id ? 'os-fav-tile--dragging' : ''}`
+            const pinClass = `os-fav-tile ${
+              draggingId === pin.id ? 'os-fav-tile--dragging' : ''
+            } ${dropTargetId === pin.id ? 'os-fav-tile--drop' : ''}`
             const pinFace = (
               <>
                 <AgentAvatar
@@ -1124,6 +1184,8 @@ export default function AgentSidebar({
               draggable: true as const,
               onDragStart: (event: ReactDragEvent) => beginRowDrag(event, pin),
               onDragEnd: finishDrag,
+              onDragOver: (event: ReactDragEvent) => allowRowDrop(event, pin.id),
+              onDrop: (event: ReactDragEvent) => dropPinReorder(event, pin.id),
               onClick: pickOrClose,
               onContextMenu: (event: ReactMouseEvent) => {
                 event.preventDefault()
@@ -1169,25 +1231,40 @@ export default function AgentSidebar({
         </div>
 
         <nav className="min-h-0 flex-1 overflow-y-auto px-2 pb-3" aria-label="Agent list">
-          {loadingList ? (
-            <p className="px-2 py-3 text-sm text-base-content/45">Loading agents…</p>
-          ) : loadFailed ? (
-            <p className="px-2 py-3 text-sm text-base-content/45">Could not load agents.</p>
-          ) : visibleCount === 0 ? (
-            <p className="px-2 py-3 text-sm text-base-content/45">No agents yet.</p>
-          ) : (
-            <ul className="space-y-0.5">
-              {orderedRows.map((row, index) => (
-                <li key={row.id} data-rail-id={row.id} data-rail-index={index}>
-                  {row.kind === 'team'
-                    ? renderTeamRow(row.team)
-                    : row.kind === 'remote'
-                      ? renderRemoteRow(row.remote, false)
-                      : renderAgentRow(row.agent, false)}
-                </li>
-              ))}
-            </ul>
-          )}
+          <div
+            className={`os-agent-list ${listDropActive ? 'os-agent-list--unfav' : ''}`}
+            data-testid="agent-list-drop"
+            data-unfavourite-target="true"
+            onDragOver={allowListUnfavourite}
+            onDragLeave={(event) => {
+              if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+                setListDropActive(false)
+              }
+            }}
+            onDrop={dropUnfavourite}
+          >
+            {loadingList ? (
+              <p className="px-2 py-3 text-sm text-base-content/45">Loading agents…</p>
+            ) : loadFailed ? (
+              <p className="px-2 py-3 text-sm text-base-content/45">Could not load agents.</p>
+            ) : visibleCount === 0 ? (
+              <p className="px-2 py-3 text-sm text-base-content/45">
+                {isPinnedId(draggingId) ? 'drop here to unfavourite' : 'No agents yet.'}
+              </p>
+            ) : (
+              <ul className="space-y-0.5">
+                {orderedRows.map((row, index) => (
+                  <li key={row.id} data-rail-id={row.id} data-rail-index={index}>
+                    {row.kind === 'team'
+                      ? renderTeamRow(row.team)
+                      : row.kind === 'remote'
+                        ? renderRemoteRow(row.remote, false)
+                        : renderAgentRow(row.agent, false)}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
 
           <div
             className={`os-hide-drop os-drop-target ${hideDropActive ? 'os-hide-drop--active' : ''}`}

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -56,7 +56,7 @@ import {
 import {
   endAgentDrag,
   excludePinnedFromList,
-  loadPinnedAgents,
+  loadOrSeedPinnedAgents,
   movePinnedAgent,
   parseAgentDragPayload,
   pinAgent,
@@ -207,7 +207,7 @@ export default function AgentSidebar({
   const [hiddenIds, setHiddenIds] = useState<string[] | null>(() =>
     hasHiddenAgentsStorage() ? loadHiddenAgentIds() : null,
   )
-  const [pins, setPins] = useState<PinnedAgent[]>(() => loadPinnedAgents())
+  const [pins, setPins] = useState<PinnedAgent[]>(() => loadOrSeedPinnedAgents())
   const [hiddenOpen, setHiddenOpen] = useState(false)
   const [pluginsOpen, setPluginsOpen] = useState(false)
   const [hostname, setHostname] = useState(() => loadHostname())
@@ -1148,10 +1148,17 @@ export default function AgentSidebar({
         </div>
 
         <div
-          className={`os-fav-grid ${dropActive ? 'os-fav-grid--active' : ''}`}
+          className={`os-fav-grid ${dropActive ? 'os-fav-grid--active' : ''} ${
+            visiblePins.length === 0 &&
+            !dropActive &&
+            !(draggingId && !isPinnedId(draggingId))
+              ? 'os-fav-grid--bare'
+              : ''
+          } ${visiblePins.length === 0 ? 'os-fav-grid--empty' : ''}`}
           aria-label="Pinned agents"
           data-fav-layout="2-up"
           data-testid="agent-fav-grid"
+          data-fav-empty={visiblePins.length === 0 ? 'true' : 'false'}
           onDragOver={(event) => {
             event.preventDefault()
             try {
@@ -1164,6 +1171,11 @@ export default function AgentSidebar({
           onDragLeave={() => setDropActive(false)}
           onDrop={dropPin}
         >
+          {visiblePins.length === 0 ? (
+            <div className="os-fav-grid__hint" data-testid="fav-empty-hint">
+              {dropActive || (draggingId && !isPinnedId(draggingId)) ? 'drop' : '+'}
+            </div>
+          ) : null}
           {visiblePins.map((pin) => {
             const live = agents.find((agent) => agent.id === pin.id)
             const pinName = live ? agentLabel(live) : pin.name || pin.id

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -1167,11 +1167,40 @@ export default function AgentSidebar({
           {visiblePins.map((pin) => {
             const live = agents.find((agent) => agent.id === pin.id)
             const pinName = live ? agentLabel(live) : pin.name || pin.id
+            const role = live ? agentRole(live) : 'default'
+            const badge = live ? roleBadgeLabel(role) : ''
+            const pinActive = Boolean(selectedId && selectedId === pin.id)
             const pinClass = `os-fav-tile ${
               draggingId === pin.id ? 'os-fav-tile--dragging' : ''
-            } ${dropTargetId === pin.id ? 'os-fav-tile--drop' : ''}`
+            } ${dropTargetId === pin.id ? 'os-fav-tile--drop' : ''} ${
+              pinActive ? 'os-fav-tile--active' : ''
+            }`
             const pinFace = (
               <>
+                {badge ? (
+                  <span
+                    className={`os-fav-tile__badge os-agent-role-badge ${roleCssClass(role)}`}
+                    data-role={role}
+                    data-definition-id={pin.id}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Open ${role} settings`}
+                    onClick={(event) => {
+                      event.preventDefault()
+                      event.stopPropagation()
+                      openDefinition('role', pin.id, { blueprintId: pin.id })
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        openDefinition('role', pin.id, { blueprintId: pin.id })
+                      }
+                    }}
+                  >
+                    {badge}
+                  </span>
+                ) : null}
                 <AgentAvatar
                   src={live?.avatar_path}
                   size="lg"

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -146,6 +146,11 @@ function SearchProbe() {
   return <span data-testid="os-test-search">{params.toString()}</span>
 }
 
+/** Empty `[]` is a user preference (no re-seed). Missing key = first load. */
+function rememberEmptyFavourites() {
+  localStorage.setItem(PINNED_AGENTS_STORAGE_KEY, '[]')
+}
+
 function renderSidebar(initialEntry = '/chat', onOpenSearch = () => undefined) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -177,6 +182,7 @@ function railIds(list: HTMLElement): string[] {
 describe('AgentSidebar Grok rail', () => {
   beforeEach(() => {
     localStorage.clear()
+    rememberEmptyFavourites()
     vi.stubGlobal('fetch', mockFetch())
   })
 
@@ -777,6 +783,7 @@ describe('AgentSidebar special roles', () => {
 
   beforeEach(() => {
     localStorage.clear()
+    rememberEmptyFavourites()
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -807,6 +814,7 @@ describe('AgentSidebar special roles', () => {
 describe('AgentSidebar teams', () => {
   beforeEach(() => {
     localStorage.clear()
+    rememberEmptyFavourites()
     vi.stubGlobal(
       'fetch',
       vi.fn().mockImplementation(async (input: RequestInfo) => {
@@ -922,12 +930,43 @@ describe('AgentSidebar teams', () => {
 describe('AgentSidebar favourites grid (REQ-94)', () => {
   beforeEach(() => {
     localStorage.clear()
+    rememberEmptyFavourites()
     vi.stubGlobal('fetch', mockFetch())
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
     localStorage.clear()
+  })
+
+  it('seeds Support as the first-load favourite when prefs are missing', async () => {
+    localStorage.removeItem(PINNED_AGENTS_STORAGE_KEY)
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const grid = screen.getByTestId('agent-fav-grid')
+    const supportTile = await within(grid).findByRole('link', { name: 'Support' })
+    expect(supportTile.querySelector('.os-fav-tile__badge')).toHaveAttribute('data-role', 'support')
+    expect(within(list).queryByRole('link', { name: /Support/ })).not.toBeInTheDocument()
+    expect(JSON.parse(localStorage.getItem(PINNED_AGENTS_STORAGE_KEY) || '[]')).toEqual([
+      { id: 'support', name: 'Support' },
+    ])
+  })
+
+  it('keeps an empty favourites grid bare with a quiet + until a drag starts', async () => {
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const codey = await within(list).findByRole('link', { name: /Codey/ })
+    const grid = screen.getByTestId('agent-fav-grid')
+    expect(grid).toHaveClass('os-fav-grid--bare')
+    expect(grid).toHaveAttribute('data-fav-empty', 'true')
+    expect(screen.getByTestId('fav-empty-hint')).toHaveTextContent('+')
+    expect(within(grid).queryByRole('link')).not.toBeInTheDocument()
+
+    const dt = mockDataTransfer()
+    fireEvent.dragStart(codey, { dataTransfer: dt })
+    expect(grid).not.toHaveClass('os-fav-grid--bare')
+    expect(screen.getByTestId('fav-empty-hint')).toHaveTextContent('drop')
+    fireEvent.dragEnd(codey, { dataTransfer: dt })
   })
 
   it('drops a row onto the 2-up grid as a named large avatar and removes it from the list', async () => {
@@ -1084,6 +1123,7 @@ describe('AgentSidebar favourites grid (REQ-94)', () => {
 describe('AgentSidebar pin unpin + plugins (REQ-5c #322)', () => {
   beforeEach(() => {
     localStorage.clear()
+    rememberEmptyFavourites()
     vi.stubGlobal('fetch', mockFetch())
   })
 
@@ -1177,6 +1217,7 @@ const STACK_REMOTES = {
 describe('AgentSidebar stacked avatars (REQ-68)', () => {
   beforeEach(() => {
     localStorage.clear()
+    rememberEmptyFavourites()
     vi.stubGlobal(
       'fetch',
       vi.fn().mockImplementation(async (input: RequestInfo) => {
@@ -1357,6 +1398,7 @@ describe('AgentSidebar special roles', () => {
 
   beforeEach(() => {
     localStorage.clear()
+    rememberEmptyFavourites()
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -975,6 +975,72 @@ describe('AgentSidebar favourites grid (REQ-94)', () => {
     expect(within(list).queryByRole('link', { name: /Codey/ })).not.toBeInTheDocument()
     expect(within(list).queryByRole('link', { name: /Stewie/ })).not.toBeInTheDocument()
   })
+
+  it('unfavourites when a tile is dropped onto the agents list (no duplicate)', async () => {
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const codey = await within(list).findByRole('link', { name: /Codey/ })
+    const grid = screen.getByTestId('agent-fav-grid')
+    dragTo(codey, grid)
+
+    const tile = await within(grid).findByRole('link', { name: 'Codey' })
+    expect(within(list).queryByRole('link', { name: /Codey/ })).not.toBeInTheDocument()
+
+    const drop = screen.getByTestId('agent-list-drop')
+    dragTo(tile, drop)
+
+    await waitFor(() => {
+      expect(within(grid).queryByRole('link', { name: 'Codey' })).not.toBeInTheDocument()
+    })
+    expect(within(list).getByRole('link', { name: /Codey/ })).toBeInTheDocument()
+    expect(within(list).getAllByRole('link', { name: /Codey/ })).toHaveLength(1)
+    expect(JSON.parse(localStorage.getItem(PINNED_AGENTS_STORAGE_KEY) || '[]')).toEqual([])
+  })
+
+  it('unfavourites when a tile is dropped onto a list row', async () => {
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const codey = await within(list).findByRole('link', { name: /Codey/ })
+    const grid = screen.getByTestId('agent-fav-grid')
+    dragTo(codey, grid)
+    const tile = await within(grid).findByRole('link', { name: 'Codey' })
+    const stewie = within(list).getByRole('link', { name: /Stewie/ })
+    dragTo(tile, stewie)
+
+    await waitFor(() => {
+      expect(within(grid).queryByRole('link', { name: 'Codey' })).not.toBeInTheDocument()
+    })
+    expect(within(list).getByRole('link', { name: /Codey/ })).toBeInTheDocument()
+    expect(JSON.parse(localStorage.getItem(PINNED_AGENTS_STORAGE_KEY) || '[]')).toEqual([])
+  })
+
+  it('reorders favourite tiles within the grid and persists', async () => {
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const codey = await within(list).findByRole('link', { name: /Codey/ })
+    const stewie = within(list).getByRole('link', { name: /Stewie/ })
+    const grid = screen.getByTestId('agent-fav-grid')
+    dragTo(codey, grid)
+    dragTo(stewie, grid)
+
+    let tiles = within(grid).getAllByRole('link')
+    expect(tiles.map((link) => link.getAttribute('aria-label'))).toEqual(['Codey', 'Stewie'])
+
+    dragTo(tiles[1], tiles[0])
+    await waitFor(() => {
+      expect(
+        within(grid)
+          .getAllByRole('link')
+          .map((link) => link.getAttribute('aria-label')),
+      ).toEqual(['Stewie', 'Codey'])
+    })
+    expect(JSON.parse(localStorage.getItem(PINNED_AGENTS_STORAGE_KEY) || '[]')).toEqual([
+      { id: 'stewie', name: 'Stewie' },
+      { id: 'codey', name: 'Codey' },
+    ])
+    expect(within(list).queryByRole('link', { name: /Codey/ })).not.toBeInTheDocument()
+    expect(within(list).queryByRole('link', { name: /Stewie/ })).not.toBeInTheDocument()
+  })
 })
 
 describe('AgentSidebar pin unpin + plugins (REQ-5c #322)', () => {

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -975,6 +975,45 @@ describe('AgentSidebar favourites grid (REQ-94)', () => {
     expect(within(list).queryByRole('link', { name: /Stewie/ })).not.toBeInTheDocument()
   })
 
+  it('overlays a role badge inside a favourite tile when the agent has a role', async () => {
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const support = await within(list).findByRole('link', { name: /Support/ })
+    const codey = within(list).getByRole('link', { name: /Codey/ })
+    const grid = screen.getByTestId('agent-fav-grid')
+    dragTo(support, grid)
+    dragTo(codey, grid)
+
+    const supportTile = await within(grid).findByRole('link', { name: 'Support' })
+    const badge = supportTile.querySelector('.os-fav-tile__badge')
+    expect(badge).toBeTruthy()
+    expect(badge).toHaveClass('os-agent-role-badge')
+    expect(badge).toHaveAttribute('data-role', 'support')
+    expect(badge).toHaveTextContent('Support')
+    expect(support.contains(badge)).toBe(false)
+
+    const codeyTile = within(grid).getByRole('link', { name: 'Codey' })
+    expect(codeyTile.querySelector('.os-fav-tile__badge')).toBeNull()
+    expect(codeyTile.querySelector('.os-agent-role-badge')).toBeNull()
+  })
+
+  it('keeps favourite tiles ghost until hover or selected', async () => {
+    renderSidebar('/chat?blueprint=codey')
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const codey = await within(list).findByRole('link', { name: /Codey/ })
+    const stewie = within(list).getByRole('link', { name: /Stewie/ })
+    const grid = screen.getByTestId('agent-fav-grid')
+    dragTo(codey, grid)
+    dragTo(stewie, grid)
+
+    const codeyTile = await within(grid).findByRole('link', { name: 'Codey' })
+    const stewieTile = within(grid).getByRole('link', { name: 'Stewie' })
+    expect(codeyTile).toHaveClass('os-fav-tile--active')
+    expect(stewieTile).not.toHaveClass('os-fav-tile--active')
+    expect(stewieTile.className).toMatch(/\bos-fav-tile\b/)
+    expect(getComputedStyle(stewieTile).backgroundColor).toMatch(/rgba?\(0,\s*0,\s*0,\s*0\)|transparent/)
+  })
+
   it('unfavourites when a tile is dropped onto the agents list (no duplicate)', async () => {
     renderSidebar()
     const list = await screen.findByRole('navigation', { name: 'Agent list' })

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -250,7 +250,6 @@ describe('AgentSidebar Grok rail', () => {
     expect(within(list).getByRole('link', { name: /pi_agent/ })).toBeInTheDocument()
     expect(within(list).queryByRole('link', { name: /Codey/ })).not.toBeInTheDocument()
   })
-  })
 
   it('seeds Hidden with gate and skeptic on first load; Support stays visible', async () => {
     renderSidebar()

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -331,6 +331,22 @@ html[data-theme="light"] #root {
   border-color: color-mix(in srgb, var(--color-primary) 55%, var(--color-base-300));
   background: color-mix(in srgb, var(--color-base-300) 50%, transparent);
 }
+.os-fav-grid--bare {
+  border-color: transparent;
+  background: transparent;
+  min-height: 2.75rem;
+}
+.os-fav-grid__hint {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.25rem;
+  font-size: 0.85rem;
+  font-weight: 650;
+  color: color-mix(in srgb, var(--color-base-content) 35%, transparent);
+  pointer-events: none;
+}
 .os-fav-tile {
   position: relative;
   display: flex;

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -332,6 +332,7 @@ html[data-theme="light"] #root {
   background: color-mix(in srgb, var(--color-base-300) 50%, transparent);
 }
 .os-fav-tile {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -341,10 +342,19 @@ html[data-theme="light"] #root {
   height: auto;
   padding: 0.45rem 0.3rem 0.4rem;
   border-radius: 0.65rem;
-  background: color-mix(in srgb, var(--color-base-content) 6%, transparent);
+  background: transparent;
 }
-.os-fav-tile:hover {
+.os-fav-tile:hover,
+.os-fav-tile--active,
+.os-fav-tile--drop {
   background: color-mix(in srgb, var(--color-base-content) 12%, transparent);
+}
+.os-fav-tile__badge {
+  position: absolute;
+  top: 0.2rem;
+  right: 0.2rem;
+  z-index: 1;
+  max-width: calc(100% - 0.3rem);
 }
 .os-fav-tile__name {
   max-width: 100%;

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -394,6 +394,18 @@ button.os-agent-row {
 .os-fav-tile--dragging {
   opacity: 0.4;
 }
+.os-fav-tile--drop {
+  box-shadow: inset 0 2px 0 color-mix(in srgb, var(--color-primary) 70%, transparent);
+}
+.os-agent-list {
+  min-height: 3rem;
+  border-radius: 0.65rem;
+}
+.os-agent-list--unfav {
+  outline: 2px dashed color-mix(in srgb, var(--color-primary) 55%, var(--color-base-300));
+  outline-offset: 2px;
+  background: color-mix(in srgb, var(--color-base-300) 40%, transparent);
+}
 .os-agent-row--drop {
   box-shadow: inset 0 2px 0 color-mix(in srgb, var(--color-primary) 70%, transparent);
 }

--- a/webui/frontend/src/lib/__tests__/pinnedAgents.test.ts
+++ b/webui/frontend/src/lib/__tests__/pinnedAgents.test.ts
@@ -3,6 +3,7 @@ import {
   PINNED_AGENTS_STORAGE_KEY,
   excludePinnedFromList,
   loadPinnedAgents,
+  movePinnedAgent,
   pinAgent,
   unpinAgent,
 } from '../pinnedAgents'
@@ -24,6 +25,15 @@ describe('pinnedAgents persistence', () => {
     const pinned = pinAgent({ id: 'stewie', name: 'Stewie' }, [{ id: 'codey', name: 'Codey' }])
     expect(unpinAgent('codey', pinned)).toEqual([{ id: 'stewie', name: 'Stewie' }])
     expect(loadPinnedAgents()).toEqual([{ id: 'stewie', name: 'Stewie' }])
+  })
+
+  it('reorders favourites and persists the new order', () => {
+    const pinned = pinAgent({ id: 'stewie', name: 'Stewie' }, [{ id: 'codey', name: 'Codey' }])
+    const next = movePinnedAgent('stewie', 'codey', pinned)
+    expect(next.map((pin) => pin.id)).toEqual(['stewie', 'codey'])
+    expect(loadPinnedAgents().map((pin) => pin.id)).toEqual(['stewie', 'codey'])
+    expect(movePinnedAgent('stewie', 'stewie', next)).toEqual(next)
+    expect(movePinnedAgent('missing', 'codey', next)).toEqual(next)
   })
 
   it('drops favourited ids from the rail list (move, not copy)', () => {

--- a/webui/frontend/src/lib/__tests__/pinnedAgents.test.ts
+++ b/webui/frontend/src/lib/__tests__/pinnedAgents.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
+  DEFAULT_PINNED_SUPPORT,
   PINNED_AGENTS_STORAGE_KEY,
   excludePinnedFromList,
+  loadOrSeedPinnedAgents,
   loadPinnedAgents,
   movePinnedAgent,
   pinAgent,
@@ -11,6 +13,13 @@ import {
 describe('pinnedAgents persistence', () => {
   afterEach(() => {
     localStorage.removeItem(PINNED_AGENTS_STORAGE_KEY)
+  })
+
+  it('seeds Support on first load when prefs are missing, but not when empty []', () => {
+    expect(loadOrSeedPinnedAgents()).toEqual([DEFAULT_PINNED_SUPPORT])
+    expect(loadPinnedAgents()).toEqual([DEFAULT_PINNED_SUPPORT])
+    localStorage.setItem(PINNED_AGENTS_STORAGE_KEY, '[]')
+    expect(loadOrSeedPinnedAgents()).toEqual([])
   })
 
   it('starts empty and pins without duplicates', () => {

--- a/webui/frontend/src/lib/pinnedAgents.ts
+++ b/webui/frontend/src/lib/pinnedAgents.ts
@@ -10,6 +10,17 @@
 export const PINNED_AGENTS_STORAGE_KEY = 'swarm_pinned_agents'
 export const AGENT_DRAG_MIME = 'application/x-swarm-agent'
 
+/** First-load favourite when `swarm_pinned_agents` is missing (empty prefs). */
+export const DEFAULT_PINNED_SUPPORT: PinnedAgent = { id: 'support', name: 'Support' }
+
+export function hasPinnedAgentsStorage(): boolean {
+  try {
+    return localStorage.getItem(PINNED_AGENTS_STORAGE_KEY) !== null
+  } catch {
+    return false
+  }
+}
+
 export interface PinnedAgent {
   id: string
   name: string
@@ -44,6 +55,13 @@ function normalizePin(value: unknown): PinnedAgent | null {
     id: rec.id,
     name: typeof rec.name === 'string' && rec.name.length > 0 ? rec.name : rec.id,
   }
+}
+
+export function loadOrSeedPinnedAgents(): PinnedAgent[] {
+  if (hasPinnedAgentsStorage()) return loadPinnedAgents()
+  const seeded = [DEFAULT_PINNED_SUPPORT]
+  savePinnedAgents(seeded)
+  return seeded
 }
 
 export function loadPinnedAgents(): PinnedAgent[] {

--- a/webui/frontend/src/lib/pinnedAgents.ts
+++ b/webui/frontend/src/lib/pinnedAgents.ts
@@ -98,6 +98,23 @@ export function unpinAgent(id: string, current: PinnedAgent[]): PinnedAgent[] {
   return next
 }
 
+/** Move an existing favourite so it sits immediately before `beforeId`. */
+export function movePinnedAgent(
+  fromId: string,
+  beforeId: string,
+  current: PinnedAgent[],
+): PinnedAgent[] {
+  if (!fromId || !beforeId || fromId === beforeId) return current
+  const from = current.find((item) => item.id === fromId)
+  if (!from) return current
+  const without = current.filter((item) => item.id !== fromId)
+  const index = without.findIndex((item) => item.id === beforeId)
+  if (index < 0) return current
+  without.splice(index, 0, from)
+  savePinnedAgents(without)
+  return without
+}
+
 /** Ids currently sitting in the favourite grid (hidden pins stay in storage). */
 export function pinnedAgentIds(pins: PinnedAgent[]): Set<string> {
   return new Set(pins.map((pin) => pin.id))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Favourites stay a true **move** — pin and unpin via native HTML5 DnD; order is user-controlled. Large tiles stay quiet chrome (role badge overlay, ghost until hover/selected). First load seeds Support; an empty grid stays chrome-less.

## Success

1. Drag a favourite tile onto the main agents list → **unfavourite**, no duplicate.
2. Drag favourites among themselves → **persistent reorder**.
3. List → favourites still works.
4. Role badge overlays **inside** the favourite tile when a role applies (same rail-row semantics).
5. Resting tiles are **ghost/transparent**; fill only on hover or selected.
6. First load / missing prefs seeds **Support** as the favourite.
7. Completely empty favourites: **no border/chrome**, quiet `+`; dashed chrome + `drop` when a list drag starts or at least one pin exists.
8. DaisyUI 5 / React 18; native HTML5 DnD. No secrets. No Neon.
9. Fixes #532. Same PR for all Matthew addenda.

## Constraints

ASAP product bugfix after #528. Own-diff CI. GitHub squash then engineer FF `:8001`.

## Owner

open-swarm engineer + Cursor cloud. CoS: Open Swarm. Skeptic text-only.

## Change

- Unfavourite by tile→list drop; reorder by tile→tile; `movePinnedAgent` persists `swarm_pinned_agents`.
- `os-fav-tile__badge` overlays the rail role badge inside large tiles.
- Resting tile background is transparent.
- `loadOrSeedPinnedAgents` seeds Support when the storage key is missing (`[]` is a user empty set).
- `os-fav-grid--bare` + quiet `+` / `drop` hint.

## Tests

Vitest favourites / seed / empty-grid / badge / ghost: **12 passed**. Pytest REQ-94 contracts: **3 passed**.

Python Tests CI collection fails on pre-existing `ChatAttachment` import (`tests/views/test_chat_attachments.py`) — not this diff.

[After pin: codey and StewieBlueprint tiles](https://cursor.com/agents/bc-a8811f5f-3373-41fe-8e51-4badc4c5a51a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffavourites_after_pin.png)
[After in-grid reorder: StewieBlueprint then codey](https://cursor.com/agents/bc-a8811f5f-3373-41fe-8e51-4badc4c5a51a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffavourites_after_reorder.png)
[After unfavourite: only codey remains](https://cursor.com/agents/bc-a8811f5f-3373-41fe-8e51-4badc4c5a51a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffavourites_after_unfavourite.png)
[Support tile shows in-tile Support badge; unselected codey is ghost](https://cursor.com/agents/bc-a8811f5f-3373-41fe-8e51-4badc4c5a51a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffavourites_badge_and_ghost.png)
[First load seeds Support as the favourite tile](https://cursor.com/agents/bc-a8811f5f-3373-41fe-8e51-4badc4c5a51a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffavourites_seeded_support.png)

Fixes #532


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8811f5f-3373-41fe-8e51-4badc4c5a51a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8811f5f-3373-41fe-8e51-4badc4c5a51a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

