### PR TITLE
fix(webui): show Remotes dropdown only on remote agents and remote-backed teams (REQ-132, Fixes #522)

### DIFF
--- a/tests/unit/test_req132_remotes_dropdown_scope.py
+++ b/tests/unit/test_req132_remotes_dropdown_scope.py
@@ -1,0 +1,26 @@
+"""REQ-132: Remotes dropdown only on remote agents (not every agent)."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHAT_PAGE_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "pages" / "ChatPage.tsx"
+CHAT_PAGE_TEST_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "pages" / "__tests__" / "ChatPage.test.tsx"
+
+
+def test_chat_page_guards_remotes_dropdown():
+    tsx = CHAT_PAGE_TSX.read_text(encoding="utf-8")
+    assert "isRemoteBackedTeam" in tsx
+    assert "isRemoteAgent" in tsx
+    assert "showRemotesControl" in tsx
+
+    # Must be conditionally rendered, omitted entirely when false (no empty stub)
+    assert "{showRemotesControl ? (" in tsx
+    assert "<RemoteSelect" in tsx
+    assert ") : null}" in tsx
+
+
+def test_chat_page_test_covers_req132():
+    test_tsx = CHAT_PAGE_TEST_TSX.read_text(encoding="utf-8")
+    assert "hides the Remotes control on local API and CLI agents" in test_tsx
+    assert "hides the Remotes control on local teams" in test_tsx
+    assert "shows the Remotes control on remote-backed teams" in test_tsx

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -254,6 +254,30 @@ const ChatPage = () => {
             : selectedBlueprint
   const signInHref = chatLoginHref(searchParams)
 
+  const isRemoteBackedTeam = Boolean(
+    selectedTeam && (
+      (selectedTeam as { kind?: string }).kind === 'remote' ||
+      Boolean((selectedTeam as { remote?: string }).remote) ||
+      selectedTeam.members?.some(
+        (m) =>
+          m.kind === 'remote' ||
+          (m as { role?: string }).role === 'remote' ||
+          Boolean((m as { remote?: string }).remote),
+      )
+    ),
+  )
+
+  const isRemoteAgent = Boolean(
+    remoteFromUrl ||
+      selectedRemote ||
+      agentKind === 'remote' ||
+      selectedAgent?.kind === 'remote' ||
+      (selectedAgent as { agent_type?: string })?.agent_type === 'remote' ||
+      Boolean((selectedAgent as { remote?: string })?.remote),
+  )
+
+  const showRemotesControl = isRemoteAgent || isRemoteBackedTeam
+
   useEffect(() => {
     // REQ-28: a selected composition team uses ?team=; do not clobber it
     // with the Support default (REQ-23 owns send-to-all).
@@ -921,13 +945,15 @@ const ChatPage = () => {
           ) : null}
         </div>
         <div className="flex items-center gap-2">
-          <RemoteSelect
-            remotes={remotesQuery.data}
-            value={selectedRemoteId}
-            onChange={setSelectedRemoteId}
-            size="sm"
-            className="h-8 max-w-[10rem]"
-          />
+          {showRemotesControl ? (
+            <RemoteSelect
+              remotes={remotesQuery.data}
+              value={selectedRemoteId}
+              onChange={setSelectedRemoteId}
+              size="sm"
+              className="h-8 max-w-[10rem]"
+            />
+          ) : null}
           {teamFromUrl ? (
             <select
               className="select select-sm h-8 max-w-[12rem] border border-base-300 bg-base-100"

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -1226,7 +1226,7 @@ describe('ChatPage remotes dropdown (REQ-59)', () => {
     vi.unstubAllGlobals()
   })
 
-  it('lists only configured remotes plus Add remote', async () => {
+  it('lists only configured remotes plus Add remote on remote agents', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockImplementation(async (input: RequestInfo) => {
@@ -1263,7 +1263,7 @@ describe('ChatPage remotes dropdown (REQ-59)', () => {
         } as Response
       }),
     )
-    renderChat()
+    renderChat('/chat?remote=omb')
     await act(async () => {
       MockWebSocket.instances[0]?.open()
     })
@@ -1277,6 +1277,99 @@ describe('ChatPage remotes dropdown (REQ-59)', () => {
     expect(options).not.toContain('Rakazo')
     expect(options).not.toContain('OMB')
     expect(select.textContent).not.toMatch(/\bOMB\b/)
+  })
+
+  it('hides the Remotes control on local API and CLI agents', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          kinds: [{ id: 'omb', label: 'OpenMousBot' }],
+          configured: [{ id: 'omb', kind: 'omb', label: 'OpenMousBot' }],
+        }),
+      } as Response),
+    )
+    renderChat('/chat?blueprint=codey')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+    expect(screen.queryByRole('combobox', { name: 'Remote' })).not.toBeInTheDocument()
+  })
+
+  it('hides the Remotes control on local teams', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('team-rosters')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => [
+              {
+                id: 'local-team',
+                name: 'Local Team',
+                members: [{ id: 'codey', kind: 'agent' }],
+              },
+            ],
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [] }),
+        } as Response
+      }),
+    )
+    renderChat('/chat?team=local-team')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+    expect(screen.queryByRole('combobox', { name: 'Remote' })).not.toBeInTheDocument()
+  })
+
+  it('shows the Remotes control on remote-backed teams', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('team-rosters')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => [
+              {
+                id: 'remote-team',
+                name: 'Remote Team',
+                members: [{ id: 'omb-bot', kind: 'remote' }],
+              },
+            ],
+          } as Response
+        }
+        if (url.includes('/v1/remotes')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              kinds: [{ id: 'omb', label: 'OpenMousBot' }],
+              configured: [{ id: 'omb', kind: 'omb', label: 'OpenMousBot' }],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [] }),
+        } as Response
+      }),
+    )
+    renderChat('/chat?team=remote-team')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+    expect(await screen.findByRole('combobox', { name: 'Remote' })).toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
## REQ-132 — Hide Remotes dropdown on non-remote agents

Fixes #522

### Quote (from #522)
**Intent:** Don’t clutter local API/CLI/team chrome with remotes-only controls.

**Success:**
1. **Remotes** dropdown/control is **visible only** when the selected/current rail item is a **remote** agent (or remote team/channel row).
2. Hidden for local API agents, CLI agents, local teams (unless that team is itself remote-backed — then show).
3. No empty stub / disabled control left behind on local agents — omit entirely.
4. Tests: local agent view → no Remotes control; remote agent view → control present. DaisyUI 5 / React 18. No secrets. No live host.

### Feasibility
High. Guard `<RemoteSelect>` in `ChatPage.tsx` with `showRemotesControl` derived from `isRemoteAgent || isRemoteBackedTeam`. Omit entirely when false.

### Changes
- In `ChatPage.tsx`, compute `showRemotesControl` based on whether the current selection is a remote agent (`remoteFromUrl`, `selectedRemote`, `agentKind === 'remote'`) or a remote-backed team (team or member with `kind === 'remote'`).
- Conditionally render `<RemoteSelect>` only when `showRemotesControl` is true (renders `null` otherwise; no empty stub).
- Updated `ChatPage.test.tsx` to verify omission on local API/CLI agents and local teams, and display on remote agents/teams.
- Added unit test `tests/unit/test_req132_remotes_dropdown_scope.py` (2/2 passing).

Ready-to-squash SHA: 53b9b9cd