### PR TITLE
feat(webui): remove persistent kind borders on team and remote rail rows (Fixes #633)

### DIFF
--- a/tests/unit/test_req178_rail_no_kind_borders.py
+++ b/tests/unit/test_req178_rail_no_kind_borders.py
@@ -1,0 +1,21 @@
+"""REQ-178: No special border chrome on team/remote rail rows (Fixes #633)."""
+
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INDEX_CSS = REPO_ROOT / "webui" / "frontend" / "src" / "index.css"
+
+
+def test_no_persistent_kind_borders_on_team_and_remote_rows():
+    css = INDEX_CSS.read_text(encoding="utf-8")
+
+    # Team rows must not have a persistent kind-coloured inset border
+    assert not re.search(r"\.os-agent-row--team\s*\{[^}]*?box-shadow:\s*inset 2px 0 0 #6b7c8a", css)
+
+    # Remote rows must not have a persistent kind-coloured inset border
+    assert not re.search(r"\.os-agent-row--remote\s*\{[^}]*?box-shadow:\s*inset 2px 0 0 #5a7a6a", css)
+
+    # Inset 2px border should not exist anywhere for agent rows
+    assert "inset 2px 0 0 #6b7c8a" not in css
+    assert "inset 2px 0 0 #5a7a6a" not in css

--- a/webui/frontend/src/components/__tests__/RailNoKindBorders.test.tsx
+++ b/webui/frontend/src/components/__tests__/RailNoKindBorders.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+describe('Rail No Kind Borders (REQ-178)', () => {
+  it('does not define persistent kind borders for team and remote rows in index.css', () => {
+    const cssPath = path.resolve(__dirname, '../../index.css')
+    const css = fs.readFileSync(cssPath, 'utf-8')
+
+    expect(css).not.toMatch(/\.os-agent-row--team\s*\{[^}]*?box-shadow:\s*inset 2px 0 0/)
+    expect(css).not.toMatch(/\.os-agent-row--remote\s*\{[^}]*?box-shadow:\s*inset 2px 0 0/)
+    expect(css).not.toContain('inset 2px 0 0 #6b7c8a')
+    expect(css).not.toContain('inset 2px 0 0 #5a7a6a')
+  })
+})

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -540,9 +540,6 @@ button.os-agent-row {
 .os-agent-row--drop {
   box-shadow: inset 0 2px 0 color-mix(in srgb, var(--color-primary) 70%, transparent);
 }
-.os-agent-row--team {
-  box-shadow: inset 2px 0 0 #6b7c8a;
-}
 .os-agent-row--nested {
   margin-left: 0.85rem;
 }
@@ -1372,9 +1369,6 @@ html[data-theme="light"] .os-code--collapsible.os-code--collapsed::after {
   padding: 0 1.1rem 0.45rem;
   font-size: 0.75rem;
   color: color-mix(in srgb, currentColor 52%, transparent);
-}
-.os-agent-row--remote {
-  box-shadow: inset 2px 0 0 #5a7a6a;
 }
 .os-agent-role-badge[data-kind="remote"] { color: #5a7a6a; }
 


### PR DESCRIPTION
## Overview
Fixes #633

### Quoted Issue Context
> **Intent:** Visual parity across rail row kinds.
>
> **Success:**
> 1. Team/remote/CLI rows have no persistent kind-coloured border at rest.
> 2. Selected/hover states use the same system as normal agents.
> 3. Tests/CSS assert. `Fixes` this Issue.
>
> **Constraints:** UI-only. Prefer agy. Coordinate #464 colour pass.
>
> **Owner:** agy. CoS: Open Swarm.

### Feasibility & Changes
- Removed persistent kind-coloured left border box-shadows (`box-shadow: inset 2px 0 0 #6b7c8a;` on `.os-agent-row--team` and `box-shadow: inset 2px 0 0 #5a7a6a;` on `.os-agent-row--remote`) in `webui/frontend/src/index.css`.
- Team and remote rail rows now have visual parity with standard agent rows at rest. Hover and active states continue to use uniform `.os-agent-row:hover` and `.os-agent-row--active` styling.
- Added contract test `tests/unit/test_req178_rail_no_kind_borders.py` and frontend test `webui/frontend/src/components/__tests__/RailNoKindBorders.test.tsx`.

Ready to squash. SHA: e6a158da