### PR TITLE
feat(webui): centre and enlarge search popup (REQ-113, Fixes #492)

### DIFF
--- a/tests/unit/test_req113_search_centered.py
+++ b/tests/unit/test_req113_search_centered.py
@@ -1,0 +1,30 @@
+"""REQ-113: Search popup — centered and larger."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INDEX_CSS = REPO_ROOT / "webui" / "frontend" / "src" / "index.css"
+SEARCH_PALETTE_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "SearchPalette.tsx"
+
+
+def test_index_css_search_overlay_centered():
+    css = INDEX_CSS.read_text(encoding="utf-8")
+    assert ".os-search-overlay" in css
+    # Horizontally and vertically centered modal overlay
+    assert "justify-content: center;" in css
+    assert "align-items: center;" in css
+
+
+def test_index_css_search_palette_enlarged():
+    css = INDEX_CSS.read_text(encoding="utf-8")
+    assert ".os-search-palette" in css
+    # Roomy sizing: ~min(560px, 90vw / calc(100vw - 2rem))
+    assert "560px" in css
+    assert "max-height" in css
+
+
+def test_search_palette_component_has_centered_classes():
+    tsx = SEARCH_PALETTE_TSX.read_text(encoding="utf-8")
+    assert "os-search-overlay--centered" in tsx
+    assert "os-search-palette--centered" in tsx
+    assert "os-search-palette--large" in tsx

--- a/webui/frontend/src/components/SearchPalette.tsx
+++ b/webui/frontend/src/components/SearchPalette.tsx
@@ -221,7 +221,8 @@ export default function SearchPalette({ open, onClose }: SearchPaletteProps) {
 
   return (
     <div
-      className="os-search-overlay"
+      className="os-search-overlay os-search-overlay--centered"
+      data-testid="os-search-overlay"
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) onClose()
       }}
@@ -231,7 +232,9 @@ export default function SearchPalette({ open, onClose }: SearchPaletteProps) {
         role="dialog"
         aria-modal="true"
         aria-label="Search"
-        className="os-search-palette"
+        data-testid="os-search-palette"
+        data-centered="true"
+        className="os-search-palette os-search-palette--centered os-search-palette--large"
       >
         <div className="os-search-palette__field">
           <Search className="h-4 w-4 shrink-0 text-base-content/45" aria-hidden="true" />

--- a/webui/frontend/src/components/__tests__/SearchPalette.test.tsx
+++ b/webui/frontend/src/components/__tests__/SearchPalette.test.tsx
@@ -56,6 +56,10 @@ describe('SearchPalette', () => {
 
     const dialog = screen.getByRole('dialog', { name: 'Search' })
     expect(dialog).toBeInTheDocument()
+    expect(dialog).toHaveClass('os-search-palette--centered')
+    expect(dialog).toHaveClass('os-search-palette--large')
+    const overlay = screen.getByTestId('os-search-overlay')
+    expect(overlay).toHaveClass('os-search-overlay--centered')
     const input = screen.getByRole('combobox', { name: 'Search' })
     expect(input).toHaveAttribute('placeholder', 'Search')
 

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -849,12 +849,19 @@ button.os-agent-row {
   inset: 0;
   z-index: 100;
   background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
 }
 .os-search-palette {
-  position: absolute;
-  top: 1rem;
-  left: 1rem;
-  width: min(42rem, calc(100vw - 2rem));
+  position: relative;
+  width: min(48rem, calc(100vw - 2rem));
+  min-width: min(560px, calc(100vw - 2rem));
+  max-width: 52rem;
+  max-height: calc(100vh - 4rem);
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
   border-radius: 1.5rem;
   border: 1px solid color-mix(in srgb, var(--color-base-content) 10%, transparent);
@@ -902,7 +909,7 @@ button.os-agent-row {
   color: inherit;
 }
 .os-search-palette__list {
-  max-height: 24rem;
+  max-height: min(32rem, 60vh);
   overflow-y: auto;
   padding: 0.25rem 0.5rem 0.7rem;
 }


### PR DESCRIPTION
Fixes #492

- Horizontally and vertically centre search overlay in viewport
- Enlarge search palette width (min 560px, up to 48rem) and max list height
- Preserve keyboard navigation, tabs, and escape/backdrop dismiss
- Add tests in SearchPalette.test.tsx and test_req113_search_centered.py