### PR TITLE
fix(cli): resolve grok/agy/pi when Daphne PATH is stripped

### DIFF
--- a/src/swarm/core/cli_adapter.py
+++ b/src/swarm/core/cli_adapter.py
@@ -28,7 +28,6 @@ import codecs
 import json
 import logging
 import os
-import shutil
 import signal
 import time
 from collections.abc import AsyncIterator
@@ -324,10 +323,20 @@ class CliAdapter:
 
     def is_available(self) -> bool:
         """True when the CLI executable is resolvable on PATH (or absolute)."""
-        exe = self.config.cmd[0]
-        if os.path.sep in exe:
-            return os.path.isfile(exe) and os.access(exe, os.X_OK)
-        return shutil.which(exe) is not None
+        from swarm.core.cli_catalog import which_cli
+
+        return which_cli(self.config.cmd[0]) is not None
+
+    def _resolved_argv(self, argv: list[str]) -> list[str]:
+        """Pin argv[0] to an absolute path so a stripped Daphne PATH still runs."""
+        if not argv:
+            return argv
+        from swarm.core.cli_catalog import which_cli
+
+        resolved = which_cli(argv[0])
+        if not resolved:
+            return argv
+        return [resolved, *argv[1:]]
 
     def _build_invocation(
         self,
@@ -466,6 +475,7 @@ class CliAdapter:
             )
             return
 
+        argv = self._resolved_argv(argv)
         start = time.monotonic()
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -634,6 +644,9 @@ class CliAdapter:
             env[key] = _apply_tokens(val, prompt, workdir)
         if extra_env:
             env.update(extra_env)
+        from swarm.core.cli_catalog import host_cli_path
+
+        env["PATH"] = host_cli_path(env.get("PATH", os.environ.get("PATH", "")))
         return env
 
     async def check_auth(self) -> str:
@@ -650,7 +663,7 @@ class CliAdapter:
         if not cfg.auth_check:
             return AUTH_UNKNOWN
         workdir = os.getcwd()
