### PR TITLE
feat(webui): resizable left rail with hover handle, max width, and avatar-only mode (Fixes #497)

### DIFF
--- a/tests/unit/test_req116_rail_resizer.py
+++ b/tests/unit/test_req116_rail_resizer.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+def test_req116_rail_resize_module_and_helpers_exist():
+    repo_root = Path(__file__).resolve().parents[2]
+    module_ts = repo_root / "webui" / "frontend" / "src" / "lib" / "railResize.ts"
+    assert module_ts.exists()
+    content = module_ts.read_text(encoding="utf-8")
+
+    assert "MIN_RAIL_WIDTH" in content
+    assert "MAX_RAIL_WIDTH" in content
+    assert "AVATAR_ONLY_THRESHOLD" in content
+    assert "clampRailWidth" in content
+    assert "loadRailWidth" in content
+    assert "saveRailWidth" in content
+    assert "isAvatarOnlyWidth" in content
+
+
+def test_req116_agent_sidebar_and_css_wired():
+    repo_root = Path(__file__).resolve().parents[2]
+    sidebar_tsx = repo_root / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+    assert sidebar_tsx.exists()
+    sidebar_content = sidebar_tsx.read_text(encoding="utf-8")
+
+    assert 'data-testid="rail-resize-handle"' in sidebar_content
+    assert 'data-avatar-only=' in sidebar_content
+    assert "os-rail-resizer" in sidebar_content
+    assert "os-agent-sidebar--avatar-only" in sidebar_content
+    assert "clampRailWidth" in sidebar_content
+
+    index_css = repo_root / "webui" / "frontend" / "src" / "index.css"
+    assert index_css.exists()
+    css_content = index_css.read_text(encoding="utf-8")
+
+    assert ".os-rail-resizer" in css_content
+    assert "cursor: col-resize;" in css_content
+    assert ".os-agent-sidebar--avatar-only" in css_content

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -101,6 +101,15 @@ import SessionPicker from './SessionPicker'
 import { openSettingsSheet } from './SettingsSheet'
 import AvatarStack from './AvatarStack'
 import StackedAvatars from './StackedAvatars'
+import {
+  clampRailWidth,
+  loadRailWidth,
+  saveRailWidth,
+  isAvatarOnlyWidth,
+  MIN_RAIL_WIDTH,
+  MAX_RAIL_WIDTH,
+  AVATAR_ONLY_THRESHOLD,
+} from '../lib/railResize'
 
 const EMPTY_BLUEPRINTS: Blueprint[] = []
 
@@ -251,6 +260,78 @@ export default function AgentSidebar({
   const searchShortcutLabel = isMac ? '⌘K' : 'Ctrl+K'
   const [addWizardOpen, setAddWizardOpen] = useState(false)
   const sessionsByAgent = useMemo(() => loadAllAgentSessions(), [sessionTick])
+
+  const [railWidth, setRailWidth] = useState(() => loadRailWidth())
+  const [isResizing, setIsResizing] = useState(false)
+  const isAvatarOnly = !narrow && isAvatarOnlyWidth(railWidth)
+
+  const startDragXRef = useRef(0)
+  const startWidthRef = useRef(railWidth)
+
+  const handleResizeStart = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault()
+      setIsResizing(true)
+      startDragXRef.current = event.clientX
+      startWidthRef.current = railWidth
+      const target = event.currentTarget
+      try {
+        target.setPointerCapture(event.pointerId)
+      } catch {}
+
+      const handlePointerMove = (e: PointerEvent) => {
+        const delta = e.clientX - startDragXRef.current
+        const next = clampRailWidth(startWidthRef.current + delta, window.innerWidth)
+        setRailWidth(next)
+      }
+
+      const handlePointerUp = (e: PointerEvent) => {
+        setIsResizing(false)
+        try {
+          target.releasePointerCapture(e.pointerId)
+        } catch {}
+        window.removeEventListener('pointermove', handlePointerMove)
+        window.removeEventListener('pointerup', handlePointerUp)
+        window.removeEventListener('pointercancel', handlePointerUp)
+        const finalDelta = e.clientX - startDragXRef.current
+        const finalWidth = clampRailWidth(startWidthRef.current + finalDelta, window.innerWidth)
+        setRailWidth(finalWidth)
+        saveRailWidth(finalWidth)
+      }
+
+      window.addEventListener('pointermove', handlePointerMove)
+      window.addEventListener('pointerup', handlePointerUp)
+      window.addEventListener('pointercancel', handlePointerUp)
+    },
+    [railWidth],
+  )
+
+  const handleResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault()
+      setRailWidth((prev) => {
+        const next = clampRailWidth(prev - 12, window.innerWidth)
+        saveRailWidth(next)
+        return next
+      })
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault()
+      setRailWidth((prev) => {
+        const next = clampRailWidth(prev + 12, window.innerWidth)
+        saveRailWidth(next)
+        return next
+      })
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      setRailWidth(MIN_RAIL_WIDTH)
+      saveRailWidth(MIN_RAIL_WIDTH)
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      const max = clampRailWidth(MAX_RAIL_WIDTH, window.innerWidth)
+      setRailWidth(max)
+      saveRailWidth(max)
+    }
+  }, [])
 
   useEffect(() => {
     const onChange = () => setSessionTick((n) => n + 1)
@@ -1246,15 +1327,32 @@ export default function AgentSidebar({
       />
 
       <aside
-        className={`os-agent-sidebar fixed inset-y-0 left-0 z-40 flex w-64 shrink-0 flex-col transition-transform duration-200 lg:static lg:z-0 lg:translate-x-0 ${
+        className={`os-agent-sidebar fixed inset-y-0 left-0 z-40 flex shrink-0 flex-col transition-transform duration-200 lg:static lg:z-0 lg:translate-x-0 ${
           open ? 'translate-x-0' : '-translate-x-full'
-        }`}
+        } ${isAvatarOnly ? 'os-agent-sidebar--avatar-only' : ''}`}
+        style={!narrow ? { width: `${railWidth}px` } : { width: '16rem' }}
         aria-label="Agents"
         data-testid="os-agent-rail"
         data-rail-open={open ? 'true' : 'false'}
+        data-avatar-only={isAvatarOnly ? 'true' : 'false'}
         aria-hidden={drawerHidden || undefined}
         {...(drawerHidden ? { inert: '' } : {})}
       >
+        {!narrow ? (
+          <div
+            className={`os-rail-resizer ${isResizing ? 'os-rail-resizer--active' : ''}`}
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize agent sidebar"
+            aria-valuenow={railWidth}
+            aria-valuemin={MIN_RAIL_WIDTH}
+            aria-valuemax={MAX_RAIL_WIDTH}
+            tabIndex={0}
+            data-testid="rail-resize-handle"
+            onPointerDown={handleResizeStart}
+            onKeyDown={handleResizeKeyDown}
+          />
+        ) : null}
         <div className="flex items-center justify-end px-3 pt-3 lg:hidden">
           <button
             type="button"
@@ -1568,9 +1666,11 @@ export default function AgentSidebar({
             type="button"
             className="flex w-full items-center gap-2 rounded-md px-1 py-1.5 text-sm text-base-content/60 hover:bg-base-300/30 hover:text-base-content"
             onClick={() => setPluginsOpen(true)}
+            title="Plugins"
+            aria-label="Plugins"
           >
-            <Plug className="h-4 w-4" aria-hidden="true" />
-            Plugins
+            <Plug className="h-4 w-4 shrink-0" aria-hidden="true" />
+            <span className="os-plugins-label">Plugins</span>
           </button>
           <div className="relative os-rail-hostname-row">
             <button

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -1658,3 +1658,51 @@ describe('AgentSidebar REQ-129 — Hidden Bots row chrome', () => {
   })
 })
 
+describe('AgentSidebar REQ-116 — Resizable left rail', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    rememberEmptyFavourites()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ object: 'list', data: [] }),
+      } as Response),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    localStorage.clear()
+  })
+
+  it('renders resizer handle on desktop and sets avatar-only state when narrow', async () => {
+    renderSidebar({ narrow: false })
+    const resizer = await screen.findByTestId('rail-resize-handle')
+    expect(resizer).toBeInTheDocument()
+    expect(resizer).toHaveAttribute('role', 'separator')
+
+    const rail = screen.getByTestId('os-agent-rail')
+    expect(rail).toHaveAttribute('data-avatar-only', 'false')
+
+    // Simulate resizing with keyboard ArrowLeft to shrink past threshold
+    fireEvent.keyDown(resizer, { key: 'Home' }) // jumps to MIN_RAIL_WIDTH (68px)
+    expect(rail).toHaveAttribute('data-avatar-only', 'true')
+    expect(rail).toHaveClass('os-agent-sidebar--avatar-only')
+
+    // Simulate expanding back
+    fireEvent.keyDown(resizer, { key: 'End' }) // jumps to MAX_RAIL_WIDTH (420px)
+    expect(rail).toHaveAttribute('data-avatar-only', 'false')
+    expect(rail).not.toHaveClass('os-agent-sidebar--avatar-only')
+  })
+
+  it('initializes in avatar-only mode if stored width is <= threshold', async () => {
+    localStorage.setItem('swarm_rail_width', '80')
+    renderSidebar({ narrow: false })
+    const rail = await screen.findByTestId('os-agent-rail')
+    expect(rail).toHaveAttribute('data-avatar-only', 'true')
+    expect(rail).toHaveClass('os-agent-sidebar--avatar-only')
+  })
+})
+

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -156,6 +156,82 @@ html[data-theme="light"] #root {
 .os-agent-sidebar {
   background: var(--os-chrome-sidebar);
   border-right: 1px solid color-mix(in srgb, var(--color-base-content) 8%, transparent);
+  position: relative;
+}
+
+/* REQ-116: Left rail resizer affordance */
+.os-rail-resizer {
+  position: absolute;
+  top: 0;
+  right: -3px;
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 50;
+  touch-action: none;
+  background: transparent;
+  transition: background-color 0.15s ease;
+}
+.os-rail-resizer:hover,
+.os-rail-resizer:focus-visible,
+.os-rail-resizer--active {
+  background-color: var(--color-primary, #3b82f6);
+  outline: none;
+}
+
+/* REQ-116: Avatar-only rail mode when width <= AVATAR_ONLY_THRESHOLD */
+.os-agent-sidebar--avatar-only .os-agent-row {
+  justify-content: center;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+.os-agent-sidebar--avatar-only .os-agent-row > span.flex-1 {
+  display: none;
+}
+.os-agent-sidebar--avatar-only .os-fav-grid {
+  grid-template-columns: 1fr;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+  padding: 0.25rem 0.15rem;
+}
+.os-agent-sidebar--avatar-only .os-fav-tile {
+  min-height: auto;
+  padding: 0.35rem 0;
+}
+.os-agent-sidebar--avatar-only .os-fav-tile__name,
+.os-agent-sidebar--avatar-only .os-fav-tile__shortcut,
+.os-agent-sidebar--avatar-only .os-fav-tile__badge {
+  display: none;
+}
+.os-agent-sidebar--avatar-only .os-rail-search-row {
+  padding-left: 0.35rem;
+  padding-right: 0.35rem;
+  justify-content: center;
+}
+.os-agent-sidebar--avatar-only .os-rail-search__input,
+.os-agent-sidebar--avatar-only .os-rail-search__kbd {
+  display: none;
+}
+.os-agent-sidebar--avatar-only .os-rail-search {
+  padding: 0.4rem;
+  justify-content: center;
+  flex: none;
+}
+.os-agent-sidebar--avatar-only .os-search-add-btn {
+  display: none;
+}
+.os-agent-sidebar--avatar-only .os-keybinding-tips {
+  display: none;
+}
+.os-agent-sidebar--avatar-only .os-hidden-bots-label,
+.os-agent-sidebar--avatar-only .os-hidden-bots-tail {
+  display: none;
+}
+.os-agent-sidebar--avatar-only .os-rail-hostname {
+  display: none;
+}
+.os-agent-sidebar--avatar-only .os-plugins-label {
+  display: none;
 }
 .os-agent-avatar {
   display: block;

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -179,60 +179,6 @@ html[data-theme="light"] #root {
   outline: none;
 }
 
-/* REQ-116: Avatar-only rail mode when width <= AVATAR_ONLY_THRESHOLD */
-.os-agent-sidebar--avatar-only .os-agent-row {
-  justify-content: center;
-  padding-left: 0.25rem;
-  padding-right: 0.25rem;
-}
-.os-agent-sidebar--avatar-only .os-agent-row > span.flex-1 {
-  display: none;
-}
-.os-agent-sidebar--avatar-only .os-fav-grid {
-  grid-template-columns: 1fr;
-  margin-left: 0.25rem;
-  margin-right: 0.25rem;
-  padding: 0.25rem 0.15rem;
-}
-.os-agent-sidebar--avatar-only .os-fav-tile {
-  min-height: auto;
-  padding: 0.35rem 0;
-}
-.os-agent-sidebar--avatar-only .os-fav-tile__name,
-.os-agent-sidebar--avatar-only .os-fav-tile__shortcut,
-.os-agent-sidebar--avatar-only .os-fav-tile__badge {
-  display: none;
-}
-.os-agent-sidebar--avatar-only .os-rail-search-row {
-  padding-left: 0.35rem;
-  padding-right: 0.35rem;
-  justify-content: center;
-}
-.os-agent-sidebar--avatar-only .os-rail-search__input,
-.os-agent-sidebar--avatar-only .os-rail-search__kbd {
-  display: none;
-}
-.os-agent-sidebar--avatar-only .os-rail-search {
-  padding: 0.4rem;
-  justify-content: center;
-  flex: none;
-}
-.os-agent-sidebar--avatar-only .os-search-add-btn {
-  display: none;
-}
-.os-agent-sidebar--avatar-only .os-keybinding-tips {
-  display: none;
-}
-.os-agent-sidebar--avatar-only .os-hidden-bots-label,
-.os-agent-sidebar--avatar-only .os-hidden-bots-tail {
-  display: none;
-}
-.os-agent-sidebar--avatar-only .os-rail-hostname {
-  display: none;
-}
-.os-agent-sidebar--avatar-only .os-plugins-label {
-  display: none;
-}
 .os-agent-avatar {
   display: block;
   flex: 0 0 auto;
@@ -623,6 +569,63 @@ button.os-agent-row {
   font-weight: 700;
 }
 .os-agent-role-badge[data-kind="team"] { color: #6b7c8a; }
+
+/* REQ-116: Avatar-only rail mode when width <= AVATAR_ONLY_THRESHOLD */
+.os-agent-sidebar--avatar-only .os-agent-row {
+  justify-content: center;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+.os-agent-sidebar--avatar-only .os-agent-row > span.flex-1 {
+  display: none;
+}
+.os-agent-sidebar--avatar-only .os-fav-grid {
+  grid-template-columns: 1fr;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+  padding: 0.25rem 0.15rem;
+}
+.os-agent-sidebar--avatar-only .os-fav-tile {
+  min-height: auto;
+  padding: 0.35rem 0;
+  background: transparent;
+}
+.os-agent-sidebar--avatar-only .os-fav-tile__name,
+.os-agent-sidebar--avatar-only .os-fav-tile__shortcut,
+.os-agent-sidebar--avatar-only .os-fav-tile__badge {
+  display: none;
+}
+.os-agent-sidebar--avatar-only .os-rail-search-row {
+  padding-left: 0.35rem;
+  padding-right: 0.35rem;
+  justify-content: center;
+}
+.os-agent-sidebar--avatar-only .os-rail-search__input,
+.os-agent-sidebar--avatar-only .os-rail-search__kbd {
+  display: none;
+}
+.os-agent-sidebar--avatar-only .os-rail-search {
+  padding: 0.4rem;
+  justify-content: center;
+  flex: none;
+}
+.os-agent-sidebar--avatar-only .os-search-add-btn {
+  display: none;
+}
+.os-agent-sidebar--avatar-only .os-keybinding-tips {
+  display: none;
+}
+.os-agent-sidebar--avatar-only .os-hidden-bots-label,
+.os-agent-sidebar--avatar-only .os-hidden-bots-tail {
+  display: none;
+}
+.os-agent-sidebar--avatar-only .os-rail-hostname {
+  display: none;
+}
+.os-agent-sidebar--avatar-only .os-plugins-label {
+  display: none;
+}
+
 .os-identity-btn {
   background: transparent;
   border: 0;

--- a/webui/frontend/src/lib/__tests__/railResize.test.ts
+++ b/webui/frontend/src/lib/__tests__/railResize.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  clampRailWidth,
+  loadRailWidth,
+  saveRailWidth,
+  isAvatarOnlyWidth,
+  MIN_RAIL_WIDTH,
+  MAX_RAIL_WIDTH,
+  DEFAULT_RAIL_WIDTH,
+  AVATAR_ONLY_THRESHOLD,
+  RAIL_WIDTH_STORAGE_KEY,
+} from '../railResize'
+
+describe('railResize (REQ-116)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('clamps rail width within min and max boundaries', () => {
+    expect(clampRailWidth(50)).toBe(MIN_RAIL_WIDTH)
+    expect(clampRailWidth(100)).toBe(100)
+    expect(clampRailWidth(500)).toBe(MAX_RAIL_WIDTH)
+  })
+
+  it('clamps rail width to viewport ceiling when specified', () => {
+    // 45% of 600px is 270px, which is below MAX_RAIL_WIDTH (420px)
+    expect(clampRailWidth(350, 600)).toBe(270)
+  })
+
+  it('loads default width when nothing is stored or value is invalid', () => {
+    expect(loadRailWidth()).toBe(DEFAULT_RAIL_WIDTH)
+
+    localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, 'invalid')
+    expect(loadRailWidth()).toBe(DEFAULT_RAIL_WIDTH)
+  })
+
+  it('persists and retrieves valid width from localStorage', () => {
+    saveRailWidth(180)
+    expect(localStorage.getItem(RAIL_WIDTH_STORAGE_KEY)).toBe('180')
+    expect(loadRailWidth()).toBe(180)
+  })
+
+  it('identifies avatar-only width threshold', () => {
+    expect(isAvatarOnlyWidth(MIN_RAIL_WIDTH)).toBe(true)
+    expect(isAvatarOnlyWidth(AVATAR_ONLY_THRESHOLD)).toBe(true)
+    expect(isAvatarOnlyWidth(AVATAR_ONLY_THRESHOLD + 1)).toBe(false)
+    expect(isAvatarOnlyWidth(256)).toBe(false)
+  })
+})

--- a/webui/frontend/src/lib/railResize.ts
+++ b/webui/frontend/src/lib/railResize.ts
@@ -1,0 +1,37 @@
+/**
+ * REQ-116: Left rail resizer constants and persistence helpers.
+ */
+
+export const MIN_RAIL_WIDTH = 68
+export const MAX_RAIL_WIDTH = 420
+export const DEFAULT_RAIL_WIDTH = 256
+export const AVATAR_ONLY_THRESHOLD = 96
+export const RAIL_WIDTH_STORAGE_KEY = 'swarm_rail_width'
+
+export function clampRailWidth(width: number, viewportWidth?: number): number {
+  const max = viewportWidth ? Math.min(MAX_RAIL_WIDTH, Math.floor(viewportWidth * 0.45)) : MAX_RAIL_WIDTH
+  return Math.min(Math.max(width, MIN_RAIL_WIDTH), max)
+}
+
+export function loadRailWidth(): number {
+  try {
+    const raw = localStorage.getItem(RAIL_WIDTH_STORAGE_KEY)
+    if (raw) {
+      const parsed = Number(raw)
+      if (!Number.isNaN(parsed)) {
+        return clampRailWidth(parsed)
+      }
+    }
+  } catch {}
+  return DEFAULT_RAIL_WIDTH
+}
+
+export function saveRailWidth(width: number): void {
+  try {
+    localStorage.setItem(RAIL_WIDTH_STORAGE_KEY, String(width))
+  } catch {}
+}
+
+export function isAvatarOnlyWidth(width: number): boolean {
+  return width <= AVATAR_ONLY_THRESHOLD
+}


### PR DESCRIPTION
Fixes #497

### Quoted Issue #497 (REQ-116)
> **Intent:** User can give the rail more or less room; at a narrow width it becomes an icon strip without truncating ugly half-text.
>
> **Success:**
> 1. **Handle:** On hover (and pointer near the rail’s right/inner edge), show a resize affordance (cursor `col-resize`). Drag changes rail width. Touch: long-press/drag on the edge if feasible; desktop is primary.
> 2. **Limits:** Min width ≈ avatar-only strip; **max width** capped (e.g. ~min(420px, 40vw) — engineer picks sane constants, document). Cannot drag past max/min.
> 3. **Persist:** Remember width in `localStorage` (or existing UI prefs) across reloads.
> 4. **Avatar-only mode:** When width ≤ threshold (e.g. ~72–88px), rows show **avatar only** — hide display name, last-message preview, and timestamp (#443). Tooltips on hover still show the name. Favourites grid may stack or collapse similarly (honest: favourites 2-up may become 1-up avatars — document).
> 5. **Expand again:** Dragging wider than threshold restores full text chrome without a reload.
> 6. **Tests:** width clamp; cross threshold toggles avatar-only class/state; persistence round-trip. DaisyUI 5 / React 18. Native resize (no heavy DnD lib required). No live host. No secrets.
> 7. Mobile: don’t fight #374 tuck; resize can be desktop-only if touch is awkward — say so in PR.
>
> **Constraints:**
> - Parked; one cloud when capacity. `Fixes` this Issue.
> - GitHub-only. No Neon. Don’t break rail context menu (#435) hit targets in avatar-only mode (right-click still works on avatar).
>
> **Owner:** open-swarm engineer + Cursor cloud. CoS: Open Swarm. Skeptic text-only PASS/FAIL.

### Summary of Changes
- **Constants & Helpers (`railResize.ts`):**
  - `MIN_RAIL_WIDTH = 68` px
  - `MAX_RAIL_WIDTH = 420` px
  - `DEFAULT_RAIL_WIDTH = 256` px
  - `AVATAR_ONLY_THRESHOLD = 96` px
  - `clampRailWidth(width, viewportWidth?)` clamps between min and max (and 45% viewport width)
  - `loadRailWidth()` and `saveRailWidth()` persisting to `localStorage['swarm_rail_width']`
- **Hover Resize Handle:**
  - Added desktop resize handle along sidebar's right edge (`data-testid="rail-resize-handle"`, `col-resize` cursor, hover highlight).
  - Pointer down captures pointer, drag adjusts width smoothly and persists on release.
  - Keyboard accessible (`ArrowLeft`, `ArrowRight`, `Home`, `End`) with `role="separator"`.
  - Desktop-only resize handle; mobile drawer remains standard width without fighting tuck.
- **Avatar-Only Mode:**
  - When `railWidth <= AVATAR_ONLY_THRESHOLD` (96px), activates `data-avatar-only="true"` and `os-agent-sidebar--avatar-only`.
  - Hides display names, snippets, role badges, timestamps, search input text, and hostname input.
  - Favourites grid collapses from 2-up to 1-up avatar column.
  - Rows and tiles maintain hover tooltips (`title={name}`) and full right-click context menu hit-targets (#435).
- **Tests:**
  - Unit tests for helpers in `webui/frontend/src/lib/__tests__/railResize.test.ts`.
  - Unit tests for resize handle, keyboard navigation, and avatar-only toggle in `webui/frontend/src/components/__tests__/AgentSidebar.test.tsx`.
  - Contract test in `tests/unit/test_req116_rail_resizer.py`.