### PR TITLE
feat(webui): ensure search input placeholder is exactly Search (Fixes #641)

### DIFF
--- a/tests/unit/test_req185_search_placeholder.py
+++ b/tests/unit/test_req185_search_placeholder.py
@@ -1,0 +1,24 @@
+"""REQ-185: Search placeholder is just "Search" (no Ctrl/⌘ in the text)."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT_SIDEBAR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+SEARCH_BAR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar" / "SearchBar.tsx"
+SEARCH_PALETTE_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "SearchPalette.tsx"
+
+
+def test_sidebar_search_placeholder_is_exactly_search():
+    sidebar = AGENT_SIDEBAR_TSX.read_text(encoding="utf-8")
+    assert 'placeholder="Search"' in sidebar
+    assert "Search Ctrl" not in sidebar
+    assert "Search ⌘" not in sidebar
+    assert "Search Cmd" not in sidebar
+
+
+def test_search_components_placeholder_clean():
+    search_bar = SEARCH_BAR_TSX.read_text(encoding="utf-8")
+    assert 'placeholder="Search"' in search_bar
+
+    palette = SEARCH_PALETTE_TSX.read_text(encoding="utf-8")
+    assert 'placeholder="Search"' in palette

--- a/webui/frontend/src/components/AgentSidebar/SearchBar.tsx
+++ b/webui/frontend/src/components/AgentSidebar/SearchBar.tsx
@@ -19,7 +19,7 @@ export const SearchBar = memo(function SearchBar({ value, onChange, onOpen }: Se
           onChange={(e) => onChange(e.target.value)}
           onFocus={() => onOpen?.()}
           onClick={() => onOpen?.()}
-          placeholder="Search…"
+          placeholder="Search"
           className="input input-sm input-bordered w-full pl-8 pr-8"
         />
         {value ? (

--- a/webui/frontend/src/components/__tests__/SearchPlaceholder.test.tsx
+++ b/webui/frontend/src/components/__tests__/SearchPlaceholder.test.tsx
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SearchBar } from '../AgentSidebar/SearchBar'
+
+describe('Search Placeholder (REQ-185)', () => {
+  it('renders search input with placeholder exactly "Search"', () => {
+    render(<SearchBar value="" onChange={vi.fn()} />)
+    const input = screen.getByRole('searchbox')
+    expect(input).toHaveAttribute('placeholder', 'Search')
+    expect(input.getAttribute('placeholder')).not.toMatch(/Ctrl|⌘|Cmd/i)
+  })
+})


### PR DESCRIPTION
## Overview
Fixes #641

### Quoted Issue Context
> **Intent:** Clean empty-state label; no mangled “Search Ctrl” text.
>
> **Success:**
> 1. Placeholder / empty label text is exactly `Search` (no Ctrl, ⌘, or shortcut suffix).
> 2. Shortcut still discoverable via chip or tips once #577 lands — not required in the placeholder.
> 3. Test asserts placeholder. `Fixes` this Issue. May land inside #577 rebase or a one-line agy PR.
>
> **Constraints:** Tiny. Prefer fold into #577 if rebasing now; else agy hotfix. No secrets.
>
> **Owner:** Cursor (#577) or agy hotfix. CoS: Open Swarm.

### Feasibility & Changes
- In `AgentSidebar.tsx` and `SearchPalette.tsx`, the search placeholder is already `"Search"`. Shortcut teaching is cleanly isolated in the ghost kbd chip (`<kbd className="os-rail-search__kbd kbd kbd-xs">{searchShortcut}</kbd>`), never embedded in the placeholder string.
- Standardized `AgentSidebar/SearchBar.tsx` from `Search…` to `Search`.
- Added contract test `tests/unit/test_req185_search_placeholder.py` verifying exact `"Search"` placeholder across sidebar and search palette, and frontend test `webui/frontend/src/components/__tests__/SearchPlaceholder.test.tsx`.

Ready to squash. SHA: 21912083