### PR TITLE
feat(webui): name rail cli_agent, api_agent, Hermes, OpenMousBot

### DIFF
--- a/src/swarm/consumers.py
+++ b/src/swarm/consumers.py
@@ -370,12 +370,23 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
                     cli_name = raw_cli.strip()
             if not cli_name:
                 cli_name = cli_from_rail_id(blueprint_id)
-            run_id = "cli_agent" if cli_name else blueprint_id
-            blueprint_instance = await get_blueprint_instance(run_id)
-            if blueprint_instance is not None and cli_name and hasattr(
-                blueprint_instance, "set_params"
-            ):
-                blueprint_instance.set_params({"cli": cli_name})
+            if str(blueprint_id).strip().lower() == "api_agent":
+                run_id = "chatbot"
+                blueprint_instance = await get_blueprint_instance(run_id)
+                profile = None
+                if isinstance(params, dict):
+                    raw_model = params.get("model") or params.get("llm_profile")
+                    if isinstance(raw_model, str) and raw_model.strip() and raw_model.strip() != "default":
+                        profile = raw_model.strip()
+                if blueprint_instance is not None and profile:
+                    blueprint_instance.llm_profile_name = profile
+            else:
+                run_id = "cli_agent" if cli_name else blueprint_id
+                blueprint_instance = await get_blueprint_instance(run_id)
+                if blueprint_instance is not None and cli_name and hasattr(
+                    blueprint_instance, "set_params"
+                ):
+                    blueprint_instance.set_params({"cli": cli_name})
         except Exception:
             logger.error(
                 f"Error loading blueprint '{blueprint_id}'", exc_info=True

--- a/src/swarm/core/cli_catalog.py
+++ b/src/swarm/core/cli_catalog.py
@@ -513,23 +513,39 @@ def cli_from_rail_id(agent_id: str | None) -> str | None:
 
 
 def rail_cli_rows() -> list[dict[str, Any]]:
-    """Rows for the Grok conversation rail (id ``grok_agent``, …)."""
-    rows: list[dict[str, Any]] = []
-    for spec in listed_cli_specs():
-        name = str(spec.get("cli") or spec.get("agent_id") or "")
-        if not name:
-            continue
-        meta = CLI_SIDEBAR.get(name) or {}
-        rows.append({
-            "id": rail_cli_agent_id(name),
+    """Named kind rows for the conversation rail: ``cli_agent`` + ``api_agent``.
+
+    Host CLIs (grok/agy/opencode/pi) are picked from the chat CLI dropdown, not
+    as four separate rail ids. ``grok_agent``-style ids still map via
+    :func:`cli_from_rail_id` for old bookmarks.
+    """
+    default_cli = next(
+        (name for name in SIDEBAR_CLIS if name in CATALOG and which_cli(CATALOG[name]["cmd"][0])),
+        SIDEBAR_CLIS[0] if SIDEBAR_CLIS else "grok",
+    )
+    installed = any(
+        name in CATALOG and which_cli(CATALOG[name]["cmd"][0]) for name in SIDEBAR_CLIS
+    )
+    return [
+        {
+            "id": "cli_agent",
             "object": "cli.agent",
-            "name": rail_cli_agent_id(name),
-            "cli": name,
+            "name": "cli_agent",
+            "cli": default_cli,
             "kind": "cli",
-            "description": meta.get("description") or spec.get("description") or f"{name} CLI",
-            "installed": bool(which_cli(CATALOG[name]["cmd"][0])),
-        })
-    return rows
+            "description": "Host CLI — pick grok, agy, opencode, or pi in the header.",
+            "installed": installed,
+        },
+        {
+            "id": "api_agent",
+            "object": "cli.agent",
+            "name": "api_agent",
+            "cli": "",
+            "kind": "api",
+            "description": "LiteLLM — pick a profile (orchestration, auxiliary, …).",
+            "installed": True,
+        },
+    ]
 
 
 def session_policy(name: str) -> dict[str, Any] | None:

--- a/tests/core/test_cli_catalog.py
+++ b/tests/core/test_cli_catalog.py
@@ -115,15 +115,18 @@ def test_listed_cli_specs_are_first_class_sidebar_agents():
     assert specs["pi"]["cli"] == "pi"
 
 
-def test_rail_cli_rows_use_star_agent_ids():
+def test_rail_cli_rows_use_named_kind_ids():
     rows = {r["id"]: r for r in cli_catalog.rail_cli_rows()}
-    for name in ("grok", "agy", "opencode", "pi"):
-        row = rows[f"{name}_agent"]
-        assert row["cli"] == name
-        assert row["kind"] == "cli"
-        assert cli_catalog.cli_from_rail_id(row["id"]) == name
+    assert set(rows) == {"cli_agent", "api_agent"}
+    assert rows["cli_agent"]["kind"] == "cli"
+    assert rows["cli_agent"]["name"] == "cli_agent"
+    assert rows["api_agent"]["kind"] == "api"
+    assert rows["api_agent"]["name"] == "api_agent"
+    assert cli_catalog.cli_from_rail_id("grok_agent") == "grok"
+    assert cli_catalog.cli_from_rail_id("agy") == "agy"
     assert cli_catalog.cli_from_rail_id("grok") == "grok"
     assert cli_catalog.cli_from_rail_id("nope") is None
+    assert cli_catalog.cli_from_rail_id("cli_agent") is None
 
 
 def test_which_cli_finds_user_local_bin_when_path_is_stripped(tmp_path, monkeypatch):
@@ -139,7 +142,7 @@ def test_which_cli_finds_user_local_bin_when_path_is_stripped(tmp_path, monkeypa
     monkeypatch.setenv("PATH", str(empty))
     assert cli_catalog.which_cli("grok") == str(grok)
     rows = {r["id"]: r for r in cli_catalog.rail_cli_rows()}
-    assert rows["grok_agent"]["installed"] is True
+    assert rows["cli_agent"]["installed"] is True
     adapter = CliAdapter.from_config("grok", {"cmd": ["grok", "-p", "{prompt}"]})
     assert adapter.is_available()
     assert adapter._resolved_argv(["grok", "-p", "hi"])[0] == str(grok)

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -164,24 +164,30 @@ function sidebarHref(agent: { id: string; kind?: string }): string {
 }
 
 function toSidebarCli(row: CliRailAgent): SidebarAgent {
+  const kind = row.kind === 'api' ? 'api' : 'cli'
   return {
     id: row.id,
     object: 'blueprint',
     name: row.name,
-    description: row.installed ? row.description : `${row.description} (not on PATH)`,
+    description:
+      kind === 'cli' && !row.installed ? `${row.description} (not on PATH)` : row.description,
     abbreviation: null,
     required_mcp_servers: [],
-    tags: ['cli'],
+    tags: [kind],
     installed: row.installed,
     compiled: true,
-    kind: 'cli',
+    kind,
     cli: row.cli,
   }
 }
 
-/** Host CLI verify rows (grok_agent, agy_agent, …) stay on the rail. */
+/** Named kind rows (cli_agent, api_agent) stay on the rail. */
 function isCliRailAgent(agent: { id?: string; kind?: string }): boolean {
   return agent.kind === 'cli'
+}
+
+function isApiRailAgent(agent: { id?: string; kind?: string }): boolean {
+  return agent.kind === 'api' || agent.id === 'api_agent'
 }
 
 function toSidebarHerdr(row: HerdrAgent): SidebarAgent {
@@ -403,18 +409,19 @@ export default function AgentSidebar({
       }
     }
     const herdr = (herdrQuery.data?.data ?? []).map(toSidebarHerdr)
-    const clis = (cliQuery.data?.rail ?? []).map(toSidebarCli)
-    const cliIds = new Set(clis.map((a) => a.id))
-    const fromBlueprintsNoCli = fromBlueprints.filter((a) => !cliIds.has(a.id))
+    const named = (cliQuery.data?.rail ?? []).map(toSidebarCli)
+    const namedIds = new Set(named.map((a) => a.id))
+    const fromBlueprintsNoCli = fromBlueprints.filter((a) => !namedIds.has(a.id) && a.id !== 'api_agent')
     const list = [...fromRosters, ...fromBlueprintsNoCli, ...herdr]
     const support = list.filter((a) => isSupportAgent(a))
-    const rest = list.filter((a) => !isSupportAgent(a))
-    const merged = [...support, ...clis, ...rest]
+    const rest = list.filter((a) => !isSupportAgent(a) && !isApiRailAgent(a))
+    const merged = [...support, ...named, ...rest]
     const railRank = (a: SidebarAgent) => {
       if (isSupportAgent(a)) return 0
-      if (a.kind === 'cli') return 1
-      if (isChiefOfStaff(roleFromAgent(a))) return 2
-      return 3
+      if (isCliRailAgent(a)) return 1
+      if (isApiRailAgent(a)) return 2
+      if (isChiefOfStaff(roleFromAgent(a))) return 3
+      return 4
     }
     return merged.sort((a, b) => railRank(a) - railRank(b))
   }, [catalog, cliQuery.data, herdrQuery.data, teams])
@@ -449,14 +456,18 @@ export default function AgentSidebar({
   const visibleAgents = useMemo(
     () =>
       agents.filter(
-        (agent) => isCliRailAgent(agent) || !resolvedHiddenIds.includes(agent.id),
+        (agent) =>
+          isCliRailAgent(agent) || isApiRailAgent(agent) || !resolvedHiddenIds.includes(agent.id),
       ),
     [agents, resolvedHiddenIds],
   )
   const hiddenAgents = useMemo(
     () =>
       agents.filter(
-        (agent) => !isCliRailAgent(agent) && resolvedHiddenIds.includes(agent.id),
+        (agent) =>
+          !isCliRailAgent(agent) &&
+          !isApiRailAgent(agent) &&
+          resolvedHiddenIds.includes(agent.id),
       ),
     [agents, resolvedHiddenIds],
   )
@@ -485,9 +496,10 @@ export default function AgentSidebar({
   const loadingList = blueprintsQuery.isPending && teamsQuery.isPending
   const loadFailed = blueprintsQuery.isError && teamsQuery.isError && visibleCount === 0
   const supportAgents = visibleAgents.filter((agent) => isSupportAgent(agent))
-  const cliAgents = visibleAgents.filter((agent) => agent.kind === 'cli')
+  const cliAgents = visibleAgents.filter((agent) => isCliRailAgent(agent))
+  const apiAgents = visibleAgents.filter((agent) => isApiRailAgent(agent))
   const otherAgents = visibleAgents.filter(
-    (agent) => !isSupportAgent(agent) && agent.kind !== 'cli',
+    (agent) => !isSupportAgent(agent) && !isCliRailAgent(agent) && !isApiRailAgent(agent),
   )
   const catalogRows = useMemo<RailRow[]>(() => {
     const supportRows: RailRow[] = supportAgents.map((agent) => ({
@@ -496,6 +508,11 @@ export default function AgentSidebar({
       agent,
     }))
     const cliRows: RailRow[] = cliAgents.map((agent) => ({
+      kind: 'agent',
+      id: agent.id,
+      agent,
+    }))
+    const apiRows: RailRow[] = apiAgents.map((agent) => ({
       kind: 'agent',
       id: agent.id,
       agent,
@@ -516,10 +533,10 @@ export default function AgentSidebar({
       agent,
     }))
     return excludePinnedFromList(
-      [...supportRows, ...cliRows, ...teamRows, ...remoteRows, ...otherRows],
+      [...supportRows, ...cliRows, ...apiRows, ...teamRows, ...remoteRows, ...otherRows],
       pins,
     )
-  }, [supportAgents, cliAgents, visibleRootTeams, visibleRemotes, otherAgents, pins])
+  }, [supportAgents, cliAgents, apiAgents, visibleRootTeams, visibleRemotes, otherAgents, pins])
   const orderedRows = useMemo(
     () => applyRailOrder(catalogRows, railOrder),
     [catalogRows, railOrder],
@@ -696,7 +713,12 @@ export default function AgentSidebar({
    */
   const hideFromRail = (id: string) => {
     if (!id) return
-    if (agents.some((agent) => agent.id === id && isCliRailAgent(agent))) return
+    if (
+      agents.some(
+        (agent) => agent.id === id && (isCliRailAgent(agent) || isApiRailAgent(agent)),
+      )
+    )
+      return
     setHiddenIds((current) => hideAgentId(id, current ?? resolvedHiddenIds))
   }
 

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -105,10 +105,8 @@ function mockFetch(extraBlueprints = blueprints, extraRosters = rosters) {
           native_consensus: {},
           catalog: {},
           rail: [
-            { id: 'grok_agent', object: 'cli.agent', name: 'grok_agent', cli: 'grok', kind: 'cli', description: 'Host grok CLI', installed: true },
-            { id: 'agy_agent', object: 'cli.agent', name: 'agy_agent', cli: 'agy', kind: 'cli', description: 'Host agy CLI', installed: true },
-            { id: 'opencode_agent', object: 'cli.agent', name: 'opencode_agent', cli: 'opencode', kind: 'cli', description: 'Host opencode CLI', installed: true },
-            { id: 'pi_agent', object: 'cli.agent', name: 'pi_agent', cli: 'pi', kind: 'cli', description: 'Host pi CLI', installed: true },
+            { id: 'cli_agent', object: 'cli.agent', name: 'cli_agent', cli: 'grok', kind: 'cli', description: 'Host CLI', installed: true },
+            { id: 'api_agent', object: 'cli.agent', name: 'api_agent', cli: '', kind: 'api', description: 'LiteLLM', installed: true },
           ],
         }),
       } as Response
@@ -233,33 +231,29 @@ describe('AgentSidebar Grok rail', () => {
     )
   })
 
-  it('lists grok_agent, agy_agent, opencode_agent, and pi_agent after Support', async () => {
+  it('lists cli_agent then api_agent after Support', async () => {
     renderSidebar()
     const list = await screen.findByRole('navigation', { name: 'Agent list' })
-    await within(list).findByRole('link', { name: /grok_agent/ })
+    await within(list).findByRole('link', { name: /cli_agent/ })
     const hrefs = within(list)
       .getAllByRole('link')
       .map((el) => el.getAttribute('href'))
-    expect(hrefs.slice(0, 5)).toEqual([
+    expect(hrefs.slice(0, 3)).toEqual([
       '/chat?blueprint=support',
-      '/chat?blueprint=grok_agent',
-      '/chat?blueprint=agy_agent',
-      '/chat?blueprint=opencode_agent',
-      '/chat?blueprint=pi_agent',
+      '/chat?blueprint=cli_agent',
+      '/chat?blueprint=api_agent',
     ])
   })
 
-  it('keeps CLI rail rows listed even if they were previously hidden', async () => {
+  it('keeps cli_agent and api_agent listed even if they were previously hidden', async () => {
     localStorage.setItem(
       HIDDEN_AGENTS_STORAGE_KEY,
-      JSON.stringify(['grok_agent', 'agy_agent', 'opencode_agent', 'pi_agent', 'codey']),
+      JSON.stringify(['cli_agent', 'api_agent', 'codey']),
     )
     renderSidebar()
     const list = await screen.findByRole('navigation', { name: 'Agent list' })
-    await within(list).findByRole('link', { name: /grok_agent/ })
-    expect(within(list).getByRole('link', { name: /agy_agent/ })).toBeInTheDocument()
-    expect(within(list).getByRole('link', { name: /opencode_agent/ })).toBeInTheDocument()
-    expect(within(list).getByRole('link', { name: /pi_agent/ })).toBeInTheDocument()
+    await within(list).findByRole('link', { name: /cli_agent/ })
+    expect(within(list).getByRole('link', { name: /api_agent/ })).toBeInTheDocument()
     expect(within(list).queryByRole('link', { name: /Codey/ })).not.toBeInTheDocument()
   })
 

--- a/webui/frontend/src/lib/__tests__/remotesCatalog.test.ts
+++ b/webui/frontend/src/lib/__tests__/remotesCatalog.test.ts
@@ -38,7 +38,9 @@ describe('remotesCatalog (REQ-68)', () => {
         },
       ],
     })
-    expect(rail.map((row) => row.title)).toEqual([OPENMOUSBOT_LABEL, 'Lab swarm'])
+    expect(rail.map((row) => row.id)).toEqual(['hermes', 'omb', 'omb', 'lab-swarm'])
+    expect(rail.map((row) => row.title)).toContain('Hermes')
+    expect(rail.map((row) => row.title)).toContain(OPENMOUSBOT_LABEL)
     expect(JSON.stringify(rail)).not.toMatch(/\bOMB\b/)
   })
 

--- a/webui/frontend/src/lib/__tests__/sessionRestore.test.ts
+++ b/webui/frontend/src/lib/__tests__/sessionRestore.test.ts
@@ -11,6 +11,7 @@ import {
 describe('restoreKindForAgent (REQ-161)', () => {
   it('classifies CLI, API, remote, and team ids', () => {
     expect(restoreKindForAgent('cli_agent')).toBe('cli')
+    expect(restoreKindForAgent('api_agent')).toBe('api')
     expect(restoreKindForAgent('grok_agent')).toBe('cli')
     expect(restoreKindForAgent('agy_agent')).toBe('cli')
     expect(restoreKindForAgent('opencode_agent')).toBe('cli')

--- a/webui/frontend/src/lib/api.ts
+++ b/webui/frontend/src/lib/api.ts
@@ -806,7 +806,7 @@ export interface CliRailAgent {
   object: 'cli.agent'
   name: string
   cli: string
-  kind: 'cli'
+  kind: 'cli' | 'api'
   description: string
   installed: boolean
 }

--- a/webui/frontend/src/lib/remotesCatalog.ts
+++ b/webui/frontend/src/lib/remotesCatalog.ts
@@ -123,8 +123,15 @@ export function parseRemote(raw: unknown): RemoteEntry | null {
   return { id, kind, title, configured, agents }
 }
 
-/** Only remotes the operator added, or that already report agents/bots. */
+/** Always listed on the conversation rail (Hermes + OpenMousBot). */
+export const PINNED_RAIL_REMOTE_IDS = new Set(['hermes', 'omb', 'openmousbot', 'openmausbot'])
+
+/** Pinned remotes, plus any the operator added or that already report agents. */
 export function isRailRemote(remote: RemoteEntry): boolean {
+  const id = String(remote.id || '').trim().toLowerCase()
+  if (PINNED_RAIL_REMOTE_IDS.has(id) || PINNED_RAIL_REMOTE_IDS.has(String(remote.kind || '').toLowerCase())) {
+    return true
+  }
   return remote.configured || remote.agents.length > 0
 }
 

--- a/webui/frontend/src/lib/sessionRestore.ts
+++ b/webui/frontend/src/lib/sessionRestore.ts
@@ -27,7 +27,8 @@ export function restoreKindForAgent(agentId: string): RestoreKind {
   ) {
     return 'remote'
   }
-  if (isCliBlueprintId(id) || /_agent$/.test(id)) return 'cli'
+  if (id === 'api_agent') return 'api'
+  if (isCliBlueprintId(id) || id === 'cli_agent' || /_agent$/.test(id)) return 'cli'
   return classifyAgentKind(id)
 }
 

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -33,7 +33,8 @@ import {
   getRecentSlashIds,
   recordRecentSlashId,
 } from '../lib/slashMenu'
-import { fetchConfigOptions, fetchBlueprints, fetchCliAgents, fetchCliModels, fetchModels, fetchRemotes } from '../lib/api'
+import { fetchConfigOptions, fetchBlueprints, fetchCliAgents, fetchCliModels, fetchLlmProfiles, fetchModels, fetchRemotes } from '../lib/api'
+import { profileIds } from '../lib/llmProfiles'
 import {
   agentIdFromBlueprint,
   appendAgentMessage,
@@ -288,7 +289,9 @@ const ChatPage = () => {
     ? selectedTeamSession?.name || selectedTeam?.name || teamFromUrl
     : remoteFromUrl
       ? selectedRemoteSession?.name || selectedRemote?.title || remoteFromUrl
-      : selectedCli
+      : selectedBlueprint === 'api_agent'
+        ? 'api_agent'
+        : selectedCli
         ? selectedCli.name
         : selectedAgent
           ? agentLabel(selectedAgent)
@@ -341,6 +344,7 @@ const ChatPage = () => {
         })),
   )
 
+  const isNamedApiAgent = selectedBlueprint === 'api_agent'
   const isApiAgent = Boolean(
     !teamFromUrl &&
       !remoteFromUrl &&
@@ -348,6 +352,13 @@ const ChatPage = () => {
       !isRemoteAgent &&
       !isCliAgent,
   )
+
+  const llmProfilesQuery = useQuery({
+    queryKey: ['llm-profiles'],
+    queryFn: fetchLlmProfiles,
+    enabled: Boolean(isNamedApiAgent || isApiAgent),
+    retry: 1,
+  })
 
   const discoveredClis = useMemo(
     () => discoverChatClis(cliQuery.data, searchParams.get('cli') || selectedCli?.cli),
@@ -382,9 +393,15 @@ const ChatPage = () => {
     [blueprints],
   )
   const availableApiModels = useMemo(() => {
+    if (isNamedApiAgent) {
+      const ids = profileIds(llmProfilesQuery.data)
+      const fallback = llmProfilesQuery.data?.default_llm_profile
+      const list = ids.length ? ids : fallback ? [fallback] : []
+      return list.length ? list : ['default']
+    }
     const list = modelsQuery.data?.data?.map((m) => m.id) ?? []
     return list.length ? list : ['default']
-  }, [modelsQuery.data])
+  }, [isNamedApiAgent, llmProfilesQuery.data, modelsQuery.data])
 
   const currentApiModel = useMemo(() => {
     const fromParam = (searchParams.get('model') ?? '').trim()
@@ -1427,7 +1444,33 @@ const ChatPage = () => {
               </select>
             </>
           ) : null}
-          {isApiAgent ? (
+          {isNamedApiAgent ? (
+            <select
+              className="select select-sm h-8 max-w-[10rem] border border-base-300 bg-base-100"
+              value={currentApiModel}
+              aria-label="API"
+              data-testid="api-select"
+              onChange={(e) => {
+                const nextModel = e.target.value
+                const prev = currentApiModel
+                setSearchParams(
+                  (prevParams) => {
+                    const nextParams = new URLSearchParams(prevParams)
+                    nextParams.set('model', nextModel)
+                    return nextParams
+                  },
+                  { replace: true },
+                )
+                recordDropdownChange('api', prev, nextModel)
+              }}
+            >
+              {availableApiModels.map((m) => (
+                <option key={m} value={m}>
+                  {m}
+                </option>
+              ))}
+            </select>
+          ) : isApiAgent ? (
             <>
               <select
                 className="select select-sm h-8 max-w-[10rem] border border-base-300 bg-base-100"


### PR DESCRIPTION
# Summary
The conversation rail names the three runtimes the operator actually uses: **cli_agent** (header dropdown of host CLIs: grok, agy, opencode, pi), **api_agent** (header dropdown of LiteLLM profiles), plus pinned remotes **Hermes** and **OpenMousBot**. The four `grok_agent`/`agy_agent`/`opencode_agent`/`pi_agent` verify rows collapse into the one CLI row.

## Problem it solves
The sidepane listed every host CLI as its own agent, and API chat listed blueprints instead of LiteLLM profiles. The operator wants one CLI agent, one API/LiteLLM agent, and two remotes (Hermes, OpenMousBot).

## How it works
`rail_cli_rows()` returns `cli_agent` + `api_agent`. Chat maps `cli_agent` through the existing CLI dropdown (`?cli=`). `api_agent` runs the `chatbot` blueprint with `llm_profile_name` from `?model=`. Hermes and OpenMousBot are always rail remotes even when still `source=default`. Old `grok_agent` bookmarks still map via `cli_from_rail_id`.

## Measured impact
n/a — rail catalog shape change; no new services.

## Test coverage
`tests/core/test_cli_catalog.py` named-kind rows. AgentSidebar lists `cli_agent` then `api_agent` after Support and cannot hide them. remotesCatalog pins hermes+omb. ChatPage.test.tsx: same 5 avatar/remote failures as `origin/main`.

## Risks / follow-ups
Other remotes (Rakazo, nested swarm) still appear only when configured. `api_agent` uses chatbot, not Support. Rollback: revert this PR.

## Build footprint
None.