### PR TITLE
feat(webui): interesting default avatars (Blobs) with bland static settings opt-in (Fixes #563)

### DIFF
--- a/src/swarm/static/js/chrome_avatar_theme.js
+++ b/src/swarm/static/js/chrome_avatar_theme.js
@@ -9,17 +9,18 @@
   function readTheme() {
     try {
       var stored = localStorage.getItem(KEY);
-      if (stored === "default" || stored === "blobs") return stored;
+      if (stored === "bland" || stored === "default") return "bland";
+      if (stored === "blobs") return "blobs";
     } catch (err) {
       /* storage unavailable */
     }
-    return "default";
+    return "blobs";
   }
 
   function writeTheme(theme) {
-    var next = theme === "blobs" ? "blobs" : "default";
+    var next = theme === "bland" || theme === "default" ? "bland" : "blobs";
     try {
-      if (next === "default") {
+      if (next === "blobs") {
         localStorage.removeItem(KEY);
       } else {
         localStorage.setItem(KEY, next);

--- a/src/swarm/templates/settings_dashboard.html
+++ b/src/swarm/templates/settings_dashboard.html
@@ -144,21 +144,21 @@
     {% endif %}
   </section>
 
-  <!-- REQ-34: avatar theme (localStorage; does not rewrite blueprints) -->
+  <!-- REQ-34 / REQ-155: avatar theme (localStorage; does not rewrite blueprints) -->
   <section class="chat-retention-card mb-4" aria-labelledby="avatar-theme-title">
     <div class="dashboard-header-top">
       <div>
         <h2 class="dashboard-title" id="avatar-theme-title">Avatar theme</h2>
         <p class="dashboard-subtitle mb-0">
-          Default keeps today’s rail dots. Blobs are per-agent shapes with capsule eyes.
+          Blobs are per-agent shapes with eyes (default). Bland static uses identical grey circles.
           The choice stays in this browser and does not rewrite blueprints.
         </p>
       </div>
     </div>
     <label class="form-label mt-3" for="os-avatar-theme">Avatar theme</label>
     <select id="os-avatar-theme" class="form-select os-avatar-theme-select">
-      <option value="default">Default</option>
-      <option value="blobs">Blobs</option>
+      <option value="blobs">Blobs with eyes (default)</option>
+      <option value="bland">Bland static circle</option>
     </select>
   </section>
 

--- a/tests/unit/test_req155_avatar_theme.py
+++ b/tests/unit/test_req155_avatar_theme.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+
+def test_req155_settings_dashboard_template_avatar_options():
+    repo_root = Path(__file__).resolve().parents[2]
+    template_path = repo_root / "src" / "swarm" / "templates" / "settings_dashboard.html"
+    assert template_path.exists()
+    content = template_path.read_text(encoding="utf-8")
+
+    assert 'id="os-avatar-theme"' in content
+    assert '<option value="blobs">Blobs with eyes (default)</option>' in content
+    assert '<option value="bland">Bland static circle</option>' in content
+
+
+def test_req155_chrome_avatar_theme_script_defaults_to_blobs():
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "src" / "swarm" / "static" / "js" / "chrome_avatar_theme.js"
+    assert script_path.exists()
+    content = script_path.read_text(encoding="utf-8")
+
+    assert 'return "blobs";' in content
+    assert 'theme === "bland"' in content
+    assert 'localStorage.removeItem(KEY);' in content
+
+
+def test_req155_frontend_avatar_theme_defaults():
+    repo_root = Path(__file__).resolve().parents[2]
+    theme_ts_path = repo_root / "webui" / "frontend" / "src" / "lib" / "avatarTheme.ts"
+    assert theme_ts_path.exists()
+    content = theme_ts_path.read_text(encoding="utf-8")
+
+    assert "defaultAvatarTheme(): AvatarTheme" in content
+    assert "return 'blobs'" in content
+    assert "'blobs', 'bland'" in content
+
+
+def test_req155_avatar_theme_picker_labels():
+    repo_root = Path(__file__).resolve().parents[2]
+    picker_path = repo_root / "webui" / "frontend" / "src" / "components" / "AvatarThemePicker.tsx"
+    assert picker_path.exists()
+    content = picker_path.read_text(encoding="utf-8")
+
+    assert "Blobs with eyes (default)" in content
+    assert "Bland static circle" in content

--- a/webui/frontend/e2e/settings-sheet.spec.ts
+++ b/webui/frontend/e2e/settings-sheet.spec.ts
@@ -138,6 +138,7 @@ test('gear opens a DaisyUI modal-end settings sheet over chat', async ({ page })
   await expect(sections.getByRole('button', { name: 'Rail' })).toBeVisible()
   await expect(sections.getByRole('button', { name: 'System' })).toBeVisible()
 
+  await sections.getByRole('button', { name: 'Retention' }).click()
   await expect(page.getByRole('radiogroup', { name: 'Retention mode' })).toHaveClass(/join/)
   await page.getByRole('radio', { name: 'Trash' }).click()
   await page.getByRole('button', { name: 'Save retention' }).click()
@@ -153,6 +154,14 @@ test('gear opens a DaisyUI modal-end settings sheet over chat', async ({ page })
   await expect
     .poll(() => page.evaluate(() => localStorage.getItem('swarm_hostname_override')))
     .toBe('swarm.example.com')
+
+  await page.getByRole('button', { name: 'Rail' }).click()
+  await expect(page.getByLabel('Avatar theme')).toBeVisible()
+  await expect(page.getByLabel('Avatar theme')).toHaveValue('blobs')
+  await page.getByLabel('Avatar theme').selectOption('bland')
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem('swarm_avatar_theme')))
+    .toBe('bland')
 
   await page.getByRole('button', { name: 'System' }).click()
   await expect(page.getByRole('heading', { name: 'System' })).toBeVisible()

--- a/webui/frontend/src/components/AgentAvatar.tsx
+++ b/webui/frontend/src/components/AgentAvatar.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react'
+import { useAvatarTheme } from '../lib/useAvatarTheme'
+import BlobAvatar from './BlobAvatar'
 
 /**
  * Bland circular fallback — not the Bert-like default owned by REQ-6 (#309).
@@ -17,11 +19,13 @@ export const DEFAULT_AGENT_AVATAR_SRC =
 export type AgentAvatarSize = 'sm' | 'md' | 'lg' | 'xl'
 
 export interface AgentAvatarProps {
-  /** Custom face URL. Blank / missing / broken uses the bland default. */
+  /** Custom face URL. Blank / missing / broken uses the themed default (or bland if selected in settings). */
   src?: string | null
   alt?: string
   size?: AgentAvatarSize
   className?: string
+  agentId?: string | null
+  active?: boolean
 }
 
 export function resolveAgentAvatarSrc(src?: string | null): string {
@@ -34,38 +38,82 @@ export function agentAvatarKind(src?: string | null): 'custom' | 'default' {
 }
 
 /**
- * Shared agent face for the rail tile and the chat header.
- * Display-only: no click handler. Sizes: rail sm, header lg.
+ * Shared agent face for the rail tile, favourites large tiles, and the chat header.
+ * Display-only: no click handler. Sizes: rail sm, header/favs lg.
+ * Unset or broken avatars resolve to Blobs-with-eyes by default (REQ-155),
+ * or bland static circles when opt-in chosen in Settings. Custom faces always win.
  */
 export default function AgentAvatar({
   src,
   alt = '',
   size = 'sm',
   className = '',
+  agentId,
+  active = false,
 }: AgentAvatarProps) {
   const [broken, setBroken] = useState(false)
+  const theme = useAvatarTheme()
 
   useEffect(() => {
     setBroken(false)
   }, [src])
 
-  const resolved = broken ? DEFAULT_AGENT_AVATAR_SRC : resolveAgentAvatarSrc(src)
-  const kind = resolved === DEFAULT_AGENT_AVATAR_SRC ? 'default' : 'custom'
+  const customSrc = typeof src === 'string' ? src.trim() : ''
+  const isCustom = Boolean(customSrc && !broken)
 
+  if (isCustom) {
+    return (
+      <div
+        className={`avatar ${className}`.trim()}
+        data-agent-avatar="custom"
+        aria-hidden={alt ? undefined : true}
+      >
+        <div className={`os-agent-avatar os-agent-avatar--${size} rounded-full`}>
+          <img
+            src={customSrc}
+            alt={alt}
+            draggable={false}
+            data-agent-avatar="custom"
+            onError={() => setBroken(true)}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  // Unset or broken face -> resolve via avatar theme
+  if (theme === 'blobs') {
+    return (
+      <div
+        className={`avatar ${className}`.trim()}
+        data-agent-avatar="default"
+        data-avatar-theme="blobs"
+        data-eye-state={active ? 'active' : 'idle'}
+        aria-hidden={alt ? undefined : true}
+      >
+        <BlobAvatar
+          agentId={agentId || 'agent'}
+          active={active}
+          size={size}
+          className=""
+        />
+      </div>
+    )
+  }
+
+  // Bland static fallback
   return (
     <div
       className={`avatar ${className}`.trim()}
-      data-agent-avatar={kind}
+      data-agent-avatar="default"
       aria-hidden={alt ? undefined : true}
     >
       <div className={`os-agent-avatar os-agent-avatar--${size} rounded-full`}>
         <img
-          src={resolved}
+          src={DEFAULT_AGENT_AVATAR_SRC}
           alt={alt}
           draggable={false}
-          onError={() => {
-            if (resolved !== DEFAULT_AGENT_AVATAR_SRC) setBroken(true)
-          }}
+          data-agent-avatar="default"
         />
       </div>
     </div>

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -796,6 +796,7 @@ export default function AgentSidebar({
       ) : (
         <AgentAvatar
           src={agent.avatar_path}
+          agentId={agent.id}
           size="sm"
           className="mt-1.5"
         />
@@ -1382,6 +1383,7 @@ export default function AgentSidebar({
                 ) : null}
                 <AgentAvatar
                   src={live?.avatar_path}
+                  agentId={pin.id}
                   size="lg"
                   className="os-fav-tile__avatar"
                 />

--- a/webui/frontend/src/components/AvatarThemePicker.tsx
+++ b/webui/frontend/src/components/AvatarThemePicker.tsx
@@ -5,9 +5,10 @@ export interface AvatarThemePickerProps {
   id?: string
 }
 
-/** Settings control: Default (current dots) or Blobs. Persists like hostname. */
+/** Settings control: Blobs (default) or Bland static. Persists like hostname (REQ-155). */
 export default function AvatarThemePicker({ id = 'os-avatar-theme' }: AvatarThemePickerProps) {
   const theme = useAvatarTheme()
+  const selectValue = theme === 'default' ? 'bland' : theme
 
   return (
     <div className="flex w-full flex-col gap-1">
@@ -17,17 +18,17 @@ export default function AvatarThemePicker({ id = 'os-avatar-theme' }: AvatarThem
       <select
         id={id}
         className="select select-bordered select-sm w-full"
-        value={theme}
+        value={selectValue}
         onChange={(event) => {
           saveAvatarTheme(event.target.value)
         }}
       >
-        <option value="default">Default</option>
-        <option value="blobs">Blobs</option>
+        <option value="blobs">Blobs with eyes (default)</option>
+        <option value="bland">Bland static circle</option>
       </select>
       <p className="text-xs text-base-content/55">
-        Default keeps the current marks. Blobs are per-agent shapes with eyes.
-        This does not rewrite blueprints.
+        Blobs are per-agent shapes with eyes (default). Bland static uses identical grey circles.
+        Custom uploaded faces always win.
       </p>
     </div>
   )

--- a/webui/frontend/src/components/BlobAvatar.tsx
+++ b/webui/frontend/src/components/BlobAvatar.tsx
@@ -7,7 +7,7 @@ export interface BlobAvatarProps {
   agentId: string
   /** Selected conversation and/or streaming — eyes wander slowly. */
   active?: boolean
-  size?: 'sm' | 'md'
+  size?: 'sm' | 'md' | 'lg' | 'xl'
   className?: string
 }
 

--- a/webui/frontend/src/components/SettingsSheet.tsx
+++ b/webui/frontend/src/components/SettingsSheet.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AlertCircle, FileCode2, HardDrive, Plus, Server } from 'lucide-react'
 import { Alert, Button, Input, Modal, Select, useToast } from './DaisyUI'
 import DefinitionPane from './DefinitionPane'
+import AvatarThemePicker from './AvatarThemePicker'
 import {
   EMPTY_LOCAL_STORE,
   createRemote,
@@ -842,6 +843,9 @@ function RailPane({
         On: when a generation finishes, that agent moves to the top of the
         visible list. Off: order changes only by drag.
       </p>
+      <div className="pt-2 border-t border-base-200">
+        <AvatarThemePicker />
+      </div>
     </div>
   )
 }

--- a/webui/frontend/src/components/__tests__/AgentAvatar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentAvatar.test.tsx
@@ -1,20 +1,54 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect } from 'vitest'
 import { fireEvent, render } from '@testing-library/react'
 import AgentAvatar, {
   DEFAULT_AGENT_AVATAR_SRC,
   agentAvatarKind,
   resolveAgentAvatarSrc,
 } from '../AgentAvatar'
+import {
+  AVATAR_THEME_STORAGE_KEY,
+  saveAvatarTheme,
+} from '../../lib/avatarTheme'
 
 describe('AgentAvatar', () => {
-  it('uses the bland default when no custom src is set', () => {
-    const { container } = render(<AgentAvatar />)
+  afterEach(() => {
+    localStorage.removeItem(AVATAR_THEME_STORAGE_KEY)
+  })
+
+  it('uses Blobs-with-eyes by default when no custom src is set', () => {
+    const { container } = render(<AgentAvatar agentId="codey" />)
     const face = container.querySelector('[data-agent-avatar]')
     expect(face).toHaveAttribute('data-agent-avatar', 'default')
-    expect(container.querySelector('img')).toHaveAttribute('src', DEFAULT_AGENT_AVATAR_SRC)
-    expect(DEFAULT_AGENT_AVATAR_SRC).toMatch(/^data:image\/svg\+xml/)
+    expect(face).toHaveAttribute('data-avatar-theme', 'blobs')
+    const svg = container.querySelector('svg[data-avatar-theme="blobs"]')
+    expect(svg).toBeInTheDocument()
+    expect(svg).toHaveAttribute('data-agent-id', 'codey')
     expect(agentAvatarKind(null)).toBe('default')
     expect(resolveAgentAvatarSrc('')).toBe(DEFAULT_AGENT_AVATAR_SRC)
+  })
+
+  it('renders distinct deterministic blob shapes for different agentIds', () => {
+    const render1 = render(<AgentAvatar agentId="codey" />)
+    const svg1 = render1.container.querySelector('svg')
+    const shape1 = svg1?.getAttribute('data-blob-shape')
+    render1.unmount()
+
+    const render2 = render(<AgentAvatar agentId="stewie" />)
+    const svg2 = render2.container.querySelector('svg')
+    const shape2 = svg2?.getAttribute('data-blob-shape')
+    render2.unmount()
+
+    expect(shape1).toBeDefined()
+    expect(shape2).toBeDefined()
+  })
+
+  it('uses the bland default static circle when opted in via settings', () => {
+    saveAvatarTheme('bland')
+    const { container } = render(<AgentAvatar agentId="codey" />)
+    const face = container.querySelector('[data-agent-avatar]')
+    expect(face).toHaveAttribute('data-agent-avatar', 'default')
+    expect(face).not.toHaveAttribute('data-avatar-theme', 'blobs')
+    expect(container.querySelector('img')).toHaveAttribute('src', DEFAULT_AGENT_AVATAR_SRC)
   })
 
   it('paints a custom src', () => {
@@ -31,16 +65,30 @@ describe('AgentAvatar', () => {
     expect(agentAvatarKind('/avatars/codey_avatar.png')).toBe('custom')
   })
 
-  it('treats blank custom src as the default', () => {
-    const { container } = render(<AgentAvatar src="   " />)
+  it('treats blank custom src as the default (blobs)', () => {
+    const { container } = render(<AgentAvatar src="   " agentId="codey" />)
     expect(container.querySelector('[data-agent-avatar]')).toHaveAttribute(
       'data-agent-avatar',
       'default',
     )
+    expect(container.querySelector('svg[data-avatar-theme="blobs"]')).toBeInTheDocument()
   })
 
-  it('falls back to the default when a custom src errors', () => {
-    const { container } = render(<AgentAvatar src="/avatars/missing.png" />)
+  it('falls back to blobs default when a custom src errors under default theme', () => {
+    const { container } = render(<AgentAvatar src="/avatars/missing.png" agentId="codey" />)
+    const img = container.querySelector('img')!
+    expect(img).toHaveAttribute('src', '/avatars/missing.png')
+    fireEvent.error(img)
+    expect(container.querySelector('[data-agent-avatar]')).toHaveAttribute(
+      'data-agent-avatar',
+      'default',
+    )
+    expect(container.querySelector('svg[data-avatar-theme="blobs"]')).toBeInTheDocument()
+  })
+
+  it('falls back to bland static circle when a custom src errors under bland theme', () => {
+    saveAvatarTheme('bland')
+    const { container } = render(<AgentAvatar src="/avatars/missing.png" agentId="codey" />)
     const img = container.querySelector('img')!
     expect(img).toHaveAttribute('src', '/avatars/missing.png')
     fireEvent.error(img)

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -260,6 +260,14 @@ html[data-theme="light"] #root {
   width: 2.35rem;
   height: 2.35rem;
 }
+.os-blob-avatar--lg {
+  width: 2.75rem;
+  height: 2.75rem;
+}
+.os-blob-avatar--xl {
+  width: 3.5rem;
+  height: 3.5rem;
+}
 .os-blob-eyes {
   transform-box: fill-box;
   transform-origin: 0 0;
@@ -288,6 +296,10 @@ html[data-theme="light"] #root {
   }
 }
 .os-fav-tile .os-agent-avatar--lg {
+  width: 3rem;
+  height: 3rem;
+}
+.os-fav-tile .os-blob-avatar {
   width: 3rem;
   height: 3rem;
 }

--- a/webui/frontend/src/lib/__tests__/avatarTheme.test.ts
+++ b/webui/frontend/src/lib/__tests__/avatarTheme.test.ts
@@ -12,20 +12,27 @@ describe('avatar theme persist', () => {
     localStorage.removeItem(AVATAR_THEME_STORAGE_KEY)
   })
 
-  it('defaults to Default and persists Blobs like hostname', () => {
+  it('defaults to Blobs and persists Bland like hostname', () => {
     expect(loadAvatarTheme()).toBe(defaultAvatarTheme())
-    expect(loadAvatarTheme()).toBe('default')
-    expect(saveAvatarTheme('blobs')).toBe('blobs')
-    expect(localStorage.getItem(AVATAR_THEME_STORAGE_KEY)).toBe('blobs')
     expect(loadAvatarTheme()).toBe('blobs')
+    expect(saveAvatarTheme('bland')).toBe('bland')
+    expect(localStorage.getItem(AVATAR_THEME_STORAGE_KEY)).toBe('bland')
+    expect(loadAvatarTheme()).toBe('bland')
   })
 
-  it('treats unknown values as Default and clears storage for Default', () => {
-    expect(saveAvatarTheme('not-a-theme')).toBe('default')
+  it('treats unknown values as Blobs (default) and clears storage for Blobs', () => {
+    expect(saveAvatarTheme('not-a-theme')).toBe('blobs')
     expect(localStorage.getItem(AVATAR_THEME_STORAGE_KEY)).toBeNull()
-    localStorage.setItem(AVATAR_THEME_STORAGE_KEY, 'blobs')
-    expect(saveAvatarTheme('default')).toBe('default')
+    localStorage.setItem(AVATAR_THEME_STORAGE_KEY, 'bland')
+    expect(saveAvatarTheme('blobs')).toBe('blobs')
     expect(localStorage.getItem(AVATAR_THEME_STORAGE_KEY)).toBeNull()
+  })
+
+  it('migrates legacy default to bland', () => {
+    localStorage.setItem(AVATAR_THEME_STORAGE_KEY, 'default')
+    expect(loadAvatarTheme()).toBe('bland')
+    expect(saveAvatarTheme('default')).toBe('bland')
+    expect(localStorage.getItem(AVATAR_THEME_STORAGE_KEY)).toBe('bland')
   })
 
   it('dispatches a same-tab event so pickers update without reload', () => {
@@ -34,8 +41,8 @@ describe('avatar theme persist', () => {
       seen.push((event as CustomEvent<string>).detail)
     }
     window.addEventListener(AVATAR_THEME_SET_EVENT, onSet)
-    saveAvatarTheme('blobs')
+    saveAvatarTheme('bland')
     window.removeEventListener(AVATAR_THEME_SET_EVENT, onSet)
-    expect(seen).toEqual(['blobs'])
+    expect(seen).toEqual(['bland'])
   })
 })

--- a/webui/frontend/src/lib/avatarTheme.ts
+++ b/webui/frontend/src/lib/avatarTheme.ts
@@ -1,27 +1,30 @@
 /**
- * Avatar theme preference. Default keeps today's os-agent-dot marks.
- * Blobs is a Grok-Bot-style geometric set. Persist is best-effort localStorage,
- * same contract as the rail hostname override.
+ * Avatar theme preference (REQ-155).
+ * Default is an approved interesting pack (Blobs with eyes).
+ * Bland static circular fallback is opt-in via Settings.
+ * Persist is best-effort localStorage, same contract as the rail hostname override.
  */
 
 export const AVATAR_THEME_STORAGE_KEY = 'swarm_avatar_theme'
 export const AVATAR_THEME_SET_EVENT = 'swarm:set-avatar-theme'
 
-export const AVATAR_THEMES = ['default', 'blobs'] as const
+export const AVATAR_THEMES = ['blobs', 'bland', 'default'] as const
 export type AvatarTheme = (typeof AVATAR_THEMES)[number]
 
 export function isAvatarTheme(value: unknown): value is AvatarTheme {
-  return value === 'default' || value === 'blobs'
+  return value === 'blobs' || value === 'bland' || value === 'default'
 }
 
 export function defaultAvatarTheme(): AvatarTheme {
-  return 'default'
+  return 'blobs'
 }
 
 export function loadAvatarTheme(): AvatarTheme {
   try {
     const stored = localStorage.getItem(AVATAR_THEME_STORAGE_KEY)
-    if (isAvatarTheme(stored)) return stored
+    if (isAvatarTheme(stored)) {
+      return stored === 'default' ? 'bland' : stored
+    }
   } catch {
     /* storage unavailable */
   }
@@ -29,7 +32,8 @@ export function loadAvatarTheme(): AvatarTheme {
 }
 
 export function saveAvatarTheme(value: string): AvatarTheme {
-  const next = isAvatarTheme(value) ? value : defaultAvatarTheme()
+  const normalized = value === 'default' ? 'bland' : value
+  const next = isAvatarTheme(normalized) ? normalized : defaultAvatarTheme()
   try {
     if (next === defaultAvatarTheme()) {
       localStorage.removeItem(AVATAR_THEME_STORAGE_KEY)

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -1240,6 +1240,8 @@ const ChatPage = () => {
           {!teamFromUrl ? (
             <AgentAvatar
               src={selectedAgent?.avatar_path}
+              agentId={agentIdFromBlueprint(selectedBlueprint)}
+              active={Boolean(streamingMessage || status === 'open')}
               size="lg"
               className="os-chat-header__avatar"
             />

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -1199,13 +1199,10 @@ describe('ChatPage Grok composer and per-agent threads', () => {
     expect(screen.getByRole('button', { name: 'Edit agent' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Voice input' })).toBeInTheDocument()
     expect(screen.getByLabelText('Tokens in context')).toBeInTheDocument()
-    expect(document.querySelector('.os-chat-header [data-avatar-theme="blobs"]')).not.toBeInTheDocument()
+    expect(document.querySelector('.os-chat-header [data-avatar-theme="blobs"]')).toBeInTheDocument()
   })
 
-  it('shows a Blobs header avatar when that theme is persisted', async () => {
-    act(() => {
-      saveAvatarTheme('blobs')
-    })
+  it('shows a Blobs header avatar by default and falls back to bland when opted in', async () => {
     renderChat('/chat?blueprint=codey')
     await act(async () => {
       MockWebSocket.instances[0]?.open()
@@ -1213,10 +1210,12 @@ describe('ChatPage Grok composer and per-agent threads', () => {
     const headerBlob = document.querySelector('.os-chat-header [data-avatar-theme="blobs"]')
     expect(headerBlob).toBeInTheDocument()
     expect(headerBlob).toHaveAttribute('data-eye-state', 'active')
-    localStorage.removeItem(AVATAR_THEME_STORAGE_KEY)
+
     act(() => {
-      saveAvatarTheme('default')
+      saveAvatarTheme('bland')
     })
+    expect(document.querySelector('.os-chat-header [data-avatar-theme="blobs"]')).not.toBeInTheDocument()
+    localStorage.removeItem(AVATAR_THEME_STORAGE_KEY)
   })
 
   it('opens a unique websocket thread per agent', async () => {


### PR DESCRIPTION
### Intent
Unset agents currently resolve to identical bland circular icons across the UI. REQ-155 provides an approved interesting theme (Blobs with eyes) as the default avatar, deterministic per `agentId`. Settings provides an opt-in fallback to "Bland static circle". Custom uploaded agent faces always win across favourites, rail, and chat header.

Fixes #563

### Changes
1. **Default Theme**: Flipped default theme in `avatarTheme.ts` and `chrome_avatar_theme.js` to `'blobs'`. Migrates legacy `'default'` to `'bland'`.
2. **Unified AgentAvatar Resolver**:
   - Custom face `src` always takes precedence.
   - Unset / broken avatars default to `BlobAvatar` (Blobs with eyes), deterministic by `agentId` with wander animations.
   - Bland static circle is rendered only when user selects "Bland static circle" in Settings.
3. **Placements**:
   - Rail row: passes `agentId={agent.id}`.
   - Favourites large tiles: passes `agentId={pin.id}`.
   - Chat header: passes `agentId={agentIdFromBlueprint(selectedBlueprint)}` and `active`.
   - SettingsSheet: mounted `<AvatarThemePicker />` in `RailPane`.
4. **Theme Pickers**: Updated options in SPA `AvatarThemePicker.tsx` and Django `settings_dashboard.html` to "Blobs with eyes (default)" vs "Bland static circle".
5. **Tests**: Updated vitest suites for avatar theme & `AgentAvatar`, added Python contract tests in `tests/unit/test_req155_avatar_theme.py`, updated Playwright e2e settings-sheet test.

### Success
- Default theme is Blobs-with-eyes for all unset agents across rail, favourites, and chat header.
- Custom uploaded avatars still take precedence.
- Switching to "Bland static circle" in Settings restores static circles and persists in localStorage.

### Constraints
- Rebased cleanly on latest main (`04969c35`).
- DaisyUI 5 / React 18 standards; no Neon; no secrets; Grok simplicity.
- Own-diff CI green.