### PR TITLE
feat(webui): composer / popup to search skills and actions (Fixes #594)

### DIFF
--- a/tests/unit/test_req169_composer_slash_catalog.py
+++ b/tests/unit/test_req169_composer_slash_catalog.py
@@ -1,0 +1,52 @@
+"""
+Contract and unit tests for REQ-169 slash catalog (skills and actions).
+Verifies that slash actions and skills expected by the composer popup are
+registered and discoverable in the backend.
+"""
+
+import pytest
+from swarm.core.slash_commands import slash_registry
+from swarm.core.skills import discover_skills
+
+
+def test_core_slash_actions_registered():
+    """Verify standard composer slash actions exist in slash_registry."""
+    expected_actions = [
+        "/compact",
+        "/help",
+        "/model",
+        "/clear",
+        "/approval",
+        "/history",
+    ]
+    for action in expected_actions:
+        fn = slash_registry.get(action)
+        assert fn is not None, f"Expected action {action} to be registered in slash_registry"
+        assert callable(fn)
+
+
+def test_standard_skills_discoverable():
+    """Verify standard skills referenced in the frontend composer catalog exist."""
+    skills = discover_skills()
+    expected_skills = [
+        "conventional-commit",
+        "counting-lines",
+        "reviewing-code",
+        "support-session-ownership",
+        "writing-changelog",
+    ]
+    for skill_name in expected_skills:
+        assert skill_name in skills, f"Expected skill {skill_name} in discovered skills"
+        skill = skills[skill_name]
+        assert skill.name == skill_name
+        assert skill.description, f"Skill {skill_name} must have a description"
+        assert skill.instructions, f"Skill {skill_name} must have instructions"
+
+
+def test_compact_action_callable():
+    """Verify /compact slash command returns expected error or summary string."""
+    fn = slash_registry.get("/compact")
+    # Calling without active context returns fallback message
+    res = fn()
+    assert isinstance(res, str)
+    assert "compact" in res.lower()

--- a/webui/frontend/src/components/ComposerSlashPopup.tsx
+++ b/webui/frontend/src/components/ComposerSlashPopup.tsx
@@ -1,0 +1,190 @@
+import { useMemo, useEffect, useRef } from 'react'
+import {
+  Layers,
+  HelpCircle,
+  Cpu,
+  Trash2,
+  Shield,
+  History,
+  GitCommit,
+  FileText,
+  CheckSquare,
+  LifeBuoy,
+  ListPlus,
+  Sparkles,
+  Terminal,
+} from 'lucide-react'
+import { SlashItem, groupSlashItems } from '../lib/slashMenu'
+
+export interface ComposerSlashPopupProps {
+  open: boolean
+  query: string
+  items: SlashItem[]
+  selectedIndex: number
+  onSelectIndex: (index: number) => void
+  onSelectItem: (item: SlashItem) => void
+  recentIds?: string[]
+}
+
+function SlashIcon({ iconName, className }: { iconName?: string; className?: string }) {
+  switch (iconName) {
+    case 'Layers':
+      return <Layers className={className} aria-hidden="true" />
+    case 'HelpCircle':
+      return <HelpCircle className={className} aria-hidden="true" />
+    case 'Cpu':
+      return <Cpu className={className} aria-hidden="true" />
+    case 'Trash2':
+      return <Trash2 className={className} aria-hidden="true" />
+    case 'Shield':
+      return <Shield className={className} aria-hidden="true" />
+    case 'History':
+      return <History className={className} aria-hidden="true" />
+    case 'GitCommit':
+      return <GitCommit className={className} aria-hidden="true" />
+    case 'FileText':
+      return <FileText className={className} aria-hidden="true" />
+    case 'CheckSquare':
+      return <CheckSquare className={className} aria-hidden="true" />
+    case 'LifeBuoy':
+      return <LifeBuoy className={className} aria-hidden="true" />
+    case 'ListPlus':
+      return <ListPlus className={className} aria-hidden="true" />
+    case 'Sparkles':
+      return <Sparkles className={className} aria-hidden="true" />
+    default:
+      return <Terminal className={className} aria-hidden="true" />
+  }
+}
+
+export function ComposerSlashPopup({
+  open,
+  query,
+  items,
+  selectedIndex,
+  onSelectIndex,
+  onSelectItem,
+  recentIds = [],
+}: ComposerSlashPopupProps) {
+  const listRef = useRef<HTMLDivElement>(null)
+
+  const groups = useMemo(
+    () => groupSlashItems(items, query, recentIds),
+    [items, query, recentIds],
+  )
+
+  // Scroll active item into view
+  useEffect(() => {
+    if (!open || !listRef.current) return
+    const activeEl = listRef.current.querySelector('[aria-selected="true"]')
+    if (activeEl && typeof activeEl.scrollIntoView === 'function') {
+      activeEl.scrollIntoView({ block: 'nearest' })
+    }
+  }, [open, selectedIndex])
+
+  if (!open) return null
+
+  let itemCounter = 0
+
+  return (
+    <div
+      ref={listRef}
+      id="composer-slash-menu"
+      role="listbox"
+      aria-label="Skills and actions"
+      className="os-slash-popup absolute bottom-[calc(100%+0.5rem)] left-0 right-0 z-30 max-h-80 overflow-y-auto rounded-2xl border border-base-300 bg-base-100/95 p-1.5 shadow-2xl backdrop-blur-md"
+      data-testid="composer-slash-popup"
+    >
+      {items.length === 0 ? (
+        <div
+          className="py-6 text-center text-sm text-base-content/50"
+          data-testid="slash-empty"
+        >
+          No matching skills or actions
+        </div>
+      ) : (
+        groups.map((group) => (
+          <div key={group.label} className="mb-1.5 last:mb-0">
+            <div className="px-2.5 py-1 text-[11px] font-semibold tracking-wider uppercase text-base-content/40">
+              {group.label}
+            </div>
+            <div className="space-y-0.5">
+              {group.items.map((item) => {
+                const currentIndex = itemCounter++
+                const isSelected = currentIndex === selectedIndex
+                return (
+                  <button
+                    key={`${group.label}-${item.id}`}
+                    type="button"
+                    role="option"
+                    aria-selected={isSelected}
+                    data-testid={`slash-item-${item.id}`}
+                    data-slash-kind={item.kind}
+                    className={`group flex w-full min-h-[44px] items-center justify-between gap-3 rounded-xl px-3 py-2 text-left transition-colors ${
+                      isSelected
+                        ? 'bg-base-200 text-base-content font-medium'
+                        : 'text-base-content/85 hover:bg-base-200/60'
+                    }`}
+                    onMouseEnter={() => onSelectIndex(currentIndex)}
+                    onClick={(e) => {
+                      e.preventDefault()
+                      onSelectItem(item)
+                    }}
+                  >
+                    <div className="flex items-center gap-2.5 min-w-0 flex-1">
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-base-300/60 text-base-content/70 group-hover:text-base-content">
+                        <SlashIcon iconName={item.iconName} className="h-4 w-4" />
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium text-sm truncate">{item.title}</span>
+                          <code className="text-xs text-base-content/50 font-mono">
+                            {item.command}
+                          </code>
+                        </div>
+                        <p className="text-xs text-base-content/60 truncate">
+                          {item.description}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      {group.label === 'Recent' ? (
+                        <span className="badge badge-xs badge-ghost text-[10px] text-base-content/60 px-1.5 py-0.5">
+                          Recent
+                        </span>
+                      ) : null}
+                      {item.kind === 'action' ? (
+                        <span className="badge badge-xs badge-primary badge-outline text-[10px] tracking-wide uppercase px-1.5 py-0.5">
+                          Action
+                        </span>
+                      ) : (
+                        <span className="badge badge-xs badge-neutral text-[10px] tracking-wide uppercase px-1.5 py-0.5">
+                          Skill
+                        </span>
+                      )}
+                    </div>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        ))
+      )}
+
+      <div className="border-t border-base-300/50 mt-1 px-3 py-1.5 flex items-center justify-between text-[11px] text-base-content/40">
+        <span>Type to filter</span>
+        <span className="hidden sm:flex items-center gap-1.5">
+          <kbd className="kbd kbd-xs">↑</kbd>
+          <kbd className="kbd kbd-xs">↓</kbd>
+          <span>navigate</span>
+          <span className="mx-0.5">·</span>
+          <kbd className="kbd kbd-xs">↵</kbd>
+          <span>select</span>
+          <span className="mx-0.5">·</span>
+          <kbd className="kbd kbd-xs">esc</kbd>
+          <span>dismiss</span>
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/webui/frontend/src/components/__tests__/ComposerSlashPopup.test.tsx
+++ b/webui/frontend/src/components/__tests__/ComposerSlashPopup.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ComposerSlashPopup } from '../ComposerSlashPopup'
+import { buildSlashCatalog, filterSlashItems } from '../../lib/slashMenu'
+
+describe('ComposerSlashPopup', () => {
+  const catalog = buildSlashCatalog()
+
+  it('renders nothing when open is false', () => {
+    const { container } = render(
+      <ComposerSlashPopup
+        open={false}
+        query=""
+        items={catalog}
+        selectedIndex={0}
+        onSelectIndex={vi.fn()}
+        onSelectItem={vi.fn()}
+      />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders Actions and Skills sections when query is empty', () => {
+    const items = filterSlashItems(catalog, '', [])
+    render(
+      <ComposerSlashPopup
+        open={true}
+        query=""
+        items={items}
+        selectedIndex={0}
+        onSelectIndex={vi.fn()}
+        onSelectItem={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByTestId('composer-slash-popup')).toBeInTheDocument()
+    expect(screen.getByText('Actions')).toBeInTheDocument()
+    expect(screen.getByText('Skills')).toBeInTheDocument()
+    expect(screen.getByText('Compact')).toBeInTheDocument()
+    expect(screen.getByText('/compact')).toBeInTheDocument()
+    expect(screen.getByText('Conventional Commit')).toBeInTheDocument()
+  })
+
+  it('renders Recent section when recentIds are provided with empty query', () => {
+    const recentIds = ['compact']
+    const items = filterSlashItems(catalog, '', recentIds)
+    render(
+      <ComposerSlashPopup
+        open={true}
+        query=""
+        items={items}
+        selectedIndex={0}
+        onSelectIndex={vi.fn()}
+        onSelectItem={vi.fn()}
+        recentIds={recentIds}
+      />,
+    )
+
+    const recentElements = screen.getAllByText('Recent')
+    // Section title + badge
+    expect(recentElements.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('displays empty state when items list is empty', () => {
+    render(
+      <ComposerSlashPopup
+        open={true}
+        query="nonexistent"
+        items={[]}
+        selectedIndex={0}
+        onSelectIndex={vi.fn()}
+        onSelectItem={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByTestId('slash-empty')).toHaveTextContent(
+      'No matching skills or actions',
+    )
+  })
+
+  it('calls onSelectItem when an item is clicked', () => {
+    const onSelectItem = vi.fn()
+    const items = filterSlashItems(catalog, '', [])
+    render(
+      <ComposerSlashPopup
+        open={true}
+        query=""
+        items={items}
+        selectedIndex={0}
+        onSelectIndex={vi.fn()}
+        onSelectItem={onSelectItem}
+      />,
+    )
+
+    const compactBtn = screen.getByTestId('slash-item-compact')
+    fireEvent.click(compactBtn)
+    expect(onSelectItem).toHaveBeenCalledTimes(1)
+    expect(onSelectItem).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'compact', kind: 'action' }),
+    )
+  })
+
+  it('calls onSelectIndex on mouse enter and reflects selectedIndex', () => {
+    const onSelectIndex = vi.fn()
+    const items = filterSlashItems(catalog, '', [])
+    render(
+      <ComposerSlashPopup
+        open={true}
+        query=""
+        items={items}
+        selectedIndex={1}
+        onSelectIndex={onSelectIndex}
+        onSelectItem={vi.fn()}
+      />,
+    )
+
+    const options = screen.getAllByRole('option')
+    expect(options[1]).toHaveAttribute('aria-selected', 'true')
+
+    fireEvent.mouseEnter(options[0])
+    expect(onSelectIndex).toHaveBeenCalledWith(0)
+  })
+})

--- a/webui/frontend/src/lib/__tests__/slashMenu.test.ts
+++ b/webui/frontend/src/lib/__tests__/slashMenu.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  buildSlashCatalog,
+  filterSlashItems,
+  groupSlashItems,
+  getRecentSlashIds,
+  recordRecentSlashId,
+  clearRecentSlashIds,
+  DEFAULT_ACTIONS,
+  DEFAULT_SKILLS,
+  SlashItem,
+} from '../slashMenu'
+
+describe('slashMenu helpers', () => {
+  beforeEach(() => {
+    clearRecentSlashIds()
+  })
+
+  it('buildSlashCatalog combines default actions, default skills, and dynamic skills', () => {
+    const catalog = buildSlashCatalog([
+      { name: 'custom-skill', description: 'Custom dynamic skill' },
+    ])
+    expect(catalog.length).toBe(DEFAULT_ACTIONS.length + DEFAULT_SKILLS.length + 1)
+    const custom = catalog.find((item) => item.id === 'custom-skill')
+    expect(custom).toBeDefined()
+    expect(custom?.kind).toBe('skill')
+    expect(custom?.title).toBe('Custom Skill')
+    expect(custom?.command).toBe('/skill custom-skill')
+  })
+
+  it('records recency and maintains most recent at front', () => {
+    expect(getRecentSlashIds()).toEqual([])
+    recordRecentSlashId('compact')
+    recordRecentSlashId('conventional-commit')
+    expect(getRecentSlashIds()).toEqual(['conventional-commit', 'compact'])
+
+    // Re-recording moves to front
+    recordRecentSlashId('compact')
+    expect(getRecentSlashIds()).toEqual(['compact', 'conventional-commit'])
+  })
+
+  it('empty query puts recent items first, then alphabetical within section', () => {
+    const catalog = buildSlashCatalog()
+    const recentIds = ['conventional-commit', 'clear']
+
+    const result = filterSlashItems(catalog, '', recentIds)
+    // First two items should be recents in order
+    expect(result[0].id).toBe('conventional-commit')
+    expect(result[1].id).toBe('clear')
+
+    // Remaining items should be actions (alphabetical), then skills (alphabetical)
+    const nonRecents = result.slice(2)
+    const nonRecentActions = nonRecents.filter((x) => x.kind === 'action')
+    const nonRecentSkills = nonRecents.filter((x) => x.kind === 'skill')
+
+    expect(nonRecentActions.map((a) => a.title)).toEqual([
+      'Approval',
+      'Compact',
+      'Help',
+      'History',
+      'Model',
+    ])
+    expect(nonRecentSkills.map((s) => s.title)).toEqual([
+      'Counting Lines',
+      'Reviewing Code',
+      'Support Session Ownership',
+      'Writing Changelog',
+    ])
+  })
+
+  it('filters by query and ranks command/name starts-with higher', () => {
+    const catalog = buildSlashCatalog()
+    // query "co" matches "compact", "conventional-commit", "counting-lines"
+    const result = filterSlashItems(catalog, '/co', [])
+    const ids = result.map((r) => r.id)
+    expect(ids).toContain('compact')
+    expect(ids).toContain('conventional-commit')
+    expect(ids).toContain('counting-lines')
+  })
+
+  it('filters by description substring', () => {
+    const catalog = buildSlashCatalog()
+    // "backlog" appears in compact description
+    const result = filterSlashItems(catalog, 'backlog', [])
+    expect(result.length).toBe(1)
+    expect(result[0].id).toBe('compact')
+  })
+
+  it('groupSlashItems partitions into Recent, Actions, Skills when query empty', () => {
+    const catalog = buildSlashCatalog()
+    const groups = groupSlashItems(catalog, '', ['compact'])
+    expect(groups.length).toBe(3)
+    expect(groups[0].label).toBe('Recent')
+    expect(groups[0].items.map((i) => i.id)).toEqual(['compact'])
+    expect(groups[1].label).toBe('Actions')
+    expect(groups[2].label).toBe('Skills')
+  })
+
+  it('groupSlashItems partitions into Actions and Skills when query non-empty', () => {
+    const catalog = buildSlashCatalog()
+    const filtered = filterSlashItems(catalog, 'co', [])
+    const groups = groupSlashItems(filtered, 'co', [])
+    expect(groups.map((g) => g.label)).toEqual(['Actions', 'Skills'])
+  })
+})

--- a/webui/frontend/src/lib/slashMenu.ts
+++ b/webui/frontend/src/lib/slashMenu.ts
@@ -1,0 +1,340 @@
+/**
+ * Data structures, catalog definitions, and recency/filter helpers
+ * for the Composer slash popup (REQ-169).
+ */
+
+export type SlashItemKind = 'action' | 'skill'
+
+export interface SlashItem {
+  id: string
+  kind: SlashItemKind
+  name: string
+  command: string
+  title: string
+  description: string
+  iconName?: string
+}
+
+export const RECENT_SLASH_STORAGE_KEY = 'open_swarm_recent_slash_commands'
+const MAX_RECENT_ITEMS = 10
+
+export const DEFAULT_ACTIONS: SlashItem[] = [
+  {
+    id: 'compact',
+    kind: 'action',
+    name: 'compact',
+    command: '/compact',
+    title: 'Compact',
+    description: 'Summarise conversation backlog into nested summary blocks',
+    iconName: 'Layers',
+  },
+  {
+    id: 'help',
+    kind: 'action',
+    name: 'help',
+    command: '/help',
+    title: 'Help',
+    description: 'List available slash commands and assistant capabilities',
+    iconName: 'HelpCircle',
+  },
+  {
+    id: 'model',
+    kind: 'action',
+    name: 'model',
+    command: '/model',
+    title: 'Model',
+    description: 'View current LLM profile or override settings',
+    iconName: 'Cpu',
+  },
+  {
+    id: 'clear',
+    kind: 'action',
+    name: 'clear',
+    command: '/clear',
+    title: 'Clear',
+    description: 'Clear conversation context or reset current turn',
+    iconName: 'Trash2',
+  },
+  {
+    id: 'approval',
+    kind: 'action',
+    name: 'approval',
+    command: '/approval',
+    title: 'Approval',
+    description: 'Toggle or display auto-approval mode',
+    iconName: 'Shield',
+  },
+  {
+    id: 'history',
+    kind: 'action',
+    name: 'history',
+    command: '/history',
+    title: 'History',
+    description: 'Display session command and file history',
+    iconName: 'History',
+  },
+]
+
+export const DEFAULT_SKILLS: SlashItem[] = [
+  {
+    id: 'conventional-commit',
+    kind: 'skill',
+    name: 'conventional-commit',
+    command: '/skill conventional-commit',
+    title: 'Conventional Commit',
+    description: 'Format commits following Conventional Commits specification',
+    iconName: 'GitCommit',
+  },
+  {
+    id: 'counting-lines',
+    kind: 'skill',
+    name: 'counting-lines',
+    command: '/skill counting-lines',
+    title: 'Counting Lines',
+    description: 'Count non-blank lines in files using bundled count tool',
+    iconName: 'FileText',
+  },
+  {
+    id: 'reviewing-code',
+    kind: 'skill',
+    name: 'reviewing-code',
+    command: '/skill reviewing-code',
+    title: 'Reviewing Code',
+    description: 'Review diffs for bugs, security vulnerabilities, and test coverage',
+    iconName: 'CheckSquare',
+  },
+  {
+    id: 'support-session-ownership',
+    kind: 'skill',
+    name: 'support-session-ownership',
+    command: '/skill support-session-ownership',
+    title: 'Support Session Ownership',
+    description: 'Session continuity and thread ownership protocols',
+    iconName: 'LifeBuoy',
+  },
+  {
+    id: 'writing-changelog',
+    kind: 'skill',
+    name: 'writing-changelog',
+    command: '/skill writing-changelog',
+    title: 'Writing Changelog',
+    description: 'Generate Keep a Changelog formatted changelog entries',
+    iconName: 'ListPlus',
+  },
+]
+
+/**
+ * Builds the complete slash catalog by combining default actions with default
+ * skills and any dynamic skills discovered from the backend.
+ */
+export function buildSlashCatalog(
+  dynamicSkills?: { name: string; description?: string }[],
+): SlashItem[] {
+  const items: SlashItem[] = [...DEFAULT_ACTIONS]
+  const seenSkills = new Set<string>()
+
+  // Add dynamic skills first if available
+  if (dynamicSkills && dynamicSkills.length > 0) {
+    for (const s of dynamicSkills) {
+      if (!s.name || seenSkills.has(s.name)) continue
+      seenSkills.add(s.name)
+      const existing = DEFAULT_SKILLS.find((def) => def.name === s.name)
+      items.push({
+        id: s.name,
+        kind: 'skill',
+        name: s.name,
+        command: `/skill ${s.name}`,
+        title: existing ? existing.title : formatSkillTitle(s.name),
+        description: s.description || existing?.description || `Skill: ${s.name}`,
+        iconName: existing?.iconName || 'Sparkles',
+      })
+    }
+  }
+
+  // Add remaining default skills
+  for (const s of DEFAULT_SKILLS) {
+    if (!seenSkills.has(s.name)) {
+      seenSkills.add(s.name)
+      items.push(s)
+    }
+  }
+
+  return items
+}
+
+function formatSkillTitle(name: string): string {
+  return name
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+/** Retrieve list of recently used slash item IDs. */
+export function getRecentSlashIds(): string[] {
+  try {
+    const raw = localStorage.getItem(RECENT_SLASH_STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (Array.isArray(parsed)) {
+      return parsed.filter((x): x is string => typeof x === 'string')
+    }
+  } catch {
+    // Ignore parse errors or unavailable localStorage
+  }
+  return []
+}
+
+/** Record a used slash item ID to the top of recency. */
+export function recordRecentSlashId(id: string): void {
+  if (!id) return
+  try {
+    const recents = getRecentSlashIds().filter((existing) => existing !== id)
+    recents.unshift(id)
+    if (recents.length > MAX_RECENT_ITEMS) {
+      recents.length = MAX_RECENT_ITEMS
+    }
+    localStorage.setItem(RECENT_SLASH_STORAGE_KEY, JSON.stringify(recents))
+  } catch {
+    // Ignore storage quota or access issues
+  }
+}
+
+/** Clear recency store (useful for tests). */
+export function clearRecentSlashIds(): void {
+  try {
+    localStorage.removeItem(RECENT_SLASH_STORAGE_KEY)
+  } catch {
+    // Ignore
+  }
+}
+
+/**
+ * Filter and sort slash items based on user query and recent history.
+ * - If query is empty: recent items come first, followed by remaining items
+ *   alphabetically by title within their kind (Action / Skill).
+ * - If query is non-empty: items matching query by name, title, command, or description,
+ *   with exact starts-with matches and recents ranked higher.
+ */
+export function filterSlashItems(
+  items: SlashItem[],
+  rawQuery: string,
+  recentIds: string[] = [],
+): SlashItem[] {
+  const query = rawQuery.replace(/^\//, '').trim().toLowerCase()
+
+  if (!query) {
+    // Empty query: recent items first (in order of recency)
+    const recentMap = new Map<string, number>()
+    recentIds.forEach((id, index) => recentMap.set(id, index))
+
+    const recents: SlashItem[] = []
+    const actions: SlashItem[] = []
+    const skills: SlashItem[] = []
+
+    for (const item of items) {
+      if (recentMap.has(item.id)) {
+        recents.push(item)
+      } else if (item.kind === 'action') {
+        actions.push(item)
+      } else {
+        skills.push(item)
+      }
+    }
+
+    // Sort recents by recency index
+    recents.sort((a, b) => (recentMap.get(a.id) ?? 0) - (recentMap.get(b.id) ?? 0))
+    // Sort rest alphabetically
+    actions.sort((a, b) => a.title.localeCompare(b.title))
+    skills.sort((a, b) => a.title.localeCompare(b.title))
+
+    return [...recents, ...actions, ...skills]
+  }
+
+  // Filter matching items
+  const matched = items.filter((item) => {
+    const nameMatch = item.name.toLowerCase().includes(query)
+    const titleMatch = item.title.toLowerCase().includes(query)
+    const cmdMatch = item.command.toLowerCase().includes(query)
+    const descMatch = item.description.toLowerCase().includes(query)
+    return nameMatch || titleMatch || cmdMatch || descMatch
+  })
+
+  // Rank matches
+  matched.sort((a, b) => {
+    const aCmdStarts = a.name.toLowerCase().startsWith(query) || a.command.replace(/^\//, '').toLowerCase().startsWith(query)
+    const bCmdStarts = b.name.toLowerCase().startsWith(query) || b.command.replace(/^\//, '').toLowerCase().startsWith(query)
+    if (aCmdStarts && !bCmdStarts) return -1
+    if (!aCmdStarts && bCmdStarts) return 1
+
+    const aRecentIdx = recentIds.indexOf(a.id)
+    const bRecentIdx = recentIds.indexOf(b.id)
+    const aIsRecent = aRecentIdx !== -1
+    const bIsRecent = bRecentIdx !== -1
+
+    if (aIsRecent && !bIsRecent) return -1
+    if (!aIsRecent && bIsRecent) return 1
+    if (aIsRecent && bIsRecent) return aRecentIdx - bRecentIdx
+
+    return a.title.localeCompare(b.title)
+  })
+
+  return matched
+}
+
+export interface SlashGroup {
+  label: string
+  items: SlashItem[]
+}
+
+/**
+ * Group filtered slash items for sectioned display.
+ */
+export function groupSlashItems(
+  items: SlashItem[],
+  rawQuery: string,
+  recentIds: string[] = [],
+): SlashGroup[] {
+  const query = rawQuery.replace(/^\//, '').trim()
+
+  if (!query) {
+    const recentSet = new Set(recentIds)
+    const recents: SlashItem[] = []
+    const actions: SlashItem[] = []
+    const skills: SlashItem[] = []
+
+    for (const item of items) {
+      if (recentSet.has(item.id)) {
+        recents.push(item)
+      } else if (item.kind === 'action') {
+        actions.push(item)
+      } else {
+        skills.push(item)
+      }
+    }
+
+    const groups: SlashGroup[] = []
+    if (recents.length > 0) {
+      groups.push({ label: 'Recent', items: recents })
+    }
+    if (actions.length > 0) {
+      groups.push({ label: 'Actions', items: actions })
+    }
+    if (skills.length > 0) {
+      groups.push({ label: 'Skills', items: skills })
+    }
+    return groups
+  }
+
+  // When filtered by query, group by kind
+  const actions = items.filter((item) => item.kind === 'action')
+  const skills = items.filter((item) => item.kind === 'skill')
+
+  const groups: SlashGroup[] = []
+  if (actions.length > 0) {
+    groups.push({ label: 'Actions', items: actions })
+  }
+  if (skills.length > 0) {
+    groups.push({ label: 'Skills', items: skills })
+  }
+  return groups
+}

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ChangeEvent,
   type FormEvent,
   type KeyboardEvent,
 } from 'react'
@@ -24,7 +25,15 @@ import { useRailChrome } from '../components/RailChrome'
 import { ComputerControlStub } from '../components/ComputerControlStub'
 import { RemoteSelect } from '../components/RemoteSelect'
 import { ChatMessageBubble } from '../components/ChatMessageBubble'
-import { fetchBlueprints, fetchCliAgents, fetchCliModels, fetchModels, fetchRemotes } from '../lib/api'
+import { ComposerSlashPopup } from '../components/ComposerSlashPopup'
+import {
+  type SlashItem,
+  buildSlashCatalog,
+  filterSlashItems,
+  getRecentSlashIds,
+  recordRecentSlashId,
+} from '../lib/slashMenu'
+import { fetchConfigOptions, fetchBlueprints, fetchCliAgents, fetchCliModels, fetchModels, fetchRemotes } from '../lib/api'
 import {
   agentIdFromBlueprint,
   appendAgentMessage,
@@ -170,6 +179,10 @@ const ChatPage = () => {
     Record<string, ConversationSummary[]>
   >({})
   const [input, setInput] = useState('')
+  const [slashDismissed, setSlashDismissed] = useState(false)
+  const [slashSelectedIndex, setSlashSelectedIndex] = useState(0)
+  const [recentSlashIds, setRecentSlashIds] = useState<string[]>(() => getRecentSlashIds())
+  const [dynamicSkills, setDynamicSkills] = useState<{ name: string; description?: string }[]>([])
   const [status, setStatus] = useState<ConnectionStatus>('connecting')
   const [memberTarget, setMemberTarget] = useState(ALL_MEMBERS_TARGET)
   const [connectAttempt, setConnectAttempt] = useState(0)
@@ -227,6 +240,7 @@ const ChatPage = () => {
   const scrollBoxRef = useRef<HTMLDivElement | null>(null)
   const composerRef = useRef<HTMLInputElement | null>(null)
   const plusRef = useRef<HTMLDivElement | null>(null)
+  const composerWrapRef = useRef<HTMLDivElement | null>(null)
   /** Monotonic counter for collision-free user-echo keys. */
   const userKeyCounterRef = useRef(0)
   const prevStatusRef = useRef<ConnectionStatus>('connecting')
@@ -939,11 +953,59 @@ const ChatPage = () => {
     setInput('')
   }
 
-  const handleComposerKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Escape' && input.length > 0) {
-      event.preventDefault()
-      setInput('')
+  // Dynamic skills loading for slash catalog (REQ-169)
+  useEffect(() => {
+    let unmounted = false
+    void fetchConfigOptions()
+      .then((opts) => {
+        if (!unmounted && opts?.skills) {
+          setDynamicSkills(
+            opts.skills.map((s) => ({ name: s.name, description: s.description })),
+          )
+        }
+      })
+      .catch(() => {
+        // Silently ignore if config options endpoint is unavailable
+      })
+    return () => {
+      unmounted = true
     }
+  }, [])
+
+  const slashCatalog = useMemo(() => buildSlashCatalog(dynamicSkills), [dynamicSkills])
+  const isSlashOpen = input.startsWith('/') && !slashDismissed
+  const slashQuery = input.startsWith('/') ? input.slice(1) : ''
+  const filteredSlashItems = useMemo(
+    () => filterSlashItems(slashCatalog, slashQuery, recentSlashIds),
+    [slashCatalog, slashQuery, recentSlashIds],
+  )
+
+  useEffect(() => {
+    setSlashSelectedIndex(0)
+  }, [slashQuery])
+
+  useEffect(() => {
+    if (!isSlashOpen) return
+    const onPointerDown = (event: MouseEvent | TouchEvent) => {
+      if (composerWrapRef.current && !composerWrapRef.current.contains(event.target as Node)) {
+        setSlashDismissed(true)
+      }
+    }
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('touchstart', onPointerDown)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('touchstart', onPointerDown)
+    }
+  }, [isSlashOpen])
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value
+    if (val.startsWith('/') && !input.startsWith('/')) {
+      setSlashDismissed(false)
+      setSlashSelectedIndex(0)
+    }
+    setInput(val)
   }
 
   const handleMic = () => {
@@ -1037,6 +1099,66 @@ const ChatPage = () => {
       })
     }
   }, [addToast, conversationId, messages, selectedBlueprint, teamFromUrl, threadKey])
+
+  const handleSelectSlashItem = useCallback(
+    (item: SlashItem) => {
+      recordRecentSlashId(item.id)
+      setRecentSlashIds(getRecentSlashIds())
+      setSlashDismissed(true)
+
+      if (item.id === 'compact') {
+        void handleCompact()
+        setInput('')
+      } else {
+        setInput(`${item.command} `)
+      }
+      setTimeout(() => {
+        composerRef.current?.focus()
+      }, 0)
+    },
+    [handleCompact],
+  )
+
+  const handleComposerKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (isSlashOpen) {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        setSlashSelectedIndex((prev) =>
+          filteredSlashItems.length > 0 ? (prev + 1) % filteredSlashItems.length : 0,
+        )
+        return
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        setSlashSelectedIndex((prev) =>
+          filteredSlashItems.length > 0
+            ? (prev - 1 + filteredSlashItems.length) % filteredSlashItems.length
+            : 0,
+        )
+        return
+      }
+      if (event.key === 'Enter' || event.key === 'Tab') {
+        if (filteredSlashItems.length > 0) {
+          event.preventDefault()
+          const selected = filteredSlashItems[slashSelectedIndex] || filteredSlashItems[0]
+          if (selected) {
+            handleSelectSlashItem(selected)
+            return
+          }
+        }
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setSlashDismissed(true)
+        return
+      }
+    }
+
+    if (event.key === 'Escape' && input.length > 0) {
+      event.preventDefault()
+      setInput('')
+    }
+  }
 
   const tokenCount = estimateTokensInContext(contextTextsForMeter(messages, summaries))
   const tokenPct = Math.min(100, Math.round((tokenCount / CONTEXT_METER_TOKENS) * 100))
@@ -1434,59 +1556,73 @@ const ChatPage = () => {
       </div>
 
       <form onSubmit={handleSend} className="os-composer-wrap">
-        <div className="os-composer">
-          <div className="relative" ref={plusRef}>
+        <div className="relative" ref={composerWrapRef}>
+          <ComposerSlashPopup
+            open={isSlashOpen}
+            query={slashQuery}
+            items={filteredSlashItems}
+            selectedIndex={slashSelectedIndex}
+            onSelectIndex={setSlashSelectedIndex}
+            onSelectItem={handleSelectSlashItem}
+            recentIds={recentSlashIds}
+          />
+          <div className="os-composer">
+            <div className="relative" ref={plusRef}>
+              <button
+                type="button"
+                className="os-composer__icon"
+                aria-label="Add"
+                aria-haspopup="menu"
+                aria-expanded={plusOpen}
+                onClick={() => setPlusOpen((value) => !value)}
+              >
+                <Plus className="h-4 w-4" aria-hidden="true" />
+              </button>
+              {plusOpen && (
+                <ul
+                  role="menu"
+                  aria-label="Chat actions"
+                  className="os-plus-menu"
+                >
+                  <li role="none">
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="os-plus-menu__item"
+                      onClick={() => {
+                        void handleCompact()
+                      }}
+                    >
+                      <Layers className="h-4 w-4" aria-hidden="true" />
+                      Compact
+                    </button>
+                  </li>
+                </ul>
+              )}
+            </div>
+            <input
+              ref={composerRef}
+              type="text"
+              className="os-composer__input"
+              placeholder={composerPlaceholder}
+              value={input}
+              onChange={handleInputChange}
+              onKeyDown={handleComposerKeyDown}
+              disabled={status !== 'open'}
+              aria-label="Chat message"
+              aria-haspopup="listbox"
+              aria-expanded={isSlashOpen}
+              aria-controls={isSlashOpen ? 'composer-slash-menu' : undefined}
+            />
             <button
               type="button"
               className="os-composer__icon"
-              aria-label="Add"
-              aria-haspopup="menu"
-              aria-expanded={plusOpen}
-              onClick={() => setPlusOpen((value) => !value)}
+              aria-label="Voice input"
+              onClick={handleMic}
             >
-              <Plus className="h-4 w-4" aria-hidden="true" />
+              <Mic className="h-4 w-4" aria-hidden="true" />
             </button>
-            {plusOpen && (
-              <ul
-                role="menu"
-                aria-label="Chat actions"
-                className="os-plus-menu"
-              >
-                <li role="none">
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className="os-plus-menu__item"
-                    onClick={() => {
-                      void handleCompact()
-                    }}
-                  >
-                    <Layers className="h-4 w-4" aria-hidden="true" />
-                    Compact
-                  </button>
-                </li>
-              </ul>
-            )}
           </div>
-          <input
-            ref={composerRef}
-            type="text"
-            className="os-composer__input"
-            placeholder={composerPlaceholder}
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={handleComposerKeyDown}
-            disabled={status !== 'open'}
-            aria-label="Chat message"
-          />
-          <button
-            type="button"
-            className="os-composer__icon"
-            aria-label="Voice input"
-            onClick={handleMic}
-          >
-            <Mic className="h-4 w-4" aria-hidden="true" />
-          </button>
         </div>
         <button type="submit" className="sr-only" disabled={!canSend}>
           Send

--- a/webui/frontend/src/pages/__tests__/ChatPage.slashMenu.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.slashMenu.test.tsx
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import ChatPage from '../ChatPage'
+import { ToastProvider } from '../../components/DaisyUI'
+import { clearRecentSlashIds } from '../../lib/slashMenu'
+
+type WsHandler = ((ev?: Event) => void) | null
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  static instances: MockWebSocket[] = []
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: WsHandler = null
+  onmessage: WsHandler = null
+  onclose: WsHandler = null
+  send = vi.fn()
+  close = vi.fn(() => {
+    this.readyState = 3
+    this.onclose?.(new CloseEvent('close', { code: 1000 }))
+  })
+
+  url: string
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+}
+
+function renderChat() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <MemoryRouter initialEntries={['/chat']}>
+          <ChatPage />
+        </MemoryRouter>
+      </ToastProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('ChatPage slash menu (REQ-169)', () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+    clearRecentSlashIds()
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string | URL | Request) => {
+        const urlStr = String(url)
+        if (urlStr.includes('/v1/config-options/')) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                skills: [
+                  {
+                    name: 'custom-skill',
+                    description: 'Custom dynamic skill',
+                    assets: [],
+                    instructions: '',
+                  },
+                ],
+                inference: { traits: [], cli_traits: {}, model_traits: {}, model_flags: {} },
+                tools: { capabilities: [], mcp_catalog: [] },
+              }),
+              { status: 200 },
+            ),
+          )
+        }
+        if (urlStr.includes('/chat/compact/')) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                summaries: [],
+                summary: { id: 'sum-1', span: [0, 1], body: 'Compact summary' },
+              }),
+              { status: 200 },
+            ),
+          )
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify([]), { status: 200 }),
+        )
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    clearRecentSlashIds()
+  })
+
+  async function openWebSocket() {
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+  }
+
+  it('opens slash popup immediately when typing / as first character', async () => {
+    renderChat()
+    await openWebSocket()
+
+    const input = screen.getByRole('textbox', { name: 'Chat message' })
+    expect(screen.queryByTestId('composer-slash-popup')).not.toBeInTheDocument()
+
+    fireEvent.change(input, { target: { value: '/' } })
+    expect(screen.getByTestId('composer-slash-popup')).toBeInTheDocument()
+    expect(screen.getByText('Actions')).toBeInTheDocument()
+    expect(screen.getByText('Skills')).toBeInTheDocument()
+    expect(screen.getByTestId('slash-item-compact')).toBeInTheDocument()
+  })
+
+  it('filters results when typing characters after /', async () => {
+    renderChat()
+    await openWebSocket()
+
+    const input = screen.getByRole('textbox', { name: 'Chat message' })
+    fireEvent.change(input, { target: { value: '/clear' } })
+
+    expect(screen.getByTestId('composer-slash-popup')).toBeInTheDocument()
+    expect(screen.getByTestId('slash-item-clear')).toBeInTheDocument()
+    // Unrelated items are filtered out
+    expect(screen.queryByTestId('slash-item-help')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('slash-item-compact')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('slash-item-conventional-commit')).not.toBeInTheDocument()
+  })
+
+  it('closes popup when clearing / with backspace', async () => {
+    renderChat()
+    await openWebSocket()
+
+    const input = screen.getByRole('textbox', { name: 'Chat message' })
+    fireEvent.change(input, { target: { value: '/' } })
+    expect(screen.getByTestId('composer-slash-popup')).toBeInTheDocument()
+
+    fireEvent.change(input, { target: { value: '' } })
+    expect(screen.queryByTestId('composer-slash-popup')).not.toBeInTheDocument()
+  })
+
+  it('dismisses popup on Escape key', async () => {
+    renderChat()
+    await openWebSocket()
+
+    const input = screen.getByRole('textbox', { name: 'Chat message' })
+    fireEvent.change(input, { target: { value: '/' } })
+    expect(screen.getByTestId('composer-slash-popup')).toBeInTheDocument()
+
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(screen.queryByTestId('composer-slash-popup')).not.toBeInTheDocument()
+  })
+
+  it('navigates with ArrowDown/ArrowUp and selects with Enter', async () => {
+    renderChat()
+    await openWebSocket()
+
+    const input = screen.getByRole('textbox', { name: 'Chat message' })
+    fireEvent.change(input, { target: { value: '/help' } })
+
+    // Help should be matched and highlighted at index 0
+    const helpItem = screen.getByTestId('slash-item-help')
+    expect(helpItem).toHaveAttribute('aria-selected', 'true')
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    // Selecting help should insert /help into composer and close popup
+    expect(screen.queryByTestId('composer-slash-popup')).not.toBeInTheDocument()
+    expect(input).toHaveValue('/help ')
+  })
+
+  it('selecting compact action triggers compact flow and clears composer input', async () => {
+    renderChat()
+    await openWebSocket()
+
+    const input = screen.getByRole('textbox', { name: 'Chat message' })
+    fireEvent.change(input, { target: { value: '/compact' } })
+
+    const compactItem = screen.getByTestId('slash-item-compact')
+    fireEvent.click(compactItem)
+
+    expect(screen.queryByTestId('composer-slash-popup')).not.toBeInTheDocument()
+    expect(input).toHaveValue('')
+  })
+
+  it('selecting a skill inserts /skill <name> into composer', async () => {
+    renderChat()
+    await openWebSocket()
+
+    const input = screen.getByRole('textbox', { name: 'Chat message' })
+    fireEvent.change(input, { target: { value: '/conventional' } })
+
+    const skillItem = screen.getByTestId('slash-item-conventional-commit')
+    fireEvent.click(skillItem)
+
+    expect(screen.queryByTestId('composer-slash-popup')).not.toBeInTheDocument()
+    expect(input).toHaveValue('/skill conventional-commit ')
+  })
+
+  it('shows recently used items first in empty query mode', async () => {
+    renderChat()
+    await openWebSocket()
+
+    const input = screen.getByRole('textbox', { name: 'Chat message' })
+
+    // Select conventional-commit skill
+    fireEvent.change(input, { target: { value: '/conventional' } })
+    fireEvent.click(screen.getByTestId('slash-item-conventional-commit'))
+
+    // Reopen slash menu
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.change(input, { target: { value: '/' } })
+
+    expect(screen.getByTestId('composer-slash-popup')).toBeInTheDocument()
+    const recentElements = screen.getAllByText('Recent')
+    expect(recentElements.length).toBeGreaterThanOrEqual(1)
+    // The conventional-commit item should be in the recent section
+    expect(screen.getByTestId('slash-item-conventional-commit')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- In the chat composer, typing `/` as the first character immediately opens an input-connected `ComposerSlashPopup` menu anchored above the composer (REQ-169, Fixes #594).
- The catalog displays standard actions (`/compact`, `/help`, `/model`, `/clear`, `/approval`, `/history`) and standard skills (`/skill conventional-commit`, `counting-lines`, `reviewing-code`, `support-session-ownership`, `writing-changelog`), and merges dynamic skills from `/v1/config-options/`.
- Supports substring filtering across title, command, name, and description.
- Recency store (`localStorage`) surfaces recently selected items first under a **Recent** section on empty query.
- Full keyboard support: `ArrowDown` / `ArrowUp` navigate, `Enter` / `Tab` select, `Escape` dismisses.
- Clicking outside or backspacing past `/` closes the popup.
- Trigger action: selecting `compact` invokes the existing `handleCompact()` action and clears the composer; selecting a skill or other command inserts the slash command into the composer and restores input focus.
- 100% overlay: chat stays mounted throughout.
- Unit and integration test coverage across `slashMenu.test.ts`, `ComposerSlashPopup.test.tsx`, `ChatPage.slashMenu.test.tsx`, and backend contract `test_req169_composer_slash_catalog.py`.