### PR TITLE
feat(webui): scale add-agent circle button height to match search pill (Fixes #639)

### DIFF
--- a/tests/unit/test_req183_add_agent_button_height.py
+++ b/tests/unit/test_req183_add_agent_button_height.py
@@ -1,0 +1,30 @@
+"""REQ-183: Add-agent + circle height <= Search pill (Fixes #639)."""
+
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INDEX_CSS = REPO_ROOT / "webui" / "frontend" / "src" / "index.css"
+
+
+def test_add_agent_button_height_matches_or_less_than_search_pill():
+    css = INDEX_CSS.read_text(encoding="utf-8")
+
+    # Verify .os-rail-search height
+    search_pill_match = re.search(r"\.os-rail-search\s*\{[^}]*?height:\s*([^;]+);", css)
+    assert search_pill_match, ".os-rail-search height rule must exist"
+    search_pill_height = search_pill_match.group(1).strip()
+
+    # Verify .os-search-add-btn height
+    add_btn_match = re.search(r"\.os-search-add-btn\s*\{[^}]*?height:\s*([^;]+);", css)
+    assert add_btn_match, ".os-search-add-btn height rule must exist"
+    add_btn_height = add_btn_match.group(1).strip()
+
+    # Both should be 2.25rem (36px)
+    assert add_btn_height == search_pill_height == "2.25rem"
+
+    # Verify touch target hit-area pseudo-element
+    assert ".os-search-add-btn::before" in css
+    before_match = re.search(r"\.os-search-add-btn::before\s*\{[^}]*?min-width:\s*([^;]+);", css)
+    assert before_match
+    assert before_match.group(1).strip() == "44px"

--- a/webui/frontend/src/components/__tests__/AddAgentButtonHeight.test.tsx
+++ b/webui/frontend/src/components/__tests__/AddAgentButtonHeight.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+describe('Add Agent Button Height (REQ-183)', () => {
+  it('defines .os-search-add-btn with height matching .os-rail-search', () => {
+    const cssPath = path.resolve(__dirname, '../../index.css')
+    const css = fs.readFileSync(cssPath, 'utf-8')
+
+    expect(css).toMatch(/\.os-search-add-btn\s*\{[^}]*?height:\s*2\.25rem;/)
+    expect(css).toMatch(/\.os-rail-search\s*\{[^}]*?height:\s*2\.25rem;/)
+    expect(css).toMatch(/\.os-search-add-btn::before\s*\{[^}]*?min-width:\s*44px;/)
+  })
+})

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -368,13 +368,14 @@ html[data-theme="light"] #root {
 }
 
 .os-search-add-btn {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 44px;
-  min-height: 44px;
-  width: 44px;
-  height: 44px;
+  min-width: 2.25rem;
+  min-height: 2.25rem;
+  width: 2.25rem;
+  height: 2.25rem;
   flex-shrink: 0;
   border-radius: 999px;
   border: 1px solid color-mix(in srgb, var(--color-base-content) 12%, transparent);
@@ -382,6 +383,13 @@ html[data-theme="light"] #root {
   background: color-mix(in srgb, var(--color-base-100) 40%, transparent);
   transition: all 0.15s ease-in-out;
   cursor: pointer;
+}
+.os-search-add-btn::before {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  min-width: 44px;
+  min-height: 44px;
 }
 .os-search-add-btn:hover,
 .os-search-add-btn:focus-visible {


### PR DESCRIPTION
## Overview
Fixes #639

### Quoted Issue Context
> **Intent:** Search row looks balanced; + doesn’t dominate.
>
> **Success:**
> 1. `+` control outer height ≤ Search field outer height (same band).
> 2. Still ≥ ~44px touch target on mobile if possible (or full-row tap hit-area with smaller visible circle — document).
> 3. Visual/CSS test or snapshot assert. DaisyUI/React. `Fixes` this Issue.
>
> **Constraints:** Placement stays beside Search. Prefer agy quick polish wave. No secrets.
>
> **Owner:** agy. CoS: Open Swarm.

### Feasibility & Changes
- Adjusted `.os-search-add-btn` sizing in `webui/frontend/src/index.css` from `44px` (2.75rem) to `2.25rem` (36px), matching `.os-rail-search` outer height (`height: 2.25rem;`).
- Added `position: relative` and `::before` pseudo-element with `inset: -4px` and `min-width: 44px; min-height: 44px;` to preserve an accessible ≥ 44px tap hit area for touch/mobile devices without enlarging the visible circular border.
- Added contract test `tests/unit/test_req183_add_agent_button_height.py` and frontend test `webui/frontend/src/components/__tests__/AddAgentButtonHeight.test.tsx`.

Ready to squash. SHA: 4d65fbb1