### PR TITLE
fix(webui): render CLI and API dropdowns with model selectors (REQ-133, Fixes #523)

### DIFF
--- a/src/swarm/views/chat_persist_views.py
+++ b/src/swarm/views/chat_persist_views.py
@@ -133,9 +133,9 @@ def _sync_django_and_memory(user, messages, conversation_ids: list[str]) -> None
 
 @login_required
 @ensure_csrf_cookie
-@require_http_methods(["GET", "PATCH"])
+@require_http_methods(["GET", "POST", "PATCH"])
 def chat_thread(request):
-    """Hydrate (GET) or edit (PATCH) the persisted transcript for one agent."""
+    """Hydrate (GET), append (POST), or edit (PATCH) the persisted transcript for one agent."""
     from swarm.core.agent_settings import is_new_chat_per_task
     from swarm.core.session_policy import list_active_task_sessions
 
@@ -144,7 +144,7 @@ def chat_thread(request):
     user_key = _user_key(request.user)
     conversation_id = chat_store.conversation_id_for(request.user, agent)
     requested_cid = (request.GET.get("conversation_id") or "").strip()
-    if request.method == "PATCH":
+    if request.method in ("PATCH", "POST"):
         body = _json_body(request)
         if isinstance(body.get("conversation_id"), str) and body["conversation_id"].strip():
             requested_cid = body["conversation_id"].strip()
@@ -203,6 +203,34 @@ def chat_thread(request):
     }
     if request.method == "GET":
         return JsonResponse(payload)
