### PR TITLE
feat(webui): render real member avatars in team and scale-out avatar stacks (Fixes #637)

### DIFF
--- a/tests/unit/test_req181_team_real_member_avatars.py
+++ b/tests/unit/test_req181_team_real_member_avatars.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+def test_avatar_stack_renders_agent_avatar():
+    """AvatarStack must embed AgentAvatar inside .os-stacked-avatar instead of blank discs."""
+    src = Path("webui/frontend/src/components/AvatarStack.tsx").read_text(encoding="utf-8")
+    assert "import AgentAvatar from './AgentAvatar'" in src
+    assert "<AgentAvatar" in src
+    assert "agentId={face.id}" in src
+    assert "src={face.avatarSrc || face.src}" in src
+
+
+def test_session_picker_passes_member_avatar_to_faces():
+    """sessionPicker passes avatarSrc from team members to MemberSession and StackFace."""
+    src = Path("webui/frontend/src/lib/sessionPicker.ts").read_text(encoding="utf-8")
+    assert "avatarSrc: session.avatarSrc" in src
+    assert "avatarSrc:" in src
+    assert "member.avatarSrc || member.avatar_path || member.avatar || member.src" in src
+
+
+def test_team_roster_supports_avatar_fields():
+    """TeamMember interface supports optional avatar fields for customized team members."""
+    src = Path("webui/frontend/src/lib/teamRosters.ts").read_text(encoding="utf-8")
+    assert "avatarSrc?: string" in src
+    assert "avatar_path?: string" in src
+    assert "avatar?: string" in src
+
+
+def test_avatar_stack_limit_is_documented_and_bounded():
+    """STACK_FACE_LIMIT must cap rail faces (default 3) with +N remainder for CoS/scale-out."""
+    src = Path("webui/frontend/src/lib/avatarStack.ts").read_text(encoding="utf-8")
+    assert "STACK_FACE_LIMIT = 3" in src

--- a/webui/frontend/src/components/AgentAvatar.tsx
+++ b/webui/frontend/src/components/AgentAvatar.tsx
@@ -16,7 +16,7 @@ export const DEFAULT_AGENT_AVATAR_SRC =
     </svg>`,
   )
 
-export type AgentAvatarSize = 'sm' | 'md' | 'lg' | 'xl'
+export type AgentAvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
 
 export interface AgentAvatarProps {
   /** Custom face URL. Blank / missing / broken uses the themed default (or bland if selected in settings). */
@@ -26,6 +26,7 @@ export interface AgentAvatarProps {
   className?: string
   agentId?: string | null
   active?: boolean
+  style?: React.CSSProperties
 }
 
 export function resolveAgentAvatarSrc(src?: string | null): string {
@@ -50,6 +51,7 @@ export default function AgentAvatar({
   className = '',
   agentId,
   active = false,
+  style,
 }: AgentAvatarProps) {
   const [broken, setBroken] = useState(false)
   const theme = useAvatarTheme()
@@ -67,14 +69,19 @@ export default function AgentAvatar({
         className={`avatar ${className}`.trim()}
         data-agent-avatar="custom"
         aria-hidden={alt ? undefined : true}
+        style={style}
       >
-        <div className={`os-agent-avatar os-agent-avatar--${size} rounded-full`}>
+        <div
+          className={`os-agent-avatar os-agent-avatar--${size} rounded-full`}
+          style={size === 'xs' ? { width: '100%', height: '100%' } : undefined}
+        >
           <img
             src={customSrc}
             alt={alt}
             draggable={false}
             data-agent-avatar="custom"
             onError={() => setBroken(true)}
+            style={size === 'xs' ? { width: '100%', height: '100%', objectFit: 'cover' } : undefined}
           />
         </div>
       </div>
@@ -90,12 +97,14 @@ export default function AgentAvatar({
         data-avatar-theme="blobs"
         data-eye-state={active ? 'active' : 'idle'}
         aria-hidden={alt ? undefined : true}
+        style={style}
       >
         <BlobAvatar
           agentId={agentId || 'agent'}
           active={active}
           size={size}
           className=""
+          style={size === 'xs' ? { width: '100%', height: '100%' } : undefined}
         />
       </div>
     )
@@ -107,13 +116,18 @@ export default function AgentAvatar({
       className={`avatar ${className}`.trim()}
       data-agent-avatar="default"
       aria-hidden={alt ? undefined : true}
+      style={style}
     >
-      <div className={`os-agent-avatar os-agent-avatar--${size} rounded-full`}>
+      <div
+        className={`os-agent-avatar os-agent-avatar--${size} rounded-full`}
+        style={size === 'xs' ? { width: '100%', height: '100%' } : undefined}
+      >
         <img
           src={DEFAULT_AGENT_AVATAR_SRC}
           alt={alt}
           draggable={false}
           data-agent-avatar="default"
+          style={size === 'xs' ? { width: '100%', height: '100%', objectFit: 'cover' } : undefined}
         />
       </div>
     </div>

--- a/webui/frontend/src/components/AvatarStack.tsx
+++ b/webui/frontend/src/components/AvatarStack.tsx
@@ -1,4 +1,5 @@
 import { agentMarkColor, agentMarkIndex } from '../lib/hiddenAgents'
+import AgentAvatar from './AgentAvatar'
 import {
   STACK_FACE_LIMIT,
   earliestStartedAt,
@@ -66,7 +67,7 @@ export default function AvatarStack({
       {shown.map((face) => (
         <span
           key={face.id}
-          className={`os-stacked-avatar os-avatar-stack__face os-stacked-avatar--stacked${
+          className={`os-stacked-avatar os-avatar-stack__face os-stacked-avatar--stacked overflow-hidden flex items-center justify-center${
             animate ? ' os-stacked-avatar--pulse' : ''
           }${face.working ? ' os-avatar-stack__face--working' : ''}`}
           data-testid="os-stacked-avatar"
@@ -78,11 +79,20 @@ export default function AvatarStack({
           title={face.name}
           style={{
             backgroundColor: agentMarkColor(face.markId || face.id),
+            overflow: 'hidden',
             ...(animate
               ? { animationDelay: `${stackAnimationDelayMs(face.startedAt, origin)}ms` }
               : {}),
           }}
-        />
+        >
+          <AgentAvatar
+            agentId={face.id}
+            src={face.avatarSrc || face.src}
+            alt={face.name || face.id}
+            size="xs"
+            className="w-full h-full flex items-center justify-center pointer-events-none"
+          />
+        </span>
       ))}
       {extra > 0 ? (
         <span

--- a/webui/frontend/src/components/BlobAvatar.tsx
+++ b/webui/frontend/src/components/BlobAvatar.tsx
@@ -7,8 +7,9 @@ export interface BlobAvatarProps {
   agentId: string
   /** Selected conversation and/or streaming — eyes wander slowly. */
   active?: boolean
-  size?: 'sm' | 'md' | 'lg' | 'xl'
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
   className?: string
+  style?: React.CSSProperties
 }
 
 function BlobShapePath({ shape, color }: { shape: BlobShape; color: string }) {
@@ -71,6 +72,7 @@ export default function BlobAvatar({
   active = false,
   size = 'sm',
   className = '',
+  style,
 }: BlobAvatarProps) {
   const spec = useMemo(() => blobSpecForAgent(agentId), [agentId])
   const eyeState: BlobEyeState = active ? 'active' : 'idle'
@@ -86,6 +88,10 @@ export default function BlobAvatar({
       data-blob-shape={spec.shape}
       data-eye-state={eyeState}
       data-agent-id={agentId}
+      style={{
+        ...(size === 'xs' ? { width: '100%', height: '100%' } : {}),
+        ...style,
+      }}
     >
       <BlobShapePath shape={spec.shape} color={spec.color} />
       <g

--- a/webui/frontend/src/components/__tests__/AvatarStackRealAvatars.test.tsx
+++ b/webui/frontend/src/components/__tests__/AvatarStackRealAvatars.test.tsx
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import AvatarStack from '../AvatarStack'
+import { sessionsForTeam, facesFromSessions } from '../../lib/sessionPicker'
+import type { TeamRoster } from '../../lib/teamRosters'
+
+describe('REQ-181: AvatarStack real member avatars', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders real Blobs avatars by default instead of blank circles', () => {
+    render(
+      <AvatarStack
+        faces={[
+          { id: 'alice', name: 'Alice', startedAt: 100 },
+          { id: 'bob', name: 'Bob', startedAt: 200 },
+        ]}
+      />,
+    )
+
+    const stackedContainers = screen.getAllByTestId('os-stacked-avatar')
+    expect(stackedContainers).toHaveLength(2)
+
+    // Each stacked avatar should contain an avatar element rather than being empty
+    for (const container of stackedContainers) {
+      expect(container.children.length).toBeGreaterThan(0)
+    }
+
+    // Default theme should render BlobAvatars with the respective agentIds
+    const blobAvatars = screen.getAllByRole('img', { hidden: true })
+    const agentIds = blobAvatars.map((el) => el.getAttribute('data-agent-id')).filter(Boolean)
+    expect(agentIds).toContain('alice')
+    expect(agentIds).toContain('bob')
+  })
+
+  it('renders custom avatar image when member specifies avatarSrc', () => {
+    render(
+      <AvatarStack
+        faces={[
+          {
+            id: 'custom-bot',
+            name: 'Custom Bot',
+            startedAt: 100,
+            avatarSrc: 'https://example.com/bot-face.png',
+          },
+        ]}
+      />,
+    )
+
+    const img = screen.getByRole('img', { hidden: true })
+    expect(img).toHaveAttribute('src', 'https://example.com/bot-face.png')
+    expect(img).toHaveAttribute('data-agent-avatar', 'custom')
+  })
+
+  it('renders bland fallback when theme is set to bland', () => {
+    localStorage.setItem('swarm_avatar_theme', 'bland')
+
+    render(
+      <AvatarStack
+        faces={[
+          { id: 'bland-bot', name: 'Bland Bot', startedAt: 100 },
+        ]}
+      />,
+    )
+
+    const img = screen.getByRole('img', { hidden: true })
+    expect(img.getAttribute('src')).toContain('data:image/svg+xml')
+    expect(img).toHaveAttribute('data-agent-avatar', 'default')
+  })
+
+  it('limits visible faces to maxFaces (default 3) and shows remainder chip for large rosters', () => {
+    render(
+      <AvatarStack
+        faces={[
+          { id: 'm1', name: 'Member 1', startedAt: 100 },
+          { id: 'm2', name: 'Member 2', startedAt: 200 },
+          { id: 'm3', name: 'Member 3', startedAt: 300 },
+          { id: 'm4', name: 'Member 4', startedAt: 400 },
+          { id: 'm5', name: 'Member 5', startedAt: 500 },
+        ]}
+      />,
+    )
+
+    const stackedContainers = screen.getAllByTestId('os-stacked-avatar')
+    expect(stackedContainers).toHaveLength(3)
+
+    const remainder = screen.getByTestId('os-stacked-remainder')
+    expect(remainder).toHaveTextContent('+2')
+  })
+
+  it('integrates with sessionsForTeam and facesFromSessions with custom avatar', () => {
+    const team: TeamRoster = {
+      id: 'alpha-team',
+      name: 'Alpha Team',
+      description: 'Alpha team roster',
+      members: [
+        {
+          id: 'lead',
+          name: 'Lead Agent',
+          role: 'cos',
+          avatarSrc: 'https://example.com/lead.png',
+        },
+        {
+          id: 'dev',
+          name: 'Dev Agent',
+          role: 'engineer',
+        },
+      ],
+    }
+
+    const sessions = sessionsForTeam(team)
+    expect(sessions[0].avatarSrc).toBe('https://example.com/lead.png')
+    expect(sessions[1].avatarSrc).toBeNull()
+
+    const faces = facesFromSessions(sessions)
+    expect(faces[0].avatarSrc).toBe('https://example.com/lead.png')
+    expect(faces[1].avatarSrc).toBeNull()
+
+    const { container } = render(<AvatarStack faces={faces} />)
+    const customImg = container.querySelector('img[data-agent-avatar="custom"]')
+    expect(customImg).not.toBeNull()
+    expect(customImg).toHaveAttribute('src', 'https://example.com/lead.png')
+
+    const blobSvg = container.querySelector('svg[data-avatar-theme="blobs"]')
+    expect(blobSvg).not.toBeNull()
+    expect(blobSvg).toHaveAttribute('data-agent-id', 'dev')
+  })
+})

--- a/webui/frontend/src/lib/avatarStack.ts
+++ b/webui/frontend/src/lib/avatarStack.ts
@@ -24,6 +24,9 @@ export interface StackFace {
   /** Color-hash key; defaults to `id`. */
   markId?: string
   role?: string
+  working?: boolean
+  avatarSrc?: string | null
+  src?: string | null
 }
 
 export interface StackSelection<T extends StackFace = StackFace> {

--- a/webui/frontend/src/lib/sessionPicker.ts
+++ b/webui/frontend/src/lib/sessionPicker.ts
@@ -23,6 +23,7 @@ export interface MemberSession {
   startedAt: number
   href: string
   role?: string
+  avatarSrc?: string | null
 }
 
 export function facesFromSessions(sessions: MemberSession[]): StackFace[] {
@@ -32,6 +33,7 @@ export function facesFromSessions(sessions: MemberSession[]): StackFace[] {
     startedAt: session.startedAt,
     role: session.role,
     working: session.status === 'running',
+    avatarSrc: session.avatarSrc,
   }))
 }
 
@@ -78,6 +80,7 @@ export function sessionsForTeam(team: TeamRoster): MemberSession[] {
       startedAt,
       href,
       role: member.role,
+      avatarSrc: member.avatarSrc || member.avatar_path || member.avatar || member.src || null,
     }
   })
 }
