### PR TITLE
feat(webui): add agent popup wizard beside favourites (REQ-109, Fixes #478)

### DIFF
--- a/tests/unit/test_req109_add_agent_wizard.py
+++ b/tests/unit/test_req109_add_agent_wizard.py
@@ -1,0 +1,60 @@
+"""REQ-109: + beside favourites opens Add agent popup wizard (CLI | API | Remote).
+
+Intent: Fast path to create a new agent without hunting Settings.
+Rules:
+1. + control immediately to the right of favourites (dashed / grid) region in left rail.
+   Accessible name: 'Add agent'. Tap target >=44px. Works when favourites empty or filled.
+2. Overlay: opens popup wizard pane (DaisyUI modal). Chat stays mounted (#364). Esc / backdrop closes.
+3. Kind step: chooses CLI | API | Remote. Remote copy says OpenMousBot not OMB (#409).
+4. Follow-on steps: create flows per kind (name, blueprint/CLI catalog, remote config).
+5. Teams: Out of scope. Agent create only.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SIDEBAR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+WIZARD_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AddAgentWizard.tsx"
+INDEX_CSS = REPO_ROOT / "webui" / "frontend" / "src" / "index.css"
+
+
+def test_sidebar_has_add_button_beside_favourites():
+    content = SIDEBAR_TSX.read_text(encoding="utf-8")
+    assert "os-fav-section" in content
+    assert "os-fav-add-btn" in content
+    assert 'aria-label="Add agent"' in content
+    assert 'data-testid="add-agent-button"' in content
+    assert "AddAgentWizard" in content
+    assert "addWizardOpen" in content
+
+
+def test_add_agent_wizard_implements_three_kinds_and_openmousbot_copy():
+    content = WIZARD_TSX.read_text(encoding="utf-8")
+    # Overlay modal
+    assert "Modal" in content
+    assert "isOpen" in content
+    assert "onClose" in content
+
+    # Three kinds present
+    assert "'cli'" in content
+    assert "'api'" in content
+    assert "'remote'" in content
+    assert "data-testid=\"kind-option-cli\"" in content
+    assert "data-testid=\"kind-option-api\"" in content
+    assert "data-testid=\"kind-option-remote\"" in content
+
+    # REQ-409: Remote copy must use OpenMousBot, never OMB in user-facing labels
+    assert "OPENMOUSBOT_LABEL" in content
+    assert "OpenMousBot" in content
+
+    # Creation API calls
+    assert "createCustomBlueprint" in content
+    assert "createRemote" in content
+
+
+def test_css_tap_target_and_flex_layout():
+    css = INDEX_CSS.read_text(encoding="utf-8")
+    assert ".os-fav-section {" in css
+    assert ".os-fav-add-btn {" in css
+    assert "min-width: 44px;" in css
+    assert "min-height: 44px;" in css

--- a/webui/frontend/src/components/AddAgentWizard.tsx
+++ b/webui/frontend/src/components/AddAgentWizard.tsx
@@ -1,0 +1,415 @@
+import { useState, useId } from 'react'
+import { Terminal, Bot, Globe, ArrowLeft, Plus } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
+import { Modal, Button, Alert } from './DaisyUI'
+import { createCustomBlueprint, createRemote } from '../lib/api'
+import { OPENMOUSBOT_LABEL } from '../lib/remotesCatalog'
+
+export type AgentKind = 'cli' | 'api' | 'remote'
+
+export interface AddAgentWizardProps {
+  isOpen: boolean
+  onClose: () => void
+  onCreated?: (agent: { id: string; name: string; kind: AgentKind }) => void
+}
+
+/**
+ * REQ-109: Add agent popup wizard (CLI | API | Remote) opened beside favourites.
+ *
+ * - Step 1: Choose agent kind (CLI, API, Remote with OpenMousBot copy).
+ * - Step 2: Configure and create agent.
+ * - Overlay only: chat stays mounted (#364). Esc / backdrop cancels without creating.
+ */
+export default function AddAgentWizard({
+  isOpen,
+  onClose,
+  onCreated,
+}: AddAgentWizardProps) {
+  const queryClient = useQueryClient()
+  const titleId = useId()
+
+  const [step, setStep] = useState<'select_kind' | 'configure'>('select_kind')
+  const [selectedKind, setSelectedKind] = useState<AgentKind>('cli')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // CLI fields
+  const [cliName, setCliName] = useState('')
+  const [cliCommand, setCliCommand] = useState('')
+  const [cliDescription, setCliDescription] = useState('')
+
+  // API fields
+  const [apiName, setApiName] = useState('')
+  const [apiDescription, setApiDescription] = useState('')
+  const [apiPrompt, setApiPrompt] = useState('')
+
+  // Remote fields
+  const [remoteKind, setRemoteKind] = useState<'omb' | 'generic'>('omb')
+  const [remoteBaseUrl, setRemoteBaseUrl] = useState('')
+  const [remoteApiKey, setRemoteApiKey] = useState('')
+
+  const handleClose = () => {
+    // Reset state and close
+    setStep('select_kind')
+    setSelectedKind('cli')
+    setError(null)
+    setSubmitting(false)
+    setCliName('')
+    setCliCommand('')
+    setCliDescription('')
+    setApiName('')
+    setApiDescription('')
+    setApiPrompt('')
+    setRemoteKind('omb')
+    setRemoteBaseUrl('')
+    setRemoteApiKey('')
+    onClose()
+  }
+
+  const handleSelectKind = (kind: AgentKind) => {
+    setSelectedKind(kind)
+    setError(null)
+    setStep('configure')
+  }
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    setError(null)
+    setSubmitting(true)
+
+    try {
+      if (selectedKind === 'cli') {
+        const name = cliName.trim()
+        const command = cliCommand.trim()
+        if (!name) throw new Error('Agent name is required')
+        if (!command) throw new Error('CLI command or binary is required')
+
+        const created = await createCustomBlueprint({
+          name,
+          description: cliDescription.trim() || `CLI: ${command}`,
+          category: 'cli',
+          code: `# CLI agent: ${name}\n# Command: ${command}\n`,
+          tags: ['cli'],
+        })
+
+        await queryClient.invalidateQueries({ queryKey: ['blueprints'] })
+        await queryClient.invalidateQueries({ queryKey: ['cli-agents'] })
+        onCreated?.({ id: created.id, name: created.name, kind: 'cli' })
+        handleClose()
+      } else if (selectedKind === 'api') {
+        const name = apiName.trim()
+        if (!name) throw new Error('Agent name is required')
+
+        const created = await createCustomBlueprint({
+          name,
+          description: apiDescription.trim(),
+          category: 'ai_assistants',
+          code: apiPrompt.trim() || `# API Assistant: ${name}\n`,
+          tags: ['api'],
+        })
+
+        await queryClient.invalidateQueries({ queryKey: ['blueprints'] })
+        onCreated?.({ id: created.id, name: created.name, kind: 'api' })
+        handleClose()
+      } else if (selectedKind === 'remote') {
+        const baseUrl = remoteBaseUrl.trim()
+        if (!baseUrl) throw new Error('Base URL is required')
+
+        const created = await createRemote({
+          kind: remoteKind === 'omb' ? 'omb' : 'remote',
+          base_url: baseUrl,
+          ...(remoteApiKey.trim() ? { api_key: remoteApiKey.trim() } : {}),
+        })
+
+        await queryClient.invalidateQueries({ queryKey: ['configured-remotes'] })
+        await queryClient.invalidateQueries({ queryKey: ['settings-remotes'] })
+        onCreated?.({
+          id: created.id,
+          name: remoteKind === 'omb' ? OPENMOUSBOT_LABEL : created.id,
+          kind: 'remote',
+        })
+        handleClose()
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create agent')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      size="md"
+      placement="middle"
+      aria-label="Add agent wizard"
+    >
+      <div className="space-y-4" data-testid="add-agent-wizard">
+        <div className="flex items-center justify-between border-b border-base-300 pb-3">
+          <div className="flex items-center gap-2">
+            {step === 'configure' ? (
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm btn-circle"
+                aria-label="Back to kind selection"
+                onClick={() => {
+                  setError(null)
+                  setStep('select_kind')
+                }}
+              >
+                <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+              </button>
+            ) : (
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <Plus className="h-4 w-4" aria-hidden="true" />
+              </div>
+            )}
+            <div>
+              <h3 id={titleId} className="text-base font-semibold">
+                {step === 'select_kind'
+                  ? 'Add Agent'
+                  : selectedKind === 'cli'
+                  ? 'Configure CLI Agent'
+                  : selectedKind === 'api'
+                  ? 'Configure API Agent'
+                  : 'Configure Remote Agent'}
+              </h3>
+              <p className="text-xs text-base-content/60">
+                {step === 'select_kind'
+                  ? 'Choose the type of agent to create'
+                  : selectedKind === 'cli'
+                  ? 'Connect a local command-line executable or script'
+                  : selectedKind === 'api'
+                  ? 'Create an autonomous API recipe or assistant'
+                  : `Connect an external ${OPENMOUSBOT_LABEL} or HTTP worker`}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {error ? (
+          <Alert type="error" className="py-2 text-xs">
+            {error}
+          </Alert>
+        ) : null}
+
+        {step === 'select_kind' ? (
+          <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-3" role="radiogroup" aria-label="Agent kinds">
+            {/* CLI */}
+            <button
+              type="button"
+              className="flex flex-col items-start gap-2 rounded-xl border border-base-300 bg-base-100 p-3.5 text-left transition hover:border-primary hover:bg-base-200/50"
+              onClick={() => handleSelectKind('cli')}
+              data-testid="kind-option-cli"
+            >
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-emerald-500/10 text-emerald-500">
+                <Terminal className="h-4 w-4" aria-hidden="true" />
+              </div>
+              <div>
+                <span className="block text-sm font-semibold">CLI</span>
+                <span className="mt-0.5 block text-xs text-base-content/60 leading-tight">
+                  Run command-line binaries or local terminal tools
+                </span>
+              </div>
+            </button>
+
+            {/* API */}
+            <button
+              type="button"
+              className="flex flex-col items-start gap-2 rounded-xl border border-base-300 bg-base-100 p-3.5 text-left transition hover:border-primary hover:bg-base-200/50"
+              onClick={() => handleSelectKind('api')}
+              data-testid="kind-option-api"
+            >
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-sky-500/10 text-sky-500">
+                <Bot className="h-4 w-4" aria-hidden="true" />
+              </div>
+              <div>
+                <span className="block text-sm font-semibold">API</span>
+                <span className="mt-0.5 block text-xs text-base-content/60 leading-tight">
+                  Autonomous assistant with custom prompt and code
+                </span>
+              </div>
+            </button>
+
+            {/* Remote */}
+            <button
+              type="button"
+              className="flex flex-col items-start gap-2 rounded-xl border border-base-300 bg-base-100 p-3.5 text-left transition hover:border-primary hover:bg-base-200/50"
+              onClick={() => handleSelectKind('remote')}
+              data-testid="kind-option-remote"
+            >
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-purple-500/10 text-purple-500">
+                <Globe className="h-4 w-4" aria-hidden="true" />
+              </div>
+              <div>
+                <span className="block text-sm font-semibold">Remote</span>
+                <span className="mt-0.5 block text-xs text-base-content/60 leading-tight">
+                  Connect {OPENMOUSBOT_LABEL} or HTTP worker
+                </span>
+              </div>
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-3.5" data-testid="add-agent-form">
+            {selectedKind === 'cli' ? (
+              <>
+                <div className="space-y-1">
+                  <label className="block text-xs font-medium text-base-content/80">
+                    Agent Name <span className="text-error">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    className="input input-sm input-bordered w-full"
+                    placeholder="e.g. Claude Code CLI"
+                    value={cliName}
+                    onChange={(e) => setCliName(e.target.value)}
+                    required
+                    autoFocus
+                    aria-label="Agent name"
+                    data-testid="input-cli-name"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="block text-xs font-medium text-base-content/80">
+                    Command or Executable <span className="text-error">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    className="input input-sm input-bordered w-full font-mono text-xs"
+                    placeholder="e.g. claude, bash, python"
+                    value={cliCommand}
+                    onChange={(e) => setCliCommand(e.target.value)}
+                    required
+                    aria-label="CLI command"
+                    data-testid="input-cli-command"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="block text-xs font-medium text-base-content/80">
+                    Description (optional)
+                  </label>
+                  <input
+                    type="text"
+                    className="input input-sm input-bordered w-full text-xs"
+                    placeholder="Brief description of what this agent does"
+                    value={cliDescription}
+                    onChange={(e) => setCliDescription(e.target.value)}
+                    aria-label="Description"
+                  />
+                </div>
+              </>
+            ) : null}
+
+            {selectedKind === 'api' ? (
+              <>
+                <div className="space-y-1">
+                  <label className="block text-xs font-medium text-base-content/80">
+                    Agent Name <span className="text-error">*</span>
+                  </label>
+                  <input
+                    type="text"
+                    className="input input-sm input-bordered w-full"
+                    placeholder="e.g. Research Analyst"
+                    value={apiName}
+                    onChange={(e) => setApiName(e.target.value)}
+                    required
+                    autoFocus
+                    aria-label="Agent name"
+                    data-testid="input-api-name"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="block text-xs font-medium text-base-content/80">
+                    Description (optional)
+                  </label>
+                  <input
+                    type="text"
+                    className="input input-sm input-bordered w-full text-xs"
+                    placeholder="e.g. Specialized in technical analysis and summaries"
+                    value={apiDescription}
+                    onChange={(e) => setApiDescription(e.target.value)}
+                    aria-label="Description"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="block text-xs font-medium text-base-content/80">
+                    System Instructions / Prompt
+                  </label>
+                  <textarea
+                    className="textarea textarea-sm textarea-bordered w-full font-mono text-xs"
+                    rows={3}
+                    placeholder="You are an expert AI assistant..."
+                    value={apiPrompt}
+                    onChange={(e) => setApiPrompt(e.target.value)}
+                    aria-label="System prompt"
+                    data-testid="input-api-prompt"
+                  />
+                </div>
+              </>
+            ) : null}
+
+            {selectedKind === 'remote' ? (
+              <>
+                <div className="space-y-1">
+                  <label className="block text-xs font-medium text-base-content/80">
+                    Remote Type <span className="text-error">*</span>
+                  </label>
+                  <select
+                    className="select select-sm select-bordered w-full"
+                    value={remoteKind}
+                    onChange={(e) => setRemoteKind(e.target.value as 'omb' | 'generic')}
+                    aria-label="Remote type"
+                    data-testid="select-remote-kind"
+                  >
+                    <option value="omb">{OPENMOUSBOT_LABEL}</option>
+                    <option value="generic">Generic Remote Agent</option>
+                  </select>
+                </div>
+                <div className="space-y-1">
+                  <label className="block text-xs font-medium text-base-content/80">
+                    Base URL <span className="text-error">*</span>
+                  </label>
+                  <input
+                    type="url"
+                    className="input input-sm input-bordered w-full font-mono text-xs"
+                    placeholder="http://localhost:8000"
+                    value={remoteBaseUrl}
+                    onChange={(e) => setRemoteBaseUrl(e.target.value)}
+                    required
+                    autoFocus
+                    aria-label="Base URL"
+                    data-testid="input-remote-url"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="block text-xs font-medium text-base-content/80">
+                    API Key / Token (optional)
+                  </label>
+                  <input
+                    type="password"
+                    className="input input-sm input-bordered w-full text-xs"
+                    placeholder="Optional authorization token"
+                    value={remoteApiKey}
+                    onChange={(e) => setRemoteApiKey(e.target.value)}
+                    aria-label="API Key"
+                    data-testid="input-remote-key"
+                  />
+                </div>
+              </>
+            ) : null}
+
+            <div className="flex items-center justify-end gap-2 pt-2">
+              <Button type="button" variant="ghost" size="sm" onClick={handleClose} disabled={submitting}>
+                Cancel
+              </Button>
+              <Button type="submit" variant="primary" size="sm" loading={submitting} data-testid="submit-create-agent">
+                Create Agent
+              </Button>
+            </div>
+          </form>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -9,7 +9,8 @@ import {
 } from 'react'
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Eye, EyeOff, Pencil, Pin, PinOff, Plug, Search, Users, X } from 'lucide-react'
+import { Eye, EyeOff, Pencil, Pin, PinOff, Plug, Plus, Search, Users, X } from 'lucide-react'
+import AddAgentWizard, { type AgentKind } from './AddAgentWizard'
 import {
   fetchBlueprints,
   fetchCliAgents,
@@ -239,6 +240,19 @@ export default function AgentSidebar({
     typeof navigator !== 'undefined' &&
     /Mac|iPod|iPhone|iPad/.test(navigator.platform || navigator.userAgent)
   const searchShortcutLabel = isMac ? '⌘K' : 'Ctrl+K'
+  const [addWizardOpen, setAddWizardOpen] = useState(false)
+  const handleAgentCreated = useCallback(
+    (created: { id: string; name: string; kind: AgentKind }) => {
+      setAddWizardOpen(false)
+      if (created.kind === 'remote') {
+        navigate(`/chat?remote=${encodeURIComponent(created.id)}`)
+      } else {
+        navigate(`/chat?blueprint=${encodeURIComponent(created.id)}`)
+      }
+      onClose?.()
+    },
+    [navigate, onClose],
+  )
   const sessionsByAgent = useMemo(() => loadAllAgentSessions(), [sessionTick])
 
   useEffect(() => {
@@ -1249,35 +1263,40 @@ export default function AgentSidebar({
           </div>
         </div>
 
-        <div
-          className={`os-fav-grid ${dropActive ? 'os-fav-grid--active' : ''} ${
-            visiblePins.length === 0 &&
-            !dropActive &&
-            !(draggingId && !isPinnedId(draggingId))
-              ? 'os-fav-grid--bare'
-              : ''
-          } ${visiblePins.length === 0 ? 'os-fav-grid--empty' : ''}`}
-          aria-label="Pinned agents"
-          data-fav-layout="2-up"
-          data-testid="agent-fav-grid"
-          data-fav-empty={visiblePins.length === 0 ? 'true' : 'false'}
-          onDragOver={(event) => {
-            event.preventDefault()
-            try {
-              event.dataTransfer.dropEffect = 'move'
-            } catch {
-              /* synthetic events may omit dataTransfer */
-            }
-            setDropActive(true)
-          }}
-          onDragLeave={() => setDropActive(false)}
-          onDrop={dropPin}
-        >
-          {visiblePins.length === 0 ? (
-            <div className="os-fav-grid__hint" data-testid="fav-empty-hint">
-              {dropActive || (draggingId && !isPinnedId(draggingId)) ? 'drop' : '+'}
-            </div>
-          ) : null}
+        <div className="os-fav-section" data-testid="fav-section">
+          <div
+            className={`os-fav-grid ${dropActive ? 'os-fav-grid--active' : ''} ${
+              visiblePins.length === 0 &&
+              !dropActive &&
+              !(draggingId && !isPinnedId(draggingId))
+                ? 'os-fav-grid--bare'
+                : ''
+            } ${visiblePins.length === 0 ? 'os-fav-grid--empty' : ''}`}
+            aria-label="Pinned agents"
+            data-fav-layout="2-up"
+            data-testid="agent-fav-grid"
+            data-fav-empty={visiblePins.length === 0 ? 'true' : 'false'}
+            onDragOver={(event) => {
+              event.preventDefault()
+              try {
+                event.dataTransfer.dropEffect = 'move'
+              } catch {
+                /* synthetic events may omit dataTransfer */
+              }
+              setDropActive(true)
+            }}
+            onDragLeave={() => setDropActive(false)}
+            onDrop={dropPin}
+          >
+            {visiblePins.length === 0 ? (
+              <div
+                className="os-fav-grid__hint cursor-pointer"
+                data-testid="fav-empty-hint"
+                onClick={() => setAddWizardOpen(true)}
+              >
+                {dropActive || (draggingId && !isPinnedId(draggingId)) ? 'drop' : '+'}
+              </div>
+            ) : null}
           {visiblePins.map((pin, pinIdx) => {
             const live = agents.find((agent) => agent.id === pin.id)
             const pinName = live ? agentLabel(live) : pin.name || pin.id
@@ -1379,6 +1398,17 @@ export default function AgentSidebar({
               </Link>
             )
           })}
+          </div>
+          <button
+            type="button"
+            className="os-fav-add-btn"
+            aria-label="Add agent"
+            title="Add agent"
+            data-testid="add-agent-button"
+            onClick={() => setAddWizardOpen(true)}
+          >
+            <Plus className="h-5 w-5" aria-hidden="true" />
+          </button>
         </div>
 
         <nav className="min-h-0 flex-1 overflow-y-auto px-2 pb-3" aria-label="Agent list">
@@ -1696,6 +1726,11 @@ export default function AgentSidebar({
           </button>
         </div>
       )}
+      <AddAgentWizard
+        isOpen={addWizardOpen}
+        onClose={() => setAddWizardOpen(false)}
+        onCreated={handleAgentCreated}
+      />
     </>
   )
 }

--- a/webui/frontend/src/components/__tests__/AddAgentWizard.test.tsx
+++ b/webui/frontend/src/components/__tests__/AddAgentWizard.test.tsx
@@ -1,0 +1,199 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import AddAgentWizard from '../AddAgentWizard'
+import * as api from '../../lib/api'
+import { OPENMOUSBOT_LABEL } from '../../lib/remotesCatalog'
+
+function renderWizard(props: Partial<Parameters<typeof AddAgentWizard>[0]> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  const onClose = vi.fn()
+  const onCreated = vi.fn()
+
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <AddAgentWizard
+        isOpen={true}
+        onClose={onClose}
+        onCreated={onCreated}
+        {...props}
+      />
+    </QueryClientProvider>,
+  )
+
+  return { ...view, onClose, onCreated, queryClient }
+}
+
+describe('AddAgentWizard (REQ-109)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders three agent kinds on step 1 with OpenMousBot copy for remote', () => {
+    renderWizard()
+
+    expect(screen.getByTestId('add-agent-wizard')).toBeInTheDocument()
+    expect(screen.getByTestId('kind-option-cli')).toBeInTheDocument()
+    expect(screen.getByTestId('kind-option-api')).toBeInTheDocument()
+    expect(screen.getByTestId('kind-option-remote')).toBeInTheDocument()
+
+    // Must use OpenMousBot copy (not OMB)
+    expect(screen.getByText(new RegExp(OPENMOUSBOT_LABEL, 'i'))).toBeInTheDocument()
+    expect(screen.queryByText(/^OMB$/)).not.toBeInTheDocument()
+  })
+
+  it('closes wizard when Cancel button is clicked without creating', () => {
+    const { onClose, onCreated } = renderWizard()
+
+    // Select CLI kind to see form
+    fireEvent.click(screen.getByTestId('kind-option-cli'))
+    expect(screen.getByTestId('add-agent-form')).toBeInTheDocument()
+
+    // Click Cancel
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onCreated).not.toHaveBeenCalled()
+  })
+
+  it('creates a CLI agent on happy-path submit', async () => {
+    const createSpy = vi.spyOn(api, 'createCustomBlueprint').mockResolvedValue({
+      id: 'custom_cli_agent',
+      name: 'My CLI Tool',
+      description: 'CLI: custom-tool',
+      category: 'cli',
+      tags: ['cli'],
+      requirements: '',
+      code: '# CLI agent: My CLI Tool\n',
+      required_mcp_servers: [],
+      env_vars: [],
+    })
+
+    const { onCreated, onClose } = renderWizard()
+
+    // Select CLI
+    fireEvent.click(screen.getByTestId('kind-option-cli'))
+    expect(screen.getByTestId('input-cli-name')).toBeInTheDocument()
+
+    // Fill in inputs
+    fireEvent.change(screen.getByTestId('input-cli-name'), {
+      target: { value: 'My CLI Tool' },
+    })
+    fireEvent.change(screen.getByTestId('input-cli-command'), {
+      target: { value: 'custom-tool' },
+    })
+
+    // Submit
+    fireEvent.click(screen.getByTestId('submit-create-agent'))
+
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'My CLI Tool',
+          category: 'cli',
+        }),
+      )
+      expect(onCreated).toHaveBeenCalledWith({
+        id: 'custom_cli_agent',
+        name: 'My CLI Tool',
+        kind: 'cli',
+      })
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+
+  it('creates an API agent on happy-path submit', async () => {
+    const createSpy = vi.spyOn(api, 'createCustomBlueprint').mockResolvedValue({
+      id: 'api_researcher',
+      name: 'Researcher',
+      description: 'Deep market research',
+      category: 'ai_assistants',
+      tags: ['api'],
+      requirements: '',
+      code: 'You are a researcher',
+      required_mcp_servers: [],
+      env_vars: [],
+    })
+
+    const { onCreated, onClose } = renderWizard()
+
+    // Select API
+    fireEvent.click(screen.getByTestId('kind-option-api'))
+    expect(screen.getByTestId('input-api-name')).toBeInTheDocument()
+
+    // Fill in inputs
+    fireEvent.change(screen.getByTestId('input-api-name'), {
+      target: { value: 'Researcher' },
+    })
+    fireEvent.change(screen.getByTestId('input-api-prompt'), {
+      target: { value: 'You are a researcher' },
+    })
+
+    // Submit
+    fireEvent.click(screen.getByTestId('submit-create-agent'))
+
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Researcher',
+          category: 'ai_assistants',
+        }),
+      )
+      expect(onCreated).toHaveBeenCalledWith({
+        id: 'api_researcher',
+        name: 'Researcher',
+        kind: 'api',
+      })
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+
+  it('connects a Remote agent on happy-path submit', async () => {
+    const createRemoteSpy = vi.spyOn(api, 'createRemote').mockResolvedValue({
+      id: 'omb-remote-1',
+      kind: 'omb',
+      base_url: 'http://localhost:8000',
+      agents: [],
+      configured: true,
+      created: 123456,
+      object: 'remote',
+    } as any)
+
+    const { onCreated, onClose } = renderWizard()
+
+    // Select Remote
+    fireEvent.click(screen.getByTestId('kind-option-remote'))
+    expect(screen.getByTestId('input-remote-url')).toBeInTheDocument()
+
+    // Fill in URL
+    fireEvent.change(screen.getByTestId('input-remote-url'), {
+      target: { value: 'http://localhost:8000' },
+    })
+
+    // Submit
+    fireEvent.click(screen.getByTestId('submit-create-agent'))
+
+    await waitFor(() => {
+      expect(createRemoteSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'omb',
+          base_url: 'http://localhost:8000',
+        }),
+      )
+      expect(onCreated).toHaveBeenCalledWith({
+        id: 'omb-remote-1',
+        name: OPENMOUSBOT_LABEL,
+        kind: 'remote',
+      })
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+})

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -718,6 +718,22 @@ describe('AgentSidebar Grok rail', () => {
     expect(storedRailOrder()).not.toContain('codey')
   })
 
+  it('REQ-109: displays + button beside favourites and opens Add agent wizard', async () => {
+    renderSidebar()
+    const addBtn = await screen.findByRole('button', { name: 'Add agent' })
+    expect(addBtn).toBeInTheDocument()
+    expect(addBtn).toHaveAttribute('data-testid', 'add-agent-button')
+
+    // Click + button to open wizard
+    fireEvent.click(addBtn)
+
+    expect(await screen.findByTestId('add-agent-wizard')).toBeInTheDocument()
+    expect(screen.getByText('Add Agent')).toBeInTheDocument()
+    expect(screen.getByTestId('kind-option-cli')).toBeInTheDocument()
+    expect(screen.getByTestId('kind-option-api')).toBeInTheDocument()
+    expect(screen.getByTestId('kind-option-remote')).toBeInTheDocument()
+  })
+
   it('keeps a scale-out agent as one stacked row and opens a session picker', async () => {
     const running: AgentSession[] = [1, 2, 3, 4].map((n) => ({
       id: `run-${n}`,

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -326,6 +326,41 @@ html[data-theme="light"] #root {
   flex-shrink: 0;
 }
 
+.os-fav-section {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin: 0 0.75rem 0.5rem;
+}
+.os-fav-section .os-fav-grid {
+  margin: 0;
+  flex: 1;
+  min-width: 0;
+}
+.os-fav-add-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  border-radius: 0.75rem;
+  border: 1px dashed color-mix(in srgb, var(--color-base-content) 16%, transparent);
+  color: color-mix(in srgb, var(--color-base-content) 60%, transparent);
+  background: transparent;
+  transition: all 0.15s ease-in-out;
+  cursor: pointer;
+}
+.os-fav-add-btn:hover,
+.os-fav-add-btn:focus-visible {
+  border-color: color-mix(in srgb, var(--color-primary) 65%, transparent);
+  color: var(--color-primary);
+  background: color-mix(in srgb, var(--color-primary) 8%, transparent);
+  outline: none;
+}
+
 .os-fav-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
## Summary
Fixes #478 (REQ-109: + beside favourites → create-agent wizard).

### Changes
1. **Placement**:
   - Placed a dedicated `+` control immediately to the right of the favourites (grid/empty) box in the left rail (`os-fav-add-btn`), within the same vertical band.
   - Accessible name: `Add agent`, min tap target ≥ 44px (`44px x 44px`).
   - Also wired empty favourites hint click to open the wizard.
2. **AddAgentWizard overlay**:
   - Modal overlay using DaisyUI Modal (`AddAgentWizard.tsx`). Chat stays mounted (#364).
   - Step 1: choose kind (**CLI** | **API** | **Remote**).
   - Remote copy explicitly uses **OpenMousBot**, never OMB (#409).
   - Step 2: configure details and submit (creates blueprint / remote connection, invalidates queries, and navigates to the new agent).
   - Esc / Cancel closes without creating anything.
3. **Tests**:
   - Frontend unit tests in `AddAgentWizard.test.tsx` and `AgentSidebar.test.tsx`.
   - Python unit tests in `tests/unit/test_req109_add_agent_wizard.py`.