-        argv = [_apply_tokens(p, "", workdir) for p in cfg.auth_check]
+        argv = self._resolved_argv([_apply_tokens(p, "", workdir) for p in cfg.auth_check])
         try:
             proc = await asyncio.create_subprocess_exec(
                 *argv,
@@ -778,8 +791,10 @@ class CliAdapterRegistry:
         out: list[CliDiscovery] = []
         for name in self.names():
             cfg = self._adapters[name].config
+            from swarm.core.cli_catalog import which_cli
+
             exe = cfg.cmd[0]
-            resolved = exe if os.path.sep in exe else shutil.which(exe)
+            resolved = which_cli(exe) or (exe if os.path.sep in exe else None)
             out.append(
                 CliDiscovery(
                     name=name,

--- a/src/swarm/core/cli_catalog.py
+++ b/src/swarm/core/cli_catalog.py
@@ -40,6 +40,65 @@ import os
 import shutil
 from typing import Any
 
+# User-local bins Daphne often misses when started with PATH=/usr/bin:/bin.
+_EXTRA_BIN_REL = (
+    (".local", "bin"),
+    ("bin",),
+    (".grok", "bin"),
+    (".npm-global", "bin"),
+    (".local", "share", "pnpm"),
+)
+
+
+def extra_cli_path_dirs() -> list[str]:
+    """User and nvm bin dirs that commonly hold grok/agy/pi/opencode."""
+    home = os.path.expanduser("~")
+    dirs: list[str] = []
+    for parts in _EXTRA_BIN_REL:
+        path = os.path.join(home, *parts)
+        if os.path.isdir(path):
+            dirs.append(path)
+    nvm = os.path.join(home, ".nvm", "versions", "node")
+    if os.path.isdir(nvm):
+        for ver in sorted(os.listdir(nvm), reverse=True):
+            path = os.path.join(nvm, ver, "bin")
+            if os.path.isdir(path):
+                dirs.append(path)
+    for path in ("/usr/local/bin",):
+        if os.path.isdir(path):
+            dirs.append(path)
+    return dirs
+
+
+def host_cli_path(current: str | None = None) -> str:
+    """``PATH`` with extra user bin dirs prepended (deduped)."""
+    current = os.environ.get("PATH", "") if current is None else current
+    parts: list[str] = []
+    seen: set[str] = set()
+    for d in [*extra_cli_path_dirs(), *current.split(os.pathsep)]:
+        if d and d not in seen:
+            seen.add(d)
+            parts.append(d)
+    return os.pathsep.join(parts)
+
+
+def which_cli(exe: str) -> str | None:
+    """Resolve ``exe`` on PATH, then user-local bins (nvm, ~/.local/bin, …)."""
+    if not exe:
+        return None
+    if os.path.sep in exe:
+        return exe if os.path.isfile(exe) and os.access(exe, os.X_OK) else None
+    found = shutil.which(exe)
+    if found:
+        return found
+    extra = extra_cli_path_dirs()
+    if not extra:
+        return None
+    try:
+        return shutil.which(exe, path=os.pathsep.join(extra))
+    except TypeError:
+        return None
+
 # name -> adapter config dict (same shape as one `cli_agents` entry).
 CATALOG: dict[str, dict[str, Any]] = {
     "grok": {
@@ -468,7 +527,7 @@ def rail_cli_rows() -> list[dict[str, Any]]:
             "cli": name,
             "kind": "cli",
             "description": meta.get("description") or spec.get("description") or f"{name} CLI",
-            "installed": bool(shutil.which(CATALOG[name]["cmd"][0])),
+            "installed": bool(which_cli(CATALOG[name]["cmd"][0])),
         })
     return rows
 
@@ -486,7 +545,7 @@ def catalog_names() -> list[str]:
 
 def installed_catalog_clis() -> list[str]:
     """Catalog CLIs whose executable resolves on this host (sorted)."""
-    return [n for n in catalog_names() if shutil.which(CATALOG[n]["cmd"][0])]
+    return [n for n in catalog_names() if which_cli(CATALOG[n]["cmd"][0])]
 
 
 def _executable_on_path(exe: str) -> bool:
@@ -495,7 +554,7 @@ def _executable_on_path(exe: str) -> bool:
         return False
     if os.path.sep in exe:
         return os.path.isfile(exe) and os.access(exe, os.X_OK)
-    return shutil.which(exe) is not None
+    return which_cli(exe) is not None
 
 
 def installed_host_clis(config: dict[str, Any] | None = None) -> list[str]:
@@ -589,7 +648,7 @@ def suggest_unconfigured(
     for name, cfg in CATALOG.items():
         if name in configured:
             continue
-        if installed_only and shutil.which(cfg["cmd"][0]) is None:
+        if installed_only and which_cli(cfg["cmd"][0]) is None:
             continue
         out[name] = _deepcopy(cfg)
     return out

--- a/tests/core/test_cli_catalog.py
+++ b/tests/core/test_cli_catalog.py
@@ -126,6 +126,27 @@ def test_rail_cli_rows_use_star_agent_ids():
     assert cli_catalog.cli_from_rail_id("nope") is None
 
 
+def test_which_cli_finds_user_local_bin_when_path_is_stripped(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    grok = local_bin / "grok"
+    grok.write_text("#!/bin/sh\n")
+    grok.chmod(0o755)
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PATH", str(empty))
+    assert cli_catalog.which_cli("grok") == str(grok)
+    rows = {r["id"]: r for r in cli_catalog.rail_cli_rows()}
+    assert rows["grok_agent"]["installed"] is True
+    adapter = CliAdapter.from_config("grok", {"cmd": ["grok", "-p", "{prompt}"]})
+    assert adapter.is_available()
+    assert adapter._resolved_argv(["grok", "-p", "hi"])[0] == str(grok)
+    path = cli_catalog.host_cli_path(str(empty))
+    assert str(local_bin) in path.split(":")
+
+
 def test_pi_catalog_print_mode_is_positional_prompt():
     e = cli_catalog.catalog_entry("pi")
     assert e["cmd"][0] == "pi"
@@ -175,7 +196,7 @@ def test_suggest_all_when_nothing_configured():
 
 def test_suggest_installed_only_filters_by_path(monkeypatch):
     # Only 'codex' resolves on PATH -> only codex is suggested.
-    def fake_which(exe):
+    def fake_which(exe, path=None):
         return "/usr/bin/codex" if exe == "codex" else None
 
     monkeypatch.setattr(cli_catalog.shutil, "which", fake_which)
@@ -184,7 +205,7 @@ def test_suggest_installed_only_filters_by_path(monkeypatch):
 
 
 def test_suggest_returns_deep_copies(monkeypatch):
-    monkeypatch.setattr(cli_catalog.shutil, "which", lambda exe: "/x")
+    monkeypatch.setattr(cli_catalog.shutil, "which", lambda exe, path=None: "/x")
     s = cli_catalog.suggest_unconfigured([], installed_only=True)
     s["claude"]["cmd"].append("--mutated")
     assert "--mutated" not in cli_catalog.CATALOG["claude"]["cmd"]


### PR DESCRIPTION
# Summary
CLI discovery no longer depends on Daphne inheriting a full login PATH. `which_cli()` also searches `~/.local/bin`, `~/.grok/bin`, nvm node bins, and a few other user bin dirs, and `CliAdapter` pins `argv[0]` to that absolute path so rail verify chats still spawn grok/agy/pi/opencode. Fixes #580.

## Problem it solves
Standalone Daphne on `:8001` is often restarted with `PATH=/usr/bin:/bin`. `GET /v1/cli-agents/` then marked `grok_agent`, `agy_agent`, and `pi_agent` as not installed (only `opencode` in `/usr/bin` stayed true), and subprocess spawn could not find those CLIs. The sidepane is supposed to list those four rows so each host CLI can be verified.

## How it works
`swarm.core.cli_catalog.which_cli()` tries `shutil.which` on `PATH`, then the extra user/nvm dirs. Rail `installed` flags, catalog suggestions, and `CliAdapter.is_available()` use that helper. Adapter launches prepend those dirs onto the child `PATH` and replace `argv[0]` with the resolved absolute path so a stripped server PATH cannot hide the binary.

## Measured impact
n/a — lookup is a handful of `os.path.isdir` / `shutil.which` calls on a small dir list; no benchmark change.

## Test coverage
`tests/core/test_cli_catalog.py::test_which_cli_finds_user_local_bin_when_path_is_stripped` plants a fake `~/.local/bin/grok` with `PATH` empty and asserts rail `installed`, `is_available()`, and resolved argv. Existing catalog + `tests/cli/test_cli_agents_command.py`: 42 passed.

## Risks / follow-ups
Extra dirs are only well-known user bins plus `/usr/local/bin`; a same-named binary earlier in those dirs wins (nvm versions are newest-first). Rollback is revert. Live Daphne still needs a process restart to load the Python change.

## Build footprint
None — no new dependencies, services, or frontend assets.