### PR TITLE
docs: ADR-002 config ownership — .env vs XDG vs Django (REQ-145)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,5 +1,10 @@
 # Swarm Configuration Guide
 
+Ownership of `.env` vs XDG `swarm_config.json` vs Django (what is live SoT
+after boot, what WebUI writes, Docker volumes) is decided in
+**[ADR-002](docs/adr/002-config-ownership.md)** (REQ-145 / #541). This page
+remains the schema and environment-variable reference.
+
 ## Quickstart: Configuring Swarm
 
 Swarm supports both interactive and manual configuration. The recommended way to set up and manage your config is via the `swarm-cli`, which provides commands to initialize, edit, and validate your configuration interactively. However, you can also hand-edit the config JSON if you prefer full control or need to automate deployment.

--- a/docs/ADR-001-primary-ui.md
+++ b/docs/ADR-001-primary-ui.md
@@ -1,6 +1,7 @@
 # ADR-001: Primary UI is Django; SPA Chat only
 
 - **Status:** Accepted (2026-08-18)
+- **See also:** [ADR-002 config ownership](./adr/002-config-ownership.md) (`.env` / XDG / Django SoT)
 - **Context:** Open Swarm grew a Django/HTMx operator UI and a React SPA in parallel. Builder/AgentCreator SPA routes were unmounted; Teams/Blueprints SPA pages are leftovers while bare paths redirect to Django. Dual maintenance and confused docs were flagged as a senior-review P0.
 
 ## Decision

--- a/docs/SWARM_CONFIG.md
+++ b/docs/SWARM_CONFIG.md
@@ -1,7 +1,8 @@
 # `swarm_config.json`
 
 > **This page has moved.** The configuration reference now lives in one place to
-> avoid drift:
+> avoid drift. Config **ownership** (env vs XDG vs Django) is
+> [ADR-002](./adr/002-config-ownership.md).
 >
 > ### → [CONFIGURATION.md](../CONFIGURATION.md)
 

--- a/docs/adr/002-config-ownership.md
+++ b/docs/adr/002-config-ownership.md
@@ -1,0 +1,383 @@
+# ADR-002: Config ownership — `.env` vs XDG `swarm_config.json` vs Django DB
+
+- **Status:** Proposed (look-only; no runtime change in this PR)
+- **Date:** 2026-09-04
+- **Issue:** [#541](https://github.com/matthewhand/open-swarm/issues/541) (REQ-145)
+- **Related:** [#540](https://github.com/matthewhand/open-swarm/issues/540) (REQ-144 prefs), [#508](https://github.com/matthewhand/open-swarm/issues/508) (REQ-123 Postgres compose), [CONFIGURATION.md](../../CONFIGURATION.md)
+- **Supersedes:** none. Complements [ADR-001](../ADR-001-primary-ui.md) (UI chrome), not config SoT.
+
+This ADR is **feasibility-first**: it records what the code does on `main`
+(`04ccb53a` at writing) and then picks one ownership table. It does **not**
+implement sync, migrations, or Settings UI badges.
+
+No secrets are documented here. Use `${VAR}` names only.
+
+---
+
+## Issue quote (REQ-145)
+
+**Intent:** Operators and ephemeral deploys know where truth lives; no silent drift.
+
+**Success (this Issue):**
+
+1. Look-only Cursor cloud (or engineer) produces an **ADR markdown PR** answering the questions with file/path evidence.
+2. ADR picks **one** direction (amend strawman or replace); lists migrations / follow-up implement Issues.
+3. No code behaviour change in the ADR PR beyond docs (or a tiny inventory script if needed).
+4. `Fixes` this Issue when ADR merges.
+
+**Constraints:** Look-only / docs first. No Neon. No secrets in ADR. Park implement behind agreement. Related: #540 prefs, #508 Postgres compose, CONFIGURATION.md.
+
+Owner / CoS notes from the Issue: prefer one clear winner per concern over a bidirectional sync engine. Skeptic PASS if this ADR answers dual-SoT and Docker ephemeral.
+
+Matthew refinement (Issue comment, 2026-09-04): evaluate **A** (env bootstraps; Settings override env), **B** (DB/Settings SoT; env force-override for recovery), or a **hybrid with explicit precedence and UI badges**. Secrets stay env-only. No bidirectional sync daemon.
+
+---
+
+## 1. Feasibility (what exists today)
+
+The strawman is **mostly already true for harness topology writes**, and **already
+false for chats and per-user prefs**. The expensive parts of consolidation are
+not “pick a new store” — they are:
+
+1. **Stale boot snapshot** vs **live file re-read** (same JSON, two lifetimes).
+2. **Default Docker mounts XDG config read-only**, so WebUI persist can fail
+   even though the API writes the same path `swarm-cli` uses.
+3. **Two XDG directory helpers** that do not always resolve to the same folder.
+4. **Chat dual-write** (JSON SoT + Django mirror) and **browser-local prefs**.
+
+A sync engine would paper over (1)–(4). This ADR rejects that.
+
+---
+
+## 2. Evidence: three stores (read vs write; WebUI vs swarm-cli)
+
+### 2.1 Environment / `.env` (ops-owned; app never writes)
+
+| Surface | Read | Write |
+|---|---|---|
+| Process / systemd env | Wins over files | Operator / orchestrator |
+| XDG `~/.config/swarm/.env` | Yes (after process env) | Operator only |
+| Project-root `.env` | Yes (lowest file fallback) | Operator only |
+| Docker `env_file: .env` | Injected at container start | Host file; app does not rewrite |
+| WebUI / Django Settings | **Read** (redacted) | **No** |
+| `swarm-cli` | Reads via the same process env after dotenv load | **No** `.env` writer |
+
+**Load path (read):** `src/swarm/utils/dotenv_load.py` — `load_swarm_dotenv()`:
+
+1. Keys already in `os.environ` are never overwritten.
+2. Project-root `.env` is loaded with `override=False`.
+3. XDG `~/.config/swarm/.env` (or `$XDG_CONFIG_HOME/swarm/.env`) fills keys
+   that were **not** already in the process environment (XDG wins over
+   project-only keys).
+
+Called from `src/swarm/settings.py`, `src/manage.py`, `src/swarm/wsgi.py`,
+`src/swarm/management/commands/runserver.py`. Canonical variable list:
+[CONFIGURATION.md § Environment Variables](../../CONFIGURATION.md#environment-variables).
+
+**Substitution (read into JSON):** `${VAR}` in `swarm_config.json` is expanded
+by `src/swarm/core/config_loader.py` (`_substitute_env_vars` / `os.path.expandvars`)
+and again by `src/swarm/core/config_manager.py` (`resolve_placeholders`) and
+`src/swarm/core/blueprint_base.py` (`_load_configuration`).
+
+**WebUI:** Django `/settings/` and `GET` settings API
+(`src/swarm/views/settings_views.py`) collect env-backed flags via
+`src/swarm/views/settings_manager.py` and redact secrets. Both endpoints are
+`GET` only. `environment_variables()` lists `DJANGO_*` / `SWARM_*` / provider
+prefixes with sensitive keys masked. **No view writes `.env`.**
+
+**Docker:** `docker-compose.yml` `env_file: .env` (`required: false`). Explicit
+`environment:` keys (including `PORT`) win over the file.
+
+**Verdict:** `.env` / process env is **ops-owned, read-only to the app**.
+Feasible to keep as the secrets + deploy-flag SoT. Do not add a Settings
+plaintext editor that rewrites `.env`.
+
+---
+
+### 2.2 XDG / `SWARM_CONFIG_PATH` `swarm_config.json` (harness topology)
+
+**Discovery (read),** `src/swarm/core/config_loader.py` `find_config_file()`:
+
+1. Explicit `--config` / `specific_path`
+2. `SWARM_CONFIG_PATH` if the file exists
+3. XDG: `$XDG_CONFIG_HOME/swarm/swarm_config.json` or `~/.config/swarm/swarm_config.json`
+   (`_xdg_config_path()`)
+4. Upward search / default dir / cwd `./swarm_config.json`
+
+`swarm-cli config` / `moa-init` / `cli-agents --write` use that helper, then
+fall back to `get_user_config_dir_for_swarm() / "swarm_config.json"`
+(`src/swarm/core/swarm_cli.py`).
+
+**Boot snapshot (server):** `src/swarm/apps.py` `SwarmConfig.ready()` →
+`_load_swarm_config()` loads **once** into `AppConfig.config` from
+`SWARM_CONFIG_PATH` or `_xdg_config_path()` only (cwd is *not* loaded here).
+Comment in that function: load once so every blueprint sees the same file.
+
+**Blueprint consumers (read snapshot):** `src/swarm/core/blueprint_base.py`
+`_load_configuration()` prefers `apps.get_app_config('swarm').config` if
+non-empty, else re-discovers the file. That means a **new blueprint instance
+after boot keeps the ready() snapshot** unless `AppConfig.config` is empty.
+
+**Live re-read (same file):** remotes and LLM-settings helpers call
+`src/swarm/core/remotes.py` `resolve_config_path()` / `load_raw_config()` —
+`find_config_file()` then XDG fallback — **on each request**, not the
+`AppConfig` dict.
+
+| Writer | Path | Same file as CLI? |
+|---|---|---|
+| `swarm-cli config init\|add\|remove` | `find_config_file()` else XDG `swarm_config.json` | Yes (canonical CLI writer) |
+| `swarm-cli remotes set\|place\|unplace` | `persist_remote` / `persist_agent_team` | Yes |
+| `swarm-cli moa-init --write`, `cli-agents --init --write` | same discovery | Yes |
+| WebUI SPA Settings `PATCH /v1/llm-profiles/` | `src/swarm/views/llm_profiles_api.py` → `llm_task_routing.persist_llm_settings()` → `load_raw_config()` + `path.write_text` | **Yes** |
+| WebUI SPA `POST/PATCH/DELETE /v1/remotes/` | `src/swarm/views/remotes_api.py` → `persist_remote` | **Yes** |
+| WebUI / API `PATCH /v1/agent-team/` | `persist_agent_team` | **Yes** |
+| Django `/settings/` dashboard | `settings_manager.collect_*` via `load_config()` | **Read only** (no persist) |
+| Router designer overlay | `src/swarm/core/remote_teams.py` `persist_remote_overlay()` | Same file **and** mutates `AppConfig.config` in memory |
+
+**Remotes precedence today (already env-wins):** `load_remote()` docstring:
+“Defaults ← swarm_config.json remotes ← env (env wins).” Env keys such as
+`HERMES_BASE_URL` / `HERMES_API_KEY` overwrite the file at **read** time.
+The file is still written when Settings/CLI persist.
+
+**Docker default:** `docker-compose.yml` bind-mounts
+`${HOME}/.config/swarm:${HOME}/.config/swarm:ro` — **read-only**. The data
+volume `${HOME}/.local/share/swarm` is writable (SQLite + `/v1/responses`).
+WebUI persist to XDG **fails with `OSError` / HTTP 500** on an unmodified
+compose stack even though the code path is the same as `swarm-cli` on the host.
+
+**Path split (follow-up, not a third SoT):**
+
+- `_xdg_config_path()` → `~/.config/swarm/swarm_config.json`
+- `src/swarm/core/paths.py` `get_user_config_dir_for_swarm()` → platformdirs
+  `user_config_dir(appname="swarm", appauthor="OpenSwarm")`, documented as
+  `~/.config/OpenSwarm/swarm/`
+
+Compose mounts `~/.config/swarm`. CLI *create-if-missing* uses platformdirs.
+If both folders exist, discovery and “write new file” can disagree. Unify in
+an implement Issue; do not add a syncer.
+
+**Sibling XDG JSON (not `swarm_config.json`, same config dir family):**
+
+| File | Role | Writers |
+|---|---|---|
+| `agent_settings.json` | Per-agent `new_chat_per_task` / session ids (REQ-65) | `src/swarm/core/agent_settings.py` (API + SPA editor) |
+| `team_rosters.json` | REQ-28 composition (not `agent_team.members`) | `src/swarm/core/team_rosters.py` |
+| `teams.json` | `/v1/teams/` LLM-profile **aliases** (not remotes) | `src/swarm/views/utils.py` |
+| `router_designs.json` | Designer drafts | `src/swarm/core/router_designs.py` |
+
+These are operator topology / session policy, not Django prefs. They must
+share the **same volume** as `swarm_config.json` in Docker.
+
+**Verdict:** WebUI **does** write the same `swarm_config.json` `swarm-cli`
+writes, through the remotes / LLM persist helpers — **not** through
+`config_manager.save_config` (that module is the older CLI prompt helper).
+Django Settings HTML is an inspector, not a writer.
+
+---
+
+### 2.3 Django DB (runtime + catalog; not harness topology)
+
+| Concern | Models / files | WebUI | CLI |
+|---|---|---|---|
+| Chat transcripts (mirror) | `ChatConversation`, `ChatMessage` (`src/swarm/models/__init__.py`); websocket `src/swarm/consumers.py`; `src/swarm/views/chat_persist_views.py` `_sync_django_and_memory` | Read/write | n/a |
+| Chat transcripts (restore SoT) | JSON under `SWARM_CHAT_DIR` / platformdirs data dir — `src/swarm/core/chat_store.py` | Read/write | Settings retention uses this dir |
+| Compact summaries | `ConversationSummary` — `src/swarm/core/chat_compact.py` | API | n/a |
+| Attachment **bytes** | Files under `SWARM_ATTACHMENTS_DIR` — `src/swarm/core/chat_attachments.py` | Write | n/a |
+| Attachment **metadata** | `ChatAttachment` (`src/swarm/migrations/0012_chatattachment.py`) | Write | n/a |
+| Herdr members | `HerdrAgent` — `CONFIGURATION.md` §10; `/v1/herdr-agents/` | CRUD | `herdr` CLI wrapper |
+| Marketplace catalog | `Blueprint`, `MCPConfig`, `MarketplaceIndex` (`src/swarm/models/core_models.py`) | Marketplace views | n/a |
+
+`MCPConfig` is a **marketplace template** (`config_template`, no secrets).
+It is **not** live `mcpServers` in `swarm_config.json`. Do not treat it as a
+second MCP SoT.
+
+**DB location:** `src/swarm/settings.py` — `DATABASE_URL` → Postgres; else
+`DJANGO_DB_NAME` / `SQLITE_DB_PATH` (compose: `~/.local/share/swarm/db.sqlite3`).
+Default without env is `/tmp/db.sqlite3` (ephemeral). #508 is the Postgres
+happy-path; this ADR does not move topology into SQL.
+
+**Per-user UI prefs today:** **not** Django. SPA uses `localStorage`
+(`webui/frontend/src/lib/pinnedAgents.ts`, `hiddenAgents.ts`, `theme.ts`,
+`settingsPrefs.ts`, `railOrder.ts`, …). #540 is the implement Issue to move
+favourites / hidden (and later theme) to a per-user Django preferences API.
+
+**Verdict:** Django already owns auth, Herdr rows, marketplace indexes,
+attachment metadata, and a chat **mirror**. It does **not** own remotes, LLM
+profiles, MCP servers, or `cli_agents`.
+
+---
+
+## 3. Answers to the Issue questions
+
+### 3.1 After boot, is XDG live SoT or bootstrap?
+
+**Both, by caller — that is the dual-SoT bug.**
+
+| Caller | After `ready()` | Evidence |
+|---|---|---|
+| `AppConfig.config` / new `BlueprintBase` | **Bootstrap snapshot** (env-substituted at boot) | `apps.py` `_load_swarm_config()` once; `blueprint_base.py` prefers that dict |
+| `/v1/remotes/`, `/v1/llm-profiles/`, `load_remote()` | **Live file** (re-read + env overlay) | `load_raw_config()` / `persist_*` |
+| `persist_remote_overlay()` only | Writes file **and** patches `AppConfig.config` | `remote_teams.py` — exception, not the remotes/LLM path |
+
+A Settings save of default LLM or a remote **does not** refresh
+`AppConfig.config`. Blueprints started after that save can still see boot
+values until process restart. Remotes already apply **env over file** on every
+read, so a host env URL can disagree with the JSON operators just edited.
+
+**Decision (implement later):** treat the **file** as live SoT for topology.
+After every persist, refresh `AppConfig.config` from the same path (or drop
+the cache and always re-read). Do not invent a second DB copy.
+
+### 3.2 Does WebUI write the same file `swarm-cli` writes?
+
+**Yes, for remotes + LLM settings + agent-team membership** — same
+`resolve_config_path()` / `find_config_file()` / XDG fallback.
+
+**No, for Django `/settings/`** — inspector only.
+
+**Not in default Docker** — XDG mount is `:ro`, so the shared writer hits a
+read-only filesystem.
+
+**Not for secrets** — neither surface writes `.env`.
+
+---
+
+## 4. Decision: one ownership table (amended strawman + hybrid precedence)
+
+Pick the **CoS hybrid** (A-leaning persist, B’s recovery override), not A or B
+alone, and **not** a sync daemon.
+
+**Precedence (document + enforce in implement Issues):**
+
+1. **Explicit env force-override** — `SWARM_CONFIG_FORCE_ENV=1` or per-key
+   `SWARM_*_OVERRIDE` / existing remote env keys when marked force.
+2. **Persisted Settings / `swarm_config.json`** (and sibling XDG JSON below).
+3. **Env bootstrap defaults** — used only when the persisted key is empty
+   (first boot / missing file).
+4. **Built-in defaults** (`create_default_config`, remote `default_spec`).
+
+Today remotes skip step 3 and jump to “env always wins.” That is **B everyday**,
+which misleads operators who edited Settings. Implement Issue: env wins for
+**secrets** always; env wins for **non-secret topology** only when force-override
+is set (or the field was never persisted).
+
+### Ownership table (single winner per concern)
+
+| Concern | SoT | Who writes | Who reads | Not a SoT |
+|---|---|---|---|---|
+| Secrets & deploy flags (`DJANGO_*`, `API_AUTH_TOKEN`, provider keys, `DATABASE_URL`) | **Process env / `.env` / XDG `.env`** | Ops, compose `env_file`, systemd | App (dotenv + `${VAR}`) | Settings plaintext, Django rows, JSON literals |
+| Harness topology (`llm`, `settings.*` task map, `mcpServers`, `remotes`, `cli_agents`, `agent_team`, `moa`, `blueprints` defaults) | **`swarm_config.json`** at `SWARM_CONFIG_PATH` or XDG | `swarm-cli` **and** WebUI via the same persist helpers | CLI, APIs, boot snapshot (until refresh) | Django `MCPConfig`, `localStorage` |
+| Operator sibling topology (`team_rosters.json`, `teams.json` aliases, `router_designs.json`) | **Same XDG config dir** (own files) | Existing APIs / CLI | WebUI / API | Django; do not merge into chat tables |
+| Per-agent session policy (`new_chat_per_task`, CLI/remote session ids) | **`agent_settings.json` today** → **Django prefs in a follow-up** (same #540 registry or a sibling model) | SPA Agent editor / `/v1/agents/…` | Session policy | Do not copy into `swarm_config.json` |
+| Per-user UI prefs (favourites, hidden, rail order, theme, hostname override) | **Django per-user prefs (#540)** | SPA after #540 | SPA | `localStorage` after one-time import; not XDG |
+| Chats / session transcripts | **JSON chat store today** (documented SoT) → **Django conversation rows as destination SoT** | Chat / WS already dual-write | Restore prefers JSON, then Django | Bidirectional sync engine |
+| Attachment bytes | **Files** (`SWARM_ATTACHMENTS_DIR`) | Upload API | Chat | DB BLOBs |
+| Attachment metadata, compact summaries, Herdr members, marketplace catalog, auth users | **Django** | Existing views | Existing views | `swarm_config.json` |
+| First boot | **Seed-once** | `swarm-cli config init` / empty-volume default | — | Ongoing import loop |
+
+**Non-goals:** bidirectional XDG↔DB sync; silent dual-write of remotes into
+SQL; Settings rewriting `.env`; Neon as a config store.
+
+### Why not DB-only topology?
+
+Feasible but rejected: `swarm-cli` and hand-edited JSON are first-class
+([CONFIGURATION.md](../../CONFIGURATION.md)). Remotes/LLM persist already
+target the file. Moving topology into Django would create the sync hell this
+Issue forbids unless CLI became a DB client. Keep JSON as topology SoT.
+
+### Why not env-only topology (pure A)?
+
+Rejected for everyday edits: Settings already persist remotes and LLM maps to
+disk. Pure A would make those writes lie. Env remains the **bootstrap and
+recovery** layer.
+
+---
+
+## 5. Docker ephemeral: pick **RW config volume + existing data volume**
+
+| Option | Verdict |
+|---|---|
+| **Volume for config (RW) + volume for DB/files** | **Pick.** Topology and sibling XDG JSON survive `compose down`. Chats/DB already use `~/.local/share/swarm`. |
+| DB-only topology | Reject. See §4. |
+| Seed-once from image / cwd JSON, no volume | Reject as the **only** strategy. Optional **empty-volume init** (`config init` if file missing) is allowed; not a recurring import. |
+
+**Amend compose (implement Issue, not this PR):** change
+
+`"${HOME}/.config/swarm:${HOME}/.config/swarm:ro"`
+
+to **read-write** (or a dedicated `SWARM_CONFIG_PATH` file mount that is RW).
+Keep secrets in `env_file` / orchestrator env, not in the JSON volume as
+plaintext. Document: without the config volume, Settings remotes/LLM edits die
+with the container; without the data volume, SQLite + chat JSON die.
+
+`docker-compose.dev.yml` only adds a source bind-mount; it inherits the `:ro`
+config mount from the base file.
+
+Stale docs: `DEVELOPMENT.md` still describes mounting `./swarm_config.json` —
+compose no longer does that ([docs/debt/qa-wave3-structure-root.md](../debt/qa-wave3-structure-root.md)).
+
+---
+
+## 6. UI honesty (badge copy — implement with ownership)
+
+Settings fields that have an env twin must show one of:
+
+| Badge | When |
+|---|---|
+| **Forced by env `FOO` (read-only)** | Force-override or `SWARM_CONFIG_FORCE_ENV=1`; persist disabled |
+| **From env (not overridden)** | Persisted value empty; effective value came from bootstrap env |
+| **Overrides env `FOO`** | File/Settings value differs from bootstrap env; file wins |
+| **From config** | File value, no env twin |
+| **Built-in default** | Neither file nor env |
+
+Secrets fields stay **reference-only** (`${OPENAI_API_KEY}`, “set / not set”).
+No plaintext SoT in the UI.
+
+Django `/settings/` remains a **redacted inspector** until it either grows the
+same persist helpers + badges or clearly links to SPA Settings for writes.
+
+---
+
+## 7. Follow-up implement Issues (parked)
+
+Do not implement in this PR. Suggested filings (titles only):
+
+1. **Refresh `AppConfig.config` after persist (live SoT)** — after
+   `persist_remote` / `persist_llm_settings` / `persist_agent_team` / CLI
+   writes, reload the same path into `SwarmConfig.config` (or always
+   re-read). Tests: PATCH LLM default → new blueprint sees it without
+   restart.
+2. **Compose: RW XDG config volume** — drop `:ro` (or document a RW
+   override). Tests: persist remote inside the container; file visible on
+   the host.
+3. **Unify XDG helpers** — `_xdg_config_path()` vs
+   `get_user_config_dir_for_swarm()` must resolve one directory. Compose
+   mount and CLI init must match.
+4. **[#540](https://github.com/matthewhand/open-swarm/issues/540) Django prefs** —
+   favourites / hidden (and later theme, rail order). Seed-once from
+   `localStorage` if server empty; then server wins. No XDG copy.
+5. **Env force-override + Settings badges** — implement §4 precedence and
+   §6 copy. Remotes: stop silent everyday env-wins for non-secret URLs
+   unless force flag.
+6. **Chat SoT: Django destination** — JSON remains restore SoT today
+   (`chat_store.py`). One-way migrate JSON → Django, then Django wins;
+   keep files for attachment bytes. No JSON↔SQL loop. Coordinate with
+   [#508](https://github.com/matthewhand/open-swarm/issues/508) (local
+   Postgres default; Neon test-only).
+7. **Fold `agent_settings.json` into the #540 prefs registry** (or a
+   documented per-user/per-agent Django model). Until then it stays XDG
+   sibling topology, on the same volume.
+8. **Docs honesty** — `DEVELOPMENT.md` Docker mount; FEATURE_STATUS
+   Settings “write” vs inspector; CONFIGURATION.md pointer to this ADR
+   (this PR adds the pointer only).
+
+---
+
+## 8. Consequences
+
+- Operators: secrets in env; topology in one JSON file (plus named sibling
+  JSON); chats/prefs moving to Django on purpose, not by drift.
+- Ephemeral Docker: mount **config RW + data RW**, or accept loss.
+- Implementers: no sync service; refresh the boot cache; badges before
+  clever merge.
+- This PR: documentation only. `Fixes` #541 when merged.

--- a/docs/adr/002-config-ownership.md
+++ b/docs/adr/002-config-ownership.md
@@ -6,6 +6,12 @@
 - **Related:** [#540](https://github.com/matthewhand/open-swarm/issues/540) (REQ-144 prefs), [#508](https://github.com/matthewhand/open-swarm/issues/508) (REQ-123 Postgres compose), [CONFIGURATION.md](../../CONFIGURATION.md)
 - **Supersedes:** none. Complements [ADR-001](../ADR-001-primary-ui.md) (UI chrome), not config SoT.
 
+**Decision:** **hybrid** (not pure A, not pure B). Secrets stay env-only.
+Non-secret topology and prefs persist in the ownership-table SoT. Precedence
+is `force-env > persisted > env-bootstrap > defaults`. Settings must badge
+every field that has an env twin. Recovery uses explicit force-env flags.
+No sync daemon.
+
 This ADR is **feasibility-first**: it records what the code does on `main`
 (`04ccb53a` at writing) and then picks one ownership table. It does **not**
 implement sync, migrations, or Settings UI badges.
@@ -242,15 +248,39 @@ read-only filesystem.
 
 ---
 
-## 4. Decision: one ownership table (amended strawman + hybrid precedence)
+## 4. Evaluate A / B / hybrid — pick **hybrid**
 
-Pick the **CoS hybrid** (A-leaning persist, B’s recovery override), not A or B
-alone, and **not** a sync daemon.
+Matthew’s two models and the CoS strawman, scored against today’s code and
+UI honesty.
+
+| Model | Everyday SoT | Env role | Honesty risk | Recovery |
+|---|---|---|---|---|
+| **A** — env bootstraps; Settings override env | Persisted Settings/file after first save | Seed empty fields; then lose | High unless every override is badged — ops debug `.env` and the process ignores it | Weak: bad persist needs file/volume surgery |
+| **B** — DB/Settings SoT; env force-override | Persisted DB or file | Recovery only | Low if force is explicit and read-only | Strong: tweak env, boot past a broken volume |
+| **Hybrid (pick)** | Persisted SoT per §4 table (`swarm_config.json` for topology, Django for prefs/chats) | Secrets always; topology only as **bootstrap** or **explicit force** | Low: badges on every env twin | B’s flag (`SWARM_CONFIG_FORCE_ENV=1` / `SWARM_*_OVERRIDE`) |
+
+**Why not pure A.** Settings already persist remotes and LLM maps to
+`swarm_config.json` (`persist_remote`, `persist_llm_settings`). Pure A without
+badges is today’s remotes bug in reverse: file written, env still silently
+wins (`load_remote`: “env wins”). Pure A *with* badges is the hybrid’s
+everyday path — A’s seed + override — but A alone has no recovery story when
+the volume is garbage.
+
+**Why not pure B.** Putting topology in Django as the everyday SoT fights
+`swarm-cli` and hand-edited JSON ([CONFIGURATION.md](../../CONFIGURATION.md)).
+B’s “env can force-override” is the right **recovery** lever, not the everyday
+reader. Making env win every boot (current remotes) *is* B-everyday and
+misleads operators who just saved Settings.
+
+**Why hybrid.** Takes A’s persist-and-badge honesty and B’s explicit recovery
+without a second store or a sync daemon. Secrets never become Settings
+plaintext SoT (`${VAR}`, “set / not set” only).
 
 **Precedence (document + enforce in implement Issues):**
 
-1. **Explicit env force-override** — `SWARM_CONFIG_FORCE_ENV=1` or per-key
-   `SWARM_*_OVERRIDE` / existing remote env keys when marked force.
+1. **Explicit env force-override** — `SWARM_CONFIG_FORCE_ENV=1` (all
+   non-secret topology) or per-key `SWARM_*_OVERRIDE` /
+   `HERMES_BASE_URL` only when force is on.
 2. **Persisted Settings / `swarm_config.json`** (and sibling XDG JSON below).
 3. **Env bootstrap defaults** — used only when the persisted key is empty
    (first boot / missing file).
@@ -278,18 +308,13 @@ is set (or the field was never persisted).
 **Non-goals:** bidirectional XDG↔DB sync; silent dual-write of remotes into
 SQL; Settings rewriting `.env`; Neon as a config store.
 
-### Why not DB-only topology?
+### Why not DB-only topology? (B taken too far)
 
 Feasible but rejected: `swarm-cli` and hand-edited JSON are first-class
 ([CONFIGURATION.md](../../CONFIGURATION.md)). Remotes/LLM persist already
 target the file. Moving topology into Django would create the sync hell this
 Issue forbids unless CLI became a DB client. Keep JSON as topology SoT.
-
-### Why not env-only topology (pure A)?
-
-Rejected for everyday edits: Settings already persist remotes and LLM maps to
-disk. Pure A would make those writes lie. Env remains the **bootstrap and
-recovery** layer.
+B’s recovery flag still applies **to that file**, not only to SQL.
 
 ---
 
@@ -318,23 +343,102 @@ compose no longer does that ([docs/debt/qa-wave3-structure-root.md](../debt/qa-w
 
 ---
 
-## 6. UI honesty (badge copy — implement with ownership)
+## 6. UI honesty — Settings copy (implement with ownership)
 
-Settings fields that have an env twin must show one of:
+Every Settings field that has an env twin shows **exactly one** badge.
+Copy is for the SPA sheet (`webui/frontend/src/components/SettingsSheet.tsx`
+— Remotes / LLM profiles) and, later, the same strings on Django `/settings/`
+if that page grows writes. DaisyUI: `badge badge-ghost` / `badge-warning` /
+`badge-error`. No secret values in the badge — **names only**.
 
-| Badge | When |
-|---|---|
-| **Forced by env `FOO` (read-only)** | Force-override or `SWARM_CONFIG_FORCE_ENV=1`; persist disabled |
-| **From env (not overridden)** | Persisted value empty; effective value came from bootstrap env |
-| **Overrides env `FOO`** | File/Settings value differs from bootstrap env; file wins |
-| **From config** | File value, no env twin |
-| **Built-in default** | Neither file nor env |
+| Badge (visible text) | When | Control |
+|---|---|---|
+| `Forced by env FOO (read-only)` | `SWARM_CONFIG_FORCE_ENV=1` or `SWARM_*_OVERRIDE` / forced remote env | Input disabled; Save no-ops that field |
+| `From env FOO (not overridden)` | Persisted key empty; effective value is bootstrap env | Editable; first save becomes “Overrides…” |
+| `Overrides env FOO` | Persisted value ≠ bootstrap env; file wins | Editable; helper: “`.env` still has FOO; this instance uses Settings.” |
+| `From config` | File value, no env twin | Editable |
+| `Built-in default` | Neither file nor env | Editable |
 
-Secrets fields stay **reference-only** (`${OPENAI_API_KEY}`, “set / not set”).
-No plaintext SoT in the UI.
+Secrets (API keys, tokens): never a plaintext SoT. Show
+`Uses ${OPENAI_API_KEY} — set` / `not set`. No override badge that implies
+the UI stored the secret.
 
-Django `/settings/` remains a **redacted inspector** until it either grows the
-same persist helpers + badges or clearly links to SPA Settings for writes.
+### Example — Settings → Remotes → Hermes
+
+```
+Remotes
+  Hermes
+  Base URL
+    [ https://hermes.lab.example ]     [ Overrides env HERMES_BASE_URL ]
+    .env still has HERMES_BASE_URL; this instance uses the URL saved here.
+    Clear to Settings to fall back to env bootstrap.
+
+  API key
+    [ Uses ${HERMES_API_KEY} — set ]   [ Secret · env-only ]
+    Not editable as plaintext. Rotate the env var, then reload.
+```
+
+Same pane, recovery boot (`SWARM_CONFIG_FORCE_ENV=1` or
+`SWARM_HERMES_BASE_URL_OVERRIDE=1`):
+
+```
+  Base URL
+    [ https://hermes-rescue.example ]  [ Forced by env HERMES_BASE_URL (read-only) ]
+    Persist is ignored until you unset SWARM_CONFIG_FORCE_ENV.
+    Saved Settings URL is kept on disk for when force is off.
+```
+
+First boot, file empty, compose injected `HERMES_BASE_URL`:
+
+```
+  Base URL
+    [ https://hermes.lab.example ]     [ From env HERMES_BASE_URL (not overridden) ]
+    Save keeps this URL in swarm_config.json (then badge → Overrides…).
+    Leave unsaved to keep env as the only source.
+```
+
+### Example — Settings → LLM profiles
+
+```
+LLM profiles
+  Default
+    [ gpt-4o-mini ▼ ]                  [ Overrides env DEFAULT_LLM ]
+    Chat uses this saved profile. Process env DEFAULT_LLM is ignored
+    unless you force-override.
+
+  Override per task                    [ From config ]
+    Off: every job uses Default.
+```
+
+Force-env recovery:
+
+```
+  Default
+    [ gpt-4o ▼ ]                       [ Forced by env DEFAULT_LLM (read-only) ]
+```
+
+No env twin (auto-pick only):
+
+```
+  Default
+    [ gpt-4o-mini ▼ (auto) ]           [ Built-in default ]
+    Auto-picked Default. Chat uses this until you save another id.
+```
+
+### Example — Settings → System (secrets inspector)
+
+```
+  OPENAI_API_KEY                       [ Secret · env-only ]
+    set
+  DJANGO_SECRET_KEY                    [ Secret · env-only ]
+    set
+  API_AUTH_TOKEN                       [ Secret · env-only ]
+    set
+```
+
+Django `/settings/` (“Operator dump”) stays a **redacted inspector** until it
+either grows the same persist helpers + these badges or keeps linking to SPA
+Settings for writes (`SettingsSheet` already links “Operator dump”).
 
 ---
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,6 @@
+# Architecture decision records
+
+| ADR | Title |
+|-----|--------|
+| [ADR-001](../ADR-001-primary-ui.md) | Primary UI is Django; SPA Chat only |
+| [ADR-002](./002-config-ownership.md) | Config ownership — `.env` vs XDG `swarm_config.json` vs Django DB |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Look-only planning ADR for [#541](https://github.com/matthewhand/open-swarm/issues/541). **No runtime behaviour change.**

## Issue quote

**Intent:** Operators and ephemeral deploys know where truth lives; no silent drift.

**Success (this Issue):**
1. Look-only Cursor cloud (or engineer) produces an **ADR markdown PR** answering the questions with file/path evidence.
2. ADR picks **one** direction (amend strawman or replace); lists migrations / follow-up implement Issues.
3. No code behaviour change in the ADR PR beyond docs (or a tiny inventory script if needed).
4. `Fixes` this Issue when ADR merges.

**Constraints:** Look-only / docs first. No Neon. No secrets in ADR. Park implement behind agreement. Related: #540 prefs, #508 Postgres compose, CONFIGURATION.md.

## Pick: **hybrid** (not A, not B)

Matthew A (env bootstraps; Settings override — must badge) vs B (DB/Settings SoT; env force-override for recovery) vs CoS hybrid.

**Recommend hybrid:** secrets env-only; topology/prefs in persisted SoT (`swarm_config.json` / Django per table); precedence `force-env > persisted > env-bootstrap > defaults`; recovery via `SWARM_CONFIG_FORCE_ENV=1` / `SWARM_*_OVERRIDE`. No sync daemon.

- Pure A: no recovery when the volume is junk; today’s remotes already silently env-win after Settings save.
- Pure B: Django-as-topology-SoT fights `swarm-cli` / hand-edited JSON.

## UI honesty (Settings copy in ADR §6)

Badge strings: `Overrides env FOO` / `From env FOO (not overridden)` / `Forced by env FOO (read-only)` / `From config` / `Built-in default`. Secrets: `Uses ${VAR} — set` only.

Mocks cover Settings → Remotes → Hermes, LLM profiles Default, and System secret inspector.

## Feasibility / other answers

1. **WebUI writes the same `swarm_config.json` as `swarm-cli`** for remotes, LLM settings, and `agent_team`. Django `/settings/` is GET-only. Default Docker `:ro` makes those writes fail.
2. **After boot:** XDG is a **bootstrap snapshot** for `AppConfig.config` / new blueprints, and a **live file** for remotes/LLM APIs.
3. **Docker:** RW config volume + existing data volume.
4. **Follow-ups** parked in the ADR (live-cache refresh, RW compose, XDG unify, #540, env badges, chat SoT).

ADR: `docs/adr/002-config-ownership.md`. Pointers from `CONFIGURATION.md`, `docs/SWARM_CONFIG.md`, ADR-001.

Fixes #541.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-860744a4-26b7-40b6-adde-6d5c451841e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-860744a4-26b7-40b6-adde-6d5c451841e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

