### PR TITLE
feat(webui): remove You and agent name labels above chat bubbles (Fixes #507)

### DIFF
--- a/tests/unit/test_req122_no_bubble_names.py
+++ b/tests/unit/test_req122_no_bubble_names.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def test_req122_no_visible_names_in_chat_bubble_header():
+    repo_root = Path(__file__).resolve().parents[2]
+    bubble_tsx = repo_root / "webui" / "frontend" / "src" / "components" / "ChatMessageBubble.tsx"
+    assert bubble_tsx.exists()
+    content = bubble_tsx.read_text(encoding="utf-8")
+
+    # Verifies no visible "You" or agentName label rendered above chat bubbles
+    assert "{role === 'user' ? 'You' : agentName}" not in content
+    # Verifies accessibility aria-label is present
+    assert "aria-label=" in content
+    # Verifies edited indicator is preserved
+    assert 'data-testid="edited-hint"' in content

--- a/webui/frontend/src/components/ChatMessageBubble.tsx
+++ b/webui/frontend/src/components/ChatMessageBubble.tsx
@@ -123,19 +123,21 @@ export function ChatMessageBubble({
     }
   }
 
+  const speaker = role === 'user' ? 'You' : agentName
+
   return (
     <div
       className={`chat group ${role === 'user' ? 'chat-end' : 'chat-start'}`}
       data-message-role={role}
+      aria-label={`${speaker} message`}
     >
-      <div className="chat-header text-xs opacity-60">
-        {role === 'user' ? 'You' : agentName}
-        {edited ? (
-          <span className="ml-1 font-normal opacity-70" data-testid="edited-hint">
+      {edited ? (
+        <div className="chat-header text-xs opacity-60">
+          <span className="font-normal opacity-70" data-testid="edited-hint">
             edited
           </span>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
       {editing ? (
         <div className="chat-bubble bg-base-200 text-base-content w-full max-w-xl">
           <Textarea

--- a/webui/frontend/src/components/__tests__/ChatMessageBubble.test.tsx
+++ b/webui/frontend/src/components/__tests__/ChatMessageBubble.test.tsx
@@ -223,3 +223,65 @@ describe('REQ-117: Fenced code blocks collapse, hover expand, copy, re-collapse'
     expect(pre?.querySelector('[data-testid="code-expand"]')).toBeInTheDocument()
   })
 })
+
+describe('REQ-122: No You / agent name labels above chat bubbles', () => {
+  it('does not render visible You or agentName header labels above bubbles', () => {
+    const { rerender } = render(
+      <ChatMessageBubble
+        role="user"
+        agentName="Stewie"
+        text="Hello world"
+        streaming={false}
+        canEdit={false}
+        editing={false}
+        onStartEdit={() => {}}
+        onCancelEdit={() => {}}
+        onSaveEdit={() => {}}
+      />,
+    )
+
+    // User bubble: no visible "You" text
+    expect(screen.queryByText('You')).not.toBeInTheDocument()
+    const userContainer = screen.getByLabelText('You message')
+    expect(userContainer).toBeInTheDocument()
+
+    // Assistant bubble: no visible "Stewie" text above bubble
+    rerender(
+      <ChatMessageBubble
+        role="assistant"
+        agentName="Stewie"
+        text="Hello from assistant"
+        streaming={false}
+        canEdit={false}
+        editing={false}
+        onStartEdit={() => {}}
+        onCancelEdit={() => {}}
+        onSaveEdit={() => {}}
+      />,
+    )
+
+    expect(screen.queryByText('Stewie')).not.toBeInTheDocument()
+    const assistantContainer = screen.getByLabelText('Stewie message')
+    expect(assistantContainer).toBeInTheDocument()
+  })
+
+  it('still renders edited hint when message was edited', () => {
+    render(
+      <ChatMessageBubble
+        role="user"
+        agentName="Stewie"
+        text="Edited message"
+        streaming={false}
+        edited={true}
+        canEdit={false}
+        editing={false}
+        onStartEdit={() => {}}
+        onCancelEdit={() => {}}
+        onSaveEdit={() => {}}
+      />,
+    )
+
+    expect(screen.getByTestId('edited-hint')).toHaveTextContent('edited')
+    expect(screen.queryByText('You')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #507

### Quoted Issue #507 (REQ-122)
> **Intent:** Denser transcript; identity from layout/avatar/header, not a repeated name line on every bubble.
>
> **Success:**
> 1. User bubbles: no **“You”** (or equivalent) label above/beside the bubble text.
> 2. Assistant bubbles: no agent **display name** repeated above each message in the thread.
> 3. Role badges / system pills that are *not* the per-message name chrome may remain if they convey status (don’t strip Support/system chrome that isn’t a name label).
> 4. Accessibility: if names were the only speaker hint, ensure `aria-label` on the bubble or group still identifies speaker for screen readers.
> 5. Tests: transcript fixture has no visible “You” / agent-name heading per bubble. DaisyUI 5 / React 18. No live host. No secrets.
>
> **Constraints:**
> - Parked / small UI PR; one cloud when capacity. `Fixes` this Issue.
> - GitHub-only. No Neon. Chat stays mounted (#364).
>
> **Owner:** open-swarm engineer + Cursor cloud. CoS: Open Swarm. Skeptic text-only PASS/FAIL.

### Summary of Changes
- **Transcript Density:** Removed the visible per-message `chat-header` labels rendering "You" or the agent's display name above bubble messages.
- **Accessibility:** Added `aria-label="${speaker} message"` to the chat container so screen readers continue to reliably announce the speaker without occupying visual vertical space.
- **Status/System Preserved:** Kept the `edited` indicator hint when messages are edited; role pills and header identity remain intact.
- **Tests:**
  - Unit tests in `webui/frontend/src/components/__tests__/ChatMessageBubble.test.tsx` verifying no visible You/agent-name text while checking a11y labels and edited indicators.
  - Contract test in `tests/unit/test_req122_no_bubble_names.py`.