### PR TITLE
feat(webui): theme light/dark/system and navbar visibility toggle (Fixes #479)

### DIFF
--- a/tests/unit/test_req110_theme.py
+++ b/tests/unit/test_req110_theme.py
@@ -1,0 +1,45 @@
+"""REQ-110: Theme — Settings light/dark/system + optional navbar toggle (Fixes #479)."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+THEME_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "theme.ts"
+THEME_TOGGLE_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "ThemeToggle.tsx"
+SETTINGS_SHEET_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "SettingsSheet.tsx"
+APP_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "App.tsx"
+
+
+def test_theme_module_contracts():
+    ts = THEME_TS.read_text(encoding="utf-8")
+    assert "'system'" in ts
+    assert "'swarm_theme_navbar'" in ts
+    assert "resolveSystemTheme" in ts
+    assert "resolveTheme" in ts
+    assert "subscribeSystemTheme" in ts
+    assert "nextTheme" in ts
+    assert "initialNavbarThemeVisible" in ts
+
+
+def test_app_theme_never_sets_data_theme_to_system():
+    app = APP_TSX.read_text(encoding="utf-8")
+    assert "applyDocumentTheme(resolveTheme(initialTheme()))" in app
+    assert "theme === 'dark' ? 'dark' : 'light'" in app
+    assert "data-theme" in app
+    assert "themePreference" in app
+    assert "resolvedTheme" in app
+
+
+def test_settings_sheet_has_general_visuals_and_navbar_toggle():
+    settings = SETTINGS_SHEET_TSX.read_text(encoding="utf-8")
+    assert "'general'" in settings
+    assert "Visuals" in settings
+    assert 'value="system"' in settings
+    assert "Show theme control in top bar" in settings
+    assert "THEME_NAVBAR_SET_EVENT" in settings
+
+
+def test_theme_toggle_respects_navbar_visibility_and_cycles():
+    toggle = THEME_TOGGLE_TSX.read_text(encoding="utf-8")
+    assert "THEME_NAVBAR_SET_EVENT" in toggle
+    assert "!visible" in toggle
+    assert "nextTheme" in toggle

--- a/webui/frontend/e2e/interaction.spec.ts
+++ b/webui/frontend/e2e/interaction.spec.ts
@@ -12,8 +12,8 @@ test('theme toggle flips data-theme and persists, no uncaught JS errors', async 
   await page.goto('/')
 
   const root = page.locator('[data-theme]').first()
-  // Accessible name flips with state ("Switch to light/dark theme").
-  const toggle = page.getByRole('button', { name: /^Switch to (light|dark) theme$/ })
+  // Accessible name flips with state ("Switch to light/system/dark theme").
+  const toggle = page.getByRole('button', { name: /^Switch to (light|dark|system) theme$/ })
 
   // Default theme (no stored preference) is dark, matching Django pages.
   await expect(root).toHaveAttribute('data-theme', 'dark')
@@ -27,7 +27,15 @@ test('theme toggle flips data-theme and persists, no uncaught JS errors', async 
     .poll(() => page.evaluate(() => localStorage.getItem('swarm_theme')))
     .toBe('light')
 
-  // Flip back to dark — the control is genuinely two-way, not a one-shot.
+  // Flip to system — stores 'system' and resolves data-theme to light or dark (never 'system').
+  await toggle.click()
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem('swarm_theme')))
+    .toBe('system')
+  const resolvedAttr = await root.getAttribute('data-theme')
+  expect(['light', 'dark']).toContain(resolvedAttr)
+
+  // Flip back to dark — complete 3-way cycle.
   await toggle.click()
   await expect(root).toHaveAttribute('data-theme', 'dark')
   await expect
@@ -46,4 +54,14 @@ test('stored theme preference is restored on reload', async ({ page }) => {
 
   const root = page.locator('[data-theme]').first()
   await expect(root).toHaveAttribute('data-theme', 'light')
+})
+
+test('stored system theme preference resolves to light or dark on reload', async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('swarm_theme', 'system'))
+  await page.goto('/')
+
+  const root = page.locator('[data-theme]').first()
+  const theme = await root.getAttribute('data-theme')
+  expect(['light', 'dark']).toContain(theme)
+  expect(theme).not.toBe('system')
 })

--- a/webui/frontend/src/App.tsx
+++ b/webui/frontend/src/App.tsx
@@ -187,7 +187,7 @@ function App() {
         <RailChromeProvider value={{ narrow, railOpen, openRail, closeRail }}>
           <div
             className="flex h-screen min-h-0 flex-col bg-base-100 text-base-content"
-            data-theme={darkMode === 'dark' ? 'dark' : 'light'}
+            data-theme={resolvedTheme === 'dark' ? 'dark' : 'light'}
             data-narrow-viewport={narrow ? 'true' : undefined}
           >
             <a

--- a/webui/frontend/src/App.tsx
+++ b/webui/frontend/src/App.tsx
@@ -21,10 +21,14 @@ import { dismissSwipeHint, isSwipeHintDismissed } from './lib/swipeHint'
 import {
   initialTheme,
   persistTheme,
+  resolveTheme,
+  subscribeSystemTheme,
+  nextTheme,
   THEME_SET_EVENT,
   THEME_TOGGLE_EVENT,
   THEME_STORAGE_KEY,
   type Theme,
+  type ResolvedTheme,
 } from './lib/theme'
 
 /** EXPERIMENTAL: ⌘K command palette (see experimental/README.md). */
@@ -32,7 +36,7 @@ const SHOW_COMMAND_PALETTE = isExperimentalEnabled('command_palette')
 
 export { THEME_STORAGE_KEY }
 
-function applyDocumentTheme(theme: Theme) {
+function applyDocumentTheme(theme: ResolvedTheme) {
   if (typeof document === 'undefined') return
   const value = theme === 'dark' ? 'dark' : 'light'
   const bg = theme === 'dark' ? '#0c0c0c' : '#f4f4f5'
@@ -41,7 +45,7 @@ function applyDocumentTheme(theme: Theme) {
   if (document.body) document.body.style.backgroundColor = bg
 }
 
-applyDocumentTheme(initialTheme())
+applyDocumentTheme(resolveTheme(initialTheme()))
 
 /** Keep query string when aliasing a legacy chat path onto `/chat`. */
 export function chatPathWithSearch(search: string): string {
@@ -56,7 +60,10 @@ export function chatPathWithSearch(search: string): string {
  * Search / the settings gear.
  */
 function App() {
-  const [darkMode, setDarkMode] = useState<Theme>(initialTheme)
+  const [themePreference, setThemePreference] = useState<Theme>(initialTheme)
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
+    resolveTheme(initialTheme()),
+  )
   const [narrow, setNarrow] = useState(isNarrowViewport)
   const [railOpen, setRailOpen] = useState(() => !isNarrowViewport())
   const [swipeHint, setSwipeHint] = useState(false)
@@ -96,18 +103,28 @@ function App() {
   useLeftEdgeSwipe(narrow && !railOpen && !searchOpen && !settingsOpen, openRail)
 
   useLayoutEffect(() => {
-    applyDocumentTheme(darkMode)
-  }, [darkMode])
+    applyDocumentTheme(resolvedTheme)
+  }, [resolvedTheme])
 
   useEffect(() => {
-    persistTheme(darkMode)
-  }, [darkMode])
+    persistTheme(themePreference)
+    setResolvedTheme(resolveTheme(themePreference))
+  }, [themePreference])
 
   useEffect(() => {
-    const onToggle = () => setDarkMode((prev) => (prev === 'dark' ? 'light' : 'dark'))
+    if (themePreference !== 'system') return
+    return subscribeSystemTheme((nextResolved) => {
+      setResolvedTheme(nextResolved)
+    })
+  }, [themePreference])
+
+  useEffect(() => {
+    const onToggle = () => setThemePreference((prev) => nextTheme(prev))
     const onSet = (event: Event) => {
       const detail = (event as CustomEvent<Theme>).detail
-      if (detail === 'light' || detail === 'dark') setDarkMode(detail)
+      if (detail === 'light' || detail === 'dark' || detail === 'system') {
+        setThemePreference(detail)
+      }
     }
     const onOpenSearch = () => setSearchOpen(true)
     const onOpenSettings = (event: Event) => {

--- a/webui/frontend/src/components/SettingsSheet.tsx
+++ b/webui/frontend/src/components/SettingsSheet.tsx
@@ -52,11 +52,21 @@ import {
   type RetentionMode,
 } from '../lib/settingsPrefs'
 import { agentLabel, catalogLabel } from '../lib/supportAgent'
+import {
+  initialNavbarThemeVisible,
+  initialTheme,
+  dispatchSetNavbarThemeVisible,
+  dispatchSetTheme,
+  THEME_NAVBAR_SET_EVENT,
+  THEME_SET_EVENT,
+  type Theme,
+} from '../lib/theme'
 
 /** Window event so the rail hover-edit, command palette, and tests can open the sheet. */
 export const OPEN_SETTINGS_EVENT = 'swarm:open-settings'
 
 export type SettingsSection =
+  | 'general'
   | 'definition'
   | 'blueprint'
   | 'remotes'
@@ -160,6 +170,16 @@ export default function SettingsSheet({
             <li>
               <button
                 type="button"
+                className={section === 'general' ? 'menu-active' : undefined}
+                aria-current={section === 'general' ? 'page' : undefined}
+                onClick={() => setSection('general')}
+              >
+                General
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
                 className={section === 'definition' ? 'menu-active' : undefined}
                 aria-current={section === 'definition' ? 'page' : undefined}
                 onClick={() => setSection('definition')}
@@ -241,6 +261,7 @@ export default function SettingsSheet({
         </nav>
 
         <div className="min-w-0 flex-1 overflow-y-auto bg-base-100 p-4 sm:p-5">
+          {section === 'general' && <GeneralPane />}
           {section === 'definition' && (
             <DefinitionPane
               kind={resolvedKind}
@@ -810,6 +831,96 @@ function HostnamePane({
         Save hostname
       </Button>
     </form>
+  )
+}
+
+function GeneralPane() {
+  const [themePref, setThemePref] = useState<Theme>(initialTheme)
+  const [navbarVisible, setNavbarVisible] = useState<boolean>(initialNavbarThemeVisible)
+
+  useEffect(() => {
+    const onSet = (event: Event) => {
+      const detail = (event as CustomEvent<Theme>).detail
+      if (detail === 'light' || detail === 'dark' || detail === 'system') {
+        setThemePref(detail)
+      }
+    }
+    const onNavbarToggle = (event: Event) => {
+      const detail = (event as CustomEvent<boolean>).detail
+      setNavbarVisible(Boolean(detail))
+    }
+    window.addEventListener(THEME_SET_EVENT, onSet)
+    window.addEventListener(THEME_NAVBAR_SET_EVENT, onNavbarToggle)
+    return () => {
+      window.removeEventListener(THEME_SET_EVENT, onSet)
+      window.removeEventListener(THEME_NAVBAR_SET_EVENT, onNavbarToggle)
+    }
+  }, [])
+
+  const handleThemeChange = (value: Theme) => {
+    setThemePref(value)
+    dispatchSetTheme(value)
+  }
+
+  const handleNavbarChange = (visible: boolean) => {
+    setNavbarVisible(visible)
+    dispatchSetNavbarThemeVisible(visible)
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h4 className="text-lg font-semibold">General</h4>
+        <p className="mt-1 text-sm text-base-content/70">
+          Preferences for display and browser behavior.
+        </p>
+      </div>
+
+      <section aria-labelledby="os-visuals-heading" className="space-y-4">
+        <h5
+          id="os-visuals-heading"
+          className="text-base font-semibold border-b border-base-200 pb-1"
+        >
+          Visuals
+        </h5>
+
+        <div className="form-control w-full max-w-xs space-y-1">
+          <label htmlFor="os-theme-select" className="label py-0">
+            <span className="label-text font-medium">Theme</span>
+          </label>
+          <select
+            id="os-theme-select"
+            aria-label="Theme"
+            className="select select-bordered w-full"
+            value={themePref}
+            onChange={(e) => handleThemeChange(e.target.value as Theme)}
+          >
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+            <option value="system">Use system</option>
+          </select>
+          <p className="text-xs text-base-content/60">
+            Choose light, dark, or follow your operating system appearance (prefers-color-scheme).
+          </p>
+        </div>
+
+        <div className="form-control">
+          <label className="label cursor-pointer justify-start gap-4">
+            <input
+              type="checkbox"
+              className="toggle"
+              checked={navbarVisible}
+              onChange={(e) => handleNavbarChange(e.target.checked)}
+              aria-label="Show theme control in top bar"
+            />
+            <span className="label-text">Show theme control in top bar</span>
+          </label>
+          <p className="text-xs text-base-content/60">
+            Show a quick theme toggle button in the top navigation bar.
+          </p>
+        </div>
+      </section>
+    </div>
   )
 }
 

--- a/webui/frontend/src/components/ThemeToggle.tsx
+++ b/webui/frontend/src/components/ThemeToggle.tsx
@@ -1,39 +1,84 @@
 import { useEffect, useState } from 'react'
-import { Moon, Sun } from 'lucide-react'
+import { Laptop, Moon, Sun } from 'lucide-react'
 import {
   dispatchSetTheme,
+  initialNavbarThemeVisible,
   initialTheme,
+  nextTheme,
+  resolveTheme,
+  subscribeSystemTheme,
+  THEME_NAVBAR_SET_EVENT,
   THEME_SET_EVENT,
   THEME_TOGGLE_EVENT,
   type Theme,
 } from '../lib/theme'
 
 export default function ThemeToggle() {
+  const [visible, setVisible] = useState<boolean>(initialNavbarThemeVisible)
   const [theme, setTheme] = useState<Theme>(initialTheme)
+  const [resolvedTheme, setResolvedTheme] = useState(() => resolveTheme(initialTheme()))
 
   useEffect(() => {
     const onSet = (event: Event) => {
       const detail = (event as CustomEvent<Theme>).detail
-      if (detail === 'light' || detail === 'dark') setTheme(detail)
+      if (detail === 'light' || detail === 'dark' || detail === 'system') {
+        setTheme(detail)
+        setResolvedTheme(resolveTheme(detail))
+      }
     }
-    const onToggle = () => setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'))
+    const onToggle = () => {
+      setTheme((prev) => {
+        const next = nextTheme(prev)
+        setResolvedTheme(resolveTheme(next))
+        return next
+      })
+    }
+    const onNavbarToggle = (event: Event) => {
+      const detail = (event as CustomEvent<boolean>).detail
+      setVisible(Boolean(detail))
+    }
+
     window.addEventListener(THEME_SET_EVENT, onSet)
     window.addEventListener(THEME_TOGGLE_EVENT, onToggle)
+    window.addEventListener(THEME_NAVBAR_SET_EVENT, onNavbarToggle)
+
     return () => {
       window.removeEventListener(THEME_SET_EVENT, onSet)
       window.removeEventListener(THEME_TOGGLE_EVENT, onToggle)
+      window.removeEventListener(THEME_NAVBAR_SET_EVENT, onNavbarToggle)
     }
   }, [])
+
+  useEffect(() => {
+    if (theme !== 'system') return
+    return subscribeSystemTheme((nextResolved) => {
+      setResolvedTheme(nextResolved)
+    })
+  }, [theme])
+
+  if (!visible) return null
+
+  const next = nextTheme(theme)
+  const ariaLabel =
+    theme === 'dark'
+      ? 'Switch to light theme'
+      : theme === 'light'
+      ? 'Switch to system theme'
+      : 'Switch to dark theme'
 
   return (
     <button
       type="button"
       className="btn btn-ghost btn-sm btn-square"
-      aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-      onClick={() => dispatchSetTheme(theme === 'dark' ? 'light' : 'dark')}
+      aria-label={ariaLabel}
+      title={`Theme: ${theme}. Click to switch to ${next}`}
+      data-testid="theme-toggle-btn"
+      onClick={() => dispatchSetTheme(next)}
     >
       {theme === 'dark' ? (
         <Sun className="h-4 w-4" aria-hidden="true" />
+      ) : theme === 'light' ? (
+        <Laptop className="h-4 w-4" aria-hidden="true" />
       ) : (
         <Moon className="h-4 w-4" aria-hidden="true" />
       )}

--- a/webui/frontend/src/components/__tests__/SettingsSheet.test.tsx
+++ b/webui/frontend/src/components/__tests__/SettingsSheet.test.tsx
@@ -48,6 +48,8 @@ describe('SettingsSheet', () => {
     localStorage.removeItem(HOSTNAME_OVERRIDE_KEY)
     localStorage.removeItem(RETENTION_MODE_KEY)
     localStorage.removeItem(BUMP_COMPLETED_KEY)
+    localStorage.removeItem('swarm_theme')
+    localStorage.removeItem('swarm_theme_navbar')
     vi.unstubAllGlobals()
   })
 
@@ -61,6 +63,7 @@ describe('SettingsSheet', () => {
 
     const remotesToggle = screen.getByRole('button', { name: 'Remotes' })
     expect(remotesToggle).not.toHaveClass('menu-dropdown-toggle')
+    expect(screen.getByRole('button', { name: 'General' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Definition' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Blueprints' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Hermes' })).not.toBeInTheDocument()
@@ -787,4 +790,47 @@ describe('SettingsSheet definition pane (REQ-42)', () => {
     expect(screen.getByTestId('definition-explanation').textContent).toMatch(/YES\/NO/)
     expect(screen.queryByLabelText(/Gate blueprint Python/i)).not.toBeInTheDocument()
   })
+
+  describe('SettingsSheet General/Visuals (REQ-110)', () => {
+    it('sets light, dark, and system theme preferences via dropdown', () => {
+      renderSheet()
+      fireEvent.click(screen.getByRole('button', { name: 'General' }))
+
+      const select = screen.getByRole('combobox', { name: 'Theme' })
+      expect(select).toBeInTheDocument()
+      expect(select).toHaveValue('dark')
+
+      // Switch to light
+      fireEvent.change(select, { target: { value: 'light' } })
+      expect(select).toHaveValue('light')
+      expect(localStorage.getItem('swarm_theme')).toBe('light')
+
+      // Switch to system
+      fireEvent.change(select, { target: { value: 'system' } })
+      expect(select).toHaveValue('system')
+      expect(localStorage.getItem('swarm_theme')).toBe('system')
+
+      // Switch to dark
+      fireEvent.change(select, { target: { value: 'dark' } })
+      expect(select).toHaveValue('dark')
+      expect(localStorage.getItem('swarm_theme')).toBe('dark')
+    })
+
+    it('toggles navbar theme control visibility and persists flag', () => {
+      renderSheet()
+      fireEvent.click(screen.getByRole('button', { name: 'General' }))
+
+      const toggle = screen.getByRole('checkbox', { name: 'Show theme control in top bar' })
+      expect(toggle).toBeChecked()
+
+      fireEvent.click(toggle)
+      expect(toggle).not.toBeChecked()
+      expect(localStorage.getItem('swarm_theme_navbar')).toBe('false')
+
+      fireEvent.click(toggle)
+      expect(toggle).toBeChecked()
+      expect(localStorage.getItem('swarm_theme_navbar')).toBe('true')
+    })
+  })
 })
+

--- a/webui/frontend/src/components/__tests__/ThemeToggle.test.tsx
+++ b/webui/frontend/src/components/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,60 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import ThemeToggle from '../ThemeToggle'
+import {
+  dispatchSetNavbarThemeVisible,
+  THEME_NAVBAR_STORAGE_KEY,
+  THEME_STORAGE_KEY,
+} from '../../lib/theme'
+
+describe('ThemeToggle component (REQ-110)', () => {
+  afterEach(() => {
+    localStorage.removeItem(THEME_STORAGE_KEY)
+    localStorage.removeItem(THEME_NAVBAR_STORAGE_KEY)
+    vi.unstubAllGlobals()
+  })
+
+  it('renders with accessible label and cycles theme on click', () => {
+    render(<ThemeToggle />)
+    const button = screen.getByRole('button', { name: 'Switch to light theme' })
+    expect(button).toBeInTheDocument()
+
+    // Click 1: dark -> light
+    fireEvent.click(button)
+    expect(screen.getByRole('button', { name: 'Switch to system theme' })).toBeInTheDocument()
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('light')
+
+    // Click 2: light -> system
+    fireEvent.click(button)
+    expect(screen.getByRole('button', { name: 'Switch to dark theme' })).toBeInTheDocument()
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('system')
+
+    // Click 3: system -> dark
+    fireEvent.click(button)
+    expect(screen.getByRole('button', { name: 'Switch to light theme' })).toBeInTheDocument()
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
+  })
+
+  it('hides when navbar theme control is toggled off, and reappears when toggled on', () => {
+    render(<ThemeToggle />)
+    expect(screen.getByRole('button', { name: /Switch to (light|dark|system) theme/ })).toBeInTheDocument()
+
+    // Dispatch hide wrapped in act
+    act(() => {
+      dispatchSetNavbarThemeVisible(false)
+    })
+    expect(screen.queryByRole('button', { name: /Switch to (light|dark|system) theme/ })).not.toBeInTheDocument()
+
+    // Dispatch show wrapped in act
+    act(() => {
+      dispatchSetNavbarThemeVisible(true)
+    })
+    expect(screen.getByRole('button', { name: /Switch to (light|dark|system) theme/ })).toBeInTheDocument()
+  })
+
+  it('respects initial persisted hidden state', () => {
+    localStorage.setItem(THEME_NAVBAR_STORAGE_KEY, 'false')
+    render(<ThemeToggle />)
+    expect(screen.queryByRole('button', { name: /Switch to (light|dark|system) theme/ })).not.toBeInTheDocument()
+  })
+})

--- a/webui/frontend/src/lib/__tests__/theme.test.ts
+++ b/webui/frontend/src/lib/__tests__/theme.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  dispatchSetNavbarThemeVisible,
+  dispatchSetTheme,
+  initialNavbarThemeVisible,
+  initialTheme,
+  nextTheme,
+  persistNavbarThemeVisible,
+  persistTheme,
+  resolveSystemTheme,
+  resolveTheme,
+  subscribeSystemTheme,
+  THEME_NAVBAR_SET_EVENT,
+  THEME_NAVBAR_STORAGE_KEY,
+  THEME_SET_EVENT,
+  THEME_STORAGE_KEY,
+} from '../theme'
+
+describe('theme helpers (REQ-110)', () => {
+  afterEach(() => {
+    localStorage.removeItem(THEME_STORAGE_KEY)
+    localStorage.removeItem(THEME_NAVBAR_STORAGE_KEY)
+    vi.unstubAllGlobals()
+  })
+
+  it('initialTheme defaults to dark when nothing stored', () => {
+    expect(initialTheme()).toBe('dark')
+  })
+
+  it('initialTheme reads light, dark, or system from localStorage', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'light')
+    expect(initialTheme()).toBe('light')
+
+    localStorage.setItem(THEME_STORAGE_KEY, 'system')
+    expect(initialTheme()).toBe('system')
+
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark')
+    expect(initialTheme()).toBe('dark')
+  })
+
+  it('nextTheme cycles dark -> light -> system -> dark', () => {
+    expect(nextTheme('dark')).toBe('light')
+    expect(nextTheme('light')).toBe('system')
+    expect(nextTheme('system')).toBe('dark')
+  })
+
+  it('resolveTheme resolves light and dark directly, and system via matchMedia', () => {
+    expect(resolveTheme('light')).toBe('light')
+    expect(resolveTheme('dark')).toBe('dark')
+
+    // Mock matchMedia dark = true
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+    expect(resolveTheme('system')).toBe('dark')
+
+    // Mock matchMedia dark = false (light)
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+    expect(resolveTheme('system')).toBe('light')
+  })
+
+  it('subscribeSystemTheme listens to matchMedia change events', () => {
+    let listener: ((e: any) => void) | null = null
+    const addEventListener = vi.fn((_event: string, fn: any) => {
+      listener = fn
+    })
+    const removeEventListener = vi.fn()
+
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener,
+      removeEventListener,
+    }))
+
+    const onChange = vi.fn()
+    const unsubscribe = subscribeSystemTheme(onChange)
+
+    expect(addEventListener).toHaveBeenCalledWith('change', expect.any(Function))
+    expect(listener).not.toBeNull()
+
+    // Trigger dark change
+    listener!({ matches: false } as any)
+    expect(onChange).toHaveBeenCalledWith('light')
+
+    listener!({ matches: true } as any)
+    expect(onChange).toHaveBeenCalledWith('dark')
+
+    unsubscribe()
+    expect(removeEventListener).toHaveBeenCalledWith('change', expect.any(Function))
+  })
+
+  it('navbar theme control visibility defaults to true and persists changes', () => {
+    expect(initialNavbarThemeVisible()).toBe(true)
+
+    persistNavbarThemeVisible(false)
+    expect(localStorage.getItem(THEME_NAVBAR_STORAGE_KEY)).toBe('false')
+    expect(initialNavbarThemeVisible()).toBe(false)
+
+    persistNavbarThemeVisible(true)
+    expect(localStorage.getItem(THEME_NAVBAR_STORAGE_KEY)).toBe('true')
+    expect(initialNavbarThemeVisible()).toBe(true)
+  })
+
+  it('dispatchSetNavbarThemeVisible dispatches event and persists', () => {
+    const onNavbarToggle = vi.fn()
+    window.addEventListener(THEME_NAVBAR_SET_EVENT, onNavbarToggle)
+
+    dispatchSetNavbarThemeVisible(false)
+    expect(localStorage.getItem(THEME_NAVBAR_STORAGE_KEY)).toBe('false')
+    expect(onNavbarToggle).toHaveBeenCalled()
+
+    window.removeEventListener(THEME_NAVBAR_SET_EVENT, onNavbarToggle)
+  })
+
+  it('dispatchSetTheme dispatches event and persists theme', () => {
+    const onSet = vi.fn()
+    window.addEventListener(THEME_SET_EVENT, onSet)
+
+    dispatchSetTheme('system')
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('system')
+    expect(onSet).toHaveBeenCalled()
+
+    window.removeEventListener(THEME_SET_EVENT, onSet)
+  })
+})

--- a/webui/frontend/src/lib/theme.ts
+++ b/webui/frontend/src/lib/theme.ts
@@ -1,16 +1,56 @@
 export const THEME_STORAGE_KEY = 'swarm_theme'
 export const THEME_SET_EVENT = 'swarm:set-theme'
 export const THEME_TOGGLE_EVENT = 'swarm:toggle-theme'
+export const THEME_NAVBAR_STORAGE_KEY = 'swarm_theme_navbar'
+export const THEME_NAVBAR_SET_EVENT = 'swarm:set-theme-navbar'
 
-export type Theme = 'dark' | 'light'
+export type Theme = 'dark' | 'light' | 'system'
+export type ResolvedTheme = 'dark' | 'light'
+
+export function resolveSystemTheme(): ResolvedTheme {
+  if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+  return 'dark'
+}
+
+export function resolveTheme(theme: Theme): ResolvedTheme {
+  if (theme === 'system') return resolveSystemTheme()
+  return theme
+}
+
+export function subscribeSystemTheme(onChange: (resolved: ResolvedTheme) => void): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return () => {}
+  }
+  const media = window.matchMedia('(prefers-color-scheme: dark)')
+  const listener = (event: MediaQueryListEvent | MediaQueryList) => {
+    onChange(event.matches ? 'dark' : 'light')
+  }
+  if (typeof media.addEventListener === 'function') {
+    media.addEventListener('change', listener)
+    return () => media.removeEventListener('change', listener)
+  }
+  if (typeof (media as any).addListener === 'function') {
+    ;(media as any).addListener(listener)
+    return () => (media as any).removeListener(listener)
+  }
+  return () => {}
+}
 
 export function initialTheme(): Theme {
   try {
     const stored = localStorage.getItem(THEME_STORAGE_KEY)
-    if (stored === 'light' || stored === 'dark') return stored
+    if (stored === 'light' || stored === 'dark' || stored === 'system') return stored
   } catch {
     /* storage unavailable — fall through to the dark default */
   }
+  return 'dark'
+}
+
+export function nextTheme(theme: Theme): Theme {
+  if (theme === 'dark') return 'light'
+  if (theme === 'light') return 'system'
   return 'dark'
 }
 
@@ -23,9 +63,42 @@ export function persistTheme(theme: Theme): void {
 }
 
 export function dispatchSetTheme(theme: Theme): void {
-  window.dispatchEvent(new CustomEvent<Theme>(THEME_SET_EVENT, { detail: theme }))
+  persistTheme(theme)
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent<Theme>(THEME_SET_EVENT, { detail: theme }))
+  }
 }
 
 export function dispatchToggleTheme(): void {
-  window.dispatchEvent(new CustomEvent(THEME_TOGGLE_EVENT))
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(THEME_TOGGLE_EVENT))
+  }
+}
+
+export function initialNavbarThemeVisible(): boolean {
+  try {
+    const stored = localStorage.getItem(THEME_NAVBAR_STORAGE_KEY)
+    if (stored === 'false') return false
+    if (stored === 'true') return true
+  } catch {
+    /* storage unavailable — default is on */
+  }
+  return true
+}
+
+export function persistNavbarThemeVisible(visible: boolean): void {
+  try {
+    localStorage.setItem(THEME_NAVBAR_STORAGE_KEY, String(visible))
+  } catch {
+    /* persistence is best-effort */
+  }
+}
+
+export function dispatchSetNavbarThemeVisible(visible: boolean): void {
+  persistNavbarThemeVisible(visible)
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent<boolean>(THEME_NAVBAR_SET_EVENT, { detail: visible }),
+    )
+  }
 }


### PR DESCRIPTION
Fixes #479

### Quoted Issue Context (REQ-110 / #479)
> **Intent:** Users pick light, dark, or follow OS; and can show or hide the quick theme control in the top bar (visible by default).
>
> **Success:**
> 1. **Settings → General / Visuals** (create “Visuals” subsection under General if missing): a **dropdown** (DaisyUI `select`) with three options:
>    - Light
>    - Dark
>    - Use system (`prefers-color-scheme`)
> 2. **Persistence:** Store preference including `system` (extend `Theme` / storage key — e.g. `'light' | 'dark' | 'system'`). Applying theme: `system` resolves to light/dark from `matchMedia('(prefers-color-scheme: dark)')` and updates when the OS preference changes while set to system.
> 3. **Navbar visibility toggle:** In the same Visuals section, a **toggle** labeled clearly (e.g. “Show theme control in top bar”). **Default on.** When off, navbar theme control is hidden; Settings dropdown still works. Persist this flag (separate key, e.g. `swarm_theme_navbar`).
> 4. **Navbar control:** When the toggle is on, top navbar shows a compact theme control that stays consistent with the Settings preference (cycle or menu that can set light/dark/system — at minimum can flip effective light↔dark without losing a stored `system` preference unless the user explicitly picks light/dark). Prefer not surprising users who chose system.
> 5. **Document / apply:** `data-theme` on `html` remains `light` or `dark` (resolved); never leave `data-theme="system"`. Existing e2e theme test updated for the new model.
> 6. **Tests:** Settings dropdown sets each of three modes; system follows mocked `matchMedia`; navbar toggle default true; turning off hides navbar control; persistence survives reload. DaisyUI 5 / React 18. No live host. No secrets.
> 7. Rest-mode / Django static theme.js: out of scope unless trivial shared constant — SPA is SoT for this Issue.
>
> **Constraints:**
> - Parked until smash/wave capacity. One Cursor cloud when unblocked. `Fixes` this Issue.
> - GitHub-only. No Neon. Extend `webui/frontend/src/lib/theme.ts` + SettingsSheet + ThemeToggle.
> - Don’t fight #464 colour tokens — theme mode only.
>
> **Owner:** open-swarm engineer + Cursor cloud. CoS: Open Swarm. Skeptic text-only PASS/FAIL.

### Feasibility & Implementation Summary
- **theme.ts**: Extended `Theme` to `'light' | 'dark' | 'system'`, added `resolveTheme`, `resolveSystemTheme`, `subscribeSystemTheme`, `nextTheme`, and `swarm_theme_navbar` storage/event helpers.
- **App.tsx**: Always resolves theme before applying to document (`data-theme` is always `light` or `dark`, never `system`). Listens to OS `matchMedia` changes when in `system` mode.
- **SettingsSheet.tsx**: Added "General" section with "Visuals" subsection, containing theme dropdown (Light / Dark / Use system) and "Show theme control in top bar" toggle.
- **ThemeToggle.tsx**: Compact 3-way cycle (dark -> light -> system -> dark) with responsive icon/aria-label and automatic hiding when navbar toggle is disabled.
- **Tests**: Added unit tests in `theme.test.ts`, `ThemeToggle.test.tsx`, `SettingsSheet.test.tsx`, Playwright e2e in `interaction.spec.ts`, and contract test `tests/unit/test_req110_theme.py`.