### PR TITLE
feat(webui): navbar Edit icon hidden until hover on desktop (REQ-140, Fixes #534)

### DIFF
--- a/tests/unit/test_req140_navbar_edit_hover.py
+++ b/tests/unit/test_req140_navbar_edit_hover.py
@@ -1,0 +1,35 @@
+"""REQ-140: Navbar Edit icon — desktop hide until hover; rail pencils stay retired."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INDEX_CSS = REPO_ROOT / "webui" / "frontend" / "src" / "index.css"
+CHAT_PAGE_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "pages" / "ChatPage.tsx"
+AGENT_SIDEBAR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+
+
+def test_index_css_navbar_edit_desktop_hover_and_mobile_visible():
+    css = INDEX_CSS.read_text(encoding="utf-8")
+    assert ".os-navbar-edit-btn" in css
+    # Default visible for mobile / touch (coarse pointer, hover: none)
+    assert "opacity: 1;" in css
+
+    # Desktop hover-reveal query
+    assert "@media (hover: hover) and (pointer: fine)" in css
+    assert ".os-chat-header__identity .os-navbar-edit-btn" in css
+    assert "opacity: 0;" in css
+    assert ".os-chat-header__identity:hover .os-navbar-edit-btn" in css
+
+
+def test_chat_page_navbar_edit_button_classes():
+    tsx = CHAT_PAGE_TSX.read_text(encoding="utf-8")
+    assert "os-chat-header__identity" in tsx
+    assert "os-navbar-edit-btn" in tsx
+    assert 'aria-label="Edit agent"' in tsx
+
+
+def test_rail_row_pencils_remain_retired():
+    tsx = AGENT_SIDEBAR_TSX.read_text(encoding="utf-8")
+    # Rail rows do NOT have edit pencil buttons
+    assert "os-agent-row__edit" not in tsx
+    assert "Edit row pencil" not in tsx

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -637,6 +637,22 @@ button.os-agent-row {
   overscroll-behavior: contain;
 }
 
+/* REQ-140: Navbar Edit icon hidden until hover on desktop; always visible on mobile/touch */
+.os-navbar-edit-btn {
+  opacity: 1;
+  transition: opacity 0.15s ease;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .os-chat-header__identity .os-navbar-edit-btn {
+    opacity: 0;
+  }
+  .os-chat-header__identity:hover .os-navbar-edit-btn,
+  .os-chat-header__identity:focus-within .os-navbar-edit-btn {
+    opacity: 1;
+  }
+}
+
 .os-rail-hostname-row {
   display: flex;
   align-items: center;

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -878,7 +878,7 @@ const ChatPage = () => {
   return (
     <div className="os-chat flex h-full min-h-0 w-full flex-col">
       <header className="os-chat-header">
-        <div className="os-chat-header__identity flex min-w-0 items-center gap-2" data-testid="selected-agent-header">
+        <div className="os-chat-header__identity flex min-w-0 items-center gap-2 group" data-testid="selected-agent-header">
           {narrow ? (
             <button
               type="button"
@@ -932,7 +932,7 @@ const ChatPage = () => {
             <div className="tooltip tooltip-bottom" data-tip="Edit agent">
               <button
                 type="button"
-                className="btn btn-ghost btn-sm btn-square"
+                className="btn btn-ghost btn-sm btn-square os-navbar-edit-btn"
                 aria-label="Edit agent"
                 onClick={() =>
                   openAgentEditor({


### PR DESCRIPTION
## REQ-140 — Edit entry points after rail pencils retired

Fixes #534

### Quote (from #534)
**Intent:** Sidepane hover pencils are gone — intentional. Make the navbar Edit affordance quiet and discoverable.

**Success:**
1. On **desktop**, the navbar **Edit** icon is **hidden until hover** of the relevant header/name area (ghost until hover) — same quiet chrome as other hover-revealed controls.
2. On **mobile / touch**, keep a tappable Edit affordance without requiring hover (always available or long-press / menu — document choice; prefer always-visible small icon on touch).
3. Do **not** bring back sidepane row pencils.
4. DaisyUI 5 / React 18. Tests for desktop hover-reveal if feasible. `Fixes` this Issue. No secrets. No Neon.

### Feasibility
High. Controlled via `@media (hover: hover) and (pointer: fine)` in `index.css`: resting `opacity: 0` on desktop, revealed with `opacity: 1` on hover or focus-within. Stays `opacity: 1` on mobile/touch interfaces.

### Changes
- In `index.css`, added `.os-navbar-edit-btn` styles:
  - Default `opacity: 1` for mobile/touch (`hover: none` / coarse pointer).
  - On pointer-fine / hover-capable devices, `opacity: 0` resting state, transitioning to `opacity: 1` when hovering or focusing within `.os-chat-header__identity`.
- Added `group` to `.os-chat-header__identity` and class `.os-navbar-edit-btn` to the Edit agent button in `ChatPage.tsx`.
- Rail row pencils remain retired.
- Added unit tests in `tests/unit/test_req140_navbar_edit_hover.py` (3/3 passing).

Ready-to-squash SHA: 85eb964d