### PR TITLE
feat(webui): relocate Add-agent + beside Search (REQ-164, Fixes #585)

### DIFF
--- a/tests/unit/test_req109_add_agent_wizard.py
+++ b/tests/unit/test_req109_add_agent_wizard.py
@@ -18,10 +18,8 @@ WIZARD_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AddAgent
 INDEX_CSS = REPO_ROOT / "webui" / "frontend" / "src" / "index.css"
 
 
-def test_sidebar_has_add_button_beside_favourites():
+def test_sidebar_has_add_button():
     content = SIDEBAR_TSX.read_text(encoding="utf-8")
-    assert "os-fav-section" in content
-    assert "os-fav-add-btn" in content
     assert 'aria-label="Add agent"' in content
     assert 'data-testid="add-agent-button"' in content
     assert "AddAgentWizard" in content
@@ -52,9 +50,8 @@ def test_add_agent_wizard_implements_three_kinds_and_openmousbot_copy():
     assert "createRemote" in content
 
 
-def test_css_tap_target_and_flex_layout():
+def test_css_tap_target_and_search_button():
     css = INDEX_CSS.read_text(encoding="utf-8")
-    assert ".os-fav-section {" in css
-    assert ".os-fav-add-btn {" in css
+    assert ".os-search-add-btn {" in css
     assert "min-width: 44px;" in css
     assert "min-height: 44px;" in css

--- a/tests/unit/test_req164_add_agent_search_row.py
+++ b/tests/unit/test_req164_add_agent_search_row.py
@@ -1,0 +1,65 @@
+"""REQ-164: Move Add-agent + up beside Search (free favourites row).
+
+Intent: Keep one-tap Add agent without crowding the favourites / pin row.
+Success:
+1. + (accessible name "Add agent") sits on the Search row (trailing/right of Search field).
+   Not on the favourites/pin grid row.
+2. Favourites / pin region uses full width again (no reserved slot for + beside tiles).
+3. Click/+ opens the same Add-agent wizard (#478 behaviour).
+4. Tap target still usable (~>=44px).
+5. Tests verify Search-row + and favourites row has no +.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SIDEBAR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+INDEX_CSS = REPO_ROOT / "webui" / "frontend" / "src" / "index.css"
+
+
+def test_add_agent_button_in_search_row():
+    content = SIDEBAR_TSX.read_text(encoding="utf-8")
+
+    # Button is inside os-rail-search-row
+    assert "os-rail-search-row" in content
+    assert "os-search-add-btn" in content
+    assert 'aria-label="Add agent"' in content
+    assert 'data-testid="add-agent-button"' in content
+
+    # Search row contains both search input and add-agent-button
+    search_row_idx = content.find("os-rail-search-row")
+    fav_grid_idx = content.find('data-testid="agent-fav-grid"')
+    add_btn_idx = content.find('data-testid="add-agent-button"')
+
+    assert search_row_idx != -1
+    assert fav_grid_idx != -1
+    assert add_btn_idx != -1
+
+    # Add button appears in search row before the fav grid
+    assert search_row_idx < add_btn_idx < fav_grid_idx
+
+
+def test_favourites_row_has_no_add_button():
+    content = SIDEBAR_TSX.read_text(encoding="utf-8")
+
+    # Old favourites button class and section wrapper are gone
+    assert "os-fav-add-btn" not in content
+    assert "os-fav-section" not in content
+
+    # Favourites grid is unencumbered
+    fav_grid_start = content.find('data-testid="agent-fav-grid"')
+    nav_list_start = content.find('aria-label="Agent list"')
+    fav_grid_section = content[fav_grid_start:nav_list_start]
+
+    assert "add-agent-button" not in fav_grid_section
+    assert "setAddWizardOpen" not in fav_grid_section
+
+
+def test_css_search_add_btn_and_fav_grid_styling():
+    css = INDEX_CSS.read_text(encoding="utf-8")
+
+    assert ".os-search-add-btn {" in css
+    assert "min-width: 44px;" in css
+    assert "min-height: 44px;" in css
+    assert ".os-fav-section" not in css
+    assert ".os-fav-add-btn" not in css

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -1266,11 +1266,11 @@ export default function AgentSidebar({
           </div>
         )}
 
-        <div className="px-3 pb-2 pt-3">
+        <div className="os-rail-search-row flex items-center gap-1.5 px-3 pb-2 pt-3">
           <label className="sr-only" htmlFor="os-rail-search">
             Search
           </label>
-          <div className="os-rail-search">
+          <div className="os-rail-search min-w-0 flex-1">
             <Search className="h-3.5 w-3.5 shrink-0 text-base-content/40" aria-hidden="true" />
             <input
               id="os-rail-search"
@@ -1287,17 +1287,26 @@ export default function AgentSidebar({
             />
             <kbd className="os-rail-search__kbd kbd kbd-xs">{searchShortcutLabel}</kbd>
           </div>
+          <button
+            type="button"
+            className="os-search-add-btn"
+            aria-label="Add agent"
+            title="Add agent"
+            data-testid="add-agent-button"
+            onClick={() => setAddWizardOpen(true)}
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />
+          </button>
         </div>
 
-        <div className="os-fav-section" data-testid="fav-section">
-          <div
-            className={`os-fav-grid ${dropActive ? 'os-fav-grid--active' : ''} ${
-              visiblePins.length === 0 &&
-              !dropActive &&
-              !(draggingId && !isPinnedId(draggingId))
-                ? 'os-fav-grid--bare'
-                : ''
-            } ${visiblePins.length === 0 ? 'os-fav-grid--empty' : ''}`}
+        <div
+          className={`os-fav-grid ${dropActive ? 'os-fav-grid--active' : ''} ${
+            visiblePins.length === 0 &&
+            !dropActive &&
+            !(draggingId && !isPinnedId(draggingId))
+              ? 'os-fav-grid--bare'
+              : ''
+          } ${visiblePins.length === 0 ? 'os-fav-grid--empty' : ''}`}
             aria-label="Pinned agents"
             data-fav-layout="2-up"
             data-testid="agent-fav-grid"
@@ -1316,9 +1325,8 @@ export default function AgentSidebar({
           >
             {visiblePins.length === 0 ? (
               <div
-                className="os-fav-grid__hint cursor-pointer"
+                className="os-fav-grid__hint"
                 data-testid="fav-empty-hint"
-                onClick={() => setAddWizardOpen(true)}
               >
                 {dropActive || (draggingId && !isPinnedId(draggingId)) ? 'drop' : '+'}
               </div>
@@ -1425,17 +1433,7 @@ export default function AgentSidebar({
             )
           })}
           </div>
-          <button
-            type="button"
-            className="os-fav-add-btn"
-            aria-label="Add agent"
-            title="Add agent"
-            data-testid="add-agent-button"
-            onClick={() => setAddWizardOpen(true)}
-          >
-            <Plus className="h-5 w-5" aria-hidden="true" />
-          </button>
-        </div>
+
 
         <nav className="min-h-0 flex-1 overflow-y-auto px-2 pb-3" aria-label="Agent list">
           <div

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -718,11 +718,16 @@ describe('AgentSidebar Grok rail', () => {
     expect(storedRailOrder()).not.toContain('codey')
   })
 
-  it('REQ-109: displays + button beside favourites and opens Add agent wizard', async () => {
+  it('REQ-164 / REQ-109: displays + button beside Search input (not in favourites grid) and opens Add agent wizard', async () => {
     renderSidebar()
     const addBtn = await screen.findByRole('button', { name: 'Add agent' })
     expect(addBtn).toBeInTheDocument()
     expect(addBtn).toHaveAttribute('data-testid', 'add-agent-button')
+    expect(addBtn.closest('.os-rail-search-row')).toBeInTheDocument()
+
+    // Favourites row/grid must not contain the add button
+    const favGrid = screen.getByTestId('agent-fav-grid')
+    expect(within(favGrid).queryByTestId('add-agent-button')).toBeNull()
 
     // Click + button to open wizard
     fireEvent.click(addBtn)

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -326,18 +326,7 @@ html[data-theme="light"] #root {
   flex-shrink: 0;
 }
 
-.os-fav-section {
-  display: flex;
-  align-items: center;
-  gap: 0.375rem;
-  margin: 0 0.75rem 0.5rem;
-}
-.os-fav-section .os-fav-grid {
-  margin: 0;
-  flex: 1;
-  min-width: 0;
-}
-.os-fav-add-btn {
+.os-search-add-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -346,15 +335,15 @@ html[data-theme="light"] #root {
   width: 44px;
   height: 44px;
   flex-shrink: 0;
-  border-radius: 0.75rem;
-  border: 1px dashed color-mix(in srgb, var(--color-base-content) 16%, transparent);
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--color-base-content) 12%, transparent);
   color: color-mix(in srgb, var(--color-base-content) 60%, transparent);
-  background: transparent;
+  background: color-mix(in srgb, var(--color-base-100) 40%, transparent);
   transition: all 0.15s ease-in-out;
   cursor: pointer;
 }
-.os-fav-add-btn:hover,
-.os-fav-add-btn:focus-visible {
+.os-search-add-btn:hover,
+.os-search-add-btn:focus-visible {
   border-color: color-mix(in srgb, var(--color-primary) 65%, transparent);
   color: var(--color-primary);
   background: color-mix(in srgb, var(--color-primary) 8%, transparent);


### PR DESCRIPTION
Fixes #585

### Summary of Changes
- Relocates `+` (accessible name 'Add agent', `data-testid="add-agent-button"`) from the favourites grid row into the Search input row (`.os-rail-search-row`).
- Favourites / pin region (`.os-fav-grid`) uses full width again without any reserved slot or wrapper constricting it.
- `+` button still opens the identical `AddAgentWizard` (#478 behavior).
- Preserves >=44px tap target on mobile/touch with `.os-search-add-btn`.
- Updated existing tests and added `tests/unit/test_req164_add_agent_search_row.py`.