### PR TITLE
feat(webui): move Alt+N hover shortcut tip to top-right of pin cards (Fixes #638)

### DIFF
--- a/tests/unit/test_req182_alt_hotkey_tip_position.py
+++ b/tests/unit/test_req182_alt_hotkey_tip_position.py
@@ -1,0 +1,24 @@
+"""REQ-182: Alt+N hover tip — top-right of pin/card (Fixes #638)."""
+
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INDEX_CSS = REPO_ROOT / "webui" / "frontend" / "src" / "index.css"
+
+
+def test_alt_hotkey_tip_is_top_right():
+    css = INDEX_CSS.read_text(encoding="utf-8")
+
+    # Match .os-fav-tile__shortcut rule
+    match = re.search(r"\.os-fav-tile__shortcut\s*\{([^}]+)\}", css)
+    assert match, ".os-fav-tile__shortcut rule must exist in index.css"
+    body = match.group(1)
+
+    assert "top:" in body, "Shortcut chip must position from top, not bottom"
+    assert "bottom:" not in body, "Shortcut chip must not position from bottom"
+    assert "right:" in body, "Shortcut chip must position from right"
+
+    # Hover and focus-within reveal
+    assert ".os-fav-tile:hover .os-fav-tile__shortcut" in css
+    assert ".os-fav-tile:focus-within .os-fav-tile__shortcut" in css

--- a/webui/frontend/src/components/__tests__/AltHotkeyTipPosition.test.tsx
+++ b/webui/frontend/src/components/__tests__/AltHotkeyTipPosition.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+describe('Alt Hotkey Tip Position (REQ-182)', () => {
+  it('positions .os-fav-tile__shortcut at the top-right of favourite card', () => {
+    const cssPath = path.resolve(__dirname, '../../index.css')
+    const css = fs.readFileSync(cssPath, 'utf-8')
+
+    const match = css.match(/\.os-fav-tile__shortcut\s*\{([^}]+)\}/)
+    expect(match).not.toBeNull()
+    const ruleBody = match![1]
+
+    expect(ruleBody).toMatch(/top:\s*0\.\d+rem/)
+    expect(ruleBody).not.toMatch(/bottom:/)
+    expect(ruleBody).toMatch(/right:\s*0\.\d+rem/)
+    expect(ruleBody).toMatch(/z-index:\s*10/)
+
+    expect(css).toContain('.os-fav-tile:hover .os-fav-tile__shortcut')
+    expect(css).toContain('.os-fav-tile:focus-within .os-fav-tile__shortcut')
+  })
+})

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -466,7 +466,7 @@ html[data-theme="light"] #root {
 }
 .os-fav-tile__shortcut {
   position: absolute;
-  bottom: 0.2rem;
+  top: 0.25rem;
   right: 0.25rem;
   font-size: 0.6rem;
   font-weight: 600;
@@ -477,8 +477,10 @@ html[data-theme="light"] #root {
   opacity: 0;
   transition: opacity 0.15s ease-in-out;
   pointer-events: none;
+  z-index: 10;
 }
-.os-fav-tile:hover .os-fav-tile__shortcut {
+.os-fav-tile:hover .os-fav-tile__shortcut,
+.os-fav-tile:focus-within .os-fav-tile__shortcut {
   opacity: 1;
 }
 


### PR DESCRIPTION
## Overview
Fixes #638

### Quoted Issue Context
> **Intent:** Shortcut affordance reads as a card badge in the top corner, not a footer.
>
> **Success:**
> 1. Desktop hover (and focus-within) shows Alt+N chip at **top-right** of the pin/favourite tile (and unpinned spill targets if they show the tip).
> 2. Does not collide badly with #630 role pill on avatar — document z-order (tip on card corner; role on avatar).
> 3. Mobile: no hover tip required. Tests for placement class/position. `Fixes` this Issue.
>
> **Constraints:** UI-only. Prefer agy with #626. No secrets.
>
> **Owner:** agy. CoS: Open Swarm.

### Feasibility & Changes
- Updated `.os-fav-tile__shortcut` in `webui/frontend/src/index.css` from `bottom: 0.2rem` to `top: 0.25rem; right: 0.25rem;`.
- Added `.os-fav-tile:focus-within .os-fav-tile__shortcut` alongside `:hover` for keyboard accessibility.
- Added `z-index: 10;` to ensure the corner shortcut chip floats cleanly above card content without colliding with avatar role badges.
- Added contract test `tests/unit/test_req182_alt_hotkey_tip_position.py` and frontend test `webui/frontend/src/components/__tests__/AltHotkeyTipPosition.test.tsx`.

Ready to squash. SHA: 1c4c752b