### PR TITLE
feat(webui): remove edit pencils from rail agent rows (Fixes #627, Fixes #606)

### DIFF
--- a/tests/unit/test_req173_rail_no_pencils.py
+++ b/tests/unit/test_req173_rail_no_pencils.py
@@ -1,0 +1,19 @@
+"""REQ-173: Remove edit pencils from left rail / sidepane (Fixes #627, Fixes #606)."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT_SIDEBAR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+
+
+def test_rail_rows_have_no_edit_pencils():
+    content = AGENT_SIDEBAR_TSX.read_text(encoding="utf-8")
+
+    # Hover pencil buttons on agent rows must be removed
+    assert 'className="os-agent-edit"' not in content, "Hover pencil buttons must be removed from rail rows"
+    assert "openBlueprintEditor" not in content, "Undefined openBlueprintEditor call site must be removed (Fixes #606)"
+    assert "showsBlueprintEdit" not in content, "showsBlueprintEdit should not be needed in sidebar rows"
+
+    # Context menu edit option must remain accessible
+    assert "Edit agent" in content, "Edit agent context menu must remain available"
+    assert 'role="menuitem"' in content

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -28,7 +28,6 @@ import {
   roleBadgeLabel,
   roleCssClass,
   roleFromAgent,
-  showsBlueprintEdit,
 } from '../lib/agentRoles'
 import { openAgentEditor } from '../lib/agentSettings'
 import {
@@ -890,7 +889,6 @@ export default function AgentSidebar({
     const scaleOut = !herdr && shouldOpenSessionPicker(sessions)
     const active = !herdr && selectedId === agent.id
     const role = agentRole(agent)
-    const showEdit = !herdr && showsBlueprintEdit(agent)
     const dragging = draggingId === agent.id
     const dropping = dropTargetId === agent.id
     const badge = roleBadgeLabel(role)
@@ -1036,27 +1034,6 @@ export default function AgentSidebar({
           >
             {body}
           </button>
-          {showEdit ? (
-            <button
-              type="button"
-              className="os-agent-edit"
-              aria-label={`Edit ${name} blueprint`}
-              onClick={(event) => {
-                event.preventDefault()
-                event.stopPropagation()
-                openBlueprintEditor(agent)
-              }}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter') {
-                  event.preventDefault()
-                  event.stopPropagation()
-                  openBlueprintEditor(agent)
-                }
-              }}
-            >
-              <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
-            </button>
-          ) : null}
         </div>
       )
     }
@@ -1078,27 +1055,6 @@ export default function AgentSidebar({
         >
           {body}
         </Link>
-        {showEdit ? (
-          <button
-            type="button"
-            className="os-agent-edit"
-            aria-label={`Edit ${name}`}
-            onClick={(event) => {
-              event.preventDefault()
-              event.stopPropagation()
-              openEditor(agent)
-            }}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                event.preventDefault()
-                event.stopPropagation()
-                openEditor(agent)
-              }
-            }}
-          >
-            <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
-          </button>
-        ) : null}
       </div>
     )
   }

--- a/webui/frontend/src/components/__tests__/AgentSidebarNoPencil.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebarNoPencil.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import AgentSidebar from '../AgentSidebar'
+
+describe('AgentSidebar No Pencils (REQ-173)', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    })
+  })
+
+  it('renders agent rows without hover pencil edit buttons', () => {
+    const blueprints = [
+      {
+        id: 'support_agent',
+        object: 'blueprint' as const,
+        name: 'Support Agent',
+        description: 'Customer help',
+        role: 'support',
+        installed: true,
+        compiled: true,
+      },
+      {
+        id: 'codey',
+        object: 'blueprint' as const,
+        name: 'Codey',
+        description: 'Code assistant',
+        role: 'default',
+        installed: true,
+        compiled: true,
+      },
+    ]
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AgentSidebar blueprints={blueprints} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    // Verify no pencil edit buttons are rendered in the sidebar rows
+    expect(screen.queryByLabelText(/Edit Support Agent/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Edit Codey/i)).not.toBeInTheDocument()
+    expect(document.querySelector('.os-agent-edit')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Overview
Fixes #627
Fixes #606

### Quoted Issue Context
> **Intent:** Cleaner rail chrome; fewer accidental edits and no broken pencil affordances.
>
> **Success:**
> 1. No pencil / edit icon on rail rows (favourites, unpinned agents, teams, remotes, CLI rows, scale-out hover).
> 2. Agent edit still reachable without the pencil (document which path in PR — e.g. rail context menu Edit, chat header, manage wizard).
> 3. Tests updated (no pencil selectors; #606 path gone or covered). DaisyUI/React. No secrets. `Fixes` this Issue; `Fixes #606` if that crash site is removed.
>
> **Constraints:** UI-only. Prefer agy Wave 10. Don’t remove Edit from Settings/header/manage. GitHub then `:8001`.
>
> **Owner:** agy. CoS: Open Swarm.

### Feasibility & Changes
- Stripped `.os-agent-edit` hover pencil buttons and removed the unused `showsBlueprintEdit` condition and `showEdit` variable in `AgentSidebar.tsx`.
- Stripping the scale-out pencil deleted the undefined `openBlueprintEditor(agent)` call site, resolving the crash reported in #606.
- Agent editing remains readily accessible via:
  1. Right-click context menu on any agent row ("Edit agent" -> opens `AgentEditorSheet`).
  2. Top chat navbar pencil button (`aria-label="Edit agent"` in `ChatPage.tsx`).
  3. Settings -> Agent Editor / Blueprints.
- Added contract test `tests/unit/test_req173_rail_no_pencils.py` and frontend test `webui/frontend/src/components/__tests__/AgentSidebarNoPencil.test.tsx`.

Ready to squash. SHA: 236278b7