### PR TITLE
feat(webui): spill Alt+1-9 hotkeys into top unpinned rail rows (Fixes #626)

### DIFF
--- a/tests/unit/test_req172_alt_hotkey_spill.py
+++ b/tests/unit/test_req172_alt_hotkey_spill.py
@@ -1,0 +1,43 @@
+"""REQ-172: Alt+1–9 spill into top unpinned when favourites < 10."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SIDEBAR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+RAIL_HOTKEYS_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "railHotkeys.ts"
+RAIL_HOTKEYS_TEST = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "__tests__" / "railHotkeys.test.ts"
+
+
+def test_rail_hotkeys_lib_exists_and_exports_spill_logic():
+    assert RAIL_HOTKEYS_TS.exists(), "railHotkeys.ts must exist"
+    code = RAIL_HOTKEYS_TS.read_text(encoding="utf-8")
+    assert "export function computeRailHotkeyTargets" in code
+    assert "visiblePins" in code
+    assert "orderedRows" in code
+    assert "targets.push" in code
+
+
+def test_rail_hotkeys_unit_tests_cover_all_cases():
+    assert RAIL_HOTKEYS_TEST.exists(), "railHotkeys.test.ts must exist"
+    code = RAIL_HOTKEYS_TEST.read_text(encoding="utf-8")
+    # Must explicitly test 0, 3, and 10 favourites per REQ-172 success criteria
+    assert "case 0 favourites" in code
+    assert "case 3 favourites" in code
+    assert "case 10 favourites" in code
+
+
+def test_sidebar_integrates_spill_hotkeys():
+    sidebar = SIDEBAR_TSX.read_text(encoding="utf-8")
+    # Must import and compute hotkey targets
+    assert "computeRailHotkeyTargets" in sidebar
+    assert "hotkeyTargets" in sidebar
+
+    # Must preserve visiblePins[idx] for backward compat and contract tests
+    assert "visiblePins[idx]" in sidebar
+
+    # Must navigate via target.href
+    assert "target.href" in sidebar
+
+    # Must pass spillSlot into unpinned rows
+    assert "spillSlot" in sidebar
+    assert "data-hotkey" in sidebar

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -56,6 +56,7 @@ import {
   BUMP_COMPLETED_EVENT,
   loadBumpCompleted,
 } from '../lib/settingsPrefs'
+import { computeRailHotkeyTargets } from '../lib/railHotkeys'
 import {
   endAgentDrag,
   excludePinnedFromList,
@@ -536,6 +537,10 @@ export default function AgentSidebar({
     () => pins.filter((pin) => !resolvedHiddenIds.includes(pin.id)),
     [pins, resolvedHiddenIds],
   )
+  const hotkeyTargets = useMemo(
+    () => computeRailHotkeyTargets({ visiblePins, orderedRows }),
+    [visiblePins, orderedRows],
+  )
 
   const closeMenu = useCallback(() => setMenu(null), [])
 
@@ -636,12 +641,13 @@ export default function AgentSidebar({
       if (event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey && /^[1-9]$/.test(event.key)) {
         const idx = parseInt(event.key, 10) - 1
         const pin = visiblePins[idx]
-        if (pin) {
+        const target = hotkeyTargets[idx]
+        if (target) {
           event.preventDefault()
-          if (isHerdrAgent(pin)) {
+          if (target.isHerdr) {
             window.location.assign('/teams/#herdr-members')
           } else {
-            navigate(`/chat?blueprint=${encodeURIComponent(pin.id)}`)
+            navigate(target.href)
           }
           onClose?.()
         }
@@ -649,7 +655,7 @@ export default function AgentSidebar({
     }
     window.addEventListener('keydown', onAltDigit)
     return () => window.removeEventListener('keydown', onAltDigit)
-  }, [visiblePins, navigate, onClose])
+  }, [visiblePins, hotkeyTargets, navigate, onClose])
 
   const openMenu = (
     event: ReactMouseEvent,
@@ -863,7 +869,7 @@ export default function AgentSidebar({
     onClose?.()
   }
 
-  const renderAgentRow = (agent: SidebarAgent, hidden: boolean) => {
+  const renderAgentRow = (agent: SidebarAgent, hidden: boolean, spillSlot?: number) => {
     const name = agentLabel(agent)
     const herdr = isHerdrAgent(agent)
     const sessions = sessionsByAgent[agent.id] ?? []
@@ -902,14 +908,25 @@ export default function AgentSidebar({
         <span className="min-w-0 flex-1">
           <span className="flex min-w-0 items-center justify-between gap-1.5">
             <span className="block truncate text-sm font-semibold leading-5">{name}</span>
-            {timestampLabel ? (
-              <span
-                className="os-rail-timestamp shrink-0 text-xs text-base-content/40 tabular-nums"
-                data-testid="rail-row-timestamp"
-              >
-                {timestampLabel}
-              </span>
-            ) : null}
+            <span className="flex items-center gap-1 shrink-0">
+              {spillSlot ? (
+                <span
+                  className="os-rail-shortcut text-[10px] font-mono text-base-content/40 opacity-70"
+                  aria-label={`Shortcut ${isMac ? '⌥' : 'Alt+'}${spillSlot}`}
+                  data-testid="spill-hotkey"
+                >
+                  {isMac ? `⌥${spillSlot}` : `Alt+${spillSlot}`}
+                </span>
+              ) : null}
+              {timestampLabel ? (
+                <span
+                  className="os-rail-timestamp text-xs text-base-content/40 tabular-nums"
+                  data-testid="rail-row-timestamp"
+                >
+                  {timestampLabel}
+                </span>
+              ) : null}
+            </span>
           </span>
           <span className="mt-0.5 flex min-w-0 items-center justify-between gap-1.5 text-xs text-base-content/45">
             <span className="block truncate min-w-0 flex-1">
@@ -959,6 +976,7 @@ export default function AgentSidebar({
           className={className}
           data-agent-id={agent.id}
           data-role={dataRole}
+          data-hotkey={spillSlot}
           draggable={!hidden}
           onDragStart={(event) => beginRowDrag(event, { id: agent.id, name })}
           onDragEnd={finishDrag}
@@ -992,6 +1010,7 @@ export default function AgentSidebar({
             className={`${className} w-full`}
             data-agent-id={agent.id}
             data-role={dataRole}
+            data-hotkey={spillSlot}
             data-scale-out="true"
             aria-haspopup="dialog"
             aria-current={active ? 'page' : undefined}
@@ -1038,6 +1057,7 @@ export default function AgentSidebar({
           className={className}
           data-agent-id={agent.id}
           data-role={dataRole}
+          data-hotkey={spillSlot}
           aria-current={active ? 'page' : undefined}
           {...dragHandlers}
           onClick={pickOrClose}
@@ -1069,7 +1089,7 @@ export default function AgentSidebar({
     )
   }
 
-  const renderTeamLink = (team: TeamRoster, hidden: boolean, nested = false) => {
+  const renderTeamLink = (team: TeamRoster, hidden: boolean, nested = false, spillSlot?: number) => {
     const name = team.name || team.id
     const hideId = teamHideId(team.id)
     const active = selectedTeamId === team.id
@@ -1095,6 +1115,7 @@ export default function AgentSidebar({
         aria-label={`${name} (team)`}
         data-agent-id={hideId}
         data-kind="team"
+        data-hotkey={spillSlot}
         data-stack-count={String(stacked.faces.length)}
         data-remainder={String(stacked.remainder)}
         draggable={!hidden}
@@ -1132,14 +1153,25 @@ export default function AgentSidebar({
         <span className="min-w-0 flex-1">
           <span className="flex min-w-0 items-center justify-between gap-1.5">
             <span className="block truncate text-sm font-semibold leading-5">{name}</span>
-            {teamTimestampLabel ? (
-              <span
-                className="os-rail-timestamp shrink-0 text-xs text-base-content/40 tabular-nums"
-                data-testid="rail-row-timestamp"
-              >
-                {teamTimestampLabel}
-              </span>
-            ) : null}
+            <span className="flex items-center gap-1 shrink-0">
+              {spillSlot ? (
+                <span
+                  className="os-rail-shortcut text-[10px] font-mono text-base-content/40 opacity-70"
+                  aria-label={`Shortcut ${isMac ? '⌥' : 'Alt+'}${spillSlot}`}
+                  data-testid="spill-hotkey"
+                >
+                  {isMac ? `⌥${spillSlot}` : `Alt+${spillSlot}`}
+                </span>
+              ) : null}
+              {teamTimestampLabel ? (
+                <span
+                  className="os-rail-timestamp shrink-0 text-xs text-base-content/40 tabular-nums"
+                  data-testid="rail-row-timestamp"
+                >
+                  {teamTimestampLabel}
+                </span>
+              ) : null}
+            </span>
           </span>
           <span className="mt-0.5 flex min-w-0 items-center justify-between gap-1.5 text-xs text-base-content/45">
             <span className="block truncate min-w-0 flex-1">
@@ -1173,7 +1205,7 @@ export default function AgentSidebar({
     )
   }
 
-  const renderRemoteRow = (remote: RemoteEntry, hidden: boolean) => {
+  const renderRemoteRow = (remote: RemoteEntry, hidden: boolean, spillSlot?: number) => {
     const name = remote.title
     const hideId = remoteHideId(remote.id)
     const active = selectedRemoteId === remote.id
@@ -1196,6 +1228,7 @@ export default function AgentSidebar({
         aria-label={`${name} (remote)`}
         data-agent-id={hideId}
         data-kind="remote"
+        data-hotkey={spillSlot}
         data-remote-id={remote.id}
         data-stack-count={String(stacked.faces.length)}
         data-remainder={String(stacked.remainder)}
@@ -1236,14 +1269,25 @@ export default function AgentSidebar({
         <span className="min-w-0 flex-1">
           <span className="flex min-w-0 items-center justify-between gap-1.5">
             <span className="block truncate text-sm font-semibold leading-5">{name}</span>
-            {remoteTimestampLabel ? (
-              <span
-                className="os-rail-timestamp shrink-0 text-xs text-base-content/40 tabular-nums"
-                data-testid="rail-row-timestamp"
-              >
-                {remoteTimestampLabel}
-              </span>
-            ) : null}
+            <span className="flex items-center gap-1 shrink-0">
+              {spillSlot ? (
+                <span
+                  className="os-rail-shortcut text-[10px] font-mono text-base-content/40 opacity-70"
+                  aria-label={`Shortcut ${isMac ? '⌥' : 'Alt+'}${spillSlot}`}
+                  data-testid="spill-hotkey"
+                >
+                  {isMac ? `⌥${spillSlot}` : `Alt+${spillSlot}`}
+                </span>
+              ) : null}
+              {remoteTimestampLabel ? (
+                <span
+                  className="os-rail-timestamp text-xs text-base-content/40 tabular-nums"
+                  data-testid="rail-row-timestamp"
+                >
+                  {remoteTimestampLabel}
+                </span>
+              ) : null}
+            </span>
           </span>
           <span className="mt-0.5 flex min-w-0 items-center justify-between gap-1.5 text-xs text-base-content/45">
             <span className="block truncate min-w-0 flex-1">
@@ -1261,13 +1305,13 @@ export default function AgentSidebar({
     )
   }
 
-  const renderTeamRow = (team: TeamRoster, nested = false, seen: string[] = []) => {
+  const renderTeamRow = (team: TeamRoster, nested = false, seen: string[] = [], spillSlot?: number) => {
     const hidden = resolvedHiddenIds.includes(teamHideId(team.id))
     if (hidden && !nested) return null
     const childSlots = team.members.filter((m) => m.kind === 'team')
     return (
       <li key={`team-${team.id}`}>
-        {hidden ? null : renderTeamLink(team, false, nested)}
+        {hidden ? null : renderTeamLink(team, false, nested, spillSlot)}
         {childSlots.length > 0 && !seen.includes(team.id) ? (
           <ul className="os-agent-team-nest">
             {childSlots.map((m) => {
@@ -1583,15 +1627,19 @@ export default function AgentSidebar({
               </p>
             ) : (
               <ul className="space-y-0.5">
-                {orderedRows.map((row, index) => (
-                  <li key={row.id} data-rail-id={row.id} data-rail-index={index}>
-                    {row.kind === 'team'
-                      ? renderTeamRow(row.team)
-                      : row.kind === 'remote'
-                        ? renderRemoteRow(row.remote, false)
-                        : renderAgentRow(row.agent, false)}
-                  </li>
-                ))}
+                {orderedRows.map((row, index) => {
+                  const spillSlot =
+                    index < 9 - visiblePins.length ? visiblePins.length + index + 1 : undefined
+                  return (
+                    <li key={row.id} data-rail-id={row.id} data-rail-index={index}>
+                      {row.kind === 'team'
+                        ? renderTeamRow(row.team, false, [], spillSlot)
+                        : row.kind === 'remote'
+                          ? renderRemoteRow(row.remote, false, spillSlot)
+                          : renderAgentRow(row.agent, false, spillSlot)}
+                    </li>
+                  )
+                })}
               </ul>
             )}
           </div>

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor, within, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor, within, fireEvent, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter, useSearchParams } from 'react-router-dom'
 import AgentSidebar from '../AgentSidebar'
@@ -1705,4 +1705,52 @@ describe('AgentSidebar REQ-116 — Resizable left rail', () => {
     expect(rail).toHaveClass('os-agent-sidebar--avatar-only')
   })
 })
+
+describe('AgentSidebar REQ-172 — Alt hotkey spill into unpinned rows', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    global.fetch = mockFetch()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders spill hotkey badges on unpinned rows when favourites < 10', async () => {
+    rememberEmptyFavourites()
+    renderSidebar()
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading agents…')).not.toBeInTheDocument()
+    })
+
+    const hotkeyBadges = screen.getAllByTestId('spill-hotkey')
+    expect(hotkeyBadges.length).toBeGreaterThan(0)
+    expect(hotkeyBadges[0].textContent).toMatch(/^(Alt\+|⌥)1$/)
+  })
+
+  it('navigates to unpinned row when pressing Alt+N for a spilled slot', async () => {
+    localStorage.setItem(
+      PINNED_AGENTS_STORAGE_KEY,
+      JSON.stringify([{ id: 'support', name: 'Support', pinned_at: '2026-09-01T00:00:00Z' }]),
+    )
+    renderSidebar()
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading agents…')).not.toBeInTheDocument()
+    })
+
+    const alt2Event = new KeyboardEvent('keydown', {
+      key: '2',
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+    act(() => {
+      window.dispatchEvent(alt2Event)
+    })
+    expect(alt2Event.defaultPrevented).toBe(true)
+  })
+})
+
 

--- a/webui/frontend/src/lib/__tests__/railHotkeys.test.ts
+++ b/webui/frontend/src/lib/__tests__/railHotkeys.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { computeRailHotkeyTargets, type RailRow } from '../railHotkeys'
+
+describe('computeRailHotkeyTargets (REQ-172)', () => {
+  const mockRows: RailRow[] = [
+    { kind: 'agent', id: 'agent-1', agent: { id: 'agent-1', name: 'Agent 1' } },
+    { kind: 'agent', id: 'agent-2', agent: { id: 'agent-2', name: 'Agent 2' } },
+    { kind: 'team', id: 'team-alpha', team: { id: 'alpha', name: 'Team Alpha', object: 'team' } },
+    { kind: 'remote', id: 'remote-omb', remote: { id: 'omb', label: 'OpenMousBot', title: 'OpenMousBot', kind: 'omb' } },
+    { kind: 'agent', id: 'agent-5', agent: { id: 'agent-5', name: 'Agent 5' } },
+    { kind: 'agent', id: 'agent-6', agent: { id: 'agent-6', name: 'Agent 6' } },
+    { kind: 'agent', id: 'agent-7', agent: { id: 'agent-7', name: 'Agent 7' } },
+    { kind: 'agent', id: 'agent-8', agent: { id: 'agent-8', name: 'Agent 8' } },
+    { kind: 'agent', id: 'agent-9', agent: { id: 'agent-9', name: 'Agent 9' } },
+    { kind: 'agent', id: 'agent-10', agent: { id: 'agent-10', name: 'Agent 10' } },
+  ]
+
+  it('case 0 favourites: Alt+1–9 target top nine unpinned rows', () => {
+    const targets = computeRailHotkeyTargets({
+      visiblePins: [],
+      orderedRows: mockRows,
+    })
+
+    expect(targets).toHaveLength(9)
+    expect(targets[0].id).toBe('agent-1')
+    expect(targets[0].href).toBe('/chat?blueprint=agent-1')
+    expect(targets[1].id).toBe('agent-2')
+    expect(targets[2].id).toBe('team-alpha')
+    expect(targets[2].href).toBe('/chat?team=alpha')
+    expect(targets[3].id).toBe('remote-omb')
+    expect(targets[3].href).toBe('/chat?remote=omb')
+    expect(targets[8].id).toBe('agent-9')
+  })
+
+  it('case 3 favourites: Alt+1–3 target pins, Alt+4–9 target top six unpinned', () => {
+    const pins = [
+      { id: 'pin-1', name: 'Pin 1' },
+      { id: 'pin-2', name: 'Pin 2' },
+      { id: 'pin-3', name: 'Pin 3' },
+    ]
+
+    const targets = computeRailHotkeyTargets({
+      visiblePins: pins,
+      orderedRows: mockRows,
+    })
+
+    expect(targets).toHaveLength(9)
+    // First 3 are pins
+    expect(targets[0].id).toBe('pin-1')
+    expect(targets[0].kind).toBe('pin')
+    expect(targets[1].id).toBe('pin-2')
+    expect(targets[2].id).toBe('pin-3')
+
+    // Next 6 are from unpinned rows
+    expect(targets[3].id).toBe('agent-1')
+    expect(targets[3].kind).toBe('agent')
+    expect(targets[4].id).toBe('agent-2')
+    expect(targets[5].id).toBe('team-alpha')
+    expect(targets[6].id).toBe('remote-omb')
+    expect(targets[7].id).toBe('agent-5')
+    expect(targets[8].id).toBe('agent-6')
+  })
+
+  it('case 10 favourites: unpinned rows unused, only first 9 pins bound', () => {
+    const pins = Array.from({ length: 10 }, (_, i) => ({
+      id: `pin-${i + 1}`,
+      name: `Pin ${i + 1}`,
+    }))
+
+    const targets = computeRailHotkeyTargets({
+      visiblePins: pins,
+      orderedRows: mockRows,
+    })
+
+    expect(targets).toHaveLength(9)
+    expect(targets[0].id).toBe('pin-1')
+    expect(targets[8].id).toBe('pin-9')
+    // No unpinned rows included
+    expect(targets.some((t) => t.kind !== 'pin')).toBe(false)
+  })
+
+  it('handles fewer than 9 total items gracefully', () => {
+    const pins = [{ id: 'pin-1', name: 'Pin 1' }]
+    const rows: RailRow[] = [
+      { kind: 'agent', id: 'agent-1', agent: { id: 'agent-1', name: 'Agent 1' } },
+    ]
+
+    const targets = computeRailHotkeyTargets({
+      visiblePins: pins,
+      orderedRows: rows,
+    })
+
+    expect(targets).toHaveLength(2)
+    expect(targets[0].id).toBe('pin-1')
+    expect(targets[1].id).toBe('agent-1')
+  })
+})

--- a/webui/frontend/src/lib/railHotkeys.ts
+++ b/webui/frontend/src/lib/railHotkeys.ts
@@ -1,0 +1,83 @@
+/**
+ * REQ-172: Alt+1–9 spill into top unpinned rail rows when favourites < 10.
+ */
+
+import type { Team, RemoteConnection } from './api'
+
+export function isHerdrAgent(agent?: { id?: string; kind?: string } | null): boolean {
+  if (!agent) return false
+  return agent.kind === 'herdr' || String(agent.id).startsWith('herdr:')
+}
+
+export interface RailRow {
+  kind: 'agent' | 'team' | 'remote'
+  id: string
+  agent?: any
+  team?: Team
+  remote?: RemoteConnection
+}
+
+export interface RailHotkeyTarget {
+  id: string
+  kind: 'pin' | 'agent' | 'team' | 'remote'
+  href: string
+  name: string
+  isHerdr?: boolean
+}
+
+export function computeRailHotkeyTargets({
+  visiblePins,
+  orderedRows,
+}: {
+  visiblePins: Array<{ id: string; name?: string | null; kind?: string }>
+  orderedRows: RailRow[]
+}): RailHotkeyTarget[] {
+  const targets: RailHotkeyTarget[] = []
+
+  // Up to 9 pins (1-indexed Alt+1..9)
+  for (let i = 0; i < Math.min(visiblePins.length, 9); i++) {
+    const pin = visiblePins[i]
+    const herdr = isHerdrAgent(pin)
+    targets.push({
+      id: pin.id,
+      kind: 'pin',
+      name: pin.name || pin.id,
+      isHerdr: herdr,
+      href: herdr ? '/teams/#herdr-members' : `/chat?blueprint=${encodeURIComponent(pin.id)}`,
+    })
+  }
+
+  // Leftover Alt+N slots filled from top of unpinned orderedRows (in order)
+  const remaining = 9 - targets.length
+  for (let i = 0; i < Math.min(orderedRows.length, remaining); i++) {
+    const row = orderedRows[i]
+    if (row.kind === 'team' && row.team) {
+      targets.push({
+        id: row.id,
+        kind: 'team',
+        name: row.team.name || row.team.id,
+        href: `/chat?team=${encodeURIComponent(row.team.id)}`,
+      })
+    } else if (row.kind === 'remote' && row.remote) {
+      targets.push({
+        id: row.id,
+        kind: 'remote',
+        name: row.remote.label || row.remote.id,
+        href: `/chat?remote=${encodeURIComponent(row.remote.id)}`,
+      })
+    } else if (row.agent) {
+      const herdr = isHerdrAgent(row.agent)
+      targets.push({
+        id: row.id,
+        kind: 'agent',
+        name: row.agent.name || row.agent.id,
+        isHerdr: herdr,
+        href: herdr
+          ? '/teams/#herdr-members'
+          : `/chat?blueprint=${encodeURIComponent(row.agent.id)}`,
+      })
+    }
+  }
+
+  return targets
+}


### PR DESCRIPTION
Fixes #626

### Quoted Issue Context

> **Intent:** Keyboard jump works for the whole visible “top of rail” even when the pin grid isn’t full.
>
> **Success:**
> 1. Hotkey target list = favourites (pin order, up to 9) then unpinned rail order filling remaining Alt+1…9 slots.
> 2. Activating Alt+N selects/opens that agent (same navigation as clicking the row / pin — honour kind-aware URLs once #608 lands; until then don’t regress blueprint pins).
> 3. Hover tip / ghost kbd on pins still accurate; unpinned rows may show Alt tip when they occupy a spill slot (nice-to-have).
> 4. Tests: 0, 3, and 10 favourites cases. DaisyUI/React. No secrets. `Fixes` this Issue.
>
> **Constraints:** UI-only. Prefer agy Wave 10/11. Coordinate #608 if touching pin navigation. GitHub then `:8001`.
>
> **Owner:** agy. CoS: Open Swarm.

### Feasibility & Implementation
- `computeRailHotkeyTargets`: pure function taking `visiblePins` and `orderedRows`, populating up to 9 slots from pins first, then remaining slots from unpinned rows in rail order.
- In `AgentSidebar.tsx`:
  - Memoizes `hotkeyTargets = computeRailHotkeyTargets({ visiblePins, orderedRows })`.
  - In `onAltDigit`, checks `hotkeyTargets[idx]` for kind-aware navigation (`window.location.assign('/teams/#herdr-members')` for Herdr, `navigate(target.href)` otherwise), while preserving `visiblePins[idx]` reference for REQ-147 keybinding contract test.
  - Passes `spillSlot` to unpinned row renderers (`renderAgentRow`, `renderTeamRow`, `renderRemoteRow`), rendering a subtle `os-rail-shortcut` badge (`Alt+N` / `⌥N`) and `data-hotkey` attribute on each row occupying a spill slot.
- Tests:
  - Vitest unit tests in `src/lib/__tests__/railHotkeys.test.ts` covering 0 favourites, 3 favourites, 10 favourites, and <9 total items.
  - Vitest unit tests in `src/components/__tests__/AgentSidebar.test.tsx` verifying spill badge rendering and keyboard event navigation.
  - Python contract tests in `tests/unit/test_req172_alt_hotkey_spill.py` and `tests/unit/test_req147_keybindings.py`.