@@ -99,6 +102,7 @@ export function sessionsForRemote(remote: RemoteEntry): MemberSession[] {
       startedAt,
       href: `/chat?remote=${encodeURIComponent(remote.id)}&session=${encodeURIComponent(agent.id)}`,
       role: agent.role,
+      avatarSrc: (agent as any).avatarSrc || (agent as any).avatar_path || (agent as any).avatar || (agent as any).src || null,
     }
   })
 }

--- a/webui/frontend/src/lib/teamRosters.ts
+++ b/webui/frontend/src/lib/teamRosters.ts
@@ -27,6 +27,10 @@ export interface TeamMember {
   working?: boolean
   status?: 'running' | 'finished'
   snippet?: string
+  avatar?: string
+  avatar_path?: string
+  avatarSrc?: string
+  src?: string
 }
 
 export interface TeamRoster {


### PR DESCRIPTION
## Summary
Fixes #637 (REQ-181).

### Quoting Issue #637
> **Intent:** Team chrome matches agent chrome — recognisable faces in the rail.
>
> **Success:**
> 1. Team row (and any stacked/member preview in the rail) uses each member’s resolved avatar (same `AgentAvatar` / Blobs path as solo agents), not empty circles.
> 2. Missing avatar still falls back to Blobs/default — never a featureless grey disc unless bland-static is chosen in Settings.
> 3. CoS / scale-out stacks remain readable when many members (overlap OK; document max visible).
> 4. Tests for team row rendering with mocked member avatar ids. No secrets. `Fixes` this Issue.
>
> **Constraints:** UI-only. Prefer agy Wave with #630 pills-on-avatar. GitHub then `:8001`.
>
> **Owner:** agy. CoS: Open Swarm.

### Feasibility
- Fully feasible and zero new dependencies.
- Reuses Open Swarm's `AgentAvatar` component directly inside `AvatarStack`, taking full advantage of the default Blobs theme fallback (#563 / #619) keyed by member `id`, custom avatars when present (`avatarSrc` / `avatar_path`), and the settings-based bland fallback.
- Adds `size="xs"` handling in `AgentAvatar` and `BlobAvatar` to cleanly scale down SVGs and images within the 1.15rem stacked avatar bounds.
- Connects member avatars through `TeamMember` -> `MemberSession` -> `StackFace`.
- Disjoint file surface from PR #696 (`index.css`) and PR 3 (`chatTime.ts`).

### Key Changes
- `webui/frontend/src/components/AvatarStack.tsx`: Embeds `AgentAvatar` inside `.os-stacked-avatar` container with `overflow-hidden`, preserving stagger animation delay and test IDs.
- `webui/frontend/src/components/AgentAvatar.tsx`: Adds `xs` avatar size and optional `style` forwarding.
- `webui/frontend/src/components/BlobAvatar.tsx`: Adds `xs` avatar size and optional `style` forwarding.
- `webui/frontend/src/lib/avatarStack.ts`: Extends `StackFace` interface to support optional `avatarSrc` and `src`.
- `webui/frontend/src/lib/sessionPicker.ts`: Forwards member and remote agent `avatarSrc` into `MemberSession` and `StackFace`.
- `webui/frontend/src/lib/teamRosters.ts`: Adds optional avatar fields (`avatar`, `avatar_path`, `avatarSrc`, `src`) to `TeamMember`.
- `webui/frontend/src/components/__tests__/AvatarStackRealAvatars.test.tsx`: Vitest suite testing blob fallback, custom avatar images, bland settings fallback, 3-member max remainder bounding, and team roster integration.
- `tests/unit/test_req181_team_real_member_avatars.py`: Contract tests for `AvatarStack` integration, `sessionPicker` avatar forwarding, and `STACK_FACE_LIMIT = 3`.