### PR TITLE
feat(webui): fenced code blocks collapsed by default with hover expand and copy (Fixes #498)

### DIFF
--- a/tests/unit/test_req117_code_collapse.py
+++ b/tests/unit/test_req117_code_collapse.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+def test_req117_code_fences_module_exists():
+    repo_root = Path(__file__).resolve().parents[2]
+    code_fences_ts = repo_root / "webui" / "frontend" / "src" / "lib" / "codeFences.ts"
+    assert code_fences_ts.exists()
+    content = code_fences_ts.read_text(encoding="utf-8")
+
+    assert "CODE_LINE_THRESHOLD = 10" in content
+    assert "os-code--collapsible" in content
+    assert "os-code--collapsed" in content
+    assert "os-code--expanded" in content
+    assert "code-expand" in content
+    assert "code-collapse" in content
+    assert "code-copy" in content
+
+
+def test_req117_code_collapse_styles_exist():
+    repo_root = Path(__file__).resolve().parents[2]
+    index_css = repo_root / "webui" / "frontend" / "src" / "index.css"
+    assert index_css.exists()
+    content = index_css.read_text(encoding="utf-8")
+
+    assert ".os-code-actions" in content
+    assert ".os-code--collapsible.os-code--collapsed" in content
+    assert "max-height: 12rem;" in content

--- a/webui/frontend/src/components/ChatMessageBubble.tsx
+++ b/webui/frontend/src/components/ChatMessageBubble.tsx
@@ -54,6 +54,7 @@ export const ChatBubbleBody = memo(
     useEffect(() => {
       const root = mdRef.current
       if (!root) return
+      // Set up code-copy and collapsible code fence controls (REQ-127, REQ-117)
       setupCodeFenceControls(root, expandedIndicesRef.current)
     }, [text])
 

--- a/webui/frontend/src/components/ChatMessageBubble.tsx
+++ b/webui/frontend/src/components/ChatMessageBubble.tsx
@@ -9,8 +9,8 @@ import {
 } from 'react'
 import { Pencil } from 'lucide-react'
 import { Textarea, LoadingDots } from './DaisyUI'
-import { copyTextToClipboard } from '../lib/clipboard'
 import { renderSafeMarkdown } from '../lib/markdown'
+import { setupCodeFenceControls } from '../lib/codeFences'
 
 export interface ChatMessageBubbleProps {
   role: 'user' | 'assistant'
@@ -49,26 +49,12 @@ export const ChatBubbleBody = memo(
     streaming: boolean
   }) {
     const mdRef = useRef<HTMLDivElement | null>(null)
+    const expandedIndicesRef = useRef<Set<number>>(new Set())
 
     useEffect(() => {
       const root = mdRef.current
       if (!root) return
-      root.querySelectorAll('pre').forEach((pre) => {
-        if (pre.querySelector('[data-testid="code-copy"]')) return
-        const btn = document.createElement('button')
-        btn.type = 'button'
-        btn.className = 'btn btn-ghost btn-xs os-code-copy'
-        btn.dataset.testid = 'code-copy'
-        btn.setAttribute('aria-label', 'Copy code')
-        btn.textContent = 'Copy'
-        btn.addEventListener('click', (event) => {
-          event.preventDefault()
-          event.stopPropagation()
-          const code = pre.querySelector('code')
-          void copyTextToClipboard(code?.textContent ?? pre.textContent ?? '')
-        })
-        pre.insertBefore(btn, pre.firstChild)
-      })
+      setupCodeFenceControls(root, expandedIndicesRef.current)
     }, [text])
 
     if (text.length === 0) {

--- a/webui/frontend/src/components/__tests__/ChatMessageBubble.test.tsx
+++ b/webui/frontend/src/components/__tests__/ChatMessageBubble.test.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ChatMessageBubble } from '../ChatMessageBubble'
+import * as clipboard from '../../lib/clipboard'
+
+describe('REQ-117: Fenced code blocks collapse, hover expand, copy, re-collapse', () => {
+  const shortCode = '```typescript\nconst a = 1\nconst b = 2\nconsole.log(a + b)\n```'
+  const longCode = [
+    '```typescript',
+    'const line1 = 1',
+    'const line2 = 2',
+    'const line3 = 3',
+    'const line4 = 4',
+    'const line5 = 5',
+    'const line6 = 6',
+    'const line7 = 7',
+    'const line8 = 8',
+    'const line9 = 9',
+    'const line10 = 10',
+    'const line11 = 11',
+    'const line12 = 12',
+    '```',
+  ].join('\n')
+
+  let copySpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    copySpy = vi.spyOn(clipboard, 'copyTextToClipboard').mockResolvedValue('copied')
+  })
+
+  it('short code blocks (<=10 lines) are never clipped and have copy button', () => {
+    const { container } = render(
+      <ChatMessageBubble
+        role="assistant"
+        agentName="Codey"
+        text={shortCode}
+        streaming={false}
+        canEdit={false}
+        editing={false}
+        onStartEdit={() => {}}
+        onCancelEdit={() => {}}
+        onSaveEdit={() => {}}
+      />,
+    )
+
+    const pre = container.querySelector('pre')
+    expect(pre).toBeInTheDocument()
+    expect(pre).not.toHaveClass('os-code--collapsible')
+    expect(pre).not.toHaveClass('os-code--collapsed')
+    expect(pre?.querySelector('[data-testid="code-expand"]')).toBeNull()
+    expect(pre?.querySelector('[data-testid="code-copy"]')).toBeInTheDocument()
+  })
+
+  it('long code blocks (>10 lines) start collapsed with copy and expand buttons', () => {
+    const { container } = render(
+      <ChatMessageBubble
+        role="assistant"
+        agentName="Codey"
+        text={longCode}
+        streaming={false}
+        canEdit={false}
+        editing={false}
+        onStartEdit={() => {}}
+        onCancelEdit={() => {}}
+        onSaveEdit={() => {}}
+      />,
+    )
+
+    const pre = container.querySelector('pre')
+    expect(pre).toBeInTheDocument()
+    expect(pre).toHaveClass('os-code--collapsible')
+    expect(pre).toHaveClass('os-code--collapsed')
+    expect(pre).toHaveAttribute('data-collapsed', 'true')
+    expect(pre?.querySelector('[data-testid="code-copy"]')).toBeInTheDocument()
+
+    const expandBtn = pre?.querySelector('[data-testid="code-expand"]')
+    expect(expandBtn).toBeInTheDocument()
+    expect(expandBtn).toHaveTextContent('Expand')
+  })
+
+  it('hovering over the collapsed block does NOT auto-expand it', () => {
+    const { container } = render(
+      <ChatMessageBubble
+        role="assistant"
+        agentName="Codey"
+        text={longCode}
+        streaming={false}
+        canEdit={false}
+        editing={false}
+        onStartEdit={() => {}}
+        onCancelEdit={() => {}}
+        onSaveEdit={() => {}}
+      />,
+    )
+
+    const pre = container.querySelector('pre')!
+    fireEvent.mouseEnter(pre)
+    fireEvent.mouseOver(pre)
+
+    expect(pre).toHaveClass('os-code--collapsed')
+    expect(pre?.querySelector('[data-testid="code-expand"]')).toBeInTheDocument()
+    expect(pre?.querySelector('[data-testid="code-collapse"]')).toBeNull()
+  })
+
+  it('clicking Expand expands the block and sticks across re-renders', () => {
+    const { container, rerender } = render(
+      <ChatMessageBubble
+        role="assistant"
+        agentName="Codey"
+        text={longCode}
+        streaming={false}
+        canEdit={false}
+        editing={false}
+        onStartEdit={() => {}}
+        onCancelEdit={() => {}}
+        onSaveEdit={() => {}}
+      />,
+    )
+
+    const pre = container.querySelector('pre')!
+    const expandBtn = pre.querySelector('[data-testid="code-expand"]')!
+    fireEvent.click(expandBtn)
+
+    expect(pre).not.toHaveClass('os-code--collapsed')
+    expect(pre).toHaveClass('os-code--expanded')
+    expect(pre).toHaveAttribute('data-expanded', 'true')
+
+    const collapseBtn = pre.querySelector('[data-testid="code-collapse"]')
+    expect(collapseBtn).toBeInTheDocument()
+    expect(collapseBtn).toHaveTextContent('Collapse')
+
+    // Rerender (scrolling/props update) -> stays expanded (sticky)
+    rerender(
+      <ChatMessageBubble
+        role="assistant"
+        agentName="Codey"
+        text={longCode}
+        streaming={false}
+        canEdit={false}
+        editing={false}
+        onStartEdit={() => {}}
+        onCancelEdit={() => {}}
+        onSaveEdit={() => {}}
+      />,
+    )
+
+    const preAfterRerender = container.querySelector('pre')!
+    expect(preAfterRerender).toHaveClass('os-code--expanded')
+    expect(preAfterRerender?.querySelector('[data-testid="code-collapse"]')).toBeInTheDocument()
+  })
+
+  it('clicking Collapse returns the block to the collapsed state', () => {
+    const { container } = render(
+      <ChatMessageBubble
+        role="assistant"
+        agentName="Codey"
+        text={longCode}
+        streaming={false}
+        canEdit={false}
+        editing={false}
+        onStartEdit={() => {}}
+        onCancelEdit={() => {}}
+        onSaveEdit={() => {}}
+      />,
+    )
+
+    const pre = container.querySelector('pre')!
+    const expandBtn = pre.querySelector('[data-testid="code-expand"]')!
+    fireEvent.click(expandBtn)
+    expect(pre).toHaveClass('os-code--expanded')
+
+    const collapseBtn = pre.querySelector('[data-testid="code-collapse"]')!
+    fireEvent.click(collapseBtn)
+    expect(pre).toHaveClass('os-code--collapsed')
+    expect(pre).not.toHaveClass('os-code--expanded')
+    expect(pre.querySelector('[data-testid="code-expand"]')).toBeInTheDocument()
+  })
+
+  it('copy button copies full code text even when collapsed', () => {
+    const { container } = render(
+      <ChatMessageBubble
+        role="assistant"
+        agentName="Codey"
+        text={longCode}
+        streaming={false}
+        canEdit={false}
+        editing={false}
+        onStartEdit={() => {}}
+        onCancelEdit={() => {}}
+        onSaveEdit={() => {}}
+      />,
+    )
+
+    const pre = container.querySelector('pre')!
+    expect(pre).toHaveClass('os-code--collapsed')
+    const copyBtn = pre.querySelector('[data-testid="code-copy"]')!
+    fireEvent.click(copyBtn)
+
+    expect(copySpy).toHaveBeenCalledTimes(1)
+    const copiedText = copySpy.mock.calls[0][0]
+    expect(copiedText).toContain('const line1 = 1')
+    expect(copiedText).toContain('const line12 = 12')
+  })
+
+  it('also collapses long code blocks in user bubbles', () => {
+    const { container } = render(
+      <ChatMessageBubble
+        role="user"
+        agentName="User"
+        text={longCode}
+        streaming={false}
+        canEdit={false}
+        editing={false}
+        onStartEdit={() => {}}
+        onCancelEdit={() => {}}
+        onSaveEdit={() => {}}
+      />,
+    )
+
+    const pre = container.querySelector('pre')
+    expect(pre).toHaveClass('os-code--collapsible')
+    expect(pre).toHaveClass('os-code--collapsed')
+    expect(pre?.querySelector('[data-testid="code-expand"]')).toBeInTheDocument()
+  })
+})

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -861,9 +861,55 @@ button.os-agent-row {
   line-height: 1.4;
   padding: 0.45rem 0;
 }
-.os-code-copy {
-  float: right;
-  margin-left: 0.5rem;
+/* REQ-117: Fenced code block actions & collapse */
+.os-code {
+  position: relative;
+}
+.os-code-actions {
+  position: absolute;
+  top: 0.35rem;
+  right: 0.35rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  z-index: 2;
+}
+.os-code-copy,
+.os-code-expand {
+  font-size: 0.75rem;
+  height: 1.5rem;
+  min-height: 1.5rem;
+  padding: 0 0.45rem;
+}
+.os-code--collapsible.os-code--collapsed {
+  max-height: 12rem;
+  overflow: hidden !important;
+}
+.os-code--collapsible.os-code--collapsed::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 3.5rem;
+  background: linear-gradient(to bottom, transparent, rgba(20, 20, 20, 0.85));
+  pointer-events: none;
+}
+html[data-theme="light"] .os-code--collapsible.os-code--collapsed::after {
+  background: linear-gradient(to bottom, transparent, rgba(240, 240, 240, 0.9));
+}
+.os-code--collapsible.os-code--collapsed .os-code-expand {
+  opacity: 0;
+  transition: opacity 0.15s ease-in-out;
+}
+.os-code--collapsible.os-code--collapsed:hover .os-code-expand,
+.os-code--collapsible.os-code--collapsed:focus-within .os-code-expand {
+  opacity: 1;
+}
+@media (hover: none) {
+  .os-code--collapsible.os-code--collapsed .os-code-expand {
+    opacity: 1;
+  }
 }
 .os-composer__input::placeholder {
   color: color-mix(in srgb, var(--color-base-content) 40%, transparent);

--- a/webui/frontend/src/lib/codeFences.ts
+++ b/webui/frontend/src/lib/codeFences.ts
@@ -1,0 +1,107 @@
+import { copyTextToClipboard } from './clipboard'
+
+/** Threshold in lines to determine whether a fenced block should collapse by default (REQ-117). */
+export const CODE_LINE_THRESHOLD = 10
+
+/**
+ * Augment rendered markdown code fences with:
+ * 1. Always-available Copy button
+ * 2. If > CODE_LINE_THRESHOLD lines: collapsed by default with hover-revealed Expand button,
+ *    sticky per-message expand, and re-collapse.
+ */
+export function setupCodeFenceControls(
+  root: HTMLElement,
+  expandedIndices: Set<number>,
+  onToggle?: (index: number, expanded: boolean) => void,
+) {
+  const pres = root.querySelectorAll('pre')
+  pres.forEach((pre, index) => {
+    const code = pre.querySelector('code')
+    const fullText = code?.textContent ?? pre.textContent ?? ''
+    const lines = fullText.split('\n')
+    const effectiveLines =
+      lines.length > 1 && lines[lines.length - 1] === '' ? lines.length - 1 : lines.length
+    const isLong = effectiveLines > CODE_LINE_THRESHOLD
+
+    // Check or create the actions chrome
+    let actions = pre.querySelector<HTMLDivElement>('.os-code-actions')
+    if (!actions) {
+      actions = document.createElement('div')
+      actions.className = 'os-code-actions'
+      pre.insertBefore(actions, pre.firstChild)
+    }
+
+    // Always-available Copy button
+    let copyBtn = actions.querySelector<HTMLButtonElement>('[data-testid="code-copy"]')
+    if (!copyBtn) {
+      copyBtn = document.createElement('button')
+      copyBtn.type = 'button'
+      copyBtn.className = 'btn btn-ghost btn-xs os-code-copy'
+      copyBtn.dataset.testid = 'code-copy'
+      copyBtn.setAttribute('aria-label', 'Copy code')
+      copyBtn.textContent = 'Copy'
+      copyBtn.addEventListener('click', (event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        void copyTextToClipboard(fullText)
+      })
+      actions.appendChild(copyBtn)
+    }
+
+    if (!isLong) {
+      pre.classList.remove('os-code--collapsible', 'os-code--collapsed', 'os-code--expanded')
+      pre.removeAttribute('data-collapsed')
+      pre.removeAttribute('data-expanded')
+      const expandBtn = actions.querySelector(
+        '[data-testid="code-expand"], [data-testid="code-collapse"]',
+      )
+      if (expandBtn) expandBtn.remove()
+      return
+    }
+
+    pre.classList.add('os-code--collapsible')
+    const isExpanded = expandedIndices.has(index)
+
+    let expandBtn = actions.querySelector<HTMLButtonElement>(
+      '[data-testid="code-expand"], [data-testid="code-collapse"]',
+    )
+    if (!expandBtn) {
+      expandBtn = document.createElement('button')
+      expandBtn.type = 'button'
+      expandBtn.className = 'btn btn-ghost btn-xs os-code-expand'
+      actions.insertBefore(expandBtn, copyBtn)
+    }
+
+    if (isExpanded) {
+      pre.classList.remove('os-code--collapsed')
+      pre.classList.add('os-code--expanded')
+      pre.dataset.expanded = 'true'
+      delete pre.dataset.collapsed
+      expandBtn.dataset.testid = 'code-collapse'
+      expandBtn.setAttribute('aria-label', 'Collapse code')
+      expandBtn.textContent = 'Collapse'
+    } else {
+      pre.classList.add('os-code--collapsed')
+      pre.classList.remove('os-code--expanded')
+      pre.dataset.collapsed = 'true'
+      delete pre.dataset.expanded
+      expandBtn.dataset.testid = 'code-expand'
+      expandBtn.setAttribute('aria-label', 'Expand code')
+      expandBtn.textContent = 'Expand'
+    }
+
+    expandBtn.onclick = (event) => {
+      event.preventDefault()
+      event.stopPropagation()
+      if (expandedIndices.has(index)) {
+        expandedIndices.delete(index)
+        onToggle?.(index, false)
+        setupCodeFenceControls(root, expandedIndices, onToggle)
+      } else {
+        expandedIndices.add(index)
+        onToggle?.(index, true)
+        setupCodeFenceControls(root, expandedIndices, onToggle)
+      }
+    }
+  })
+}


### PR DESCRIPTION
### Intent
Quoting Issue #498 (REQ-117):
> Long code fences start collapsed so surrounding assistant text stays readable; expand on demand; copy always easy.

Fixes #498

### Success
1. **Default (collapsed):** Fenced code blocks taller than 10 lines collapse by default to 12rem with a bottom gradient fade. Short blocks (<=10 lines) stay open.
2. **Hover → Expand control (not auto-expand):** On desktop, hovering reveals the Expand button; expansion happens only on click/activation. Hover alone does not expand.
3. **Sticky expand:** Once expanded, the block stays expanded across scrolling and re-renders; Collapse control returns it to clipped state.
4. **Copy:** Always available on code block chrome (collapsed or expanded) copying full fence contents.
5. **Scope:** Markdown fenced blocks in assistant and user bubbles.

### Constraints & Feasibility
- Lightweight CSS max-height + DOM action controls, no heavy editor widget.
- DaisyUI 5 / React 18 standards; no Neon; no secrets.
- Own-diff CI green.

### Owner
CoS: Open Swarm.