### PR TITLE
feat(webui): agent editor role help and kind-appropriate LLM overrides (Fixes #511)

### DIFF
--- a/tests/unit/test_req124_agent_editor_llm_override.py
+++ b/tests/unit/test_req124_agent_editor_llm_override.py
@@ -1,0 +1,44 @@
+"""REQ-124: Agent editor — role explanations + show default LLM on override (Fixes #511)."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT_EDITOR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentEditor.tsx"
+AGENT_EDITS_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "agentEdits.ts"
+
+
+def test_agent_editor_role_explanation_and_remotes():
+    tsx = AGENT_EDITOR_TSX.read_text(encoding="utf-8")
+    # Role explanation blurb
+    assert "ROLE_BRIEFS" in tsx
+    assert 'data-testid="role-explanation"' in tsx
+
+    # Remote agents: override disabled / greyed with reason
+    assert "Remotes keep their own models" in tsx
+
+
+def test_agent_editor_kind_appropriate_override_and_default_label():
+    tsx = AGENT_EDITOR_TSX.read_text(encoding="utf-8")
+    # Default visibility
+    assert 'data-testid="default-llm-label"' in tsx
+    assert "Default would be:" in tsx
+
+    # CLI controls
+    assert 'aria-label="CLI override"' in tsx
+    assert "availableClis" in tsx
+    assert "availableCliModels" in tsx
+
+    # API controls
+    assert 'aria-label="API profile override"' in tsx
+    assert "availableApiModels" in tsx
+
+    # Filter out agent names from model lists
+    assert "catalogAgentIds" in tsx
+
+
+def test_agent_edits_persists_cli_and_profile_overrides():
+    ts = AGENT_EDITS_TS.read_text(encoding="utf-8")
+    assert "cliOverride?: string" in ts
+    assert "profileOverride?: string" in ts
+    assert "patch.cliOverride !== undefined" in ts
+    assert "patch.profileOverride !== undefined" in ts

--- a/webui/frontend/src/components/AgentEditor.tsx
+++ b/webui/frontend/src/components/AgentEditor.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useId, useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Button, Input, Modal, Select } from './DaisyUI'
-import { fetchBlueprints, fetchModels, type AgentRole, type Blueprint } from '../lib/api'
+import {
+  fetchBlueprints,
+  fetchCliAgents,
+  fetchCliModels,
+  fetchLlmProfiles,
+  fetchModels,
+  type AgentRole,
+  type Blueprint,
+} from '../lib/api'
 import {
   assignedBlueprintId,
   loadAgentEdit,
@@ -14,7 +22,9 @@ import {
   saveAgentSettings,
 } from '../lib/agentSettings'
 import { agentRole, exampleRoleAgents } from '../lib/agentRoles'
-import { agentLabel, catalogLabel } from '../lib/supportAgent'
+import { ROLE_BRIEFS } from '../lib/definitionExplain'
+import { agentLabel, catalogLabel, sessionKindForAgent } from '../lib/supportAgent'
+import { isCliBlueprintId } from '../lib/cliAgentContext'
 import { openSettingsSheet } from './SettingsSheet'
 
 /** Window event so the rail hover-edit and tests can open the agent editor. */
@@ -46,11 +56,11 @@ export interface AgentEditorProps {
 }
 
 /**
- * Agent-scoped editor overlay (REQ-58).
+ * Agent-scoped editor overlay (REQ-58 / REQ-124).
  *
- * Name, role, which catalog blueprint this seat uses, optional per-agent LLM
- * override. Not Settings: no Remotes, System, CLI catalog, or other instance
- * chrome. Chat stays mounted underneath.
+ * Name, role with explanation, which catalog blueprint this seat uses,
+ * kind-appropriate LLM override (disabled for remotes, CLI->model for CLIs,
+ * profile->model for API).
  */
 export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorProps) {
   const id = agentId || ''
@@ -59,6 +69,8 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
   const [role, setRole] = useState<AgentRole>('default')
   const [blueprintId, setBlueprintId] = useState('')
   const [llmOverride, setLlmOverride] = useState('')
+  const [cliOverride, setCliOverride] = useState('')
+  const [profileOverride, setProfileOverride] = useState('')
   const [newChatPerTask, setNewChatPerTask] = useState(false)
   const [savingSettings, setSavingSettings] = useState(false)
 
@@ -68,21 +80,79 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
     enabled: isOpen,
     retry: 1,
   })
-  const modelsQuery = useQuery({
-    queryKey: ['settings-llm-profiles'],
-    queryFn: fetchModels,
-    enabled: isOpen,
-    retry: 1,
-  })
 
   const catalog = useMemo(
     () => exampleRoleAgents(blueprintsQuery.data?.data ?? EMPTY_BLUEPRINTS),
     [blueprintsQuery.data],
   )
-  const models = modelsQuery.data?.data ?? []
   const agent = catalog.find((item) => item.id === id)
   const catalogName = agent ? agentLabel({ id: agent.id, name: agent.name }) : id
   const title = id ? `Edit ${catalogName}` : 'Edit agent'
+
+  const agentKind = useMemo(() => {
+    if (!id) return 'api'
+    const lowerId = id.toLowerCase()
+    if (lowerId.startsWith('remote-') || agent?.tags?.includes('remote') || lowerId.includes('remote')) {
+      return 'remote'
+    }
+    if (
+      lowerId.startsWith('cli-') ||
+      isCliBlueprintId(id) ||
+      agent?.tags?.includes('cli') ||
+      lowerId.includes('cli')
+    ) {
+      return 'cli'
+    }
+    return sessionKindForAgent({ id, tags: agent?.tags })
+  }, [id, agent])
+
+  const cliQuery = useQuery({
+    queryKey: ['cli-agents'],
+    queryFn: fetchCliAgents,
+    enabled: Boolean(isOpen && agentKind === 'cli'),
+    retry: 1,
+  })
+
+  const activeCli = cliOverride || cliQuery.data?.clis?.[0] || ''
+
+  const cliModelsQuery = useQuery({
+    queryKey: ['cli-models', activeCli],
+    queryFn: () => (activeCli ? fetchCliModels(activeCli) : Promise.resolve({ cli: '', models: [] })),
+    enabled: Boolean(isOpen && agentKind === 'cli' && activeCli),
+    retry: 1,
+  })
+
+  const llmProfilesQuery = useQuery({
+    queryKey: ['llm-profiles'],
+    queryFn: fetchLlmProfiles,
+    enabled: Boolean(isOpen && agentKind === 'api'),
+    retry: 1,
+  })
+
+  const modelsQuery = useQuery({
+    queryKey: ['settings-llm-profiles'],
+    queryFn: fetchModels,
+    enabled: Boolean(isOpen && agentKind === 'api'),
+    retry: 1,
+  })
+
+  const catalogAgentIds = useMemo(
+    () => new Set(catalog.map((item) => item.id.toLowerCase())),
+    [catalog],
+  )
+
+  const availableClis = useMemo(() => {
+    return (cliQuery.data?.clis ?? []).filter((c) => !catalogAgentIds.has(c.toLowerCase()))
+  }, [cliQuery.data, catalogAgentIds])
+
+  const availableCliModels = useMemo(() => {
+    return (cliModelsQuery.data?.models ?? []).filter((m) => !catalogAgentIds.has(m.toLowerCase()))
+  }, [cliModelsQuery.data, catalogAgentIds])
+
+  const availableApiModels = useMemo(() => {
+    const raw = modelsQuery.data?.data ?? []
+    return raw.filter((m) => !catalogAgentIds.has(m.id.toLowerCase()))
+  }, [modelsQuery.data, catalogAgentIds])
 
   useEffect(() => {
     if (!isOpen || !id) return
@@ -94,6 +164,8 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
     setRole(edit.role || agentRole({ id, name: catalogAgent?.name, role: catalogAgent?.role }))
     setBlueprintId(edit.blueprintId || id)
     setLlmOverride(edit.llmOverride || '')
+    setCliOverride(edit.cliOverride || '')
+    setProfileOverride(edit.profileOverride || '')
 
     let cancelled = false
     ;(async () => {
@@ -131,11 +203,6 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
     saveAgentEdit(id, { role: next })
   }
 
-  const persistLlm = (next: string) => {
-    setLlmOverride(next)
-    saveAgentEdit(id, { llmOverride: next })
-  }
-
   const openBlueprintInSettings = () => {
     const assigned = assignedBlueprintId(id) || blueprintId || id
     onClose()
@@ -170,18 +237,23 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
           spellCheck={false}
         />
 
-        <Select
-          label="Role"
-          name="agent-role"
-          value={role}
-          onChange={(event) => persistRole(event.target.value as AgentRole)}
-        >
-          {ROLE_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </Select>
+        <div className="form-control">
+          <Select
+            label="Role"
+            name="agent-role"
+            value={role}
+            onChange={(event) => persistRole(event.target.value as AgentRole)}
+          >
+            {ROLE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
+          <p className="text-xs text-base-content/70 mt-1" data-testid="role-explanation">
+            {ROLE_BRIEFS[role] || ROLE_BRIEFS.default}
+          </p>
+        </div>
 
         <Select
           label="Blueprint"
@@ -199,21 +271,138 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
           ))}
         </Select>
 
-        {models.length > 0 ? (
-          <Select
-            label="LLM override"
-            name="agent-llm-override"
-            value={llmOverride}
-            onChange={(event) => persistLlm(event.target.value)}
-          >
-            <option value="">Default</option>
-            {models.map((model) => (
-              <option key={model.id} value={model.id}>
-                {model.id}
-              </option>
-            ))}
-          </Select>
-        ) : null}
+        {/* LLM Override Picker by Kind (REQ-124) */}
+        {agentKind === 'remote' && (
+          <div className="rounded-box border border-base-300 bg-base-200/40 p-3 opacity-60">
+            <span className="text-sm font-semibold text-base-content/70">LLM override</span>
+            <p className="text-xs text-base-content/60 mt-1">Remotes keep their own models</p>
+          </div>
+        )}
+
+        {agentKind === 'cli' && (
+          <div className="space-y-3 rounded-box border border-base-300 bg-base-200/40 p-3">
+            <div>
+              <span className="text-sm font-semibold text-base-content/80">LLM override</span>
+              <p className="text-xs text-base-content/60 mt-0.5" data-testid="default-llm-label">
+                Default would be: {availableClis[0] || 'CLI default'} / {availableCliModels[0] || 'default'}
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="form-control">
+                <label className="label py-1">
+                  <span className="label-text text-xs">CLI</span>
+                </label>
+                <select
+                  aria-label="CLI override"
+                  className="select select-bordered select-sm w-full"
+                  value={cliOverride}
+                  onChange={(e) => {
+                    const nextCli = e.target.value
+                    setCliOverride(nextCli)
+                    saveAgentEdit(id, { cliOverride: nextCli, llmOverride })
+                  }}
+                >
+                  <option value="">Default CLI</option>
+                  {availableClis.map((cli) => (
+                    <option key={cli} value={cli}>
+                      {cli}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="form-control">
+                <label className="label py-1">
+                  <span className="label-text text-xs">Model</span>
+                </label>
+                <select
+                  aria-label="Model override"
+                  className="select select-bordered select-sm w-full"
+                  value={llmOverride}
+                  onChange={(e) => {
+                    const nextModel = e.target.value
+                    setLlmOverride(nextModel)
+                    saveAgentEdit(id, { cliOverride, llmOverride: nextModel })
+                  }}
+                >
+                  <option value="">Default model</option>
+                  {availableCliModels.map((model) => (
+                    <option key={model} value={model}>
+                      {model}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {agentKind === 'api' && (
+          <div className="space-y-3 rounded-box border border-base-300 bg-base-200/40 p-3">
+            <div>
+              <span className="text-sm font-semibold text-base-content/80">LLM override</span>
+              <p className="text-xs text-base-content/60 mt-0.5" data-testid="default-llm-label">
+                Default would be:{' '}
+                {llmProfilesQuery.data?.default_llm_profile || 'orchestration'}
+                {availableApiModels.length > 0 ? ` / ${availableApiModels[0].id}` : ''}
+              </p>
+            </div>
+
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="form-control">
+                <label className="label py-1">
+                  <span className="label-text text-xs">API / LLM profile</span>
+                </label>
+                <select
+                  aria-label="API profile override"
+                  className="select select-bordered select-sm w-full"
+                  value={profileOverride}
+                  onChange={(e) => {
+                    const nextProfile = e.target.value
+                    setProfileOverride(nextProfile)
+                    saveAgentEdit(id, { profileOverride: nextProfile, llmOverride })
+                  }}
+                >
+                  <option value="">Default profile</option>
+                  <option value="orchestration">User chat / orchestration</option>
+                  <option value="auxiliary">Auxiliary (code summary)</option>
+                  <option value="delegation">Delegation (design / coding)</option>
+                  {(llmProfilesQuery.data?.profiles ?? [])
+                    .filter((p) => !['orchestration', 'auxiliary', 'delegation'].includes(p.id))
+                    .map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.name || p.id}
+                      </option>
+                    ))}
+                </select>
+              </div>
+
+              <div className="form-control">
+                <label className="label py-1">
+                  <span className="label-text text-xs">Model</span>
+                </label>
+                <select
+                  aria-label="Model override"
+                  className="select select-bordered select-sm w-full"
+                  value={llmOverride}
+                  onChange={(e) => {
+                    const nextModel = e.target.value
+                    setLlmOverride(nextModel)
+                    saveAgentEdit(id, { profileOverride, llmOverride: nextModel })
+                  }}
+                >
+                  <option value="">Default model</option>
+                  {availableApiModels.map((model) => (
+                    <option key={model.id} value={model.id}>
+                      {model.id}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </div>
+        )}
 
         <div
           className="tooltip tooltip-bottom w-full text-left"

--- a/webui/frontend/src/components/__tests__/AgentEditor.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentEditor.test.tsx
@@ -182,4 +182,166 @@ describe('AgentEditor (REQ-58)', () => {
       'false',
     )
   })
+
+  describe('AgentEditor role explanations & LLM override by kind (REQ-124)', () => {
+    it('shows role explanation blurb and updates on change', async () => {
+      stubCatalog()
+      renderEditor({ agentId: 'codey' })
+
+      const dialog = await screen.findByRole('dialog', { name: /Edit /i, hidden: true })
+      const explanation = within(dialog).getByTestId('role-explanation')
+      expect(explanation).toBeInTheDocument()
+      expect(explanation.textContent).toMatch(/worker blueprint/i)
+
+      const roleSelect = within(dialog).getByLabelText('Role')
+      fireEvent.change(roleSelect, { target: { value: 'support' } })
+      expect(explanation.textContent).toMatch(/Support is Socratic/i)
+
+      fireEvent.change(roleSelect, { target: { value: 'gate' } })
+      expect(explanation.textContent).toMatch(/Gate is a YES\/NO/i)
+
+      fireEvent.change(roleSelect, { target: { value: 'skeptic' } })
+      expect(explanation.textContent).toMatch(/Skeptic is a bounded retry/i)
+    })
+
+    it('remote agent: LLM override is disabled with explanation', async () => {
+      stubCatalog()
+      renderEditor({ agentId: 'remote-omb' })
+
+      const dialog = await screen.findByRole('dialog', { name: /Edit /i, hidden: true })
+      expect(within(dialog).getByText(/Remotes keep their own models/i)).toBeInTheDocument()
+      expect(within(dialog).queryByRole('combobox', { name: /CLI override/i })).not.toBeInTheDocument()
+      expect(within(dialog).queryByRole('combobox', { name: /API profile override/i })).not.toBeInTheDocument()
+    })
+
+    it('CLI agent: renders CLIs and models, not agents from catalog', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+          const url = String(input)
+          if (url.includes('/v1/cli-agents/copilot/models/')) {
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                cli: 'copilot',
+                models: ['gpt-4o', 'o1-mini'],
+              }),
+            } as Response
+          }
+          if (url.includes('/v1/cli-agents/')) {
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                clis: ['copilot', 'claude-cli'],
+                native_consensus: {},
+                catalog: {},
+              }),
+            } as Response
+          }
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ object: 'list', data: catalog }),
+          } as Response
+        }),
+      )
+
+      renderEditor({ agentId: 'cli_agent' })
+      const dialog = await screen.findByRole('dialog', { name: /Edit /i, hidden: true })
+
+      const cliSelect = await within(dialog).findByRole('combobox', { name: 'CLI override' })
+      expect(within(cliSelect).getByRole('option', { name: 'copilot' })).toBeInTheDocument()
+      expect(within(cliSelect).getByRole('option', { name: 'claude-cli' })).toBeInTheDocument()
+      // Agents must NOT be listed
+      expect(within(cliSelect).queryByRole('option', { name: 'Codey' })).not.toBeInTheDocument()
+      expect(within(cliSelect).queryByRole('option', { name: 'Stewie' })).not.toBeInTheDocument()
+
+      const modelSelect = await within(dialog).findByRole('combobox', { name: 'Model override' })
+      await waitFor(() => {
+        expect(within(modelSelect).getByRole('option', { name: 'gpt-4o' })).toBeInTheDocument()
+      })
+      expect(within(modelSelect).queryByRole('option', { name: 'Codey' })).not.toBeInTheDocument()
+      expect(within(modelSelect).queryByRole('option', { name: 'Stewie' })).not.toBeInTheDocument()
+
+      expect(within(dialog).getByTestId('default-llm-label')).toBeInTheDocument()
+
+      // Save override
+      fireEvent.change(cliSelect, { target: { value: 'copilot' } })
+      fireEvent.change(modelSelect, { target: { value: 'gpt-4o' } })
+      const stored = JSON.parse(localStorage.getItem(AGENT_EDITS_KEY) || '{}')['cli_agent']
+      expect(stored.cliOverride).toBe('copilot')
+      expect(stored.llmOverride).toBe('gpt-4o')
+    })
+
+    it('API agent: renders profiles and models, not agents from catalog', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+          const url = String(input)
+          if (url.includes('/v1/llm-profiles/')) {
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                object: 'llm_profiles',
+                profiles: [{ id: 'custom-profile', name: 'Custom Profile' }],
+                default_llm_profile: 'orchestration',
+                task_llm_profiles: {},
+              }),
+            } as Response
+          }
+          if (url.includes('/v1/models')) {
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                object: 'list',
+                data: [
+                  { id: 'gpt-4o', object: 'model' },
+                  { id: 'codey', object: 'model' }, // Agent name in models list!
+                  { id: 'stewie', object: 'model' }, // Agent name in models list!
+                ],
+              }),
+            } as Response
+          }
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ object: 'list', data: catalog }),
+          } as Response
+        }),
+      )
+
+      renderEditor({ agentId: 'codey' })
+      const dialog = await screen.findByRole('dialog', { name: /Edit /i, hidden: true })
+
+      const profileSelect = await within(dialog).findByRole('combobox', { name: 'API profile override' })
+      expect(within(profileSelect).getByRole('option', { name: /User chat \/ orchestration/i })).toBeInTheDocument()
+      expect(within(profileSelect).getByRole('option', { name: 'Custom Profile' })).toBeInTheDocument()
+
+      const modelSelect = await within(dialog).findByRole('combobox', { name: 'Model override' })
+      expect(within(modelSelect).getByRole('option', { name: 'gpt-4o' })).toBeInTheDocument()
+      // Bug fixed: Agent names filtered out
+      expect(within(modelSelect).queryByRole('option', { name: 'codey' })).not.toBeInTheDocument()
+      expect(within(modelSelect).queryByRole('option', { name: 'stewie' })).not.toBeInTheDocument()
+
+      expect(within(dialog).getByTestId('default-llm-label')).toHaveTextContent(/Default would be:\s*orchestration/i)
+
+      // Save override
+      fireEvent.change(profileSelect, { target: { value: 'custom-profile' } })
+      fireEvent.change(modelSelect, { target: { value: 'gpt-4o' } })
+      const stored = JSON.parse(localStorage.getItem(AGENT_EDITS_KEY) || '{}')['codey']
+      expect(stored.profileOverride).toBe('custom-profile')
+      expect(stored.llmOverride).toBe('gpt-4o')
+
+      // Clear restores default
+      fireEvent.change(profileSelect, { target: { value: '' } })
+      fireEvent.change(modelSelect, { target: { value: '' } })
+      const cleared = JSON.parse(localStorage.getItem(AGENT_EDITS_KEY) || '{}')['codey']
+      expect(cleared?.profileOverride).toBeUndefined()
+      expect(cleared?.llmOverride).toBeUndefined()
+    })
+  })
 })

--- a/webui/frontend/src/lib/agentEdits.ts
+++ b/webui/frontend/src/lib/agentEdits.ts
@@ -28,6 +28,8 @@ export interface AgentEdit {
   llmOverride?: string
   folder?: string
   command?: string
+  cliOverride?: string
+  profileOverride?: string
 }
 
 export type AgentEditMap = Record<string, AgentEdit>
@@ -106,6 +108,16 @@ export function saveAgentEdit(agentId: string, patch: AgentEdit): AgentEdit {
     const command = patch.command.trim()
     if (command) next.command = command
     else delete next.command
+  }
+  if (patch.cliOverride !== undefined) {
+    const cli = patch.cliOverride.trim()
+    if (cli) next.cliOverride = cli
+    else delete next.cliOverride
+  }
+  if (patch.profileOverride !== undefined) {
+    const profile = patch.profileOverride.trim()
+    if (profile) next.profileOverride = profile
+    else delete next.profileOverride
   }
 
   if (Object.keys(next).length === 0) delete map[agentId]


### PR DESCRIPTION
Fixes #511

### Quoted Issue Context (REQ-124 / #511)
> **Intent:** Honest editor help + override controls that match what each agent kind can actually change.
>
> **Success:**
> 1. **Role select:** Short explanation per role (reuse `definitionExplain` / `agentRoles`). Updates on change.
> 2. **Default visible:** Wherever override exists, show “Default would be: …” (profile/model without override).
> 3. **Override picker by kind (fix the agents list bug):**
>    - **Remote agents:** **Hide or disable** LLM override (greyed + reason: “Remotes keep their own models”). Do not list anything configurable as if we own the far side.
>    - **CLI agents:** Two-step (or cascaded) control — **CLI** (discovered CLIs, not agent names) → **model** for that CLI (from that CLI’s model list / #360). Not the AGENTS roster.
>    - **API agents:** Cascaded — **API / LLM profile** (orchestration/auxiliary/delegation or configured OpenAI-compat endpoints) → **model** id from that API’s `/v1/models` (or profile catalog). Not agent names.
> 4. Saving persists the kind-appropriate override fields; clearing restores default.
> 5. Tests: remote → override absent/disabled; CLI fixture → CLIs+models not agents; API fixture → profiles+models not agents; role blurb present. DaisyUI 5 / React 18. No live host. No secrets.
>
> **Constraints:**
> - Parked; one cloud when capacity. `Fixes` this Issue.
> - GitHub-only. No Neon. OpenMousBot naming if remotes mentioned.
>
> **Owner:** open-swarm engineer + Cursor cloud. CoS: Open Swarm. Skeptic text-only PASS/FAIL.

### Feasibility & Implementation Summary
- **AgentEditor.tsx**:
  - **Role Explanation**: Integrated `ROLE_BRIEFS` under the Role `<Select>` with `data-testid="role-explanation"`; dynamically updates when role changes.
  - **Kind-Appropriate Overrides**:
    - **Remote**: LLM override section disabled and greyed out with "Remotes keep their own models".
    - **CLI**: Discovered CLIs dropdown + CLI models dropdown (via `/v1/cli-agents/` and `/v1/cli-agents/<cli>/models/`). Filters out agent names from roster. Shows "Default would be: ...".
    - **API**: API profile dropdown (`orchestration`, `auxiliary`, `delegation`, custom) + models dropdown from `/v1/models` filtered to exclude catalog agent names. Shows "Default would be: ...".
- **agentEdits.ts**: Added `cliOverride` and `profileOverride` fields to `AgentEdit` and `saveAgentEdit`. Clearing dropdowns restores default by deleting keys from storage.
- **Tests**:
  - `AgentEditor.test.tsx`: 4 new unit tests covering remote disabled reason, CLI discovered CLIs + models (not agents), API profiles + models (not agents), default visibility, and role explanation reactivity.
  - `test_req124_agent_editor_llm_override.py`: Contract tests for role explanations, remote override disabled message, kind-specific controls, and agent edit persistence.