+
+    if request.method == "POST":
+        body = _json_body(request)
+        msg = body.get("message")
+        if isinstance(msg, dict) and msg.get("content"):
+            current_messages = list(messages or [])
+            new_row = {
+                "role": str(msg.get("role") or "status"),
+                "content": str(msg.get("content") or ""),
+            }
+            current_messages.append(new_row)
+            try:
+                chat_store.save(
+                    user_key,
+                    agent,
+                    current_messages,
+                    conversation_id=conversation_id,
+                )
+            except OSError:
+                logger.exception("Failed to append chat JSON for %s/%s", user_key, agent)
+            _sync_django_and_memory(
+                request.user,
+                current_messages,
+                [conversation_id, chat_store.conversation_id_for(request.user, agent)],
+            )
+            payload["messages"] = _public_messages(current_messages)
+            return JsonResponse(payload)
+        return JsonResponse({"error": "message must be provided."}, status=400)
 
     if not can_edit_agent_messages(agent_raw or agent):
         return JsonResponse(

--- a/tests/unit/test_req133_cli_api_dropdowns_models.py
+++ b/tests/unit/test_req133_cli_api_dropdowns_models.py
@@ -1,0 +1,69 @@
+"""REQ-133: CLI and API chat dropdowns with model selectors (Fixes #523)."""
+
+from pathlib import Path
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+import json
+
+from swarm.core import chat_store
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHAT_PAGE_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "pages" / "ChatPage.tsx"
+CLI_CONTEXT_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "cliAgentContext.ts"
+CHAT_STATUS_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "chatStatus.ts"
+
+
+def test_chat_page_renders_cli_and_api_dropdowns_with_models():
+    tsx = CHAT_PAGE_TSX.read_text(encoding="utf-8")
+    assert "isCliAgent" in tsx
+    assert "isApiAgent" in tsx
+    assert "showRemotesControl" in tsx
+
+    # CLI controls
+    assert 'data-testid="cli-select"' in tsx
+    assert 'aria-label="CLI"' in tsx
+    assert 'data-testid="cli-model-select"' in tsx
+
+    # API controls
+    assert 'data-testid="api-select"' in tsx
+    assert 'aria-label="API"' in tsx
+    assert 'data-testid="api-model-select"' in tsx
+
+    # Status tracking on change
+    assert "recordDropdownChange('cli'" in tsx
+    assert "recordDropdownChange('api'" in tsx
+    assert "recordDropdownChange('model'" in tsx
+
+
+def test_chat_status_and_cli_context_contracts():
+    status_ts = CHAT_STATUS_TS.read_text(encoding="utf-8")
+    assert "'api'" in status_ts
+    assert "'cli'" in status_ts
+    assert "'model'" in status_ts
+    assert "formatDropdownStatus" in status_ts
+
+    cli_ts = CLI_CONTEXT_TS.read_text(encoding="utf-8")
+    assert "discoverChatClis" in cli_ts
+    assert "preferredChatCli" in cli_ts
+    assert "isCliAgentContext" in cli_ts
+
+
+@pytest.mark.django_db
+def test_chat_thread_post_appends_status_line():
+    user = get_user_model().objects.create_user(username="req133-tester", password="pw")
+    client = Client()
+    client.login(username="req133-tester", password="pw")
+
+    resp = client.post(
+        "/chat/thread/?agent=codey",
+        data=json.dumps({"message": {"role": "status", "content": "CLI: antigravity → grok"}}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(m["role"] == "status" and m["content"] == "CLI: antigravity → grok" for m in data["messages"])
+
+    loaded = chat_store.load(chat_store.user_key_for(user), "codey")
+    assert loaded is not None
+    assert loaded["messages"][-1]["content"] == "CLI: antigravity → grok"

--- a/tests/views/test_chat_retention.py
+++ b/tests/views/test_chat_retention.py
@@ -274,3 +274,33 @@ def test_settings_chat_group_lists_env_vars(client):
     data = json.loads(payload)
     assert "chat_persistence" in data
     assert "SWARM_CHAT_MAX_AGE_DAYS" in data["chat_persistence"]["settings"]
+
+
+@pytest.mark.django_db
+def test_chat_thread_post_appends_status_message(client, user):
+    _seed_thread(user, "codey", "prior turn")
+    resp = client.post(
+        "/chat/thread/?agent=codey",
+        data=json.dumps({"message": {"role": "status", "content": "CLI: antigravity → grok"}}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["messages"]) == 3
+    assert body["messages"][-1]["role"] == "status"
+    assert body["messages"][-1]["content"] == "CLI: antigravity → grok"
+
+    loaded = chat_store.load(chat_store.user_key_for(user), "codey")
+    assert loaded is not None
+    assert loaded["messages"][-1]["content"] == "CLI: antigravity → grok"
+
+
+@pytest.mark.django_db
+def test_chat_thread_post_requires_valid_message(client, user):
+    resp = client.post(
+        "/chat/thread/?agent=codey",
+        data=json.dumps({"message": {}}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+

--- a/webui/frontend/src/lib/agentChat.ts
+++ b/webui/frontend/src/lib/agentChat.ts
@@ -207,6 +207,35 @@ export async function patchAgentMessage(
   }
 }
 
+/** POST /chat/thread/?agent= — append a status/turn message (REQ-46). */
+export async function appendAgentMessage(
+  agentId: string,
+  message: { role: string; content: string },
+  conversationId?: string,
+): Promise<AgentThread> {
+  const agent = agentIdFromBlueprint(agentId)
+  await ensureCsrfCookie()
+  const data = await apiPost<AgentThread>(
+    `/chat/thread/?agent=${encodeURIComponent(agent)}${conversationId ? `&conversation_id=${encodeURIComponent(conversationId)}` : ''}`,
+    { message, conversation_id: conversationId },
+  )
+  const messages = Array.isArray(data?.messages)
+    ? data.messages.map(parseThreadMessage).filter((row): row is AgentThreadMessage => row != null)
+    : []
+  const kind = classifyAgentKind(agent, data?.kind)
+  return {
+    agent_id: typeof data?.agent_id === 'string' ? data.agent_id : agent,
+    conversation_id:
+      typeof data?.conversation_id === 'string' && data.conversation_id
+        ? data.conversation_id
+        : conversationId || conversationIdForAgent(agent),
+    messages,
+    summaries: parseSummaries(data?.summaries),
+    kind,
+    editable: data?.editable === true || (data?.editable !== false && kind === 'api'),
+  }
+}
+
 /** POST /chat/compact/ — summarise the backlog. Raw transcript stays on disk. */
 export async function compactAgentThread(opts: {
   conversationId: string

--- a/webui/frontend/src/lib/api.ts
+++ b/webui/frontend/src/lib/api.ts
@@ -788,6 +788,16 @@ export function fetchCliAgents(): Promise<CliAgentsInfo> {
   return apiGet<CliAgentsInfo>('/v1/cli-agents/')
 }
 
+export interface CliModelsResponse {
+  cli: string
+  models: string[]
+  warning?: string
+}
+
+export function fetchCliModels(cli: string): Promise<CliModelsResponse> {
+  return apiGet<CliModelsResponse>(`/v1/cli-agents/${encodeURIComponent(cli)}/models/`)
+}
+
 /** A 0..1 capability/priority vector over inference traits. */
 export type TraitVector = Record<string, number>
 

--- a/webui/frontend/src/lib/chatStatus.ts
+++ b/webui/frontend/src/lib/chatStatus.ts
@@ -15,13 +15,14 @@ export type StatusChromeRole = (typeof STATUS_CHROME_ROLES)[number]
 
 export type ChatTranscriptRole = 'user' | 'assistant' | StatusChromeRole
 
-export type DropdownKind = 'team' | 'cli' | 'model' | 'mode'
+export type DropdownKind = 'team' | 'cli' | 'model' | 'mode' | 'api'
 
 export const DROPDOWN_KIND_LABEL: Record<DropdownKind, string> = {
   team: 'Team target',
   cli: 'CLI',
   model: 'Model',
   mode: 'Mode',
+  api: 'API',
 }
 
 /** Navigation-only options — changing to these must not write a status line. */

--- a/webui/frontend/src/lib/cliAgentContext.ts
+++ b/webui/frontend/src/lib/cliAgentContext.ts
@@ -48,21 +48,33 @@ export function discoverChatClis(
 ): string[] {
   const seen = new Set<string>()
   const out: string[] = []
-  const push = (name: string | null | undefined) => {
-    const trimmed = (name ?? '').trim()
+  const push = (name: unknown) => {
+    const raw =
+      typeof name === 'string'
+        ? name
+        : (name as { name?: string; id?: string; cli?: string } | null | undefined)?.name ??
+          (name as { name?: string; id?: string; cli?: string } | null | undefined)?.id ??
+          (name as { name?: string; id?: string; cli?: string } | null | undefined)?.cli
+    if (typeof raw !== 'string') return
+    const trimmed = raw.trim()
     if (!trimmed || trimmed === MANAGE_CLI_VALUE || seen.has(trimmed)) return
     seen.add(trimmed)
     out.push(trimmed)
   }
-  if (info) {
-    for (const name of [...(info.installed ?? []), ...(info.configured ?? [])]) {
+  const installedOrConfigured = [
+    ...(info?.installed ?? []),
+    ...(info?.configured ?? []),
+  ]
+  if (installedOrConfigured.length > 0) {
+    for (const name of installedOrConfigured) {
       push(name)
     }
-    push(info.default_cli)
+    push(info?.default_cli)
+  } else {
+    for (const name of info?.clis ?? []) {
+      push(name)
+    }
   }
-  push(selected)
-  if (out.length > 0) return out
-  for (const name of info?.clis ?? []) push(name)
   push(selected)
   return out
 }

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -24,12 +24,14 @@ import { useRailChrome } from '../components/RailChrome'
 import { ComputerControlStub } from '../components/ComputerControlStub'
 import { RemoteSelect } from '../components/RemoteSelect'
 import { ChatMessageBubble } from '../components/ChatMessageBubble'
-import { fetchBlueprints, fetchCliAgents, fetchRemotes } from '../lib/api'
+import { fetchBlueprints, fetchCliAgents, fetchCliModels, fetchModels, fetchRemotes } from '../lib/api'
 import {
   agentIdFromBlueprint,
+  appendAgentMessage,
   compactAgentThread,
   conversationIdForAgent,
   conversationIdForTask,
+  DEFAULT_AGENT_ID,
   fetchAgentThread,
   patchAgentMessage,
   type ConversationSummary,
@@ -92,7 +94,21 @@ import {
   SUPPORT_AGENT_ID,
   supportTurnExtras,
 } from '../lib/supportAgent'
-import { asTranscriptRole, isStatusRole } from '../lib/chatStatus'
+import {
+  asTranscriptRole,
+  formatDropdownStatus,
+  isStatusRole,
+  shouldRecordDropdownChange,
+  type DropdownKind,
+} from '../lib/chatStatus'
+import {
+  discoverChatClis,
+  isCliAgentContext,
+  isCliBlueprintId,
+  preferredChatCli,
+  MANAGE_CLI_VALUE,
+  MANAGE_CLI_HREF,
+} from '../lib/cliAgentContext'
 
 /** EXPERIMENTAL flags are read once per module load; see experimental/flags.ts. */
 const SHOW_MESSAGE_ACTIONS = isExperimentalEnabled('chat_message_actions')
@@ -288,6 +304,105 @@ const ChatPage = () => {
 
   const showRemotesControl = isRemoteAgent || isRemoteBackedTeam
 
+  const modelsQuery = useQuery({
+    queryKey: ['models'],
+    queryFn: fetchModels,
+    retry: 1,
+  })
+
+  const isCliAgent = Boolean(
+    !teamFromUrl &&
+      !remoteFromUrl &&
+      !isRemoteBackedTeam &&
+      !isRemoteAgent &&
+      (selectedCli ||
+        agentKind === 'cli' ||
+        isCliBlueprintId(selectedBlueprint) ||
+        isCliAgentContext({
+          blueprintId: selectedBlueprint,
+          searchParams,
+        })),
+  )
+
+  const isApiAgent = Boolean(
+    !teamFromUrl &&
+      !remoteFromUrl &&
+      !isRemoteBackedTeam &&
+      !isRemoteAgent &&
+      !isCliAgent,
+  )
+
+  const discoveredClis = useMemo(
+    () => discoverChatClis(cliQuery.data, searchParams.get('cli') || selectedCli?.cli),
+    [cliQuery.data, searchParams, selectedCli],
+  )
+  const currentCli = useMemo(() => {
+    const fromParam = (searchParams.get('cli') ?? '').trim()
+    if (fromParam) return fromParam
+    if (selectedCli?.cli) return selectedCli.cli
+    return preferredChatCli(discoveredClis, '')
+  }, [searchParams, selectedCli, discoveredClis])
+
+  const cliModelsQuery = useQuery({
+    queryKey: ['cli-models', currentCli],
+    queryFn: () => fetchCliModels(currentCli),
+    enabled: Boolean(isCliAgent && currentCli),
+    retry: 1,
+  })
+  const availableCliModels = useMemo(() => {
+    const list = cliModelsQuery.data?.models ?? (cliQuery.data as any)?.list_models?.[currentCli] ?? []
+    return list.length ? list : ['default']
+  }, [cliModelsQuery.data, cliQuery.data, currentCli])
+
+  const currentCliModel = useMemo(() => {
+    const fromParam = (searchParams.get('model') ?? '').trim()
+    if (fromParam && availableCliModels.includes(fromParam)) return fromParam
+    return availableCliModels[0] || 'default'
+  }, [searchParams, availableCliModels])
+
+  const availableApiAgents = useMemo(
+    () => blueprints.filter((bp) => !isCliBlueprintId(bp.id)),
+    [blueprints],
+  )
+  const availableApiModels = useMemo(() => {
+    const list = modelsQuery.data?.data?.map((m) => m.id) ?? []
+    return list.length ? list : ['default']
+  }, [modelsQuery.data])
+
+  const currentApiModel = useMemo(() => {
+    const fromParam = (searchParams.get('model') ?? '').trim()
+    if (fromParam && availableApiModels.includes(fromParam)) return fromParam
+    return availableApiModels[0] || 'default'
+  }, [searchParams, availableApiModels])
+
+  const recordDropdownChange = useCallback(
+    (kind: DropdownKind, fromLabel: string, toLabel: string) => {
+      if (!shouldRecordDropdownChange(fromLabel, toLabel)) return
+      const statusText = formatDropdownStatus(kind, fromLabel, toLabel)
+      const statusMsg: ChatMessage = {
+        key: `status-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+        role: 'status',
+        text: statusText,
+        streaming: false,
+      }
+      setThreads((prev) => ({
+        ...prev,
+        [threadKey]: [...(prev[threadKey] ?? []), statusMsg],
+      }))
+      const agent = teamFromUrl
+        ? `team-${teamFromUrl}`
+        : remoteFromUrl
+          ? `remote-${remoteFromUrl}`
+          : selectedBlueprint || DEFAULT_AGENT_ID
+      void appendAgentMessage(
+        agent,
+        { role: 'status', content: statusText },
+        conversationIdRef.current || undefined,
+      ).catch(() => {})
+    },
+    [threadKey, teamFromUrl, remoteFromUrl, selectedBlueprint],
+  )
+
   useEffect(() => {
     // REQ-28: a selected composition team uses ?team=; do not clobber it
     // with the Support default (REQ-23 owns send-to-all).
@@ -346,7 +461,29 @@ const ChatPage = () => {
         setThreads((prev) => ({ ...prev, [key]: [] }))
         setSummariesByThread((prev) => ({ ...prev, [key]: [] }))
       }
-      return
+      let cancelled = false
+      ;(async () => {
+        const thread = await fetchAgentThread(key, key)
+        if (cancelled) return
+        setSummariesByThread((prev) => ({
+          ...prev,
+          [key]: thread.summaries,
+        }))
+        if (thread.messages.length === 0) return
+        setThreads((prev) => ({
+          ...prev,
+          [key]: thread.messages.map((message, index) => ({
+            key: `hist-${index}-${message.role}`,
+            role: asTranscriptRole(message.role),
+            text: message.content,
+            streaming: false,
+            edited: message.edited === true,
+          })),
+        }))
+      })()
+      return () => {
+        cancelled = true
+      }
     }
     if (remoteFromUrl) {
       const key = `remote-${remoteFromUrl}${sessionFromUrl ? `-${sessionFromUrl}` : ''}`
@@ -722,11 +859,19 @@ const ChatPage = () => {
       })
         ? supportTurnExtras()
         : undefined
-      const cliParams = selectedCli
-        ? { cli: selectedCli.cli }
-        : newChatPerTask
-          ? { new_session: messages.length === 0 }
-          : undefined
+      const selectedModelParam = (searchParams.get('model') ?? '').trim()
+      const cliParams = isCliAgent
+        ? {
+            cli: currentCli,
+            ...(selectedModelParam && selectedModelParam !== 'default' ? { model: selectedModelParam } : {}),
+          }
+        : isApiAgent && selectedModelParam && selectedModelParam !== 'default'
+          ? { model: selectedModelParam }
+          : selectedCli
+            ? { cli: selectedCli.cli }
+            : newChatPerTask
+              ? { new_session: messages.length === 0 }
+              : undefined
       ws.send(
         buildChatWsFrame(
           trimmed,
@@ -741,6 +886,11 @@ const ChatPage = () => {
       runtimeBlueprint,
       selectedBlueprint,
       selectedCli,
+      isCliAgent,
+      currentCli,
+      currentCliModel,
+      isApiAgent,
+      currentApiModel,
       teamFromUrl,
       memberTarget,
       newChatPerTask,
@@ -1000,7 +1150,13 @@ const ChatPage = () => {
                   }
                   return
                 }
+                const prev = memberTarget
+                const prevMember = (selectedTeam?.members ?? []).find((m) => m.id === prev)
+                const nextMember = (selectedTeam?.members ?? []).find((m) => m.id === value)
+                const fromLabel = prev === ALL_MEMBERS_TARGET ? 'All members' : memberOptionLabel(prevMember || { id: prev, name: prev })
+                const toLabel = value === ALL_MEMBERS_TARGET ? 'All members' : memberOptionLabel(nextMember || { id: value, name: value })
                 setMemberTarget(value)
+                recordDropdownChange('team', fromLabel, toLabel)
               }}
             >
               <option value={ALL_MEMBERS_TARGET}>All members</option>
@@ -1014,6 +1170,126 @@ const ChatPage = () => {
               </option>
               <option value={MANAGE_TEAMS_VALUE}>Manage Team</option>
             </select>
+          ) : null}
+          {isCliAgent ? (
+            <>
+              <select
+                className="select select-sm h-8 max-w-[10rem] border border-base-300 bg-base-100"
+                value={currentCli}
+                aria-label="CLI"
+                data-testid="cli-select"
+                onChange={(e) => {
+                  const nextCli = e.target.value
+                  if (nextCli === MANAGE_CLI_VALUE) {
+                    window.location.assign(MANAGE_CLI_HREF)
+                    return
+                  }
+                  const prev = currentCli
+                  setSearchParams(
+                    (prevParams) => {
+                      const nextParams = new URLSearchParams(prevParams)
+                      nextParams.set('cli', nextCli)
+                      return nextParams
+                    },
+                    { replace: true },
+                  )
+                  recordDropdownChange('cli', prev, nextCli)
+                }}
+              >
+                {discoveredClis.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+                <option disabled aria-hidden="true">
+                  ──────────
+                </option>
+                <option value={MANAGE_CLI_VALUE}>Manage Cli</option>
+              </select>
+              <select
+                className="select select-sm h-8 max-w-[10rem] border border-base-300 bg-base-100"
+                value={currentCliModel}
+                aria-label="Model"
+                data-testid="cli-model-select"
+                onChange={(e) => {
+                  const nextModel = e.target.value
+                  const prev = currentCliModel
+                  setSearchParams(
+                    (prevParams) => {
+                      const nextParams = new URLSearchParams(prevParams)
+                      nextParams.set('model', nextModel)
+                      return nextParams
+                    },
+                    { replace: true },
+                  )
+                  recordDropdownChange('model', prev, nextModel)
+                }}
+              >
+                {availableCliModels.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+            </>
+          ) : null}
+          {isApiAgent ? (
+            <>
+              <select
+                className="select select-sm h-8 max-w-[10rem] border border-base-300 bg-base-100"
+                value={selectedBlueprint}
+                aria-label="API"
+                data-testid="api-select"
+                onChange={(e) => {
+                  const nextBp = e.target.value
+                  const prevBp = selectedBlueprint
+                  const prevAgent = blueprints.find((b) => b.id === prevBp)
+                  const nextAgent = blueprints.find((b) => b.id === nextBp)
+                  const prevLabel = prevAgent ? agentLabel(prevAgent) : prevBp
+                  const nextLabel = nextAgent ? agentLabel(nextAgent) : nextBp
+                  setSearchParams(
+                    (prevParams) => {
+                      const nextParams = new URLSearchParams(prevParams)
+                      nextParams.set('blueprint', nextBp)
+                      return nextParams
+                    },
+                    { replace: true },
+                  )
+                  recordDropdownChange('api', prevLabel, nextLabel)
+                }}
+              >
+                {availableApiAgents.map((bp) => (
+                  <option key={bp.id} value={bp.id}>
+                    {agentLabel(bp)}
+                  </option>
+                ))}
+              </select>
+              <select
+                className="select select-sm h-8 max-w-[10rem] border border-base-300 bg-base-100"
+                value={currentApiModel}
+                aria-label="Model"
+                data-testid="api-model-select"
+                onChange={(e) => {
+                  const nextModel = e.target.value
+                  const prev = currentApiModel
+                  setSearchParams(
+                    (prevParams) => {
+                      const nextParams = new URLSearchParams(prevParams)
+                      nextParams.set('model', nextModel)
+                      return nextParams
+                    },
+                    { replace: true },
+                  )
+                  recordDropdownChange('model', prev, nextModel)
+                }}
+              >
+                {availableApiModels.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+            </>
           ) : null}
           <div
             className="flex items-center gap-2"
@@ -1045,8 +1321,14 @@ const ChatPage = () => {
         aria-live="polite"
         role="log"
         aria-label="Conversation"
-        data-agent-kind={remoteFromUrl ? 'remote' : selectedCli ? 'cli' : agentKind}
-        data-messages-editable={messagesEditable && !selectedCli ? 'true' : 'false'}
+        data-agent-kind={
+          remoteFromUrl || isRemoteAgent || agentKind === 'remote'
+            ? 'remote'
+            : isCliAgent
+              ? 'cli'
+              : agentKind
+        }
+        data-messages-editable={messagesEditable && !isCliAgent && agentKind !== 'remote' ? 'true' : 'false'}
         tabIndex={0}
         onScroll={(e) => {
           const el = e.currentTarget

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -2437,7 +2437,9 @@ describe('ChatPage dropdown status lines (REQ-46)', () => {
       MockWebSocket.instances[0]?.open()
     })
 
-    fireEvent.change(await screen.findByRole('combobox', { name: 'CLI' }), {
+    await screen.findByRole('option', { name: 'grok' })
+    const cliSelect = await screen.findByRole('combobox', { name: 'CLI' })
+    fireEvent.change(cliSelect, {
       target: { value: 'grok' },
     })
 
@@ -2447,4 +2449,35 @@ describe('ChatPage dropdown status lines (REQ-46)', () => {
     expect(status.querySelector('.chat-bubble')).toBeNull()
     expect(screen.getAllByTestId('chat-status')).toHaveLength(1)
   })
+
+  it('renders CLI and Model dropdowns on CLI agent and hides API and Remotes controls (REQ-133)', async () => {
+    const store = { messages: [] as { role: string; content: string }[] }
+    stubWithThreadStore(store)
+
+    renderChat('/chat?blueprint=cli_agent&mode=cli&cli=antigravity')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+
+    expect(await screen.findByRole('combobox', { name: 'CLI' })).toBeInTheDocument()
+    expect(await screen.findByRole('combobox', { name: 'Model' })).toBeInTheDocument()
+    expect(screen.queryByRole('combobox', { name: 'API' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('combobox', { name: 'Remote' })).not.toBeInTheDocument()
+  })
+
+  it('renders API and Model dropdowns on API agent and hides CLI and Remotes controls (REQ-133)', async () => {
+    const store = { messages: [] as { role: string; content: string }[] }
+    stubWithThreadStore(store)
+
+    renderChat('/chat?blueprint=codey')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+
+    expect(await screen.findByRole('combobox', { name: 'API' })).toBeInTheDocument()
+    expect(await screen.findByRole('combobox', { name: 'Model' })).toBeInTheDocument()
+    expect(screen.queryByRole('combobox', { name: 'CLI' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('combobox', { name: 'Remote' })).not.toBeInTheDocument()
+  })
 })
+


### PR DESCRIPTION
## Summary
Fixes #523 (REQ-133)

- **CLI agents**: Render CLI dropdown (`aria-label="CLI"`) listing discovered CLIs + `Manage Cli` option (`/settings/`), plus CLI Model selector (`aria-label="Model"`) populated via `GET /v1/cli-agents/<cli>/models/`.
- **API agents**: Render API dropdown (`aria-label="API"`) and Model selector (`aria-label="Model"`).
- **Mutually exclusive scope**: CLI/API dropdowns are omitted on remote agents and team sessions, preserving remote-only scope (#522).
- **Session & status tracking**: Changing dropdowns updates active session and writes a quiet centred transcript line (`{kind}: {from} → {to}`, #362 status mechanism) persisted to `chat_thread`.
- **Team hydration**: Hydrate persisted status/turns on team threads via `fetchAgentThread`.

## Verification
- Unit test: `tests/unit/test_req133_cli_api_dropdowns_models.py` (3/3 passed).
- Test suite: `tests/views/test_chat_retention.py` (20/20 passed), `tests/unit/test_req*.py` (102/102 passed).
- Frontend tests: `src/pages/__tests__/ChatPage.test.tsx` (REQ-46 & REQ-133 tests passed).
- Build: `./scripts/build_frontend.sh` builds cleanly.