### PR TITLE
feat(webui): restore-session chrome for every kind + codeblock newlines

### DIFF
--- a/tests/unit/test_req127_codeblock_roundtrip.py
+++ b/tests/unit/test_req127_codeblock_roundtrip.py
@@ -1,0 +1,31 @@
+"""REQ-127: Codeblock copy/paste keeps newlines; user fences render (Fixes #517)."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHAT_PAGE = REPO_ROOT / "webui" / "frontend" / "src" / "pages" / "ChatPage.tsx"
+MARKDOWN = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "markdown.ts"
+CLIPBOARD = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "clipboard.ts"
+BUBBLE = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "ChatMessageBubble.tsx"
+CSS = REPO_ROOT / "webui" / "frontend" / "src" / "index.css"
+
+
+def test_composer_is_textarea_that_keeps_pre_wrap():
+    page = CHAT_PAGE.read_text(encoding="utf-8")
+    assert "<textarea" in page
+    assert 'aria-label="Chat message"' in page
+    assert "Shift+Enter" in page or "shiftKey" in page
+    css = CSS.read_text(encoding="utf-8")
+    assert "white-space: pre-wrap" in css
+    assert "resize: none" in css
+
+
+def test_markdown_and_clipboard_preserve_fences():
+    md = MARKDOWN.read_text(encoding="utf-8")
+    assert "renderSafeMarkdown" in md
+    assert "<pre" in md
+    clip = CLIPBOARD.read_text(encoding="utf-8")
+    assert "navigator.clipboard?.writeText" in clip
+    bubble = BUBBLE.read_text(encoding="utf-8")
+    assert "renderSafeMarkdown" in bubble
+    assert "code-copy" in bubble

--- a/tests/unit/test_req161_restored_session.py
+++ b/tests/unit/test_req161_restored_session.py
@@ -1,0 +1,25 @@
+"""REQ-161: Restored session status for every agent kind (Fixes #572)."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SESSION_RESTORE = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "sessionRestore.ts"
+CHAT_PAGE = REPO_ROOT / "webui" / "frontend" / "src" / "pages" / "ChatPage.tsx"
+
+
+def test_session_restore_covers_cli_api_remote_team():
+    src = SESSION_RESTORE.read_text(encoding="utf-8")
+    assert "export function withRestoredSession" in src
+    assert "export function restoreKindForAgent" in src
+    assert "Resumed CLI session" in src
+    assert "Restored session" in src
+    assert "Reconnected remote" in src
+    assert "hasRestorableTurns" in src
+
+
+def test_chat_page_hydrates_remote_threads_and_banners_restore():
+    src = CHAT_PAGE.read_text(encoding="utf-8")
+    assert 'fetchAgentThread(`remote:${remoteFromUrl}`' in src
+    assert "restoredSessionNotice" in src
+    assert "restoreNotice" in src
+    assert "os-chat-status" in src

--- a/webui/frontend/src/components/ChatMessageBubble.tsx
+++ b/webui/frontend/src/components/ChatMessageBubble.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react'
 import { Pencil } from 'lucide-react'
 import { Textarea, LoadingDots } from './DaisyUI'
+import { copyTextToClipboard } from '../lib/clipboard'
 import { renderSafeMarkdown } from '../lib/markdown'
 
 export interface ChatMessageBubbleProps {
@@ -47,6 +48,29 @@ export const ChatBubbleBody = memo(
     text: string
     streaming: boolean
   }) {
+    const mdRef = useRef<HTMLDivElement | null>(null)
+
+    useEffect(() => {
+      const root = mdRef.current
+      if (!root) return
+      root.querySelectorAll('pre').forEach((pre) => {
+        if (pre.querySelector('[data-testid="code-copy"]')) return
+        const btn = document.createElement('button')
+        btn.type = 'button'
+        btn.className = 'btn btn-ghost btn-xs os-code-copy'
+        btn.dataset.testid = 'code-copy'
+        btn.setAttribute('aria-label', 'Copy code')
+        btn.textContent = 'Copy'
+        btn.addEventListener('click', (event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          const code = pre.querySelector('code')
+          void copyTextToClipboard(code?.textContent ?? pre.textContent ?? '')
+        })
+        pre.insertBefore(btn, pre.firstChild)
+      })
+    }, [text])
+
     if (text.length === 0) {
       return streaming ? (
         <LoadingDots size="sm" />
@@ -56,6 +80,7 @@ export const ChatBubbleBody = memo(
     }
     return (
       <div
+        ref={mdRef}
         data-testid="chat-md"
         className="chat-md break-words [&_p]:my-1 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_pre]:my-2 [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:bg-base-300/40 [&_pre]:p-2 [&_code]:text-sm [&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-1 [&_ol]:list-decimal [&_ol]:pl-5 [&_a]:underline"
         dangerouslySetInnerHTML={{ __html: renderSafeMarkdown(text) }}

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -842,6 +842,16 @@ button.os-agent-row {
   outline: none;
   font-size: 0.95rem;
   color: inherit;
+  resize: none;
+  white-space: pre-wrap;
+  overflow-y: auto;
+  max-height: 8rem;
+  line-height: 1.4;
+  padding: 0.45rem 0;
+}
+.os-code-copy {
+  float: right;
+  margin-left: 0.5rem;
 }
 .os-composer__input::placeholder {
   color: color-mix(in srgb, var(--color-base-content) 40%, transparent);

--- a/webui/frontend/src/lib/__tests__/clipboard.test.ts
+++ b/webui/frontend/src/lib/__tests__/clipboard.test.ts
@@ -41,6 +41,16 @@ describe('copyTextToClipboard', () => {
     expect(writeText).toHaveBeenCalledWith('full **markdown**')
   })
 
+  it('REQ-127: keeps real newlines in a fenced Python block', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    const fenced = '```python\ndef hello():\n    return 1\n```'
+    await expect(copyTextToClipboard(fenced)).resolves.toBe('copied')
+    expect(writeText).toHaveBeenCalledWith(fenced)
+    expect(writeText.mock.calls[0][0]).toContain('\n')
+    expect(writeText.mock.calls[0][0]).not.toBe(fenced.replace(/\n/g, ' '))
+  })
+
   it('returns empty without touching the clipboard', async () => {
     const writeText = vi.fn()
     Object.assign(navigator, { clipboard: { writeText } })

--- a/webui/frontend/src/lib/__tests__/markdown.test.ts
+++ b/webui/frontend/src/lib/__tests__/markdown.test.ts
@@ -25,4 +25,13 @@ describe('renderSafeMarkdown', () => {
     expect(view).toContain('def')
     expect(view).toContain('os-py-str')
   })
+
+  it('REQ-127: user-bubble fences render as pre/code with newlines kept in source', () => {
+    const source = '```python\nprint("hi")\nprint("there")\n```'
+    const view = renderSafeMarkdown(source)
+    expect(view).toContain('<pre')
+    expect(view).toContain('<code')
+    expect(view).toContain('language-python')
+    expect(source).toContain('\n')
+  })
 })

--- a/webui/frontend/src/lib/__tests__/sessionRestore.test.ts
+++ b/webui/frontend/src/lib/__tests__/sessionRestore.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RESTORED_SESSION_TEXT,
+  hasRestorableTurns,
+  isRestoreStatusText,
+  restoreKindForAgent,
+  restoredSessionNotice,
+  withRestoredSession,
+} from '../sessionRestore'
+
+describe('restoreKindForAgent (REQ-161)', () => {
+  it('classifies CLI, API, remote, and team ids', () => {
+    expect(restoreKindForAgent('cli_agent')).toBe('cli')
+    expect(restoreKindForAgent('grok_agent')).toBe('cli')
+    expect(restoreKindForAgent('agy_agent')).toBe('cli')
+    expect(restoreKindForAgent('opencode_agent')).toBe('cli')
+    expect(restoreKindForAgent('pi_agent')).toBe('cli')
+    expect(restoreKindForAgent('codey')).toBe('api')
+    expect(restoreKindForAgent('jeeves')).toBe('api')
+    expect(restoreKindForAgent('remote:omb')).toBe('remote')
+    expect(restoreKindForAgent('remote-omb')).toBe('remote')
+    expect(restoreKindForAgent('team-demo-team')).toBe('team')
+    expect(restoreKindForAgent('team:demo-team')).toBe('team')
+  })
+})
+
+describe('withRestoredSession', () => {
+  it('does not fake a line on an empty or status-only thread', () => {
+    expect(withRestoredSession([], 'api')).toEqual([])
+    expect(withRestoredSession([], 'cli')).toEqual([])
+    expect(withRestoredSession([], 'remote')).toEqual([])
+    expect(withRestoredSession([], 'team')).toEqual([])
+    const statusOnly = [{ role: 'status', content: 'CLI: antigravity → grok' }]
+    expect(hasRestorableTurns(statusOnly)).toBe(false)
+    expect(withRestoredSession(statusOnly, 'cli')).toEqual(statusOnly)
+    expect(restoredSessionNotice(statusOnly, 'cli')).toBeNull()
+  })
+
+  it('prepends kind-aware chrome when prior turns exist', () => {
+    const prior = [
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'hello' },
+    ]
+    expect(withRestoredSession(prior, 'api')[0]).toEqual({
+      role: 'status',
+      content: RESTORED_SESSION_TEXT.api,
+    })
+    expect(withRestoredSession(prior, 'cli')[0].content).toBe('Resumed CLI session')
+    expect(withRestoredSession(prior, 'remote')[0].content).toBe('Reconnected remote')
+    expect(withRestoredSession(prior, 'team')[0].content).toBe('Restored session')
+    expect(withRestoredSession(prior, 'api')).toHaveLength(3)
+  })
+
+  it('does not duplicate an existing resume/restore status', () => {
+    const already = [
+      { role: 'status', content: 'Resumed grok session.' },
+      { role: 'user', content: 'hi' },
+    ]
+    expect(withRestoredSession(already, 'cli')).toEqual(already)
+    expect(isRestoreStatusText('Started a new grok session.')).toBe(false)
+  })
+})

--- a/webui/frontend/src/lib/sessionRestore.ts
+++ b/webui/frontend/src/lib/sessionRestore.ts
@@ -1,0 +1,71 @@
+/**
+ * REQ-161 — quiet restore chrome when an existing session is reopened.
+ *
+ * Only prepend a status line when hydrate actually found prior turns.
+ * Kind-aware wording; never invent restore for an empty thread.
+ */
+
+import { classifyAgentKind } from './agentKind'
+import { isCliBlueprintId } from './cliAgentContext'
+
+export type RestoreKind = 'cli' | 'api' | 'remote' | 'team'
+
+export const RESTORED_SESSION_TEXT: Record<RestoreKind, string> = {
+  cli: 'Resumed CLI session',
+  api: 'Restored session',
+  remote: 'Reconnected remote',
+  team: 'Restored session',
+}
+
+export function restoreKindForAgent(agentId: string): RestoreKind {
+  const id = (agentId || '').trim().toLowerCase()
+  if (id.startsWith('team-') || id.startsWith('team:')) return 'team'
+  if (
+    id.startsWith('remote:') ||
+    id.startsWith('remote-') ||
+    id.startsWith('placeholder:remote:')
+  ) {
+    return 'remote'
+  }
+  if (isCliBlueprintId(id) || /_agent$/.test(id)) return 'cli'
+  return classifyAgentKind(id)
+}
+
+export function isRestoreStatusText(text: string | null | undefined): boolean {
+  const t = String(text || '').trim().toLowerCase()
+  if (!t) return false
+  return (
+    t.startsWith('restored session') ||
+    t.startsWith('resumed ') ||
+    t.startsWith('reconnected remote') ||
+    t.startsWith('continued chat')
+  )
+}
+
+export function hasRestorableTurns(messages: Array<{ role: string }>): boolean {
+  return messages.some((row) => row.role === 'user' || row.role === 'assistant')
+}
+
+export function withRestoredSession<T extends { role: string; content: string }>(
+  messages: T[],
+  kind: RestoreKind,
+): T[] {
+  if (!hasRestorableTurns(messages)) return messages
+  if (messages.some((row) => row.role === 'status' && isRestoreStatusText(row.content))) {
+    return messages
+  }
+  const line = RESTORED_SESSION_TEXT[kind]
+  return [{ role: 'status', content: line } as T, ...messages]
+}
+
+/** Banner text for hydrate, or null when nothing was actually restored. */
+export function restoredSessionNotice(
+  messages: Array<{ role: string; content?: string }>,
+  kind: RestoreKind,
+): string | null {
+  if (!hasRestorableTurns(messages)) return null
+  if (messages.some((row) => row.role === 'status' && isRestoreStatusText(row.content))) {
+    return null
+  }
+  return RESTORED_SESSION_TEXT[kind]
+}

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -110,6 +110,7 @@ import {
   shouldRecordDropdownChange,
   type DropdownKind,
 } from '../lib/chatStatus'
+import { restoreKindForAgent, restoredSessionNotice } from '../lib/sessionRestore'
 import {
   discoverChatClis,
   isCliAgentContext,
@@ -175,6 +176,7 @@ const ChatPage = () => {
   )
 
   const [threads, setThreads] = useState<Record<string, ChatMessage[]>>({})
+  const [restoreNotice, setRestoreNotice] = useState<string | null>(null)
   const [summariesByThread, setSummariesByThread] = useState<
     Record<string, ConversationSummary[]>
   >({})
@@ -238,7 +240,7 @@ const ChatPage = () => {
   conversationIdRef.current = conversationId
   const listEndRef = useRef<HTMLDivElement | null>(null)
   const scrollBoxRef = useRef<HTMLDivElement | null>(null)
-  const composerRef = useRef<HTMLInputElement | null>(null)
+  const composerRef = useRef<HTMLTextAreaElement | null>(null)
   const plusRef = useRef<HTMLDivElement | null>(null)
   const composerWrapRef = useRef<HTMLDivElement | null>(null)
   /** Monotonic counter for collision-free user-echo keys. */
@@ -483,7 +485,11 @@ const ChatPage = () => {
           ...prev,
           [key]: thread.summaries,
         }))
-        if (thread.messages.length === 0) return
+        if (thread.messages.length === 0) {
+          setRestoreNotice(null)
+          return
+        }
+        setRestoreNotice(restoredSessionNotice(thread.messages, 'team'))
         setThreads((prev) => ({
           ...prev,
           [key]: thread.messages.map((message, index) => ({
@@ -513,7 +519,33 @@ const ChatPage = () => {
         setThreads((prev) => ({ ...prev, [key]: [] }))
         setSummariesByThread((prev) => ({ ...prev, [key]: [] }))
       }
-      return
+      let cancelled = false
+      ;(async () => {
+        const thread = await fetchAgentThread(`remote:${remoteFromUrl}`, key)
+        if (cancelled) return
+        setSummariesByThread((prev) => ({
+          ...prev,
+          [key]: thread.summaries,
+        }))
+        if (thread.messages.length === 0) {
+          setRestoreNotice(null)
+          return
+        }
+        setRestoreNotice(restoredSessionNotice(thread.messages, 'remote'))
+        setThreads((prev) => ({
+          ...prev,
+          [key]: thread.messages.map((message, index) => ({
+            key: `hist-${index}-${message.role}`,
+            role: asTranscriptRole(message.role),
+            text: message.content,
+            streaming: false,
+            edited: message.edited === true,
+          })),
+        }))
+      })()
+      return () => {
+        cancelled = true
+      }
     }
 
     const agent = agentIdFromBlueprint(selectedBlueprint)
@@ -541,6 +573,7 @@ const ChatPage = () => {
     }
     if (fresh) {
       // New empty session — do not restore a prior transcript.
+      setRestoreNotice(null)
       return
     }
     let cancelled = false
@@ -557,7 +590,11 @@ const ChatPage = () => {
         ...prev,
         [threadKey]: thread.summaries,
       }))
-      if (thread.messages.length === 0) return
+      if (thread.messages.length === 0) {
+        setRestoreNotice(null)
+        return
+      }
+      setRestoreNotice(restoredSessionNotice(thread.messages, restoreKindForAgent(agent)))
       setThreads((prev) => ({
         ...prev,
         [threadKey]: thread.messages.map((message, index) => ({
@@ -999,7 +1036,7 @@ const ChatPage = () => {
     }
   }, [isSlashOpen])
 
-  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     const val = e.target.value
     if (val.startsWith('/') && !input.startsWith('/')) {
       setSlashDismissed(false)
@@ -1119,7 +1156,7 @@ const ChatPage = () => {
     [handleCompact],
   )
 
-  const handleComposerKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+  const handleComposerKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (isSlashOpen) {
       if (event.key === 'ArrowDown') {
         event.preventDefault()
@@ -1157,6 +1194,14 @@ const ChatPage = () => {
     if (event.key === 'Escape' && input.length > 0) {
       event.preventDefault()
       setInput('')
+      return
+    }
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault()
+      if (status === 'open') {
+        sendText(input)
+        setInput('')
+      }
     }
   }
 
@@ -1462,7 +1507,13 @@ const ChatPage = () => {
             <p className="text-sm">Message {selectedAgentName}</p>
           </div>
         ) : (
-          displayItems.map((item, idx) => {
+          <>
+          {restoreNotice ? (
+            <p className="os-chat-status" data-role="status" data-testid="chat-status">
+              <span>{restoreNotice}</span>
+            </p>
+          ) : null}
+          {displayItems.map((item, idx) => {
             if (item.kind === 'summary') {
               return (
                 <SummaryBlock
@@ -1550,7 +1601,8 @@ const ChatPage = () => {
                 )}
               </div>
             )
-          })
+          })}
+          </>
         )}
         <div ref={listEndRef} />
       </div>
@@ -1600,9 +1652,9 @@ const ChatPage = () => {
                 </ul>
               )}
             </div>
-            <input
+            <textarea
               ref={composerRef}
-              type="text"
+              rows={1}
               className="os-composer__input"
               placeholder={composerPlaceholder}
               value={input}

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -958,6 +958,7 @@ describe('ChatPage per-agent persistence (no retention chrome)', () => {
 
     expect(await screen.findByText('prior question')).toBeInTheDocument()
     expect(screen.getByText('prior answer')).toBeInTheDocument()
+    expect(screen.getByTestId('chat-status')).toHaveTextContent('Restored session')
     expect(screen.queryByText(/Move to trash/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/Empty trash/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/Disk used/i)).not.toBeInTheDocument()
@@ -1002,13 +1003,15 @@ describe('ChatPage per-agent persistence (no retention chrome)', () => {
       MockWebSocket.instances[0]?.open()
     })
 
-    const notice = await screen.findByTestId('chat-status')
-    expect(notice).toHaveTextContent('Started a new grok session.')
-    expect(notice).toHaveAttribute('data-role', 'status')
-    expect(notice).toHaveClass('os-chat-status')
-    expect(notice.className).not.toMatch(/chat-start|chat-end/)
-    expect(notice.querySelector('.chat-bubble')).toBeNull()
-    expect(notice.querySelector('span')).toHaveTextContent('Started a new grok session.')
+    const notices = await screen.findAllByTestId('chat-status')
+    expect(notices[0]).toHaveTextContent('Resumed CLI session')
+    const started = notices.find((n) => n.textContent?.includes('Started a new grok session.'))
+    expect(started).toBeTruthy()
+    expect(started).toHaveAttribute('data-role', 'status')
+    expect(started).toHaveClass('os-chat-status')
+    expect(started!.className).not.toMatch(/chat-start|chat-end/)
+    expect(started!.querySelector('.chat-bubble')).toBeNull()
+    expect(started!.querySelector('span')).toHaveTextContent('Started a new grok session.')
     expect(screen.getByText('hello').closest('.chat-end')).toBeTruthy()
     expect(screen.getByText('hi').closest('.chat-start')).toBeTruthy()
   })
@@ -1053,9 +1056,10 @@ describe('ChatPage per-agent persistence (no retention chrome)', () => {
     })
 
     const lines = await screen.findAllByTestId('chat-status')
-    expect(lines).toHaveLength(2)
-    expect(lines[0]).toHaveTextContent('Connecting…')
-    expect(lines[1]).toHaveTextContent('Session ready.')
+    expect(lines).toHaveLength(3)
+    expect(lines[0]).toHaveTextContent('Resumed CLI session')
+    expect(lines[1]).toHaveTextContent('Connecting…')
+    expect(lines[2]).toHaveTextContent('Session ready.')
     for (const line of lines) {
       expect(line).toHaveClass('os-chat-status')
       expect(line.className).not.toMatch(/chat-start|chat-end/)
@@ -1063,6 +1067,96 @@ describe('ChatPage per-agent persistence (no retention chrome)', () => {
     }
     expect(screen.getByText('ping').closest('.chat-end')).toBeTruthy()
     expect(screen.getByText('pong').closest('.chat-start')).toBeTruthy()
+  })
+
+  it('REQ-161: restores API / CLI / remote / team threads with a quiet status line', async () => {
+    const fixtures: Array<{ entry: string; agent: string; status: string }> = [
+      { entry: '/chat?blueprint=codey', agent: 'codey', status: 'Restored session' },
+      { entry: '/chat?blueprint=grok_agent', agent: 'grok_agent', status: 'Resumed CLI session' },
+      { entry: '/chat?remote=omb', agent: 'remote:omb', status: 'Reconnected remote' },
+      { entry: '/chat?team=demo-team', agent: 'team-demo-team', status: 'Restored session' },
+    ]
+    for (const fixture of fixtures) {
+      MockWebSocket.instances = []
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation(async (input: RequestInfo) => {
+          const url = String(input)
+          if (url.includes('/chat/thread/')) {
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                agent_id: fixture.agent,
+                conversation_id: `c-${fixture.agent}`,
+                messages: [
+                  { role: 'user', content: `prior ${fixture.agent}` },
+                  { role: 'assistant', content: 'ok' },
+                ],
+              }),
+            } as Response
+          }
+          if (url.includes('team_rosters')) {
+            return {
+              ok: true,
+              status: 200,
+              json: async () => [{ id: 'demo-team', name: 'Demo Team', members: [] }],
+            } as Response
+          }
+          return { ok: true, status: 200, json: async () => ({ data: [] }) } as Response
+        }),
+      )
+      const view = renderChat(fixture.entry)
+      await act(async () => {
+        MockWebSocket.instances[0]?.open()
+      })
+      expect(await screen.findByTestId('chat-status')).toHaveTextContent(fixture.status)
+      expect(screen.getByText(`prior ${fixture.agent}`)).toBeInTheDocument()
+      view.unmount()
+    }
+  })
+
+  it('REQ-127: composer textarea keeps fenced newlines and user bubbles render pre/code', async () => {
+    MockWebSocket.instances = []
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/chat/thread/')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              agent_id: 'codey',
+              conversation_id: 'c-codey',
+              messages: [
+                {
+                  role: 'user',
+                  content: '```python\ndef hello():\n    return 1\n```',
+                },
+              ],
+            }),
+          } as Response
+        }
+        return { ok: true, status: 200, json: async () => ({ data: [] }) } as Response
+      }),
+    )
+    renderChat('/chat?blueprint=codey')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+    const fence = await screen.findByTestId('chat-md')
+    expect(fence.querySelector('pre')).toBeTruthy()
+    expect(fence.querySelector('code')).toBeTruthy()
+    const composer = screen.getByRole('textbox', { name: 'Chat message' })
+    expect(composer.tagName).toBe('TEXTAREA')
+    fireEvent.change(composer, {
+      target: { value: '```python\nprint(1)\nprint(2)\n```' },
+    })
+    expect((composer as HTMLTextAreaElement).value).toContain('\n')
+    expect((composer as HTMLTextAreaElement).value.split('\n')).toHaveLength(4)
   })
 })
 


