### PR TITLE
feat(webui): server icon left of hostname with remote sessions popup (Fixes #499)

### DIFF
--- a/tests/unit/test_req118_server_icon.py
+++ b/tests/unit/test_req118_server_icon.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+def test_req118_agent_sidebar_server_icon_and_popup():
+    repo_root = Path(__file__).resolve().parents[2]
+    sidebar_path = repo_root / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+    assert sidebar_path.exists()
+    content = sidebar_path.read_text(encoding="utf-8")
+
+    assert "data-testid=\"rail-server-icon\"" in content
+    assert "RemoteSessionsPopup" in content
+    assert "os-rail-hostname-row" in content
+    assert "Server className=" in content
+
+
+def test_req118_remote_sessions_popup_component():
+    repo_root = Path(__file__).resolve().parents[2]
+    popup_path = repo_root / "webui" / "frontend" / "src" / "components" / "RemoteSessionsPopup.tsx"
+    assert popup_path.exists()
+    content = popup_path.read_text(encoding="utf-8")
+
+    assert "cleanRemoteUrl" in content
+    assert "isBrowsableRemote" in content
+    assert "target=\"_blank\"" in content
+    assert "rel=\"noopener noreferrer\"" in content
+    assert "No remotes configured" in content
+    assert "remoteDisplayName" in content

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -9,12 +9,13 @@ import {
 } from 'react'
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Eye, EyeOff, Pencil, Pin, PinOff, Plug, Plus, Search, Users, X } from 'lucide-react'
+import { Eye, EyeOff, Pencil, Pin, PinOff, Plug, Plus, Search, Server, Users, X } from 'lucide-react'
 import AddAgentWizard, { type AgentKind } from './AddAgentWizard'
 import {
   fetchBlueprints,
   fetchCliAgents,
   fetchHerdrAgents,
+  fetchRemotes,
   type Blueprint,
   type CliRailAgent,
   type HerdrAgent,
@@ -77,6 +78,8 @@ import { agentLabel, defaultBlueprintId, isSupportAgent } from '../lib/supportAg
 import { formatRailTimestamp, getRowLastMessage } from '../lib/chatTime'
 import { fetchTeamRosters, teamHideId, type TeamRoster } from '../lib/teamRosters'
 import { fetchConfiguredRemotes, remoteHideId, type RemoteEntry } from '../lib/remotesCatalog'
+import { configuredRemotes } from '../lib/remotes'
+import RemoteSessionsPopup from './RemoteSessionsPopup'
 import { selectStackedFaces } from '../lib/avatarStack'
 import {
   defaultSessionForRemote,
@@ -218,6 +221,7 @@ export default function AgentSidebar({
   const [hiddenOpen, setHiddenOpen] = useState(false)
   const [hoveringHidden, setHoveringHidden] = useState(false)
   const [pluginsOpen, setPluginsOpen] = useState(false)
+  const [remotesPopupOpen, setRemotesPopupOpen] = useState(false)
   const [hostname, setHostname] = useState(() => loadHostname())
   const [menu, setMenu] = useState<ContextMenuState | null>(null)
   const [settingsTick, setSettingsTick] = useState(0)
@@ -284,6 +288,15 @@ export default function AgentSidebar({
     queryFn: fetchConfiguredRemotes,
     retry: 1,
   })
+  const fullRemotesQuery = useQuery({
+    queryKey: ['remotes-list'],
+    queryFn: fetchRemotes,
+    retry: 1,
+  })
+  const configuredRemotesList = useMemo(
+    () => configuredRemotes(fullRemotesQuery.data),
+    [fullRemotesQuery.data],
+  )
   const cliQuery = useQuery({
     queryKey: ['cli-agents'],
     queryFn: fetchCliAgents,
@@ -1559,27 +1572,51 @@ export default function AgentSidebar({
             <Plug className="h-4 w-4" aria-hidden="true" />
             Plugins
           </button>
-          <label className="sr-only" htmlFor="os-rail-hostname">
-            Hostname
-          </label>
-          <input
-            id="os-rail-hostname"
-            type="text"
-            className="os-rail-hostname"
-            value={hostname}
-            spellCheck={false}
-            onChange={(event) => setHostname(event.target.value)}
-            onBlur={() => setHostname(saveHostname(hostname))}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                event.currentTarget.blur()
-              }
-              if (event.key === 'Escape') {
-                setHostname(loadHostname() || defaultHostname())
-                event.currentTarget.blur()
-              }
-            }}
-          />
+          <div className="relative os-rail-hostname-row">
+            <button
+              type="button"
+              className="os-rail-hostname-icon btn btn-ghost btn-xs btn-square h-5 w-5 min-h-0 text-base-content/60 hover:text-base-content"
+              aria-label="Remote sessions"
+              aria-expanded={remotesPopupOpen}
+              aria-haspopup="menu"
+              data-testid="rail-server-icon"
+              onClick={() => setRemotesPopupOpen((open) => !open)}
+            >
+              <Server className="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
+            <label className="sr-only" htmlFor="os-rail-hostname">
+              Hostname
+            </label>
+            <input
+              id="os-rail-hostname"
+              type="text"
+              className="os-rail-hostname"
+              value={hostname}
+              spellCheck={false}
+              onChange={(event) => setHostname(event.target.value)}
+              onBlur={() => setHostname(saveHostname(hostname))}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.currentTarget.blur()
+                }
+                if (event.key === 'Escape') {
+                  setHostname(loadHostname() || defaultHostname())
+                  event.currentTarget.blur()
+                }
+              }}
+            />
+            {remotesPopupOpen && (
+              <RemoteSessionsPopup
+                isOpen={remotesPopupOpen}
+                onClose={() => setRemotesPopupOpen(false)}
+                remotes={configuredRemotesList}
+                onOpenSettingsRemotes={() => {
+                  setRemotesPopupOpen(false)
+                  openSettingsSheet({ section: 'remotes' })
+                }}
+              />
+            )}
+          </div>
         </div>
       </aside>
 

--- a/webui/frontend/src/components/RemoteSessionsPopup.tsx
+++ b/webui/frontend/src/components/RemoteSessionsPopup.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef } from 'react'
+import type { RemoteConnection } from '../lib/api'
+import { remoteDisplayName } from '../lib/remotesCatalog'
+
+export interface RemoteSessionsPopupProps {
+  isOpen: boolean
+  onClose: () => void
+  remotes: RemoteConnection[]
+  onOpenSettingsRemotes: () => void
+}
+
+/** Strip sensitive authentication query params from remote URLs (REQ-118). */
+export function cleanRemoteUrl(rawUrl: string): string {
+  try {
+    const parsed = new URL(rawUrl)
+    const sensitive = ['token', 'api_key', 'apikey', 'key', 'auth', 'auth_token', 'password', 'secret']
+    for (const param of Array.from(parsed.searchParams.keys())) {
+      if (sensitive.some((s) => param.toLowerCase().includes(s))) {
+        parsed.searchParams.delete(param)
+      }
+    }
+    return parsed.toString()
+  } catch {
+    return rawUrl
+  }
+}
+
+export function isBrowsableRemote(remote: RemoteConnection): boolean {
+  const target = (remote.ui_url?.trim() || remote.base_url?.trim()) ?? ''
+  return Boolean(target && /^https?:\/\//i.test(target))
+}
+
+export default function RemoteSessionsPopup({
+  isOpen,
+  onClose,
+  remotes,
+  onOpenSettingsRemotes,
+}: RemoteSessionsPopupProps) {
+  const popupRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        event.stopPropagation()
+        onClose()
+      }
+    }
+    const handlePointerDown = (event: PointerEvent) => {
+      if (popupRef.current && !popupRef.current.contains(event.target as Node)) {
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('pointerdown', handlePointerDown)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('pointerdown', handlePointerDown)
+    }
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  const browsable = remotes.filter(isBrowsableRemote)
+
+  return (
+    <div
+      ref={popupRef}
+      role="menu"
+      aria-label="Remote sessions"
+      className="absolute bottom-full left-0 mb-2 w-64 rounded-box border border-base-300 bg-base-100 shadow-xl z-50 overflow-hidden"
+      data-testid="remote-sessions-popup"
+    >
+      <div className="p-2">
+        <div className="px-2 py-1 font-semibold text-base-content/80 text-[11px] uppercase tracking-wider">
+          Remote sessions
+        </div>
+        {browsable.length === 0 ? (
+          <div className="px-2 py-2 text-xs text-base-content/65" data-testid="remotes-empty-state">
+            <p>No remotes configured</p>
+            <button
+              type="button"
+              className="mt-1 text-primary hover:underline block text-left"
+              onClick={() => {
+                onClose()
+                onOpenSettingsRemotes()
+              }}
+            >
+              Configure in Settings
+            </button>
+          </div>
+        ) : (
+          <ul className="menu menu-xs p-0 gap-0.5" role="none">
+            {browsable.map((remote) => {
+              const raw = remote.ui_url?.trim() || remote.base_url?.trim() || ''
+              const url = cleanRemoteUrl(raw)
+              const label = remoteDisplayName(remote)
+              return (
+                <li key={remote.id} role="none">
+                  <a
+                    href={url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    role="menuitem"
+                    className="flex flex-col items-start gap-0.5 py-1.5 px-2 rounded hover:bg-base-200"
+                    onClick={onClose}
+                  >
+                    <span className="font-medium text-base-content">{label}</span>
+                    <span className="text-[11px] text-base-content/60 truncate max-w-[14rem]">
+                      {url}
+                    </span>
+                  </a>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -372,6 +372,21 @@ describe('AgentSidebar Grok rail', () => {
     expect(localStorage.getItem(HOSTNAME_STORAGE_KEY)).toBe('lab-box')
   })
 
+  it('renders a server icon left of hostname and clicking it opens remote sessions popup (REQ-118)', async () => {
+    renderSidebar()
+    await screen.findByRole('navigation', { name: 'Agent list' })
+    const serverBtn = screen.getByTestId('rail-server-icon')
+    expect(serverBtn).toBeInTheDocument()
+    expect(serverBtn).toHaveAttribute('aria-label', 'Remote sessions')
+
+    expect(screen.queryByTestId('remote-sessions-popup')).toBeNull()
+    fireEvent.click(serverBtn)
+    expect(screen.getByTestId('remote-sessions-popup')).toBeInTheDocument()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(screen.queryByTestId('remote-sessions-popup')).toBeNull()
+  })
+
   it('leaves the Hidden Bots area blank until something is hidden', async () => {
     localStorage.setItem(HIDDEN_AGENTS_STORAGE_KEY, JSON.stringify([]))
     renderSidebar()

--- a/webui/frontend/src/components/__tests__/RemoteSessionsPopup.test.tsx
+++ b/webui/frontend/src/components/__tests__/RemoteSessionsPopup.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import RemoteSessionsPopup, { cleanRemoteUrl, isBrowsableRemote } from '../RemoteSessionsPopup'
+import type { RemoteConnection } from '../../lib/api'
+
+describe('REQ-118: RemoteSessionsPopup', () => {
+  it('cleanRemoteUrl strips sensitive credentials from query string', () => {
+    const raw = 'http://127.0.0.1:8802/chat?token=secret123&safe=val&api_key=mykey'
+    const cleaned = cleanRemoteUrl(raw)
+    expect(cleaned).not.toContain('secret123')
+    expect(cleaned).not.toContain('mykey')
+    expect(cleaned).toContain('safe=val')
+  })
+
+  it('isBrowsableRemote checks for http/https URLs', () => {
+    expect(isBrowsableRemote({ id: '1', title: 'R1', base_url: 'http://localhost:8000' })).toBe(true)
+    expect(isBrowsableRemote({ id: '2', title: 'R2', base_url: 'https://remote.example.com' })).toBe(true)
+    expect(isBrowsableRemote({ id: '3', title: 'R3', base_url: '' })).toBe(false)
+    expect(isBrowsableRemote({ id: '4', title: 'R4', base_url: 'invalid' })).toBe(false)
+  })
+
+  it('renders empty state when no browsable remotes are configured', () => {
+    const onOpenSettings = vi.fn()
+    const onClose = vi.fn()
+
+    render(
+      <RemoteSessionsPopup
+        isOpen={true}
+        onClose={onClose}
+        remotes={[]}
+        onOpenSettingsRemotes={onOpenSettings}
+      />,
+    )
+
+    expect(screen.getByTestId('remotes-empty-state')).toBeInTheDocument()
+    expect(screen.getByText('No remotes configured')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Configure in Settings'))
+    expect(onClose).toHaveBeenCalled()
+    expect(onOpenSettings).toHaveBeenCalled()
+  })
+
+  it('renders browsable remotes with clean URLs and OpenMousBot naming', () => {
+    const remotes: RemoteConnection[] = [
+      {
+        id: 'omb',
+        title: 'omb',
+        base_url: 'http://127.0.0.1:8802?token=secret-token',
+      },
+      {
+        id: 'hermes',
+        title: 'Hermes Box',
+        base_url: 'http://10.0.0.25:8801',
+      },
+    ]
+
+    render(
+      <RemoteSessionsPopup
+        isOpen={true}
+        onClose={vi.fn()}
+        remotes={remotes}
+        onOpenSettingsRemotes={vi.fn()}
+      />,
+    )
+
+    // OpenMousBot naming requirement (#409)
+    expect(screen.getByText('OpenMousBot')).toBeInTheDocument()
+    expect(screen.queryByText(/^omb$/i)).toBeNull()
+    expect(screen.getByText('Hermes Box')).toBeInTheDocument()
+
+    const links = screen.getAllByRole('menuitem')
+    expect(links).toHaveLength(2)
+    expect(links[0]).toHaveAttribute('target', '_blank')
+    expect(links[0]).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(links[0]).toHaveAttribute('href', 'http://127.0.0.1:8802/')
+    expect(links[0].getAttribute('href')).not.toContain('secret-token')
+  })
+
+  it('closes on Escape key', () => {
+    const onClose = vi.fn()
+    render(
+      <RemoteSessionsPopup
+        isOpen={true}
+        onClose={onClose}
+        remotes={[]}
+        onOpenSettingsRemotes={vi.fn()}
+      />,
+    )
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('closes on pointerdown outside', () => {
+    const onClose = vi.fn()
+    render(
+      <div>
+        <div data-testid="outside">Outside</div>
+        <RemoteSessionsPopup
+          isOpen={true}
+          onClose={onClose}
+          remotes={[]}
+          onOpenSettingsRemotes={vi.fn()}
+        />
+      </div>,
+    )
+
+    fireEvent.pointerDown(screen.getByTestId('outside'))
+    expect(onClose).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### Intent
Quoting Issue #499 (REQ-118):
> Hostname row shows “this host”; one click surfaces deep-links to remotes the user already configured.

Fixes #499

### Success
1. **Server Glyph:** Compact server glyph immediately to the left of the system/hostname name in the rail bottom chrome (`btn btn-ghost btn-xs btn-square`).
2. **Click Icon → Remote Sessions Popup:** Opens a DaisyUI menu listing configured remotes with browsable URLs. Empty state shows "No remotes configured" with a link into Settings Remotes.
3. **External Navigation:** Each row links with `target="_blank"` and `rel="noopener noreferrer"` to the remote's URL. Sensitive credential query params (e.g. `token`, `api_key`) are stripped.
4. **Modal Behavior:** Esc or pointerdown outside closes the popup without navigating away from chat.
5. **OpenMousBot Naming:** Uses `remoteDisplayName` so `omb` is always rendered as "OpenMousBot" (#409).

### Constraints & Feasibility
- Rebased on main (`82b1b96f`).
- Disjoint file surface from PR #620.
- DaisyUI 5 / React 18 standards; no Neon; no secrets.
- Own-diff CI green.

### Owner
CoS: Open Swarm.