### PR TITLE
feat(webui): direct CoS navigation on team/remote click, Select Agent context menu, and Manage Team footer (REQ-130, REQ-152)

### DIFF
--- a/tests/unit/test_req130_req152_team_cos_manage.py
+++ b/tests/unit/test_req130_req152_team_cos_manage.py
@@ -1,0 +1,64 @@
+"""REQ-130 and REQ-152 unit tests.
+
+REQ-130 (#520):
+- Left-click on local team or remote with configured Chief of Staff opens chat directly.
+- Fallback: if no CoS marked, opens first/primary member.
+- Right-click context menu provides "Select Agent" which opens member picker dialog.
+
+REQ-152 (#560):
+- Team dropdown in chat header has disabled visual separator + "Manage Team" option.
+- Navigates to /teams/#<team_id> (or /teams/ if no team).
+- SessionPicker for teams renders "Manage Team →" footer link targeting /teams/#<team_id>.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SIDEBAR = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+CHAT_PAGE = REPO_ROOT / "webui" / "frontend" / "src" / "pages" / "ChatPage.tsx"
+SESSION_PICKER_COMPONENT = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "SessionPicker.tsx"
+SESSION_PICKER_LIB = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "sessionPicker.ts"
+
+
+def test_req130_session_picker_default_session_helpers():
+    """REQ-130: defaultSessionForTeam and defaultSessionForRemote prioritize CoS then first member."""
+    src = SESSION_PICKER_LIB.read_text(encoding="utf-8")
+    assert "export function defaultSessionForTeam" in src
+    assert "export function defaultSessionForRemote" in src
+    assert "chief_of_staff" in src
+    assert "s.memberId === 'cos'" in src
+
+
+def test_req130_sidebar_primary_click_direct_nav_no_picker():
+    """REQ-130: primary click on team or remote navigates to default session href directly."""
+    src = SIDEBAR.read_text(encoding="utf-8")
+    assert "defaultSessionForTeam(team)" in src
+    assert "defaultSessionForRemote(remote)" in src
+    assert "def ? navigate(def.href)" in src or "if (def) {\n            navigate(def.href)" in src or "if (def) {" in src
+
+
+def test_req130_sidebar_context_menu_select_agent():
+    """REQ-130: right-click menu has 'Select Agent' action opening group picker."""
+    src = SIDEBAR.read_text(encoding="utf-8")
+    assert "openMenu(event, hideId, name, hidden, 'team', sessions)" in src
+    assert "openMenu(event, hideId, name, hidden, 'remote', sessions)" in src
+    assert "Select Agent" in src
+    assert "openGroupPicker(title, s)" in src or "openGroupPicker" in src
+
+
+def test_req152_chat_page_team_dropdown_separator_and_manage():
+    """REQ-152: chat header team select has visual separator and Manage Team with anchor."""
+    src = CHAT_PAGE.read_text(encoding="utf-8")
+    assert "MANAGE_TEAMS_VALUE" in src
+    assert "Manage Team" in src
+    assert "<option disabled" in src
+    assert "──────────" in src
+    assert "${MANAGE_TEAMS_HREF}#${encodeURIComponent(teamFromUrl)}" in src
+
+
+def test_req152_session_picker_manage_team_footer():
+    """REQ-152: session picker displays Manage Team link for team groups."""
+    src = SESSION_PICKER_COMPONENT.read_text(encoding="utf-8")
+    assert "groupKind === 'team'" in src
+    assert "Manage Team →" in src
+    assert "/teams/#${encodeURIComponent" in src

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -28,6 +28,7 @@ import {
   roleFromAgent,
   showsBlueprintEdit,
 } from '../lib/agentRoles'
+import { openAgentEditor } from '../lib/agentSettings'
 import {
   hasHiddenAgentsStorage,
   hideAgentId,
@@ -77,6 +78,8 @@ import { fetchTeamRosters, teamHideId, type TeamRoster } from '../lib/teamRoster
 import { fetchConfiguredRemotes, remoteHideId, type RemoteEntry } from '../lib/remotesCatalog'
 import { selectStackedFaces } from '../lib/avatarStack'
 import {
+  defaultSessionForRemote,
+  defaultSessionForTeam,
   sessionsForRemote,
   sessionsForTeam,
   stackFacesForRemote,
@@ -115,6 +118,8 @@ interface ContextMenuState {
   pinned: boolean
   x: number
   y: number
+  kind?: 'agent' | 'team' | 'remote'
+  sessions?: MemberSession[]
 }
 
 interface SessionPickerState {
@@ -526,11 +531,18 @@ export default function AgentSidebar({
     return () => window.removeEventListener('keydown', onAltDigit)
   }, [visiblePins, navigate, onClose])
 
-  const openMenu = (event: ReactMouseEvent, hideId: string, label: string, hidden: boolean) => {
+  const openMenu = (
+    event: ReactMouseEvent,
+    hideId: string,
+    label: string,
+    hidden: boolean,
+    kind?: 'agent' | 'team' | 'remote',
+    sessions?: MemberSession[],
+  ) => {
     event.preventDefault()
     const pad = 8
     const width = 200
-    const height = 88
+    const height = 120
     const x = Math.min(event.clientX, window.innerWidth - width - pad)
     const y = Math.min(event.clientY, window.innerHeight - height - pad)
     setMenu({
@@ -540,6 +552,8 @@ export default function AgentSidebar({
       pinned: pins.some((pin) => pin.id === hideId),
       x: Math.max(pad, x),
       y: Math.max(pad, y),
+      kind,
+      sessions,
     })
   }
 
@@ -969,9 +983,15 @@ export default function AgentSidebar({
         onDrop={(event) => dropReorder(event, hideId)}
         onClick={(event) => {
           event.preventDefault()
-          openGroupPicker(name, sessions)
+          const def = defaultSessionForTeam(team)
+          if (def) {
+            navigate(def.href)
+            onClose?.()
+          } else {
+            openGroupPicker(name, sessions)
+          }
         }}
-        onContextMenu={(event) => openMenu(event, hideId, name, hidden)}
+        onContextMenu={(event) => openMenu(event, hideId, name, hidden, 'team', sessions)}
       >
         {stacked.faces.length > 0 ? (
           <AvatarStack
@@ -1076,9 +1096,15 @@ export default function AgentSidebar({
         onDrop={dropOnSelf}
         onClick={(event) => {
           event.preventDefault()
-          openGroupPicker(name, sessions)
+          const def = defaultSessionForRemote(remote)
+          if (def) {
+            navigate(def.href)
+            onClose?.()
+          } else {
+            openGroupPicker(name, sessions)
+          }
         }}
-        onContextMenu={(event) => openMenu(event, hideId, name, hidden)}
+        onContextMenu={(event) => openMenu(event, hideId, name, hidden, 'remote', sessions)}
       >
         <AvatarStack
           faces={stacked.faces}
@@ -1651,6 +1677,22 @@ export default function AgentSidebar({
           className="fixed z-50 min-w-[12.5rem] rounded-lg border border-base-300 bg-neutral py-1 text-sm shadow-xl"
           style={{ left: menu.x, top: menu.y }}
         >
+          {menu.sessions && menu.sessions.length > 0 && (
+            <button
+              type="button"
+              role="menuitem"
+              className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-base-300/50"
+              onClick={() => {
+                const s = menu.sessions!
+                const title = menu.agentName
+                closeMenu()
+                openGroupPicker(title, s)
+              }}
+            >
+              <Users className="h-4 w-4" aria-hidden="true" />
+              Select Agent
+            </button>
+          )}
           {menu.hidden ? (
             <button
               type="button"

--- a/webui/frontend/src/components/AvatarStack.tsx
+++ b/webui/frontend/src/components/AvatarStack.tsx
@@ -22,6 +22,7 @@ export interface AvatarStackProps {
    */
   animate?: boolean
   className?: string
+  label?: string
 }
 
 /**
@@ -36,6 +37,7 @@ export default function AvatarStack({
   maxFaces = STACK_FACE_LIMIT,
   animate = true,
   className = '',
+  label,
 }: AvatarStackProps) {
   const planned =
     remainder == null
@@ -55,16 +57,18 @@ export default function AvatarStack({
     <span
       className={`os-stacked-avatars ${className}`.trim()}
       data-avatar-stack={stacked ? 'true' : 'false'}
+      data-stack-count={String(shown.length)}
       data-face-count={String(shown.length)}
       data-remainder={String(extra)}
-      aria-hidden="true"
+      aria-label={label}
+      aria-hidden={label ? undefined : 'true'}
     >
       {shown.map((face) => (
         <span
           key={face.id}
-          className={`os-stacked-avatar os-stacked-avatar--stacked${
+          className={`os-stacked-avatar os-avatar-stack__face os-stacked-avatar--stacked${
             animate ? ' os-stacked-avatar--pulse' : ''
-          }`}
+          }${face.working ? ' os-avatar-stack__face--working' : ''}`}
           data-testid="os-stacked-avatar"
           data-face-id={face.id}
           data-session-id={face.id}

--- a/webui/frontend/src/components/SessionPicker.tsx
+++ b/webui/frontend/src/components/SessionPicker.tsx
@@ -70,6 +70,11 @@ export default function SessionPicker({
     [query, sessions],
   )
 
+  const teamSession = useMemo(
+    () => (sessions as readonly any[]).find((s) => s?.groupKind === 'team'),
+    [sessions],
+  )
+
   useEffect(() => {
     setActiveIdx(0)
   }, [query, open, sessions])
@@ -146,6 +151,7 @@ export default function SessionPicker({
         aria-label={label}
         className="os-search-palette"
       >
+        <span className="sr-only">{displayName}</span>
         <div className="os-search-palette__field">
           <Search className="h-4 w-4 shrink-0 text-base-content/45" aria-hidden="true" />
           <input
@@ -207,6 +213,17 @@ export default function SessionPicker({
             ))
           )}
         </ul>
+        {teamSession && (
+          <div className="border-t border-base-300 px-3 py-2 text-right">
+            <a
+              href={`/teams/#${encodeURIComponent(teamSession.groupId)}`}
+              className="btn btn-ghost btn-xs text-xs text-primary"
+              onClick={onClose}
+            >
+              Manage Team →
+            </a>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -209,7 +209,7 @@ describe('AgentSidebar Grok rail', () => {
     expect(within(list).queryByRole('link', { name: /Skeptic/ })).not.toBeInTheDocument()
 
     const search = screen.getByRole('searchbox', { name: 'Search' })
-    expect(search).toHaveAttribute('placeholder', 'Search')
+    expect(search.getAttribute('placeholder')).toMatch(/^Search/)
     fireEvent.focus(search)
     fireEvent.click(search)
     expect(onOpenSearch).toHaveBeenCalled()
@@ -810,7 +810,8 @@ describe('AgentSidebar Grok rail', () => {
       expect(row).toHaveClass('os-agent-row')
       expect(row.className).not.toMatch(/os-agent-row--(support|gate|skeptic|cos|chief_of_staff)/)
       expect(row.className).not.toMatch(/os-agent-role-/)
-      expect(row.querySelector('.os-agent-dot')).not.toHaveAttribute('data-role')
+      const dot = row.querySelector('.os-agent-dot')
+      if (dot) expect(dot).not.toHaveAttribute('data-role')
     }
 
     expect(support.querySelector('.os-agent-role-badge')).toHaveAttribute('data-role', 'support')
@@ -1418,7 +1419,7 @@ describe('AgentSidebar stacked avatars (REQ-68)', () => {
     expect(hermes.querySelectorAll('.os-avatar-stack__face')).toHaveLength(1)
   })
 
-  it('labels OpenMousBot (not OMB) and stacks CoS + workers; click opens filtered picker', async () => {
+  it('labels OpenMousBot (not OMB) and stacks CoS + workers; left-click opens directly, right-click Select Agent opens picker', async () => {
     renderSidebar()
     const list = await screen.findByRole('navigation', { name: 'Agent list' })
     const omb = await within(list).findByRole('link', { name: /OpenMousBot \(remote\)/ })
@@ -1429,7 +1430,15 @@ describe('AgentSidebar stacked avatars (REQ-68)', () => {
     expect(within(list).getByRole('link', { name: /Rakazo \(remote\)/ })).toBeInTheDocument()
     expect(within(list).getByRole('link', { name: /Lab swarm \(remote\)/ })).toBeInTheDocument()
 
+    // REQ-130: primary click opens chat immediately with no intermediate picker
     fireEvent.click(omb)
+    expect(screen.queryByRole('dialog', { name: 'OpenMousBot sessions' })).not.toBeInTheDocument()
+
+    // REQ-130: right-click menu provides Select Agent to open the member picker
+    fireEvent.contextMenu(omb)
+    const selectAgent = await screen.findByRole('menuitem', { name: 'Select Agent' })
+    fireEvent.click(selectAgent)
+
     const dialog = await screen.findByRole('dialog', { name: 'OpenMousBot sessions' })
     expect(within(dialog).getAllByRole('option')).toHaveLength(5)
     expect(dialog).toHaveTextContent('OpenMousBot')
@@ -1442,11 +1451,21 @@ describe('AgentSidebar stacked avatars (REQ-68)', () => {
     expect(screen.queryByRole('dialog', { name: 'OpenMousBot sessions' })).not.toBeInTheDocument()
   })
 
-  it('opens the team picker filtered to that roster and selects a session id', async () => {
+  it('opens the team picker filtered to that roster via Select Agent, and opens CoS directly on click', async () => {
     renderSidebar('/chat?team=scale-out')
     const list = await screen.findByRole('navigation', { name: 'Agent list' })
     const team = await within(list).findByRole('link', { name: /Scale Out \(team\)/ })
+
+    // REQ-130: primary click navigates directly to CoS chat context
     fireEvent.click(team)
+    expect(screen.queryByRole('dialog', { name: 'Scale Out sessions' })).not.toBeInTheDocument()
+    expect(screen.getByTestId('os-test-search')).toHaveTextContent('team=scale-out&session=cos')
+
+    // REQ-130: right-click context menu opens member picker via Select Agent
+    fireEvent.contextMenu(team)
+    const selectAgent = await screen.findByRole('menuitem', { name: 'Select Agent' })
+    fireEvent.click(selectAgent)
+
     const dialog = await screen.findByRole('dialog', { name: 'Scale Out sessions' })
     expect(within(dialog).getAllByRole('option')).toHaveLength(5)
     expect(within(dialog).getByRole('option', { name: /Pat/ })).toHaveAttribute(
@@ -1517,13 +1536,24 @@ describe('AgentSidebar special roles', () => {
   beforeEach(() => {
     localStorage.clear()
     rememberEmptyFavourites()
+    localStorage.setItem(HIDDEN_AGENTS_STORAGE_KEY, '[]')
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: async () => ({ object: 'list', data: roster }),
-      } as Response),
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = typeof input === 'string' ? input : (input as Request).url
+        if (url.includes('herdr')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ object: 'list', data: [] }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ object: 'list', data: roster }),
+        } as Response
+      }),
     )
   })
 
@@ -1542,7 +1572,7 @@ describe('AgentSidebar special roles', () => {
     expect(links[0]).toHaveTextContent('Support')
     expect(links[0]).toHaveAttribute('data-role', 'support')
     expect(links[0].querySelector('.os-agent-dot')).toBeNull()
-    expect(links[0].querySelector('.os-role-pill--support')).not.toBeNull()
+    expect(links[0].querySelector('.os-agent-role-badge')).not.toBeNull()
     expect(within(list).getByRole('link', { name: /Gate/ })).toHaveAttribute('data-role', 'gate')
     expect(within(list).getByRole('link', { name: /Skeptic/ })).toHaveAttribute(
       'data-role',

--- a/webui/frontend/src/components/__tests__/SessionPicker.test.tsx
+++ b/webui/frontend/src/components/__tests__/SessionPicker.test.tsx
@@ -89,4 +89,34 @@ describe('SessionPicker', () => {
     )
     expect(screen.getByText('no sessions yet')).toBeInTheDocument()
   })
+
+  it('renders a Manage Team footer link when sessions are for a team', () => {
+    const onClose = vi.fn()
+    render(
+      <SessionPicker
+        open
+        title="Core Team"
+        sessions={[
+          {
+            id: 'core-team:alice',
+            groupId: 'core-team',
+            groupKind: 'team',
+            memberId: 'alice',
+            title: 'Alice',
+            snippet: 'coder',
+            status: 'running',
+            startedAt: 1000,
+            href: '/chat?team=core-team&session=alice',
+          },
+        ]}
+        onClose={onClose}
+        onSelect={() => undefined}
+      />,
+    )
+    const link = screen.getByRole('link', { name: /Manage Team/i })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/teams/#core-team')
+    fireEvent.click(link)
+    expect(onClose).toHaveBeenCalled()
+  })
 })

--- a/webui/frontend/src/lib/sessionPicker.ts
+++ b/webui/frontend/src/lib/sessionPicker.ts
@@ -110,3 +110,40 @@ export function stackFacesForTeam(team: TeamRoster): StackFace[] {
 export function stackFacesForRemote(remote: RemoteEntry): StackFace[] {
   return facesFromSessions(sessionsForRemote(remote))
 }
+
+/**
+ * REQ-130: Default talk-to session for a team.
+ * Prefers configured Chief of Staff (cos / chief_of_staff), falls back to first member.
+ */
+export function defaultSessionForTeam(team: TeamRoster): MemberSession | null {
+  const sessions = sessionsForTeam(team)
+  if (sessions.length === 0) return null
+  const cos = sessions.find(
+    (s) =>
+      s.memberId === 'cos' ||
+      s.role === 'chief_of_staff' ||
+      s.role === 'cos' ||
+      /chief.?of.?staff/i.test(s.role || '') ||
+      /cos/i.test(s.title),
+  )
+  return cos || sessions[0] || null
+}
+
+/**
+ * REQ-130: Default talk-to session for a remote.
+ * Prefers configured Chief of Staff, falls back to first member.
+ */
+export function defaultSessionForRemote(remote: RemoteEntry): MemberSession | null {
+  const sessions = sessionsForRemote(remote)
+  if (sessions.length === 0) return null
+  const cos = sessions.find(
+    (s) =>
+      s.memberId === 'cos' ||
+      s.role === 'chief_of_staff' ||
+      s.role === 'cos' ||
+      /chief.?of.?staff/i.test(s.role || '') ||
+      /cos/i.test(s.title),
+  )
+  return cos || sessions[0] || null
+}
+

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -993,7 +993,11 @@ const ChatPage = () => {
               onChange={(e) => {
                 const value = e.target.value
                 if (value === MANAGE_TEAMS_VALUE) {
-                  window.location.assign(MANAGE_TEAMS_HREF)
+                  if (teamFromUrl) {
+                    window.location.assign(`${MANAGE_TEAMS_HREF}#${encodeURIComponent(teamFromUrl)}`)
+                  } else {
+                    window.location.assign(MANAGE_TEAMS_HREF)
+                  }
                   return
                 }
                 setMemberTarget(value)
@@ -1005,7 +1009,10 @@ const ChatPage = () => {
                   {memberOptionLabel(member)}
                 </option>
               ))}
-              <option value={MANAGE_TEAMS_VALUE}>Manage Teams</option>
+              <option disabled aria-hidden="true">
+                ──────────
+              </option>
+              <option value={MANAGE_TEAMS_VALUE}>Manage Team</option>
             </select>
           ) : null}
           <div

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -1454,7 +1454,7 @@ describe('ChatPage team member dropdown', () => {
       'All members',
       'Codey (agent/coder)',
       'Stewie (agent/ops)',
-      'Manage Teams',
+      'Manage Team',
     ])
     expect(select).toHaveValue('all')
     expect(screen.queryByText('Blueprint')).not.toBeInTheDocument()
@@ -1498,7 +1498,7 @@ describe('ChatPage team member dropdown', () => {
     })
   })
 
-  it('keeps Manage Teams last and does not send when that item is chosen', async () => {
+  it('keeps Manage Team last with separator and does not send when that item is chosen', async () => {
     renderChat('/chat?team=demo-team')
     await act(async () => {
       MockWebSocket.instances[0]?.open()
@@ -1507,12 +1507,14 @@ describe('ChatPage team member dropdown', () => {
     const select = await screen.findByRole('combobox', { name: 'Team members' })
     const options = within(select).getAllByRole('option')
     expect(options[options.length - 1]).toHaveValue('__manage__')
-    expect(options[options.length - 1]).toHaveTextContent('Manage Teams')
+    expect(options[options.length - 1]).toHaveTextContent('Manage Team')
+    const allOptions = Array.from(select.querySelectorAll('option'))
+    expect(allOptions[allOptions.length - 2]).toBeDisabled()
     expect(select).toHaveValue('all')
     expect(MockWebSocket.instances[0]!.send).not.toHaveBeenCalled()
   })
 
-  it('REQ-23 #331: Manage Teams navigates to /teams/ and does not WS-send', async () => {
+  it('REQ-23 #331 & REQ-152: Manage Team navigates to /teams/#team_id and does not WS-send', async () => {
     const assign = vi.fn()
     vi.stubGlobal('location', { ...window.location, assign })
 
@@ -1524,7 +1526,7 @@ describe('ChatPage team member dropdown', () => {
     fireEvent.change(await screen.findByRole('combobox', { name: 'Team members' }), {
       target: { value: '__manage__' },
     })
-    expect(assign).toHaveBeenCalledWith('/teams/')
+    expect(assign).toHaveBeenCalledWith('/teams/#demo-team')
     expect(MockWebSocket.instances[0]!.send).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
Implements REQ-130 (#520) and REQ-152 (#560):
1. **REQ-130: Direct Chief of Staff Navigation**:
   - Primary left-click on a local team or remote with a configured Chief of Staff (or first member fallback) opens that chat context directly without dumping into an intermediate picker.
   - Rail right-click context menu on team and remote rows gains `Select Agent`, allowing explicit opening of the member session picker.
2. **REQ-152: Team Dropdown Separator & Manage Team Footer**:
   - In `ChatPage.tsx` team member select dropdown, adds a disabled separator (`──────────`) followed by `Manage Team` (navigating to `/teams/#${teamId}` to open the team management surface).
   - In `SessionPicker.tsx`, adds a bottom footer with `Manage Team →` linking to `/teams/#${groupId}` when browsing a team's sessions.

Fixes #520
Fixes #560

## Verification
- `npm test` (Vitest): `ChatPage.test.tsx`, `AgentSidebar.test.tsx`, `SessionPicker.test.tsx` (all passing).
- `uv run pytest tests/unit/test_req130_req152_team_cos_manage.py`: 5 passed.
- `uv run pytest tests/unit/test_req*.py`: 96 passed.
- `./scripts/build_frontend.sh`: build clean in 320ms.