### PR TITLE
feat(webui): manage existing CLI/API agents from wizard and add folder field (REQ-165, REQ-167, Fixes #586, Fixes #590)

### DIFF
--- a/tests/unit/test_req165_manage_agents_wizard.py
+++ b/tests/unit/test_req165_manage_agents_wizard.py
@@ -1,0 +1,47 @@
+"""REQ-165: Manage existing CLI + API agents from Add-agent flow (#586).
+REQ-167: CLI Folder workspace field — UI only (#590).
+REQ-164 addendum: New agent bumped to top of unpinned rail (#585).
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WIZARD_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AddAgentWizard.tsx"
+SIDEBAR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+AGENT_EDITS_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "agentEdits.ts"
+
+
+def test_add_agent_wizard_manage_surface():
+    content = WIZARD_TSX.read_text(encoding="utf-8")
+    # REQ-165: manage surface
+    assert "manage-agent-surface" in content
+    assert "empty-manage-state" in content
+    assert "manage-agent-list" in content
+    assert "No CLI agents yet" in content
+    assert "No API agents yet" in content
+    assert "add-new-agent-btn" in content
+    assert "updateCustomBlueprint" in content
+
+
+def test_cli_folder_field_and_validation():
+    content = WIZARD_TSX.read_text(encoding="utf-8")
+    # REQ-167: Folder field and help text
+    assert 'data-testid="input-cli-folder"' in content
+    assert "Working directory for this CLI agent" in content
+    assert "isValidFolderPath" in content
+    assert "folder-error" in content
+
+
+def test_agent_edits_supports_folder_and_command():
+    content = AGENT_EDITS_TS.read_text(encoding="utf-8")
+    assert "folder?: string" in content
+    assert "command?: string" in content
+    assert "patch.folder !== undefined" in content
+    assert "patch.command !== undefined" in content
+
+
+def test_sidebar_unpinned_bump_and_select_agent():
+    content = SIDEBAR_TSX.read_text(encoding="utf-8")
+    # REQ-164 addendum: newly created agent placed at top of unpinned rail
+    assert "bumpRailIdToTop(base, created.id)" in content
+    assert "onSelectAgent={handleAgentSelected}" in content

--- a/webui/frontend/src/components/AddAgentWizard.tsx
+++ b/webui/frontend/src/components/AddAgentWizard.tsx
@@ -1,9 +1,17 @@
-import { useState, useId } from 'react'
-import { Terminal, Bot, Globe, ArrowLeft, Plus } from 'lucide-react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useState, useId, useMemo } from 'react'
+import { Terminal, Bot, Globe, ArrowLeft, Plus, ExternalLink, Edit3 } from 'lucide-react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Modal, Button, Alert } from './DaisyUI'
-import { createCustomBlueprint, createRemote } from '../lib/api'
+import {
+  createCustomBlueprint,
+  updateCustomBlueprint,
+  createRemote,
+  fetchBlueprints,
+  fetchCliAgents,
+  fetchCustomBlueprints,
+} from '../lib/api'
 import { OPENMOUSBOT_LABEL } from '../lib/remotesCatalog'
+import { loadAgentEdit, saveAgentEdit } from '../lib/agentEdits'
 
 export type AgentKind = 'cli' | 'api' | 'remote'
 
@@ -11,32 +19,55 @@ export interface AddAgentWizardProps {
   isOpen: boolean
   onClose: () => void
   onCreated?: (agent: { id: string; name: string; kind: AgentKind }) => void
+  onSelectAgent?: (agentId: string) => void
+}
+
+export function isValidFolderPath(path: string): boolean {
+  if (!path.trim()) return true
+  if (/[\0*?"<>|\r\n]/.test(path)) return false
+  return true
+}
+
+export interface ManageAgentItem {
+  id: string
+  name: string
+  command?: string
+  folder?: string
+  description?: string
+  prompt?: string
+  isCustom: boolean
 }
 
 /**
- * REQ-109: Add agent popup wizard (CLI | API | Remote) opened beside favourites.
+ * REQ-109 / REQ-164 / REQ-165 / REQ-167: Add agent popup wizard.
  *
  * - Step 1: Choose agent kind (CLI, API, Remote with OpenMousBot copy).
- * - Step 2: Configure and create agent.
+ * - Step 2 (CLI / API): Manage existing agents of that kind (list + edit + open + add new).
+ * - Step 3 / Configure: Create new agent or edit existing agent.
  * - Overlay only: chat stays mounted (#364). Esc / backdrop cancels without creating.
  */
 export default function AddAgentWizard({
   isOpen,
   onClose,
   onCreated,
+  onSelectAgent,
 }: AddAgentWizardProps) {
   const queryClient = useQueryClient()
   const titleId = useId()
 
-  const [step, setStep] = useState<'select_kind' | 'configure'>('select_kind')
+  const [step, setStep] = useState<'select_kind' | 'manage' | 'configure'>('select_kind')
   const [selectedKind, setSelectedKind] = useState<AgentKind>('cli')
+  const [mode, setMode] = useState<'create' | 'edit'>('create')
+  const [editingAgentId, setEditingAgentId] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   // CLI fields
   const [cliName, setCliName] = useState('')
   const [cliCommand, setCliCommand] = useState('')
+  const [cliFolder, setCliFolder] = useState('')
   const [cliDescription, setCliDescription] = useState('')
+  const [folderError, setFolderError] = useState<string | null>(null)
 
   // API fields
   const [apiName, setApiName] = useState('')
@@ -48,14 +79,35 @@ export default function AddAgentWizard({
   const [remoteBaseUrl, setRemoteBaseUrl] = useState('')
   const [remoteApiKey, setRemoteApiKey] = useState('')
 
-  const handleClose = () => {
-    // Reset state and close
-    setStep('select_kind')
-    setSelectedKind('cli')
+  // Queries for existing agents
+  const blueprintsQuery = useQuery({
+    queryKey: ['blueprints'],
+    queryFn: fetchBlueprints,
+    enabled: isOpen,
+    retry: 1,
+  })
+
+  const customBlueprintsQuery = useQuery({
+    queryKey: ['custom-blueprints'],
+    queryFn: fetchCustomBlueprints,
+    enabled: isOpen,
+    retry: 1,
+  })
+
+  const cliQuery = useQuery({
+    queryKey: ['cli-agents'],
+    queryFn: fetchCliAgents,
+    enabled: isOpen,
+    retry: 1,
+  })
+
+  const resetFormFields = () => {
     setError(null)
+    setFolderError(null)
     setSubmitting(false)
     setCliName('')
     setCliCommand('')
+    setCliFolder('')
     setCliDescription('')
     setApiName('')
     setApiDescription('')
@@ -63,54 +115,281 @@ export default function AddAgentWizard({
     setRemoteKind('omb')
     setRemoteBaseUrl('')
     setRemoteApiKey('')
+    setEditingAgentId(null)
+  }
+
+  const handleClose = () => {
+    resetFormFields()
+    setStep('select_kind')
+    setSelectedKind('cli')
+    setMode('create')
     onClose()
   }
 
   const handleSelectKind = (kind: AgentKind) => {
     setSelectedKind(kind)
     setError(null)
+    if (kind === 'remote') {
+      setMode('create')
+      setStep('configure')
+    } else {
+      setStep('manage')
+    }
+  }
+
+  // Aggregate CLI agents
+  const cliAgents = useMemo<ManageAgentItem[]>(() => {
+    const list: ManageAgentItem[] = []
+    const seen = new Set<string>()
+
+    const customList = customBlueprintsQuery.data?.data ?? []
+    for (const item of customList) {
+      if (item.category === 'cli' || item.tags?.includes('cli')) {
+        const edits = loadAgentEdit(item.id)
+        const name = edits.name || item.name || item.id
+        const commandMatch = item.code?.match(/# Command:\s*(.*)/)
+        const folderMatch = item.code?.match(/# Folder:\s*(.*)/)
+        const command =
+          edits.command || (commandMatch ? commandMatch[1].trim() : '') || item.description || ''
+        const folder = edits.folder || (folderMatch ? folderMatch[1].trim() : '')
+        seen.add(item.id)
+        list.push({
+          id: item.id,
+          name,
+          command,
+          folder,
+          description: item.description,
+          isCustom: true,
+        })
+      }
+    }
+
+    const rail = cliQuery.data?.rail ?? []
+    for (const item of rail) {
+      if (seen.has(item.id)) continue
+      const edits = loadAgentEdit(item.id)
+      const name = edits.name || item.name || item.id
+      const command = edits.command || item.cli || ''
+      const folder = edits.folder || ''
+      seen.add(item.id)
+      list.push({
+        id: item.id,
+        name,
+        command: command || (item.installed ? 'installed' : 'not on PATH'),
+        folder,
+        description: item.description,
+        isCustom: false,
+      })
+    }
+
+    const catalog = blueprintsQuery.data?.data ?? []
+    for (const item of catalog) {
+      if (seen.has(item.id)) continue
+      if (item.category === 'cli' || item.tags?.includes('cli')) {
+        const edits = loadAgentEdit(item.id)
+        const name = edits.name || item.name || item.id
+        const command = edits.command || item.description || ''
+        const folder = edits.folder || ''
+        seen.add(item.id)
+        list.push({
+          id: item.id,
+          name,
+          command,
+          folder,
+          description: item.description,
+          isCustom: false,
+        })
+      }
+    }
+
+    return list
+  }, [customBlueprintsQuery.data, cliQuery.data, blueprintsQuery.data])
+
+  // Aggregate API agents
+  const apiAgents = useMemo<ManageAgentItem[]>(() => {
+    const list: ManageAgentItem[] = []
+    const seen = new Set<string>()
+
+    const customList = customBlueprintsQuery.data?.data ?? []
+    for (const item of customList) {
+      if (item.category === 'cli' || item.tags?.includes('cli')) continue
+      const edits = loadAgentEdit(item.id)
+      const name = edits.name || item.name || item.id
+      seen.add(item.id)
+      list.push({
+        id: item.id,
+        name,
+        description: item.description || '',
+        prompt: item.code || '',
+        isCustom: true,
+      })
+    }
+
+    const catalog = blueprintsQuery.data?.data ?? []
+    for (const item of catalog) {
+      if (seen.has(item.id)) continue
+      if (item.category === 'cli' || item.tags?.includes('cli')) continue
+      const edits = loadAgentEdit(item.id)
+      const name = edits.name || item.name || item.id
+      seen.add(item.id)
+      list.push({
+        id: item.id,
+        name,
+        description: item.description || '',
+        isCustom: false,
+      })
+    }
+
+    return list
+  }, [customBlueprintsQuery.data, blueprintsQuery.data])
+
+  const handleStartAddNew = () => {
+    resetFormFields()
+    setMode('create')
     setStep('configure')
+  }
+
+  const handleStartEdit = (agent: ManageAgentItem) => {
+    setError(null)
+    setFolderError(null)
+    setEditingAgentId(agent.id)
+    setMode('edit')
+    if (selectedKind === 'cli') {
+      setCliName(agent.name)
+      setCliCommand(agent.command || '')
+      setCliFolder(agent.folder || '')
+      setCliDescription(agent.description || '')
+    } else if (selectedKind === 'api') {
+      setApiName(agent.name)
+      setApiDescription(agent.description || '')
+      setApiPrompt(agent.prompt || '')
+    }
+    setStep('configure')
+  }
+
+  const handleOpenAgent = (agentId: string) => {
+    if (onSelectAgent) {
+      onSelectAgent(agentId)
+    } else if (typeof window !== 'undefined') {
+      window.location.href = `/chat?blueprint=${encodeURIComponent(agentId)}`
+    }
+    handleClose()
+  }
+
+  const handleCancelConfigure = () => {
+    if (selectedKind === 'remote') {
+      handleClose()
+    } else {
+      resetFormFields()
+      setStep('manage')
+    }
   }
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault()
     setError(null)
+
+    if (selectedKind === 'cli' && cliFolder.trim() && !isValidFolderPath(cliFolder)) {
+      setFolderError('Please enter a valid directory path (e.g. /path/to/dir or ./dir)')
+      return
+    }
+
     setSubmitting(true)
 
     try {
       if (selectedKind === 'cli') {
         const name = cliName.trim()
         const command = cliCommand.trim()
+        const folder = cliFolder.trim()
+        const description = cliDescription.trim()
         if (!name) throw new Error('Agent name is required')
         if (!command) throw new Error('CLI command or binary is required')
 
-        const created = await createCustomBlueprint({
-          name,
-          description: cliDescription.trim() || `CLI: ${command}`,
-          category: 'cli',
-          code: `# CLI agent: ${name}\n# Command: ${command}\n`,
-          tags: ['cli'],
-        })
+        const folderComment = folder ? `# Folder: ${folder}\n` : ''
+        const code = `# CLI agent: ${name}\n# Command: ${command}\n${folderComment}`
 
-        await queryClient.invalidateQueries({ queryKey: ['blueprints'] })
-        await queryClient.invalidateQueries({ queryKey: ['cli-agents'] })
-        onCreated?.({ id: created.id, name: created.name, kind: 'cli' })
-        handleClose()
+        if (mode === 'create') {
+          const created = await createCustomBlueprint({
+            name,
+            description: description || `CLI: ${command}`,
+            category: 'cli',
+            code,
+            tags: ['cli'],
+          })
+
+          saveAgentEdit(created.id, {
+            name,
+            command,
+            folder,
+          })
+
+          await queryClient.invalidateQueries({ queryKey: ['blueprints'] })
+          await queryClient.invalidateQueries({ queryKey: ['custom-blueprints'] })
+          await queryClient.invalidateQueries({ queryKey: ['cli-agents'] })
+          onCreated?.({ id: created.id, name: created.name, kind: 'cli' })
+          handleClose()
+        } else if (mode === 'edit' && editingAgentId) {
+          saveAgentEdit(editingAgentId, {
+            name,
+            command,
+            folder,
+          })
+
+          try {
+            await updateCustomBlueprint(editingAgentId, {
+              name,
+              description: description || `CLI: ${command}`,
+              code,
+            })
+          } catch {
+            // Local edits already saved via saveAgentEdit
+          }
+
+          await queryClient.invalidateQueries({ queryKey: ['blueprints'] })
+          await queryClient.invalidateQueries({ queryKey: ['custom-blueprints'] })
+          await queryClient.invalidateQueries({ queryKey: ['cli-agents'] })
+          resetFormFields()
+          setStep('manage')
+        }
       } else if (selectedKind === 'api') {
         const name = apiName.trim()
+        const description = apiDescription.trim()
+        const prompt = apiPrompt.trim()
         if (!name) throw new Error('Agent name is required')
 
-        const created = await createCustomBlueprint({
-          name,
-          description: apiDescription.trim(),
-          category: 'ai_assistants',
-          code: apiPrompt.trim() || `# API Assistant: ${name}\n`,
-          tags: ['api'],
-        })
+        if (mode === 'create') {
+          const created = await createCustomBlueprint({
+            name,
+            description,
+            category: 'ai_assistants',
+            code: prompt || `# API Assistant: ${name}\n`,
+            tags: ['api'],
+          })
 
-        await queryClient.invalidateQueries({ queryKey: ['blueprints'] })
-        onCreated?.({ id: created.id, name: created.name, kind: 'api' })
-        handleClose()
+          saveAgentEdit(created.id, { name })
+
+          await queryClient.invalidateQueries({ queryKey: ['blueprints'] })
+          await queryClient.invalidateQueries({ queryKey: ['custom-blueprints'] })
+          onCreated?.({ id: created.id, name: created.name, kind: 'api' })
+          handleClose()
+        } else if (mode === 'edit' && editingAgentId) {
+          saveAgentEdit(editingAgentId, { name })
+
+          try {
+            await updateCustomBlueprint(editingAgentId, {
+              name,
+              description,
+              code: prompt || `# API Assistant: ${name}\n`,
+            })
+          } catch {
+            // Local edits already saved via saveAgentEdit
+          }
+
+          await queryClient.invalidateQueries({ queryKey: ['blueprints'] })
+          await queryClient.invalidateQueries({ queryKey: ['custom-blueprints'] })
+          resetFormFields()
+          setStep('manage')
+        }
       } else if (selectedKind === 'remote') {
         const baseUrl = remoteBaseUrl.trim()
         if (!baseUrl) throw new Error('Base URL is required')
@@ -131,11 +410,13 @@ export default function AddAgentWizard({
         handleClose()
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create agent')
+      setError(err instanceof Error ? err.message : 'Failed to save agent')
     } finally {
       setSubmitting(false)
     }
   }
+
+  const currentAgents = selectedKind === 'cli' ? cliAgents : apiAgents
 
   return (
     <Modal
@@ -148,14 +429,18 @@ export default function AddAgentWizard({
       <div className="space-y-4" data-testid="add-agent-wizard">
         <div className="flex items-center justify-between border-b border-base-300 pb-3">
           <div className="flex items-center gap-2">
-            {step === 'configure' ? (
+            {step !== 'select_kind' ? (
               <button
                 type="button"
                 className="btn btn-ghost btn-sm btn-circle"
-                aria-label="Back to kind selection"
+                aria-label="Back"
                 onClick={() => {
                   setError(null)
-                  setStep('select_kind')
+                  if (step === 'configure' && selectedKind !== 'remote') {
+                    setStep('manage')
+                  } else {
+                    setStep('select_kind')
+                  }
                 }}
               >
                 <ArrowLeft className="h-4 w-4" aria-hidden="true" />
@@ -169,6 +454,12 @@ export default function AddAgentWizard({
               <h3 id={titleId} className="text-base font-semibold">
                 {step === 'select_kind'
                   ? 'Add Agent'
+                  : step === 'manage'
+                  ? selectedKind === 'cli'
+                    ? 'Manage CLI Agents'
+                    : 'Manage API Agents'
+                  : mode === 'edit'
+                  ? `Edit ${selectedKind === 'cli' ? 'CLI' : 'API'} Agent`
                   : selectedKind === 'cli'
                   ? 'Configure CLI Agent'
                   : selectedKind === 'api'
@@ -177,7 +468,11 @@ export default function AddAgentWizard({
               </h3>
               <p className="text-xs text-base-content/60">
                 {step === 'select_kind'
-                  ? 'Choose the type of agent to create'
+                  ? 'Choose the type of agent to manage or create'
+                  : step === 'manage'
+                  ? selectedKind === 'cli'
+                    ? 'Launch, edit, or create local command-line agents'
+                    : 'Launch, edit, or create API assistants'
                   : selectedKind === 'cli'
                   ? 'Connect a local command-line executable or script'
                   : selectedKind === 'api'
@@ -186,6 +481,19 @@ export default function AddAgentWizard({
               </p>
             </div>
           </div>
+
+          {step === 'manage' && (
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              onClick={handleStartAddNew}
+              data-testid="add-new-agent-btn"
+            >
+              <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+              Add new
+            </Button>
+          )}
         </div>
 
         {error ? (
@@ -195,7 +503,11 @@ export default function AddAgentWizard({
         ) : null}
 
         {step === 'select_kind' ? (
-          <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-3" role="radiogroup" aria-label="Agent kinds">
+          <div
+            className="grid grid-cols-1 gap-2.5 sm:grid-cols-3"
+            role="radiogroup"
+            aria-label="Agent kinds"
+          >
             {/* CLI */}
             <button
               type="button"
@@ -250,6 +562,98 @@ export default function AddAgentWizard({
               </div>
             </button>
           </div>
+        ) : step === 'manage' ? (
+          <div className="space-y-3" data-testid="manage-agent-surface">
+            {currentAgents.length === 0 ? (
+              <div
+                className="rounded-xl border border-dashed border-base-300 py-8 text-center"
+                data-testid="empty-manage-state"
+              >
+                <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full bg-base-200 text-base-content/50">
+                  {selectedKind === 'cli' ? (
+                    <Terminal className="h-5 w-5" />
+                  ) : (
+                    <Bot className="h-5 w-5" />
+                  )}
+                </div>
+                <p className="mt-2 text-sm font-medium">
+                  {selectedKind === 'cli' ? 'No CLI agents yet' : 'No API agents yet'}
+                </p>
+                <p className="mt-1 text-xs text-base-content/60">
+                  Get started by creating your first {selectedKind === 'cli' ? 'CLI' : 'API'} agent.
+                </p>
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="sm"
+                  className="mt-4"
+                  onClick={handleStartAddNew}
+                  data-testid="empty-add-btn"
+                >
+                  Add {selectedKind === 'cli' ? 'CLI' : 'API'} Agent
+                </Button>
+              </div>
+            ) : (
+              <div className="max-h-80 overflow-y-auto space-y-2 pr-1" data-testid="manage-agent-list">
+                {currentAgents.map((agent) => (
+                  <div
+                    key={agent.id}
+                    className="flex items-center justify-between rounded-lg border border-base-300 bg-base-100 p-2.5 hover:bg-base-200/40"
+                    data-testid={`agent-row-${agent.id}`}
+                  >
+                    <div className="flex items-center gap-2.5 min-w-0">
+                      <div
+                        className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${
+                          selectedKind === 'cli'
+                            ? 'bg-emerald-500/10 text-emerald-500'
+                            : 'bg-sky-500/10 text-sky-500'
+                        }`}
+                      >
+                        {selectedKind === 'cli' ? (
+                          <Terminal className="h-3.5 w-3.5" />
+                        ) : (
+                          <Bot className="h-3.5 w-3.5" />
+                        )}
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-xs font-semibold truncate leading-tight">{agent.name}</p>
+                        <p className="text-[11px] text-base-content/60 truncate font-mono mt-0.5">
+                          {selectedKind === 'cli'
+                            ? agent.command || 'CLI'
+                            : agent.description || 'API Assistant'}
+                          {agent.folder ? ` · ${agent.folder}` : ''}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1.5 shrink-0 ml-2">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="xs"
+                        onClick={() => handleStartEdit(agent)}
+                        data-testid={`edit-agent-${agent.id}`}
+                        aria-label={`Edit ${agent.name}`}
+                      >
+                        <Edit3 className="h-3.5 w-3.5" aria-hidden="true" />
+                        Edit
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="xs"
+                        onClick={() => handleOpenAgent(agent.id)}
+                        data-testid={`open-agent-${agent.id}`}
+                        aria-label={`Open ${agent.name}`}
+                      >
+                        <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                        Open
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         ) : (
           <form onSubmit={handleSubmit} className="space-y-3.5" data-testid="add-agent-form">
             {selectedKind === 'cli' ? (
@@ -284,6 +688,41 @@ export default function AddAgentWizard({
                     aria-label="CLI command"
                     data-testid="input-cli-command"
                   />
+                </div>
+                {/* REQ-167: CLI Folder workspace field */}
+                <div className="space-y-1">
+                  <label className="block text-xs font-medium text-base-content/80">
+                    Folder <span className="text-xs font-normal text-base-content/60">(optional)</span>
+                  </label>
+                  <input
+                    type="text"
+                    className={`input input-sm input-bordered w-full font-mono text-xs ${
+                      folderError ? 'input-error' : ''
+                    }`}
+                    placeholder="/path/to/working/directory or ./project"
+                    value={cliFolder}
+                    onChange={(e) => {
+                      const val = e.target.value
+                      setCliFolder(val)
+                      if (val && !isValidFolderPath(val)) {
+                        setFolderError(
+                          'Please enter a valid directory path (e.g. /path/to/dir or ./dir)',
+                        )
+                      } else {
+                        setFolderError(null)
+                      }
+                    }}
+                    aria-label="Folder"
+                    data-testid="input-cli-folder"
+                  />
+                  <span className="block text-[11px] text-base-content/60">
+                    Working directory for this CLI agent
+                  </span>
+                  {folderError ? (
+                    <span className="block text-xs text-error" data-testid="folder-error">
+                      {folderError}
+                    </span>
+                  ) : null}
                 </div>
                 <div className="space-y-1">
                   <label className="block text-xs font-medium text-base-content/80">
@@ -400,11 +839,24 @@ export default function AddAgentWizard({
             ) : null}
 
             <div className="flex items-center justify-end gap-2 pt-2">
-              <Button type="button" variant="ghost" size="sm" onClick={handleClose} disabled={submitting}>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={handleCancelConfigure}
+                disabled={submitting}
+              >
                 Cancel
               </Button>
-              <Button type="submit" variant="primary" size="sm" loading={submitting} data-testid="submit-create-agent">
-                Create Agent
+              <Button
+                type="submit"
+                variant="primary"
+                size="sm"
+                loading={submitting}
+                disabled={Boolean(folderError)}
+                data-testid="submit-create-agent"
+              >
+                {mode === 'edit' ? 'Save Changes' : 'Create Agent'}
               </Button>
             </div>
           </form>

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -246,18 +246,6 @@ export default function AgentSidebar({
     /Mac|iPod|iPhone|iPad/.test(navigator.platform || navigator.userAgent)
   const searchShortcutLabel = isMac ? '⌘K' : 'Ctrl+K'
   const [addWizardOpen, setAddWizardOpen] = useState(false)
-  const handleAgentCreated = useCallback(
-    (created: { id: string; name: string; kind: AgentKind }) => {
-      setAddWizardOpen(false)
-      if (created.kind === 'remote') {
-        navigate(`/chat?remote=${encodeURIComponent(created.id)}`)
-      } else {
-        navigate(`/chat?blueprint=${encodeURIComponent(created.id)}`)
-      }
-      onClose?.()
-    },
-    [navigate, onClose],
-  )
   const sessionsByAgent = useMemo(() => loadAllAgentSessions(), [sessionTick])
 
   useEffect(() => {
@@ -488,6 +476,30 @@ export default function AgentSidebar({
       persistVisibleOrder(moveRailId(base, fromId, beforeId))
     },
     [railOrder, visibleRowIds, persistVisibleOrder],
+  )
+
+  const handleAgentCreated = useCallback(
+    (created: { id: string; name: string; kind: AgentKind }) => {
+      setAddWizardOpen(false)
+      const base = mergeRailOrder(railOrder, visibleRowIds)
+      persistVisibleOrder(bumpRailIdToTop(base, created.id))
+      if (created.kind === 'remote') {
+        navigate(`/chat?remote=${encodeURIComponent(created.id)}`)
+      } else {
+        navigate(`/chat?blueprint=${encodeURIComponent(created.id)}`)
+      }
+      onClose?.()
+    },
+    [navigate, onClose, railOrder, visibleRowIds, persistVisibleOrder],
+  )
+
+  const handleAgentSelected = useCallback(
+    (agentId: string) => {
+      setAddWizardOpen(false)
+      navigate(`/chat?blueprint=${encodeURIComponent(agentId)}`)
+      onClose?.()
+    },
+    [navigate, onClose],
   )
 
   useEffect(() => {
@@ -1770,6 +1782,7 @@ export default function AgentSidebar({
         isOpen={addWizardOpen}
         onClose={() => setAddWizardOpen(false)}
         onCreated={handleAgentCreated}
+        onSelectAgent={handleAgentSelected}
       />
     </>
   )

--- a/webui/frontend/src/components/__tests__/AddAgentWizard.test.tsx
+++ b/webui/frontend/src/components/__tests__/AddAgentWizard.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import AddAgentWizard from '../AddAgentWizard'
 import * as api from '../../lib/api'
 import { OPENMOUSBOT_LABEL } from '../../lib/remotesCatalog'
+import * as agentEdits from '../../lib/agentEdits'
 
 function renderWizard(props: Partial<Parameters<typeof AddAgentWizard>[0]> = {}) {
   const queryClient = new QueryClient({
@@ -14,6 +15,7 @@ function renderWizard(props: Partial<Parameters<typeof AddAgentWizard>[0]> = {})
   })
   const onClose = vi.fn()
   const onCreated = vi.fn()
+  const onSelectAgent = vi.fn()
 
   const view = render(
     <QueryClientProvider client={queryClient}>
@@ -21,21 +23,32 @@ function renderWizard(props: Partial<Parameters<typeof AddAgentWizard>[0]> = {})
         isOpen={true}
         onClose={onClose}
         onCreated={onCreated}
+        onSelectAgent={onSelectAgent}
         {...props}
       />
     </QueryClientProvider>,
   )
 
-  return { ...view, onClose, onCreated, queryClient }
+  return { ...view, onClose, onCreated, onSelectAgent, queryClient }
 }
 
-describe('AddAgentWizard (REQ-109)', () => {
+describe('AddAgentWizard (REQ-109, REQ-165, REQ-167)', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    localStorage.clear()
+    vi.spyOn(api, 'fetchBlueprints').mockResolvedValue({ object: 'list', data: [] })
+    vi.spyOn(api, 'fetchCustomBlueprints').mockResolvedValue({ object: 'list', data: [] })
+    vi.spyOn(api, 'fetchCliAgents').mockResolvedValue({
+      clis: [],
+      native_consensus: {},
+      catalog: {},
+      rail: [],
+    })
   })
 
   afterEach(() => {
     vi.clearAllMocks()
+    localStorage.clear()
   })
 
   it('renders three agent kinds on step 1 with OpenMousBot copy for remote', () => {
@@ -51,20 +64,35 @@ describe('AddAgentWizard (REQ-109)', () => {
     expect(screen.queryByText(/^OMB$/)).not.toBeInTheDocument()
   })
 
-  it('closes wizard when Cancel button is clicked without creating', () => {
+  it('shows manage surface on choosing CLI or API, with empty state when none exist', () => {
+    renderWizard()
+
+    // Select CLI kind -> shows manage surface
+    fireEvent.click(screen.getByTestId('kind-option-cli'))
+    expect(screen.getByTestId('manage-agent-surface')).toBeInTheDocument()
+    expect(screen.getByText(/No CLI agents yet/i)).toBeInTheDocument()
+    expect(screen.getByTestId('empty-add-btn')).toBeInTheDocument()
+  })
+
+  it('navigates to configure form from empty manage state and cancels back', () => {
     const { onClose, onCreated } = renderWizard()
 
-    // Select CLI kind to see form
+    // Select CLI kind to see manage surface
     fireEvent.click(screen.getByTestId('kind-option-cli'))
+    expect(screen.getByTestId('empty-add-btn')).toBeInTheDocument()
+
+    // Click Add CLI Agent
+    fireEvent.click(screen.getByTestId('empty-add-btn'))
     expect(screen.getByTestId('add-agent-form')).toBeInTheDocument()
 
-    // Click Cancel
+    // Click Cancel returns to manage surface (Cancel leaves no changes)
     fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
-    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('manage-agent-surface')).toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
     expect(onCreated).not.toHaveBeenCalled()
   })
 
-  it('creates a CLI agent on happy-path submit', async () => {
+  it('creates a CLI agent with optional Folder field on happy-path submit', async () => {
     const createSpy = vi.spyOn(api, 'createCustomBlueprint').mockResolvedValue({
       id: 'custom_cli_agent',
       name: 'My CLI Tool',
@@ -72,16 +100,21 @@ describe('AddAgentWizard (REQ-109)', () => {
       category: 'cli',
       tags: ['cli'],
       requirements: '',
-      code: '# CLI agent: My CLI Tool\n',
+      code: '# CLI agent: My CLI Tool\n# Command: custom-tool\n# Folder: /home/dev/tool\n',
       required_mcp_servers: [],
       env_vars: [],
     })
 
     const { onCreated, onClose } = renderWizard()
 
-    // Select CLI
+    // Select CLI -> manage surface -> Add new
     fireEvent.click(screen.getByTestId('kind-option-cli'))
+    fireEvent.click(screen.getByTestId('empty-add-btn'))
     expect(screen.getByTestId('input-cli-name')).toBeInTheDocument()
+
+    // REQ-167: Folder field rendered with help text
+    expect(screen.getByTestId('input-cli-folder')).toBeInTheDocument()
+    expect(screen.getByText(/Working directory for this CLI agent/i)).toBeInTheDocument()
 
     // Fill in inputs
     fireEvent.change(screen.getByTestId('input-cli-name'), {
@@ -89,6 +122,9 @@ describe('AddAgentWizard (REQ-109)', () => {
     })
     fireEvent.change(screen.getByTestId('input-cli-command'), {
       target: { value: 'custom-tool' },
+    })
+    fireEvent.change(screen.getByTestId('input-cli-folder'), {
+      target: { value: '/home/dev/tool' },
     })
 
     // Submit
@@ -99,6 +135,7 @@ describe('AddAgentWizard (REQ-109)', () => {
         expect.objectContaining({
           name: 'My CLI Tool',
           category: 'cli',
+          code: expect.stringContaining('# Folder: /home/dev/tool'),
         }),
       )
       expect(onCreated).toHaveBeenCalledWith({
@@ -108,6 +145,21 @@ describe('AddAgentWizard (REQ-109)', () => {
       })
       expect(onClose).toHaveBeenCalled()
     })
+  })
+
+  it('shows inline error on invalid folder path format', () => {
+    renderWizard()
+
+    fireEvent.click(screen.getByTestId('kind-option-cli'))
+    fireEvent.click(screen.getByTestId('empty-add-btn'))
+
+    // Type invalid folder path with wildcard character
+    fireEvent.change(screen.getByTestId('input-cli-folder'), {
+      target: { value: '/invalid/*/path' },
+    })
+
+    expect(screen.getByTestId('folder-error')).toBeInTheDocument()
+    expect(screen.getByTestId('submit-create-agent')).toBeDisabled()
   })
 
   it('creates an API agent on happy-path submit', async () => {
@@ -125,8 +177,9 @@ describe('AddAgentWizard (REQ-109)', () => {
 
     const { onCreated, onClose } = renderWizard()
 
-    // Select API
+    // Select API -> manage surface -> Add new
     fireEvent.click(screen.getByTestId('kind-option-api'))
+    fireEvent.click(screen.getByTestId('empty-add-btn'))
     expect(screen.getByTestId('input-api-name')).toBeInTheDocument()
 
     // Fill in inputs
@@ -156,6 +209,111 @@ describe('AddAgentWizard (REQ-109)', () => {
     })
   })
 
+  it('lists existing agents with Open and Edit actions', async () => {
+    vi.spyOn(api, 'fetchCustomBlueprints').mockResolvedValue({
+      object: 'list',
+      data: [
+        {
+          id: 'custom_cli_1',
+          name: 'My Custom CLI',
+          description: 'CLI tool',
+          category: 'cli',
+          tags: ['cli'],
+          requirements: '',
+          code: '# CLI agent: My Custom CLI\n# Command: my-cli\n# Folder: /tmp/my-cli\n',
+          required_mcp_servers: [],
+          env_vars: [],
+        },
+      ],
+    })
+
+    const { onSelectAgent, onClose } = renderWizard()
+
+    fireEvent.click(screen.getByTestId('kind-option-cli'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('manage-agent-list')).toBeInTheDocument()
+      expect(screen.getByText('My Custom CLI')).toBeInTheDocument()
+      expect(screen.getByTestId('open-agent-custom_cli_1')).toBeInTheDocument()
+      expect(screen.getByTestId('edit-agent-custom_cli_1')).toBeInTheDocument()
+    })
+
+    // Click Open -> selects agent and closes
+    fireEvent.click(screen.getByTestId('open-agent-custom_cli_1'))
+    expect(onSelectAgent).toHaveBeenCalledWith('custom_cli_1')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('edits an existing agent and saves changes', async () => {
+    vi.spyOn(api, 'fetchCustomBlueprints').mockResolvedValue({
+      object: 'list',
+      data: [
+        {
+          id: 'custom_cli_1',
+          name: 'My Custom CLI',
+          description: 'CLI tool',
+          category: 'cli',
+          tags: ['cli'],
+          requirements: '',
+          code: '# CLI agent: My Custom CLI\n# Command: my-cli\n# Folder: /tmp/my-cli\n',
+          required_mcp_servers: [],
+          env_vars: [],
+        },
+      ],
+    })
+
+    const updateSpy = vi.spyOn(api, 'updateCustomBlueprint').mockResolvedValue({
+      id: 'custom_cli_1',
+      name: 'Updated CLI Tool',
+      description: 'Updated description',
+      category: 'cli',
+      tags: ['cli'],
+      requirements: '',
+      code: '# CLI agent: Updated CLI Tool\n# Command: updated-cli\n# Folder: /home/repo\n',
+      required_mcp_servers: [],
+      env_vars: [],
+    })
+
+    renderWizard()
+
+    fireEvent.click(screen.getByTestId('kind-option-cli'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-agent-custom_cli_1')).toBeInTheDocument()
+    })
+
+    // Click Edit
+    fireEvent.click(screen.getByTestId('edit-agent-custom_cli_1'))
+    expect(screen.getByTestId('add-agent-form')).toBeInTheDocument()
+    expect(screen.getByTestId('input-cli-name')).toHaveValue('My Custom CLI')
+
+    // Modify fields
+    fireEvent.change(screen.getByTestId('input-cli-name'), {
+      target: { value: 'Updated CLI Tool' },
+    })
+    fireEvent.change(screen.getByTestId('input-cli-command'), {
+      target: { value: 'updated-cli' },
+    })
+    fireEvent.change(screen.getByTestId('input-cli-folder'), {
+      target: { value: '/home/repo' },
+    })
+
+    // Save changes
+    fireEvent.click(screen.getByTestId('submit-create-agent'))
+
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith(
+        'custom_cli_1',
+        expect.objectContaining({
+          name: 'Updated CLI Tool',
+          code: expect.stringContaining('# Folder: /home/repo'),
+        }),
+      )
+      // Returns to manage surface
+      expect(screen.getByTestId('manage-agent-surface')).toBeInTheDocument()
+    })
+  })
+
   it('connects a Remote agent on happy-path submit', async () => {
     const createRemoteSpy = vi.spyOn(api, 'createRemote').mockResolvedValue({
       id: 'omb-remote-1',
@@ -169,7 +327,7 @@ describe('AddAgentWizard (REQ-109)', () => {
 
     const { onCreated, onClose } = renderWizard()
 
-    // Select Remote
+    // Select Remote -> configure form
     fireEvent.click(screen.getByTestId('kind-option-remote'))
     expect(screen.getByTestId('input-remote-url')).toBeInTheDocument()
 

--- a/webui/frontend/src/lib/agentEdits.ts
+++ b/webui/frontend/src/lib/agentEdits.ts
@@ -26,6 +26,8 @@ export interface AgentEdit {
   role?: AgentRole
   blueprintId?: string
   llmOverride?: string
+  folder?: string
+  command?: string
 }
 
 export type AgentEditMap = Record<string, AgentEdit>
@@ -94,6 +96,16 @@ export function saveAgentEdit(agentId: string, patch: AgentEdit): AgentEdit {
     const llm = patch.llmOverride.trim()
     if (llm) next.llmOverride = llm
     else delete next.llmOverride
+  }
+  if (patch.folder !== undefined) {
+    const folder = patch.folder.trim()
+    if (folder) next.folder = folder
+    else delete next.folder
+  }
+  if (patch.command !== undefined) {
+    const command = patch.command.trim()
+    if (command) next.command = command
+    else delete next.command
   }
 
   if (Object.keys(next).length === 0) delete map[agentId]


### PR DESCRIPTION
Fixes #586
Fixes #590

### Summary
1. **Manage CLI & API from Add-agent (REQ-165)**: Choosing CLI or API from the Add-agent popup wizard displays a manage surface listing existing agents of that kind with short metadata (command/folder/description/model).
2. **Open & Edit**: From the manage list, open/select agents in chat and edit core fields. Cancel leaves no changes.
3. **Empty state & Add new**: Clear empty state copy with primary Add button when no agents exist. Add new CTA remains available when list is populated.
4. **Folder workspace field (REQ-167)**: Optional Folder field with label 'Folder' and help 'Working directory for this CLI agent'. Includes client-side path format validation.
5. **#585 Addendum**: New agent created from wizard bumps to top (index 0) of unpinned rail (no auto-pin).