### PR TITLE
feat(webui): discoverable keybinding tips and Grok search parity (REQ-147, Fixes #547)

### DIFF
--- a/tests/unit/test_req147_keybindings.py
+++ b/tests/unit/test_req147_keybindings.py
@@ -1,0 +1,58 @@
+"""REQ-147: Discoverable keybinding tips & Grok-Bot search parity."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+APP_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "App.tsx"
+FLAGS_TS = REPO_ROOT / "webui" / "frontend" / "src" / "experimental" / "flags.ts"
+CMD_PALETTE_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "experimental" / "CommandPalette.tsx"
+SIDEBAR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+SEARCH_PALETTE_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "SearchPalette.tsx"
+
+
+def test_app_binds_global_cmd_k_search():
+    content = APP_TSX.read_text(encoding="utf-8")
+    assert "e.key.toLowerCase() === 'k'" in content
+    assert "setSearchOpen((prev) => !prev)" in content
+    assert "window.addEventListener('keydown', onKey)" in content
+
+
+def test_command_palette_demoted_and_no_collision():
+    flags = FLAGS_TS.read_text(encoding="utf-8")
+    # command_palette must default to false unless explicitly turned on
+    assert "flag === 'command_palette'" in flags
+    assert "raw === 'on' || raw === 'true'" in flags
+    assert "return flag !== 'command_palette'" in flags
+
+    cmd_palette = CMD_PALETTE_TSX.read_text(encoding="utf-8")
+    # Must require shiftKey or not intercept bare ⌘K / Ctrl+K
+    assert "e.shiftKey" in cmd_palette
+
+
+def test_sidebar_alt_pins_and_tips():
+    sidebar = SIDEBAR_TSX.read_text(encoding="utf-8")
+    # Alt/⌥+1…9 navigation
+    assert "event.altKey" in sidebar
+    assert "/^[1-9]$/.test(event.key)" in sidebar
+    assert "visiblePins[idx]" in sidebar
+
+    # Hover shortcut badge on favourite tiles
+    assert "os-fav-tile__shortcut" in sidebar
+
+    # Search placeholder / affordance displays ⌘K / Ctrl+K
+    assert "searchShortcutLabel" in sidebar
+    assert "os-rail-search__kbd" in sidebar
+
+    # Dismissible first-load tips
+    assert "first-load-tips" in sidebar
+    assert "swarm_keybinding_tips_dismissed" in sidebar
+
+
+def test_search_palette_footer_tips():
+    palette = SEARCH_PALETTE_TSX.read_text(encoding="utf-8")
+    assert "os-search-palette__footer" in palette
+    assert "os-search-tip" in palette
+    assert "Navigate" in palette
+    assert "Select" in palette
+    assert "Close" in palette
+    assert "os-search-palette__kbd" in palette

--- a/webui/frontend/src/App.tsx
+++ b/webui/frontend/src/App.tsx
@@ -124,6 +124,13 @@ function App() {
       setEditingAgentId(detail?.agentId ?? null)
       setAgentEditorOpen(true)
     }
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setSearchOpen((prev) => !prev)
+      }
+    }
+    window.addEventListener('keydown', onKey)
     window.addEventListener(THEME_TOGGLE_EVENT, onToggle)
     window.addEventListener(THEME_SET_EVENT, onSet)
     window.addEventListener('swarm:open-search', onOpenSearch)
@@ -131,6 +138,7 @@ function App() {
     window.addEventListener(OPEN_LLM_PROFILES_EVENT, onOpenLlmProfiles)
     window.addEventListener(OPEN_AGENT_EDITOR_EVENT, onOpenAgentEditor)
     return () => {
+      window.removeEventListener('keydown', onKey)
       window.removeEventListener(THEME_TOGGLE_EVENT, onToggle)
       window.removeEventListener(THEME_SET_EVENT, onSet)
       window.removeEventListener('swarm:open-search', onOpenSearch)

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -227,6 +227,17 @@ export default function AgentSidebar({
   const [sessionPicker, setSessionPicker] = useState<SessionPickerState | null>(null)
   const menuRef = useRef<HTMLDivElement | null>(null)
   const hideDropDepth = useRef(0)
+  const [tipsDismissed, setTipsDismissed] = useState(() => {
+    try {
+      return Boolean(localStorage.getItem('swarm_keybinding_tips_dismissed'))
+    } catch {
+      return false
+    }
+  })
+  const isMac =
+    typeof navigator !== 'undefined' &&
+    /Mac|iPod|iPhone|iPad/.test(navigator.platform || navigator.userAgent)
+  const searchShortcutLabel = isMac ? '⌘K' : 'Ctrl+K'
   const sessionsByAgent = useMemo(() => loadAllAgentSessions(), [sessionTick])
 
   useEffect(() => {
@@ -493,6 +504,26 @@ export default function AgentSidebar({
       window.removeEventListener('mousedown', onPointer)
     }
   }, [menu, closeMenu])
+
+  useEffect(() => {
+    const onAltDigit = (event: KeyboardEvent) => {
+      if (event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey && /^[1-9]$/.test(event.key)) {
+        const idx = parseInt(event.key, 10) - 1
+        const pin = visiblePins[idx]
+        if (pin) {
+          event.preventDefault()
+          if (isHerdrAgent(pin)) {
+            window.location.assign('/teams/#herdr-members')
+          } else {
+            navigate(`/chat?blueprint=${encodeURIComponent(pin.id)}`)
+          }
+          onClose?.()
+        }
+      }
+    }
+    window.addEventListener('keydown', onAltDigit)
+    return () => window.removeEventListener('keydown', onAltDigit)
+  }, [visiblePins, navigate, onClose])
 
   const openMenu = (event: ReactMouseEvent, hideId: string, label: string, hidden: boolean) => {
     event.preventDefault()
@@ -1125,6 +1156,32 @@ export default function AgentSidebar({
           </button>
         </div>
 
+        {!tipsDismissed && (
+          <div className="px-3 pt-2" data-testid="first-load-tips">
+            <div className="os-keybinding-tips alert p-2 text-xs flex items-center justify-between gap-1 shadow-sm border border-base-content/10 bg-base-200/50">
+              <div className="flex flex-wrap items-center gap-1.5 min-w-0">
+                <span className="font-semibold text-base-content/80">Tips:</span>
+                <span><kbd className="kbd kbd-xs">{searchShortcutLabel}</kbd> Search</span>
+                <span><kbd className="kbd kbd-xs">{isMac ? '⌥1–9' : 'Alt+1–9'}</kbd> Pins</span>
+                <span><kbd className="kbd kbd-xs">Esc</kbd> Clear</span>
+              </div>
+              <button
+                type="button"
+                className="btn btn-ghost btn-xs btn-square shrink-0 text-base-content/60 hover:text-base-content"
+                aria-label="Dismiss tips"
+                onClick={() => {
+                  try {
+                    localStorage.setItem('swarm_keybinding_tips_dismissed', '1')
+                  } catch {}
+                  setTipsDismissed(true)
+                }}
+              >
+                <X className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+        )}
+
         <div className="px-3 pb-2 pt-3">
           <label className="sr-only" htmlFor="os-rail-search">
             Search
@@ -1135,7 +1192,7 @@ export default function AgentSidebar({
               id="os-rail-search"
               type="search"
               className="os-rail-search__input"
-              placeholder="Search"
+              placeholder={`Search ${searchShortcutLabel}`}
               readOnly
               autoComplete="off"
               onFocus={(event) => {
@@ -1144,6 +1201,7 @@ export default function AgentSidebar({
               }}
               onClick={openPalette}
             />
+            <kbd className="os-rail-search__kbd kbd kbd-xs">{searchShortcutLabel}</kbd>
           </div>
         </div>
 
@@ -1176,7 +1234,7 @@ export default function AgentSidebar({
               {dropActive || (draggingId && !isPinnedId(draggingId)) ? 'drop' : '+'}
             </div>
           ) : null}
-          {visiblePins.map((pin) => {
+          {visiblePins.map((pin, pinIdx) => {
             const live = agents.find((agent) => agent.id === pin.id)
             const pinName = live ? agentLabel(live) : pin.name || pin.id
             const role = live ? agentRole(live) : 'default'
@@ -1219,6 +1277,14 @@ export default function AgentSidebar({
                   className="os-fav-tile__avatar"
                 />
                 <span className="os-fav-tile__name">{pinName}</span>
+                {pinIdx < 9 && (
+                  <span
+                    className="os-fav-tile__shortcut"
+                    aria-label={`Shortcut ${isMac ? '⌥' : 'Alt+'}${pinIdx + 1}`}
+                  >
+                    {isMac ? `⌥${pinIdx + 1}` : `Alt+${pinIdx + 1}`}
+                  </span>
+                )}
               </>
             )
             const pinHandlers = {

--- a/webui/frontend/src/components/SearchPalette.tsx
+++ b/webui/frontend/src/components/SearchPalette.tsx
@@ -254,6 +254,11 @@ export default function SearchPalette({ open, onClose }: SearchPaletteProps) {
             autoComplete="off"
             className="os-search-palette__input"
           />
+          <kbd className="os-search-palette__kbd kbd kbd-xs">
+            {typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform || navigator.userAgent)
+              ? '⌘K'
+              : 'Ctrl+K'}
+          </kbd>
         </div>
 
         <div className="os-search-palette__tabs" role="tablist" aria-label="Search categories">
@@ -306,6 +311,12 @@ export default function SearchPalette({ open, onClose }: SearchPaletteProps) {
             ))
           )}
         </ul>
+
+        <div className="os-search-palette__footer" aria-label="Keyboard tips">
+          <span className="os-search-tip"><kbd className="kbd kbd-xs">↑↓</kbd> Navigate</span>
+          <span className="os-search-tip"><kbd className="kbd kbd-xs">↵</kbd> Select</span>
+          <span className="os-search-tip"><kbd className="kbd kbd-xs">Esc</kbd> Close</span>
+        </div>
       </div>
     </div>
   )

--- a/webui/frontend/src/experimental/CommandPalette.tsx
+++ b/webui/frontend/src/experimental/CommandPalette.tsx
@@ -100,7 +100,7 @@ export default function CommandPalette() {
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'k') {
         e.preventDefault()
         setOpen((prev) => !prev)
       }

--- a/webui/frontend/src/experimental/flags.ts
+++ b/webui/frontend/src/experimental/flags.ts
@@ -19,10 +19,13 @@ const PREFIX = 'swarm_experimental_'
 export function isExperimentalEnabled(flag: ExperimentalFlag): boolean {
   try {
     const raw = localStorage.getItem(PREFIX + flag)
+    if (flag === 'command_palette') {
+      return raw === 'on' || raw === 'true'
+    }
     if (raw === 'off' || raw === 'false') return false
     if (raw === 'on' || raw === 'true') return true
   } catch {
-    /* storage unavailable — default ON */
+    /* storage unavailable */
   }
-  return true
+  return flag !== 'command_palette'
 }

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -316,6 +316,15 @@ html[data-theme="light"] #root {
 .os-rail-search__input::placeholder {
   color: color-mix(in srgb, var(--color-base-content) 40%, transparent);
 }
+.os-rail-search__kbd {
+  font-size: 0.65rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.3rem;
+  background: color-mix(in srgb, var(--color-base-content) 8%, transparent);
+  color: color-mix(in srgb, var(--color-base-content) 50%, transparent);
+  border-color: color-mix(in srgb, var(--color-base-content) 12%, transparent);
+  flex-shrink: 0;
+}
 
 .os-fav-grid {
   display: grid;
@@ -381,6 +390,23 @@ html[data-theme="light"] #root {
   font-weight: 650;
   line-height: 1.2;
   text-align: center;
+}
+.os-fav-tile__shortcut {
+  position: absolute;
+  bottom: 0.2rem;
+  right: 0.25rem;
+  font-size: 0.6rem;
+  font-weight: 600;
+  padding: 0.05rem 0.25rem;
+  border-radius: 0.25rem;
+  background: color-mix(in srgb, var(--color-base-content) 15%, transparent);
+  color: color-mix(in srgb, var(--color-base-content) 65%, transparent);
+  opacity: 0;
+  transition: opacity 0.15s ease-in-out;
+  pointer-events: none;
+}
+.os-fav-tile:hover .os-fav-tile__shortcut {
+  opacity: 1;
 }
 
 .os-agent-row {
@@ -1026,6 +1052,29 @@ button.os-agent-row {
   text-align: center;
   font-size: 0.875rem;
   color: color-mix(in srgb, currentColor 50%, transparent);
+}
+.os-search-palette__kbd {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 0.35rem;
+  background: color-mix(in srgb, currentColor 8%, transparent);
+  color: color-mix(in srgb, currentColor 60%, transparent);
+  border-color: color-mix(in srgb, currentColor 12%, transparent);
+  flex-shrink: 0;
+}
+.os-search-palette__footer {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 0.55rem 1rem;
+  border-top: 1px solid color-mix(in srgb, currentColor 8%, transparent);
+  font-size: 0.72rem;
+  color: color-mix(in srgb, currentColor 50%, transparent);
+}
+.os-search-tip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
 }
 
 .os-swipe-hint {


### PR DESCRIPTION
## Summary
Implements REQ-147 / Grok Bot keybinding parity (Fixes #547):
- **⌘K / Ctrl+K**: Global keydown handler in `App.tsx` opens product `SearchPalette` for agent search.
- **CommandPalette Demotion**: Experimental `command_palette` defaults to OFF in `flags.ts` and requires `Shift` so it never steals `⌘K` / `Ctrl+K`.
- **Affordance & Tips**:
  - Rail search box displays platform-aware `Search ⌘K` / `Search Ctrl+K` placeholder and muted `<kbd>` chip.
  - Favourite pin tiles render ghost-until-hover `⌥1`…`⌥9` / `Alt+1`…`Alt+9` shortcut badges.
  - Alt/⌥+1…9 jumps to favourite pins.
  - SearchPalette features navigation tips in its footer (`↑↓` Navigate, `↵` Select, `Esc` Close).
  - Dismissible first-load tips banner in the rail persisted in `localStorage`.

Fixes #547