### PR TITLE
feat(webui): scrollable capped lists in dense forms and pickers (REQ-149, Fixes #549)

### DIFF
--- a/tests/unit/test_req149_scrollable_lists.py
+++ b/tests/unit/test_req149_scrollable_lists.py
@@ -1,0 +1,47 @@
+"""REQ-149: Long agent/blueprint form lists — max-height + scroll."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INDEX_CSS = REPO_ROOT / "webui" / "frontend" / "src" / "index.css"
+SETTINGS_SHEET_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "SettingsSheet.tsx"
+TEAM_COMPOSER_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "TeamComposer.tsx"
+REMOTES_SETTINGS_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "RemotesSettings.tsx"
+AGENT_EDITOR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentEditor.tsx"
+
+
+def test_index_css_scrollable_picker_utility():
+    css = INDEX_CSS.read_text(encoding="utf-8")
+    assert ".os-scrollable-picker-list" in css
+    assert ".os-capped-list" in css
+    assert "overflow-y: auto;" in css
+    assert "18rem" in css  # ~288px / 8-10 rows
+
+
+def test_settings_sheet_lists_are_capped():
+    tsx = SETTINGS_SHEET_TSX.read_text(encoding="utf-8")
+    # Blueprints list
+    assert 'aria-label="Blueprints"' in tsx
+    assert 'os-scrollable-picker-list' in tsx
+    # Configured remotes list
+    assert 'aria-label="Configured remotes"' in tsx
+    # Configured LLM profiles list
+    assert 'aria-label="Configured LLM profiles"' in tsx
+
+
+def test_team_composer_roster_and_agents_are_capped():
+    tsx = TEAM_COMPOSER_TSX.read_text(encoding="utf-8")
+    assert 'aria-label="Roster members"' in tsx
+    assert 'os-scrollable-picker-list' in tsx
+    assert 'max-h-40 overflow-y-auto' in tsx
+
+
+def test_remotes_settings_bots_list_is_capped():
+    tsx = REMOTES_SETTINGS_TSX.read_text(encoding="utf-8")
+    assert 'os-scrollable-picker-list' in tsx
+
+
+def test_agent_editor_has_internal_scroll():
+    tsx = AGENT_EDITOR_TSX.read_text(encoding="utf-8")
+    assert 'id="os-agent-editor"' in tsx
+    assert 'overflow-y-auto' in tsx

--- a/webui/frontend/src/components/AgentEditor.tsx
+++ b/webui/frontend/src/components/AgentEditor.tsx
@@ -151,7 +151,11 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
       size="lg"
       className="flex min-h-0 flex-col"
     >
-      <div id="os-agent-editor" className="space-y-4" data-agent-id={id || undefined}>
+      <div
+        id="os-agent-editor"
+        className="space-y-4 max-h-[calc(100vh-12rem)] overflow-y-auto pr-1"
+        data-agent-id={id || undefined}
+      >
         <p className="text-sm text-base-content/70">
           This pane is only about this agent. Blueprint picks a catalog recipe
           for this seat — it is not Settings.

--- a/webui/frontend/src/components/RemotesSettings.tsx
+++ b/webui/frontend/src/components/RemotesSettings.tsx
@@ -261,7 +261,7 @@ export function RemoteOperatePane({ remote }: { remote: RemoteConnection }) {
         <div className="space-y-2">
           <p className="text-sm font-medium">{isOmb ? 'Bots' : 'List'}</p>
           {listed.ok && bots.length > 0 ? (
-            <ul className="space-y-1 text-sm">
+            <ul className="space-y-1 text-sm os-scrollable-picker-list pr-1">
               {bots.map((bot) => (
                 <li key={bot.id} className="rounded-lg border border-base-300 bg-base-200/60 px-3 py-2 font-mono">
                   {bot.id}

--- a/webui/frontend/src/components/SettingsSheet.tsx
+++ b/webui/frontend/src/components/SettingsSheet.tsx
@@ -333,7 +333,7 @@ export function BlueprintsListPane({
       ) : items.length === 0 ? (
         <p className="text-sm text-base-content/60">No blueprints in the catalog.</p>
       ) : (
-        <ul role="listbox" aria-label="Blueprints" className="menu menu-md rounded-box border border-base-300 bg-base-200 p-2">
+        <ul role="listbox" aria-label="Blueprints" className="menu menu-md rounded-box border border-base-300 bg-base-200 p-2 os-scrollable-picker-list">
           {items.map((item) => {
             const selected = item.id === selectedId
             return (
@@ -618,7 +618,7 @@ function RemotesCatalogPane() {
           <span className="text-sm">No remotes configured yet.</span>
         </Alert>
       ) : configured.length === 0 ? null : (
-        <ul className="space-y-2" aria-label="Configured remotes">
+        <ul className="space-y-2 os-scrollable-picker-list" aria-label="Configured remotes">
           {configured.map((remote) => {
             const label = remoteKindLabel(remote.kind || remote.id, kinds)
             return (
@@ -1007,7 +1007,7 @@ function LlmProfilesPane() {
           </span>
         </Alert>
       ) : (
-        <ul className="space-y-1 text-sm" aria-label="Configured LLM profiles">
+        <ul className="space-y-1 text-sm os-scrollable-picker-list" aria-label="Configured LLM profiles">
           {profiles.map((profile) => (
             <li
               key={`${profile.source}:${profile.id}`}

--- a/webui/frontend/src/components/TeamComposer.tsx
+++ b/webui/frontend/src/components/TeamComposer.tsx
@@ -325,7 +325,7 @@ export default function TeamComposer({ isOpen, onClose }: TeamComposerProps) {
                 </p>
               </div>
             ) : (
-              <ul className="flex flex-col gap-2" aria-label="Roster members">
+              <ul className="flex flex-col gap-2 os-scrollable-picker-list pr-1" aria-label="Roster members">
                 {members.map((member) => {
                   const agent: TeamAgent = {
                     id: member.id,
@@ -408,9 +408,7 @@ export default function TeamComposer({ isOpen, onClose }: TeamComposerProps) {
                       </span>
                     </h4>
                     <ul
-                      className={`flex flex-col gap-1 ${
-                        kind === 'api' ? 'max-h-28 overflow-y-auto' : ''
-                      }`}
+                      className="flex flex-col gap-1 os-scrollable-picker-list max-h-40 overflow-y-auto pr-1"
                     >
                       {agentsByKind[kind].length === 0 ? (
                         <li className="px-2 py-1 text-xs text-base-content/40">None</li>

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -629,6 +629,14 @@ button.os-agent-row {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
+/* REQ-149: Scrollable capped lists in dense forms/fields (~8-10 rows / 288px) */
+.os-scrollable-picker-list,
+.os-capped-list {
+  max-height: 18rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
 .os-rail-hostname-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## REQ-149 — Scrollable capped lists in forms/fields

Fixes #549

### Quote (from #549)
**Intent:** Dense rosters stay usable without stretching the layout.

**Success:**
1. Selects, multi-selects, checklist panels, Settings pickers, team/blueprint pickers, etc. that can grow unbounded get a **max-height** (~18rem / 288px / ~8–10 rows) and **overflow-y: auto**.
2. Applies across WebUI forms that list agents/blueprints/remotes/similar — audit main offenders (Settings, team composer, agent editor, remotes, favourites-adjacent pickers).
3. DaisyUI 5 / React 18; don't break keyboard selection. Tests for max-height class / scroll container if feasible. `Fixes` this Issue.
4. No secrets. No Neon.

### Feasibility
High. Utility CSS class `.os-scrollable-picker-list` (~18rem / 288px / 8-10 rows) with `overflow-y: auto` and internal scrolling across Settings, TeamComposer, RemotesSettings, and AgentEditor.

### Changes
- Added `.os-scrollable-picker-list` and `.os-capped-list` utility classes in `index.css`.
- Capped Blueprints listbox, Configured Remotes list, and LLM Profiles list in SettingsSheet.
- Capped Roster dropzone list and all Available Agents sublists in TeamComposer.
- Capped listed bots in RemotesSettings.
- Added internal scrolling container in AgentEditor.
- Unit tests added in `tests/unit/test_req149_scrollable_lists.py` (5/5 passing).

Ready-to-squash SHA: 94829e81