### PR TITLE
fix(remotes): bounded timeout and robust listing for OpenMousBot (REQ-131, Fixes #521)

### DIFF
--- a/src/swarm/core/remote_teams.py
+++ b/src/swarm/core/remote_teams.py
@@ -394,6 +394,8 @@ _DISCOVERY_CAP = 32
 _DISCOVERY_PATHS: dict[str, tuple[str, ...]] = {
     "hermes": ("/v1/models", "/v1/agents/", "/api/sessions"),
     "rakazo": ("/api/bots", "/api/agents", "/v1/agents/", "/v1/models"),
+    "openmousbot": ("/api/bots", "/v1/agents/", "/v1/models"),
+    "omb": ("/api/bots", "/v1/agents/", "/v1/models"),
     "openmausbot": ("/api/bots", "/v1/agents/", "/v1/models"),
     "dsh": ("/v1/models", "/v1/agents/", "/api/tags"),
 }

--- a/src/swarm/core/remotes.py
+++ b/src/swarm/core/remotes.py
@@ -1120,10 +1120,16 @@ def _hermes_send(
 
 
 def _omb_list(spec: RemoteSpec, timeout: float) -> OperateResult:
-    result = http_json("GET", f"{spec.base_url}/api/bots", headers=_auth_headers(spec), timeout=timeout)
+    base_url = (spec.base_url or "").rstrip("/")
+    timeout_s = min(float(timeout or _OPERATE_TIMEOUT_S), 10.0)
+    result = http_json("GET", f"{base_url}/api/bots", headers=_auth_headers(spec), timeout=timeout_s)
     if result.status in _UP:
-        bots = result.body.get("bots") if isinstance(result.body, dict) else result.body
-        count = len(bots) if isinstance(bots, list) else "?"
+        bots = None
+        if isinstance(result.body, dict):
+            bots = result.body.get("bots") or result.body.get("agents") or result.body.get("data")
+        elif isinstance(result.body, list):
+            bots = result.body
+        count = len(bots) if isinstance(bots, list) else (1 if bots else 0)
         return OperateResult(
             remote="omb",
             op="list",
@@ -1156,16 +1162,20 @@ def _omb_send(spec: RemoteSpec, prompt: str, target: str, timeout: float) -> Ope
         return OperateResult(remote="omb", op="send", ok=False, detail="prompt is required")
     bot_id = (target or "").strip()
     headers = _auth_headers(spec)
+    base_url = (spec.base_url or "").rstrip("/")
+    timeout_s = min(float(timeout or _OPERATE_TIMEOUT_S), 10.0)
     if not bot_id:
-        listed = _omb_list(spec, timeout)
+        listed = _omb_list(spec, timeout_s)
         bots = []
         if listed.ok and isinstance(listed.data, dict):
-            bots = listed.data.get("bots") or []
+            bots = listed.data.get("bots") or listed.data.get("agents") or []
+        elif listed.ok and isinstance(listed.data, list):
+            bots = listed.data
         if isinstance(bots, list) and bots:
             first = bots[0] if isinstance(bots[0], dict) else {}
             bot_id = str(first.get("id") or "")
         if not bot_id:
-            created = http_json("POST", f"{spec.base_url}/api/bots", headers=headers, body={}, timeout=timeout)
+            created = http_json("POST", f"{base_url}/api/bots", headers=headers, body={}, timeout=timeout_s)
             if created.status in _UP and isinstance(created.body, dict):
                 bot = created.body.get("bot") or {}
                 bot_id = str(bot.get("id") or "")
@@ -1180,10 +1190,10 @@ def _omb_send(spec: RemoteSpec, prompt: str, target: str, timeout: float) -> Ope
                 )
     result = http_json(
         "POST",
-        f"{spec.base_url}/api/bots/{bot_id}/messages",
+        f"{base_url}/api/bots/{bot_id}/messages",
         headers=headers,
         body={"text": prompt},
-        timeout=timeout,
+        timeout=timeout_s,
     )
     if result.status in _UP or result.status == 202:
         return OperateResult(

--- a/tests/unit/test_req131_omb_list_timeout.py
+++ b/tests/unit/test_req131_omb_list_timeout.py
@@ -1,0 +1,94 @@
+"""REQ-131: OpenMousBot List bots — progressive populate (slow, not hung).
+
+Intent: If health is up, listing bots must complete (success or clear error)
+within a bounded timeout (<=10-15s) — never an infinite spinner.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+from swarm.core.remotes import RemoteSpec, _omb_list, HttpResult
+from swarm.core.remote_teams import _DISCOVERY_PATHS
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REMOTES_SETTINGS_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "RemotesSettings.tsx"
+API_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "api.ts"
+
+
+def test_discovery_paths_includes_openmousbot_and_omb():
+    assert "openmousbot" in _DISCOVERY_PATHS
+    assert "omb" in _DISCOVERY_PATHS
+    assert "/api/bots" in _DISCOVERY_PATHS["openmousbot"]
+    assert "/api/bots" in _DISCOVERY_PATHS["omb"]
+
+
+def test_omb_list_strips_trailing_slash_and_bounds_timeout():
+    spec = RemoteSpec(id="omb", title="OpenMousBot", host_label="OMB", base_url="http://example.com:8000/", api_key="secret")
+    with patch("swarm.core.remotes.http_json") as mock_http:
+        mock_http.return_value = HttpResult(
+            status=200,
+            body={"bots": [{"id": "bot-1", "name": "Agent 1"}]},
+            url="http://example.com:8000/api/bots",
+        )
+        res = _omb_list(spec, timeout=30.0)
+
+        # Timeout should be bounded to <= 10.0s
+        mock_http.assert_called_once()
+        _, kwargs = mock_http.call_args
+        assert kwargs["timeout"] <= 10.0
+        # URL must not contain double slashes
+        assert mock_http.call_args[0][1] == "http://example.com:8000/api/bots"
+        assert res.ok is True
+        assert "1 bot(s)" in res.detail
+
+
+def test_omb_list_handles_alternate_response_shapes():
+    spec = RemoteSpec(id="omb", title="OpenMousBot", host_label="OMB", base_url="http://example.com:8000")
+    with patch("swarm.core.remotes.http_json") as mock_http:
+        # Array response
+        mock_http.return_value = HttpResult(
+            status=200,
+            body=[{"id": "bot-a"}, {"id": "bot-b"}],
+            url="http://example.com:8000/api/bots",
+        )
+        res = _omb_list(spec, timeout=5.0)
+        assert res.ok is True
+        assert "2 bot(s)" in res.detail
+
+        # Agents key response
+        mock_http.return_value = HttpResult(
+            status=200,
+            body={"agents": [{"id": "agent-1"}]},
+            url="http://example.com:8000/api/bots",
+        )
+        res = _omb_list(spec, timeout=5.0)
+        assert res.ok is True
+        assert "1 bot(s)" in res.detail
+
+
+def test_omb_list_handles_http_error_gracefully():
+    spec = RemoteSpec(id="omb", title="OpenMousBot", host_label="OMB", base_url="http://example.com:8000")
+    with patch("swarm.core.remotes.http_json") as mock_http:
+        mock_http.return_value = HttpResult(
+            status=504,
+            error="Gateway Timeout",
+            url="http://example.com:8000/api/bots",
+        )
+        res = _omb_list(spec, timeout=5.0)
+        assert res.ok is False
+        assert "Gateway Timeout" in res.detail
+
+
+def test_frontend_operate_remote_bounded_timeout():
+    content = API_TS.read_text(encoding="utf-8")
+    assert "timeoutMs" in content
+    assert "AbortController" in content
+    assert "signal: controller.signal" in content
+    assert "OpenMousBot list operation timed out" in content
+
+
+def test_frontend_remotes_settings_bots_from_operate():
+    content = REMOTES_SETTINGS_TSX.read_text(encoding="utf-8")
+    assert "botsFromOperate" in content
+    assert "'agents' in raw" in content
+    assert "'data' in raw" in content
+    assert "timeoutMs: 12000" in content

--- a/webui/frontend/src/components/RemotesSettings.tsx
+++ b/webui/frontend/src/components/RemotesSettings.tsx
@@ -136,8 +136,19 @@ function botsFromOperate(result: RemoteOperateResult | undefined): Array<{ id: s
   if (!result?.data) return []
   const raw = result.data
   let list: unknown = raw
-  if (raw && typeof raw === 'object' && 'bots' in raw) {
-    list = (raw as { bots: unknown }).bots
+  if (raw && typeof raw === 'object') {
+    if ('bots' in raw) {
+      list = (raw as { bots: unknown }).bots
+    } else if ('agents' in raw) {
+      list = (raw as { agents: unknown }).agents
+    } else if ('data' in raw) {
+      const d = (raw as { data: unknown }).data
+      if (Array.isArray(d)) {
+        list = d
+      } else if (d && typeof d === 'object' && 'bots' in d) {
+        list = (d as { bots: unknown }).bots
+      }
+    }
   }
   if (!Array.isArray(list)) return []
   return list
@@ -176,7 +187,7 @@ export function RemoteOperatePane({ remote }: { remote: RemoteConnection }) {
   })
 
   const listMutation = useMutation({
-    mutationFn: () => operateRemote(remote.id, { op: 'list' }),
+    mutationFn: () => operateRemote(remote.id, { op: 'list' }, { timeoutMs: 12000 }),
     onSuccess: (result) => {
       setListed(result)
       const bots = botsFromOperate(result)

--- a/webui/frontend/src/components/__tests__/RemotesSettings.test.tsx
+++ b/webui/frontend/src/components/__tests__/RemotesSettings.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RemoteOperatePane } from '../RemotesSettings'
+import { ToastProvider } from '../DaisyUI'
+import * as api from '../../lib/api'
+
+function renderPane(remote = { id: 'omb', label: 'OpenMousBot', base_url: 'http://localhost:8000' }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>
+        <RemoteOperatePane remote={remote as any} />
+      </ToastProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('RemotesSettings RemoteOperatePane (REQ-131)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders List bots button and stops spinner on success', async () => {
+    vi.spyOn(api, 'operateRemote').mockResolvedValue({
+      remote: 'omb',
+      op: 'list',
+      ok: true,
+      detail: 'OpenMousBot listed 2 bot(s) via GET /api/bots',
+      data: { bots: [{ id: 'bot-1', name: 'Alpha Bot' }, { id: 'bot-2', name: 'Beta Bot' }] },
+    })
+
+    renderPane()
+
+    const listBtn = screen.getByRole('button', { name: /list bots/i })
+    expect(listBtn).toBeInTheDocument()
+
+    fireEvent.click(listBtn)
+
+    await waitFor(() => {
+      expect(screen.getByText(/bot-1 · Alpha Bot/i)).toBeInTheDocument()
+      expect(screen.getByText(/bot-2 · Beta Bot/i)).toBeInTheDocument()
+      expect(listBtn).not.toHaveAttribute('aria-busy', 'true')
+    })
+  })
+
+  it('stops spinner and renders error alert when list times out or fails', async () => {
+    vi.spyOn(api, 'operateRemote').mockRejectedValue(
+      new Error('OpenMousBot list operation timed out after 12s. Remote server is slow or hung.'),
+    )
+
+    renderPane()
+
+    const listBtn = screen.getByRole('button', { name: /list bots/i })
+    fireEvent.click(listBtn)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/OpenMousBot list operation timed out after 12s/i),
+      ).toBeInTheDocument()
+      expect(listBtn).not.toHaveAttribute('aria-busy', 'true')
+    })
+  })
+})

--- a/webui/frontend/src/lib/api.ts
+++ b/webui/frontend/src/lib/api.ts
@@ -512,14 +512,48 @@ export function probeRemoteHealth(remoteId: string): Promise<RemoteHealthResult>
   )
 }
 
-export function operateRemote(
+export interface OperateRemoteOptions {
+  timeoutMs?: number
+}
+
+/**
+ * REQ-131: Operate remote (list/send) with bounded timeout (<=10-15s).
+ * Prevents endless spinner if remote hangs or is unresponsive.
+ */
+export async function operateRemote(
   remoteId: string,
   body: { op: 'list' | 'send'; prompt?: string; target?: string },
+  options?: OperateRemoteOptions,
 ): Promise<RemoteOperateResult> {
-  return apiPost<RemoteOperateResult>(
-    `/v1/remotes/${encodeURIComponent(remoteId)}/operate/`,
-    body,
-  )
+  const timeoutMs = options?.timeoutMs ?? 12000
+  const controller = new AbortController()
+  const timer = setTimeout(() => {
+    controller.abort()
+  }, timeoutMs)
+
+  try {
+    const response = await fetch(`/v1/remotes/${encodeURIComponent(remoteId)}/operate/`, {
+      method: 'POST',
+      headers: buildHeaders(true),
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    })
+
+    if (!response.ok) {
+      await throwApiError(`/v1/remotes/${encodeURIComponent(remoteId)}/operate/`, response)
+    }
+
+    return (await response.json()) as RemoteOperateResult
+  } catch (err: unknown) {
+    if (controller.signal.aborted) {
+      throw new Error(
+        `OpenMousBot list operation timed out after ${Math.round(timeoutMs / 1000)}s. Remote server is slow or hung.`,
+      )
+    }
+    throw err
+  } finally {
+    clearTimeout(timer)
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #521

### Summary
1. **Bounded Timeout for OMB List Bots (REQ-131)**: Client-side `operateRemote` enforces a 12s bounded timeout via `AbortController` (`<=10-15s`) and backend `_omb_list` caps timeout at 10.0s.
2. **Spinner Stops Guarantee**: On timeout, error, or success, the spinner in `RemotesSettings` stops immediately, displaying either the bot roster or a clear error alert. Never spins endlessly.
3. **Robust Request/Response Paths**: Normalizes remote `base_url` by stripping trailing slashes to prevent double slashes. Handles list, array, and dict responses (`bots`, `agents`, `data`).
4. **Discovery Paths**: Added `"openmousbot"` and `"omb"` to `_DISCOVERY_PATHS` in `remote_teams.py` to ensure discovery hits `/api/bots` first.