### PR TITLE
feat(webui): Hidden Bots footer row chrome (REQ-129, Fixes #519)

### DIFF
--- a/src/swarm/static/js/agent_sidebar.js
+++ b/src/swarm/static/js/agent_sidebar.js
@@ -446,7 +446,7 @@
       if (hiddenWrap) {
         hiddenWrap.hidden = hiddenTotal === 0;
       }
-      if (hiddenCount) hiddenCount.textContent = "(" + hiddenTotal + ")";
+      if (hiddenCount) hiddenCount.textContent = String(hiddenTotal);
       hiddenListEl.hidden = !hiddenOpen;
       if (hiddenToggle) hiddenToggle.setAttribute("aria-expanded", hiddenOpen ? "true" : "false");
 

--- a/src/swarm/templates/base.html
+++ b/src/swarm/templates/base.html
@@ -99,8 +99,9 @@
                 <p class="os-agent-status" id="os-agent-status">Loading agents…</p>
                 <ul class="os-agent-ul" id="os-agent-list"></ul>
                 <div class="os-agent-hidden" id="os-agent-hidden-wrap" hidden>
-                    <button type="button" class="os-agent-hidden__toggle" id="os-agent-hidden-toggle" aria-expanded="false">
-                        Hidden <span id="os-agent-hidden-count">(0)</span>
+                    <button type="button" class="os-agent-hidden__toggle os-hidden-bots-row" id="os-agent-hidden-toggle" aria-expanded="false" aria-label="Hidden Bots">
+                        <span class="os-hidden-bots-label">Hidden Bots</span>
+                        <span class="os-hidden-bots-tail" id="os-agent-hidden-count">0</span>
                     </button>
                     <ul class="os-agent-ul" id="os-agent-hidden-list" hidden></ul>
                 </div>

--- a/tests/unit/test_req129_hidden_bots.py
+++ b/tests/unit/test_req129_hidden_bots.py
@@ -1,0 +1,44 @@
+"""REQ-129: Hidden Bots footer row chrome — label + count, hover chevron, ghost until hover."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INDEX_CSS = REPO_ROOT / "webui" / "frontend" / "src" / "index.css"
+AGENT_SIDEBAR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+BASE_HTML = REPO_ROOT / "src" / "swarm" / "templates" / "base.html"
+AGENT_SIDEBAR_JS = REPO_ROOT / "src" / "swarm" / "static" / "js" / "agent_sidebar.js"
+
+
+def test_agent_sidebar_tsx_has_hidden_bots_row_and_swap():
+    tsx = AGENT_SIDEBAR_TSX.read_text(encoding="utf-8")
+    assert "Hidden Bots" in tsx
+    assert "os-hidden-bots-row" in tsx
+    assert "os-hidden-bots-label" in tsx
+    assert "os-hidden-bots-tail" in tsx
+    assert "os-hidden-bots-count" in tsx
+    assert "os-hidden-bots-chevron" in tsx
+    assert "hoveringHidden" in tsx
+    assert "os-hide-drop--has-hidden" in tsx
+
+
+def test_index_css_hidden_bots_ghost_and_borderless():
+    css = INDEX_CSS.read_text(encoding="utf-8")
+    assert ".os-hidden-bots-row" in css
+    assert ".os-hide-drop--has-hidden" in css
+
+    # Ghost / transparent resting state with no border
+    assert "border: 0;" in css
+    assert "background: transparent;" in css
+
+    # Hover fill
+    assert ".os-hidden-bots-row:hover" in css
+
+
+def test_base_html_and_sidebar_js_updated_for_hidden_bots():
+    html = BASE_HTML.read_text(encoding="utf-8")
+    assert "Hidden Bots" in html
+    assert "os-hidden-bots-row" in html
+
+    js = AGENT_SIDEBAR_JS.read_text(encoding="utf-8")
+    # Count updated cleanly without old parenthesis-wrapped style
+    assert "String(hiddenTotal)" in js

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -209,6 +209,7 @@ export default function AgentSidebar({
   )
   const [pins, setPins] = useState<PinnedAgent[]>(() => loadOrSeedPinnedAgents())
   const [hiddenOpen, setHiddenOpen] = useState(false)
+  const [hoveringHidden, setHoveringHidden] = useState(false)
   const [pluginsOpen, setPluginsOpen] = useState(false)
   const [hostname, setHostname] = useState(() => loadHostname())
   const [menu, setMenu] = useState<ContextMenuState | null>(null)
@@ -1308,7 +1309,7 @@ export default function AgentSidebar({
           </div>
 
           <div
-            className={`os-hide-drop os-drop-target ${hideDropActive ? 'os-hide-drop--active' : ''}`}
+            className={`os-hide-drop os-drop-target ${hideDropActive ? 'os-hide-drop--active' : ''} ${hiddenCount > 0 ? 'os-hide-drop--has-hidden' : ''}`}
             data-drag-over={hideDropActive ? 'true' : undefined}
             role="region"
             aria-label="Hidden"
@@ -1338,12 +1339,24 @@ export default function AgentSidebar({
             {hiddenCount > 0 ? (
               <button
                 type="button"
-                className="os-hide-drop__action"
+                className="os-hide-drop__action os-hidden-bots-row group"
                 aria-haspopup="dialog"
                 aria-expanded={hiddenOpen}
+                aria-label={`Hidden Bots ${hiddenCount} (${hiddenCount} hidden)`}
+                data-testid="os-hidden-bots-button"
                 onClick={() => setHiddenOpen(true)}
+                onMouseEnter={() => setHoveringHidden(true)}
+                onMouseLeave={() => setHoveringHidden(false)}
               >
-                {hiddenCount} hidden
+                <span className="os-hidden-bots-label font-medium">Hidden Bots</span>
+                <span className="os-hidden-bots-tail font-mono text-xs" data-testid="os-hidden-bots-tail">
+                  <span className={`os-hidden-bots-count ${hoveringHidden ? 'hidden' : 'inline group-hover:hidden'}`} data-testid="os-hidden-bots-count">
+                    {hiddenCount}
+                  </span>
+                  <span className={`os-hidden-bots-chevron ${hoveringHidden ? 'inline' : 'hidden group-hover:inline'}`} aria-hidden="true" data-testid="os-hidden-bots-chevron">
+                    &gt;
+                  </span>
+                </span>
               </button>
             ) : (
               <p className="os-hide-drop__hint">drop here to hide</p>

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -1432,3 +1432,45 @@ describe('AgentSidebar special roles', () => {
     )
   })
 })
+
+describe('AgentSidebar REQ-129 — Hidden Bots row chrome', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    rememberEmptyFavourites()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ object: 'list', data: [] }),
+      } as Response),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    localStorage.clear()
+  })
+
+  it('renders "Hidden Bots" label with count and swaps count to > on hover', async () => {
+    localStorage.setItem(HIDDEN_AGENTS_STORAGE_KEY, JSON.stringify(['gate', 'skeptic']))
+    renderSidebar()
+    const btn = await screen.findByTestId('os-hidden-bots-button')
+    expect(btn).toBeInTheDocument()
+    expect(btn).toHaveClass('os-hidden-bots-row')
+    expect(within(btn).getByText('Hidden Bots')).toBeInTheDocument()
+
+    // Resting state: count is visible
+    const countEl = within(btn).getByTestId('os-hidden-bots-count')
+    expect(countEl).toHaveTextContent('2')
+
+    // Hover state: swaps count to >
+    fireEvent.mouseEnter(btn)
+    expect(within(btn).getByTestId('os-hidden-bots-tail')).toHaveTextContent('>')
+
+    // Leave hover state: restores count
+    fireEvent.mouseLeave(btn)
+    expect(within(btn).getByTestId('os-hidden-bots-count')).toHaveTextContent('2')
+  })
+})
+

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -593,6 +593,42 @@ button.os-agent-row {
   color: var(--color-base-content);
 }
 
+.os-hide-drop--has-hidden:not([data-drag-over]):not(.os-hide-drop--active) {
+  border: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.os-hidden-bots-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.45rem 0.6rem;
+  border: 0;
+  border-radius: 0.55rem;
+  background: transparent;
+  color: color-mix(in srgb, var(--color-base-content) 60%, transparent);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.os-hidden-bots-row:hover {
+  background: color-mix(in srgb, var(--color-base-content) 7%, transparent);
+  color: var(--color-base-content);
+}
+
+.os-hidden-bots-label {
+  font-weight: 500;
+}
+
+.os-hidden-bots-tail {
+  display: inline-flex;
+  align-items: center;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
 .os-rail-hostname-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## REQ-129 — Hidden Bots footer row chrome

Fixes #519

### Intent
Replace the compact "N hidden" style with a quieter Grok-like chrome for the hidden agents row in the rail footer.

### Changes
1. **Label + Count**: Changed label to `Hidden Bots` on left, count on right.
2. **Hover swap to `>`**: Hovering over the row swaps the count to a `>` chevron; count returns when unhovered.
3. **Ghost resting state**: No border and transparent background in resting state.
4. **Hover styling**: Light fill on hover.
5. **Preserved popup**: Clicking still opens the Hidden Agents popup.
6. **Tests**: Added Python unit tests (`tests/unit/test_req129_hidden_bots.py`) and component tests in `AgentSidebar.test.tsx`.