### PR TITLE
feat(webui): rail timestamps beside name and role badges on second row (REQ-86, REQ-125, Fixes #443, Fixes #515)

### DIFF
--- a/tests/unit/test_req86_rail_timestamps.py
+++ b/tests/unit/test_req86_rail_timestamps.py
@@ -1,0 +1,41 @@
+"""REQ-86 & REQ-125: Rail row timestamps beside name & role badges on second row."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHAT_TIME_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "chatTime.ts"
+SIDEBAR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+INDEX_CSS = REPO_ROOT / "webui" / "frontend" / "src" / "index.css"
+
+
+def test_chat_time_exports_format_rail_timestamp():
+    content = CHAT_TIME_TS.read_text(encoding="utf-8")
+    assert "export function formatRailTimestamp(" in content
+    assert "'Just now'" in content
+    assert "min ago" in content
+    assert "Today" in content
+    assert "Yesterday" in content
+    assert "export function getRowLastMessage(" in content
+
+
+def test_sidebar_name_row_has_timestamp_and_no_badge():
+    content = SIDEBAR_TSX.read_text(encoding="utf-8")
+    assert "formatRailTimestamp" in content
+    assert "getRowLastMessage" in content
+    assert "os-rail-timestamp" in content
+    assert 'data-testid="rail-row-timestamp"' in content
+
+
+def test_sidebar_second_row_has_snippet_and_role_badge():
+    content = SIDEBAR_TSX.read_text(encoding="utf-8")
+    # Role badge must be rendered after snippet on the second row
+    assert "os-agent-role-badge shrink-0" in content
+    assert "snippet || agent.description" in content
+    assert "teamSnippet || team.description" in content
+    assert "remoteSnippet ||" in content
+
+
+def test_css_defines_rail_timestamp():
+    css = INDEX_CSS.read_text(encoding="utf-8")
+    assert ".os-rail-timestamp {" in css
+    assert "tabular-nums" or "nowrap" in css

--- a/tests/unit/test_req86_rail_timestamps.py
+++ b/tests/unit/test_req86_rail_timestamps.py
@@ -29,7 +29,7 @@ def test_sidebar_name_row_has_timestamp_and_no_badge():
 def test_sidebar_second_row_has_snippet_and_role_badge():
     content = SIDEBAR_TSX.read_text(encoding="utf-8")
     # Role badge must be rendered after snippet on the second row
-    assert "os-agent-role-badge shrink-0" in content
+    assert "os-agent-role-badge" in content
     assert "snippet || agent.description" in content
     assert "teamSnippet || team.description" in content
     assert "remoteSnippet ||" in content

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -72,6 +72,7 @@ import {
   type AgentSession,
 } from '../lib/scaleOutSessions'
 import { agentLabel, defaultBlueprintId, isSupportAgent } from '../lib/supportAgent'
+import { formatRailTimestamp, getRowLastMessage } from '../lib/chatTime'
 import { fetchTeamRosters, teamHideId, type TeamRoster } from '../lib/teamRosters'
 import { fetchConfiguredRemotes, remoteHideId, type RemoteEntry } from '../lib/remotesCatalog'
 import { selectStackedFaces } from '../lib/avatarStack'
@@ -746,6 +747,8 @@ export default function AgentSidebar({
     const className = `os-agent-row ${active ? 'os-agent-row--active' : ''} ${
       dragging ? 'os-agent-row--dragging' : ''
     } ${dropping ? 'os-agent-row--drop' : ''}`
+    const { snippet, timestamp } = getRowLastMessage(agent.id, sessions, agent as any)
+    const timestampLabel = formatRailTimestamp(timestamp)
     const mark = (
       scaleOut ? (
         // Teams/remotes (#398) must not be stacked here — import AvatarStack there.
@@ -762,11 +765,24 @@ export default function AgentSidebar({
       <>
         {mark}
         <span className="min-w-0 flex-1">
-          <span className="flex items-center gap-1.5">
+          <span className="flex min-w-0 items-center justify-between gap-1.5">
             <span className="block truncate text-sm font-semibold leading-5">{name}</span>
+            {timestampLabel ? (
+              <span
+                className="os-rail-timestamp shrink-0 text-xs text-base-content/40 tabular-nums"
+                data-testid="rail-row-timestamp"
+              >
+                {timestampLabel}
+              </span>
+            ) : null}
+          </span>
+          <span className="mt-0.5 flex min-w-0 items-center justify-between gap-1.5 text-xs text-base-content/45">
+            <span className="block truncate min-w-0 flex-1">
+              {snippet || agent.description}
+            </span>
             {badge ? (
               <span
-                className={`os-agent-role-badge ${roleCssClass(role)}`}
+                className={`os-agent-role-badge shrink-0 ${roleCssClass(role)}`}
                 data-role={role}
                 data-definition-id={agent.id}
                 role="button"
@@ -790,7 +806,7 @@ export default function AgentSidebar({
             ) : null}
             {taskCount > 1 ? (
               <span
-                className="badge badge-sm badge-outline"
+                className="badge badge-sm badge-outline shrink-0"
                 data-task-sessions={taskCount}
                 title={`${taskCount} running chats`}
               >
@@ -798,11 +814,6 @@ export default function AgentSidebar({
               </span>
             ) : null}
           </span>
-          {agent.description ? (
-            <span className="mt-0.5 block truncate text-xs text-base-content/45">
-              {agent.description}
-            </span>
-          ) : null}
         </span>
       </>
     )
@@ -931,6 +942,12 @@ export default function AgentSidebar({
     const stacked = selectStackedFaces(stackFacesForTeam(team))
     const dragging = draggingId === hideId
     const dropping = dropTargetId === hideId
+    const { snippet: teamSnippet, timestamp: teamTime } = getRowLastMessage(
+      teamHideId(team.id),
+      sessions as any,
+      team as any,
+    )
+    const teamTimestampLabel = formatRailTimestamp(teamTime)
     return (
       <Link
         to={`/chat?team=${encodeURIComponent(team.id)}`}
@@ -972,8 +989,21 @@ export default function AgentSidebar({
           </span>
         )}
         <span className="min-w-0 flex-1">
-          <span className="flex min-w-0 items-center gap-1.5">
+          <span className="flex min-w-0 items-center justify-between gap-1.5">
             <span className="block truncate text-sm font-semibold leading-5">{name}</span>
+            {teamTimestampLabel ? (
+              <span
+                className="os-rail-timestamp shrink-0 text-xs text-base-content/40 tabular-nums"
+                data-testid="rail-row-timestamp"
+              >
+                {teamTimestampLabel}
+              </span>
+            ) : null}
+          </span>
+          <span className="mt-0.5 flex min-w-0 items-center justify-between gap-1.5 text-xs text-base-content/45">
+            <span className="block truncate min-w-0 flex-1">
+              {teamSnippet || team.description}
+            </span>
             <span
               className="os-agent-role-badge badge badge-ghost badge-xs shrink-0 font-medium uppercase tracking-wide text-base-content/55"
               data-kind="team"
@@ -997,11 +1027,6 @@ export default function AgentSidebar({
               Team
             </span>
           </span>
-          {team.description ? (
-            <span className="mt-0.5 block truncate text-xs text-base-content/45">
-              {team.description}
-            </span>
-          ) : null}
         </span>
       </Link>
     )
@@ -1014,6 +1039,12 @@ export default function AgentSidebar({
     const dragging = draggingId === hideId
     const sessions = sessionsForRemote(remote)
     const stacked = selectStackedFaces(stackFacesForRemote(remote))
+    const { snippet: remoteSnippet, timestamp: remoteTime } = getRowLastMessage(
+      hideId,
+      sessions as any,
+      remote as any,
+    )
+    const remoteTimestampLabel = formatRailTimestamp(remoteTime)
     return (
       <Link
         to={`/chat?remote=${encodeURIComponent(remote.id)}`}
@@ -1056,8 +1087,21 @@ export default function AgentSidebar({
           label={`${name} members`}
         />
         <span className="min-w-0 flex-1">
-          <span className="flex min-w-0 items-center gap-1.5">
+          <span className="flex min-w-0 items-center justify-between gap-1.5">
             <span className="block truncate text-sm font-semibold leading-5">{name}</span>
+            {remoteTimestampLabel ? (
+              <span
+                className="os-rail-timestamp shrink-0 text-xs text-base-content/40 tabular-nums"
+                data-testid="rail-row-timestamp"
+              >
+                {remoteTimestampLabel}
+              </span>
+            ) : null}
+          </span>
+          <span className="mt-0.5 flex min-w-0 items-center justify-between gap-1.5 text-xs text-base-content/45">
+            <span className="block truncate min-w-0 flex-1">
+              {remoteSnippet || (remote as any).description || 'Remote team'}
+            </span>
             <span
               className="os-agent-role-badge badge badge-ghost badge-xs shrink-0 font-medium uppercase tracking-wide text-base-content/55"
               data-kind="remote"

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -782,7 +782,7 @@ export default function AgentSidebar({
             </span>
             {badge ? (
               <span
-                className={`os-agent-role-badge shrink-0 ${roleCssClass(role)}`}
+                className={`os-agent-role-badge ${roleCssClass(role)}`}
                 data-role={role}
                 data-definition-id={agent.id}
                 role="button"

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -435,6 +435,12 @@ button.os-agent-row {
   background: color-mix(in srgb, var(--color-base-300) 70%, transparent);
   color: var(--color-base-content);
 }
+.os-rail-timestamp {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: color-mix(in srgb, var(--color-base-content) 45%, transparent);
+  white-space: nowrap;
+}
 .os-agent-row-wrap {
   display: flex;
   align-items: flex-start;

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -484,6 +484,7 @@ button.os-agent-row {
 .os-agent-role-badge {
   display: inline-flex;
   align-items: center;
+  flex-shrink: 0;
   border-radius: 999px;
   padding: 0 0.4rem;
   font-size: 0.62rem;

--- a/webui/frontend/src/lib/chatTime.ts
+++ b/webui/frontend/src/lib/chatTime.ts
@@ -96,3 +96,111 @@ export function shouldShowGapStamp(
   if (nextMs - previousMs >= CHAT_GAP_MS) return true
   return sydneyDayKey(previousMs, timeZone) !== sydneyDayKey(nextMs, timeZone)
 }
+
+/**
+ * REQ-86: Left-rail timestamp for an agent/team/remote row.
+ * Relative for recent (<60m), then Today HH:MM AM/PM, Yesterday, or Wed D MMM.
+ * Returns null if the thread has no messages.
+ */
+export function formatRailTimestamp(
+  ms: number | undefined | null,
+  nowMs: number = Date.now(),
+  timeZone: string = CHAT_TIME_ZONE,
+): string | null {
+  if (ms == null || !Number.isFinite(ms) || ms <= 0) return null
+  const diffMs = nowMs - ms
+  if (diffMs >= 0 && diffMs < 60 * 1000) {
+    return 'Just now'
+  }
+  if (diffMs >= 60 * 1000 && diffMs < 60 * 60 * 1000) {
+    const mins = Math.floor(diffMs / 60000)
+    return `${mins} min ago`
+  }
+  const clock = formatClock(ms, timeZone)
+  const day = sydneyDayKey(ms, timeZone)
+  const today = sydneyDayKey(nowMs, timeZone)
+  if (day === today) return `Today ${clock}`
+
+  const todayParts = partMap(nowMs, timeZone, {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+  })
+  const yesterday = addCalendarDays(
+    Number(todayParts.year),
+    Number(todayParts.month),
+    Number(todayParts.day),
+    -1,
+  )
+  const yesterdayKey = `${yesterday.year}-${String(yesterday.month).padStart(2, '0')}-${String(yesterday.day).padStart(2, '0')}`
+  if (day === yesterdayKey) return `Yesterday ${clock}`
+
+  const stamp = partMap(ms, timeZone, {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+  })
+  return `${stamp.weekday} ${stamp.day} ${stamp.month}`
+}
+
+/**
+ * Resolves the last message snippet and timestamp for a rail row.
+ */
+export function getRowLastMessage(
+  id: string,
+  sessions?: Array<{ updatedAt?: number; startedAt?: number; snippet?: string }>,
+  agentMeta?: Record<string, unknown>,
+): { snippet: string | null; timestamp: number | null } {
+  const rawTime =
+    agentMeta?.last_message_at ?? agentMeta?.lastMessageAt ?? agentMeta?.updated_at
+  let parsedTime: number | null = null
+  if (typeof rawTime === 'number' && Number.isFinite(rawTime)) {
+    parsedTime = rawTime
+  } else if (typeof rawTime === 'string') {
+    const p = Date.parse(rawTime)
+    if (Number.isFinite(p)) parsedTime = p
+  }
+
+  const rawSnippet =
+    (agentMeta?.last_message ?? agentMeta?.lastMessage ?? agentMeta?.snippet) as string | undefined
+
+  if (sessions && sessions.length > 0) {
+    const sorted = [...sessions].sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
+    const top = sorted[0]
+    if (top) {
+      return {
+        snippet: rawSnippet ?? top.snippet ?? null,
+        timestamp: parsedTime ?? top.updatedAt ?? top.startedAt ?? null,
+      }
+    }
+  }
+
+  try {
+    if (typeof localStorage !== 'undefined') {
+      const rawChats = localStorage.getItem('swarm_agent_chat_sessions')
+      if (rawChats) {
+        const parsed = JSON.parse(rawChats)
+        const session = parsed?.[id]
+        if (session && Array.isArray(session.messages) && session.messages.length > 0) {
+          const lastMsg = session.messages[session.messages.length - 1]
+          let ts = parsedTime
+          if (!ts && typeof lastMsg.key === 'string') {
+            const match = lastMsg.key.match(/-(\d{12,})$/)
+            if (match) ts = Number(match[1])
+          }
+          return {
+            snippet: rawSnippet ?? lastMsg.text ?? null,
+            timestamp: ts ?? null,
+          }
+        }
+      }
+    }
+  } catch {
+    /* storage unavailable */
+  }
+
+  return {
+    snippet: rawSnippet ?? (agentMeta?.description as string) ?? null,
+    timestamp: parsedTime,
+  }
+}


### PR DESCRIPTION
## Summary
Implements REQ-86 & REQ-125 (Fixes #443, Fixes #515):
- **Name row:** Displays agent/team/remote name on the left and last-message timestamp on the right (`os-rail-timestamp`). Role badges are removed from this line.
- **Second row:** Displays the last-message preview snippet (truncated) on the left, with the role badge at the end on the right.
- **Australia/Sydney timestamp format:**
  - Omitted when the thread has no messages.
  - Recent: `< 1 min` = `Just now`, `< 60 min` = `X min ago`.
  - Today: `Today HH:MM AM/PM` (in Sydney time).
  - Yesterday: `Yesterday HH:MM AM/PM`.
  - Older: Weekday + date (`Wed 3 Sep`).
- Applies to all rail rows: agents, teams, remotes, and CLI rows.

Fixes #443
Fixes #515