### PR DESCRIPTION
# Summary
On reopen of a real prior thread, Chat shows a quiet centred status line for CLI, API, remote, and team — not Grok-only. The composer is a textarea so fenced Python copy/paste keeps newlines, and user bubbles render those fences as `<pre><code>`. Fixes #572, Fixes #517.

Quoted from [#572](https://github.com/matthewhand/open-swarm/issues/572):
- **Intent:** Same honest chrome whether you resume grok, agy, opencode, an API thread, or a remote session.
- **Success:** Quiet centred info line for CLI, API, and remote when restore actually occurred; no fake line; tests per kind.
- **Constraints:** Small PR. Align with #449 order (status before first reply). GitHub then `:8001`.
- **Owner:** Antigravity / Cursor. CoS: Open Swarm.
- **Feasibility:** Yes. Hydrate already loads prior turns; CLI already emits `Resumed {cli} session` on send. This adds display-only restore chrome on hydrate for every kind without shifting persist indexes.

Quoted from [#517](https://github.com/matthewhand/open-swarm/issues/517):
- **Intent:** Copy → paste → send preserves code structure; user bubbles render fenced markdown like assistant bubbles.
- **Success:** Copy keeps `\\n`; composer retains them; user fixture with a python fence renders `<pre><code>`.
- **Constraints:** Coordinate with #467 clipboard fallback (must not destroy newlines). GitHub-only.
- **Owner:** open-swarm engineer + Cursor cloud. CoS: Open Swarm.
- **Feasibility:** Yes. Root cause was an `<input type="text">` composer plus user bubbles already using `renderSafeMarkdown` once source has newlines.

Surfaces overlapped on `ChatPage.tsx`, so this is **one PR** (wave max 2–3). **#563 parked for Wave 7.**

## Problem it solves
REQ-161 (#572): restore chrome was CLI-session-notice on send and looked Grok-centric; API/remote/team reopen had no equivalent. REQ-127 (#517): copying a Python fence into the composer collapsed newlines, so the user bubble never rendered as a code block.

## How it works
`sessionRestore.ts` classifies CLI/API/remote/team and returns banner text only when the hydrated thread has user/assistant turns and does not already contain a resume/restore status. ChatPage sets `restoreNotice` on hydrate (including remotes) and renders it as existing `os-chat-status` chrome — not stored in the transcript, so PATCH indexes stay aligned. Composer is a `<textarea>` (`white-space: pre-wrap`; Enter sends, Shift+Enter newline). Clipboard writeText is tested with a fenced block that still contains `\\n`. Fenced blocks in bubbles get a Copy control that copies `code.textContent`.

## Measured impact
n/a — UI chrome and composer element swap; no backend payload size change.

## Test coverage
- Vitest: `sessionRestore.test.ts`; ChatPage REQ-161 (API/CLI/remote/team) + REQ-127 textarea/fence; clipboard newline; markdown `<pre><code>`. ChatPage.test.tsx: 80 passed; 5 failures also fail on `origin/main` (avatar heading / remotes dropdown) — not worsened.
- Python: `tests/unit/test_req161_restored_session.py`, `tests/unit/test_req127_codeblock_roundtrip.py` — 4 passed.

## Risks / follow-ups
Restore banner is client-only (not persisted). CLI send still emits `Resumed {name} session` from the consumer when the host CLI actually resumes. #563 (default avatars) parked. Rollback: revert this PR.

## Build footprint
None — no new dependencies or services. Small CSS for textarea + copy button.