### PR TITLE
feat(webui): update rail preview snippet live with latest message (Fixes #632)

### DIFF
--- a/tests/unit/test_req177_rail_preview_snippet.py
+++ b/tests/unit/test_req177_rail_preview_snippet.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHAT_TIME_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "chatTime.ts"
+AGENT_CHAT_SESSIONS_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "agentChatSessions.ts"
+SIDEBAR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+CHAT_PAGE_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "pages" / "ChatPage.tsx"
+
+
+def test_chat_time_exports_preview_snippet_helpers():
+    """chatTime.ts must export selectLatestMessage and truncateSnippet for REQ-177."""
+    content = CHAT_TIME_TS.read_text(encoding="utf-8")
+    assert "export function selectLatestMessage(" in content
+    assert "export function truncateSnippet(" in content
+    assert "export const PREVIEW_SNIPPET_MAX_CHARS = 100" in content
+    assert "role === 'assistant'" in content
+    assert "role === 'user'" in content
+
+
+def test_agent_chat_sessions_dispatches_change_event():
+    """agentChatSessions.ts must dispatch AGENT_CHAT_SESSIONS_EVENT upon save."""
+    content = AGENT_CHAT_SESSIONS_TS.read_text(encoding="utf-8")
+    assert "export const AGENT_CHAT_SESSIONS_EVENT = 'swarm:agent-chat-sessions'" in content
+    assert "export function emitAgentChatSessionsChanged(" in content
+    assert "emitAgentChatSessionsChanged(agentId)" in content
+
+
+def test_sidebar_listens_to_agent_chat_sessions_event():
+    """AgentSidebar.tsx must listen to AGENT_CHAT_SESSIONS_EVENT for live updates."""
+    content = SIDEBAR_TSX.read_text(encoding="utf-8")
+    assert "AGENT_CHAT_SESSIONS_EVENT" in content
+    assert "window.addEventListener(AGENT_CHAT_SESSIONS_EVENT, onChange)" in content
+
+
+def test_chat_page_syncs_messages_for_rail_preview():
+    """ChatPage.tsx must sync active thread messages to localStorage for live rail updates."""
+    content = CHAT_PAGE_TSX.read_text(encoding="utf-8")
+    assert "putAgentChatSession(activeChatAgentId" in content
+    assert "persistableMessages" in content

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -75,6 +75,7 @@ import {
   type AgentSession,
 } from '../lib/scaleOutSessions'
 import { agentLabel, defaultBlueprintId, isSupportAgent } from '../lib/supportAgent'
+import { AGENT_CHAT_SESSIONS_EVENT } from '../lib/agentChatSessions'
 import { formatRailTimestamp, getRowLastMessage } from '../lib/chatTime'
 import { fetchTeamRosters, teamHideId, type TeamRoster } from '../lib/teamRosters'
 import { fetchConfiguredRemotes, remoteHideId, type RemoteEntry } from '../lib/remotesCatalog'
@@ -334,9 +335,13 @@ export default function AgentSidebar({
   useEffect(() => {
     const onChange = () => setSessionTick((n) => n + 1)
     window.addEventListener(SCALE_OUT_SESSIONS_EVENT, onChange)
+    window.addEventListener(AGENT_CHAT_SESSIONS_EVENT, onChange)
+    window.addEventListener(GENERATION_COMPLETE_EVENT, onChange)
     window.addEventListener('storage', onChange)
     return () => {
       window.removeEventListener(SCALE_OUT_SESSIONS_EVENT, onChange)
+      window.removeEventListener(AGENT_CHAT_SESSIONS_EVENT, onChange)
+      window.removeEventListener(GENERATION_COMPLETE_EVENT, onChange)
       window.removeEventListener('storage', onChange)
     }
   }, [])

--- a/webui/frontend/src/lib/__tests__/chatTimePreview.test.ts
+++ b/webui/frontend/src/lib/__tests__/chatTimePreview.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  getRowLastMessage,
+  selectLatestMessage,
+  truncateSnippet,
+  PREVIEW_SNIPPET_MAX_CHARS,
+} from '../chatTime'
+import {
+  AGENT_CHAT_SESSIONS_EVENT,
+  AGENT_CHAT_SESSIONS_KEY,
+  putAgentChatSession,
+} from '../agentChatSessions'
+
+describe('REQ-177: Rail preview snippet and live updates', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('truncateSnippet', () => {
+    it('returns short strings untouched and normalized', () => {
+      expect(truncateSnippet('Hello world')).toBe('Hello world')
+      expect(truncateSnippet('  Multi   space   words  ')).toBe('Multi space words')
+    })
+
+    it('truncates at maxChars and appends an ellipsis', () => {
+      const longText = 'A'.repeat(120)
+      const truncated = truncateSnippet(longText, 50)
+      expect(truncated).toHaveLength(51) // 50 chars + 1 ellipsis
+      expect(truncated.endsWith('…')).toBe(true)
+    })
+
+    it('uses PREVIEW_SNIPPET_MAX_CHARS (100) by default', () => {
+      const longText = 'B'.repeat(150)
+      const truncated = truncateSnippet(longText)
+      expect(truncated).toHaveLength(PREVIEW_SNIPPET_MAX_CHARS + 1)
+    })
+  })
+
+  describe('selectLatestMessage', () => {
+    it('returns null for empty or invalid messages', () => {
+      expect(selectLatestMessage([])).toBeNull()
+      expect(selectLatestMessage([{ role: 'status', text: 'switched model' }])).toBeNull()
+      expect(selectLatestMessage([{ role: 'assistant', text: '   ' }])).toBeNull()
+    })
+
+    it('prefers the latest assistant message over user messages', () => {
+      const messages = [
+        { role: 'user', text: 'Can you help me?', key: 'user-1' },
+        { role: 'assistant', text: 'Certainly! How can I assist you?', key: 'asst-1' },
+        { role: 'user', text: 'What is the weather?', key: 'user-2' },
+      ]
+      const selected = selectLatestMessage(messages)
+      expect(selected).not.toBeNull()
+      expect(selected?.role).toBe('assistant')
+      expect(selected?.text).toBe('Certainly! How can I assist you?')
+    })
+
+    it('falls back to the latest user message if no assistant message exists', () => {
+      const messages = [
+        { role: 'user', text: 'First query', key: 'user-1' },
+        { role: 'user', text: 'Follow-up query waiting for response', key: 'user-2' },
+      ]
+      const selected = selectLatestMessage(messages)
+      expect(selected).not.toBeNull()
+      expect(selected?.role).toBe('user')
+      expect(selected?.text).toBe('Follow-up query waiting for response')
+    })
+  })
+
+  describe('getRowLastMessage', () => {
+    it('returns null snippet and placeholder description when thread is empty', () => {
+      const res = getRowLastMessage('support', [], { description: 'Support agent description' })
+      expect(res.snippet).toBe('Support agent description')
+    })
+
+    it('resolves the latest assistant message from localStorage session', () => {
+      putAgentChatSession('support', {
+        conversationId: 'conv-123',
+        messages: [
+          { key: 'msg-user-1725500000000', role: 'user', text: 'Hello support' },
+          { key: 'msg-asst-1725500005000', role: 'assistant', text: 'Hello! I am here to help you.' },
+        ],
+      })
+
+      const res = getRowLastMessage('support', [], { description: 'Support agent description' })
+      expect(res.snippet).toBe('Hello! I am here to help you.')
+      expect(res.timestamp).toBe(1725500005000)
+    })
+
+    it('falls back to latest user message if agent has not replied yet', () => {
+      putAgentChatSession('codey', {
+        conversationId: 'conv-456',
+        messages: [
+          { key: 'user-1-1725500010000', role: 'user', text: 'Please write a script for me' },
+        ],
+      })
+
+      const res = getRowLastMessage('codey', [], { description: 'Code generator' })
+      expect(res.snippet).toBe('Please write a script for me')
+      expect(res.timestamp).toBe(1725500010000)
+    })
+
+    it('updates live and dispatches AGENT_CHAT_SESSIONS_EVENT when new message is stored', () => {
+      let eventFired = false
+      let detailAgent: string | undefined
+
+      const listener = (event: Event) => {
+        eventFired = true
+        detailAgent = (event as CustomEvent).detail?.agentId
+      }
+      window.addEventListener(AGENT_CHAT_SESSIONS_EVENT, listener)
+
+      putAgentChatSession('support', {
+        conversationId: 'conv-123',
+        messages: [
+          { key: 'user-1-1725500000000', role: 'user', text: 'Hi' },
+          { key: 'asst-1-1725500002000', role: 'assistant', text: 'Live assistant answer' },
+        ],
+      })
+
+      expect(eventFired).toBe(true)
+      expect(detailAgent).toBe('support')
+
+      const res = getRowLastMessage('support')
+      expect(res.snippet).toBe('Live assistant answer')
+
+      window.removeEventListener(AGENT_CHAT_SESSIONS_EVENT, listener)
+    })
+
+    it('clears snippet without stale leftovers when thread is emptied', () => {
+      putAgentChatSession('support', {
+        conversationId: 'conv-123',
+        messages: [
+          { key: 'asst-1', role: 'assistant', text: 'Old message' },
+        ],
+      })
+
+      expect(getRowLastMessage('support').snippet).toBe('Old message')
+
+      // Emptied thread
+      putAgentChatSession('support', {
+        conversationId: 'conv-123',
+        messages: [],
+      })
+
+      const res = getRowLastMessage('support', [], { description: 'Fallback description' })
+      expect(res.snippet).toBe('Fallback description')
+    })
+  })
+})

--- a/webui/frontend/src/lib/agentChatSessions.ts
+++ b/webui/frontend/src/lib/agentChatSessions.ts
@@ -63,20 +63,37 @@ export function loadAgentChatSessions(): AgentChatSessionMap {
   }
 }
 
-export function saveAgentChatSessions(sessions: AgentChatSessionMap): void {
+export const AGENT_CHAT_SESSIONS_EVENT = 'swarm:agent-chat-sessions'
+
+export function emitAgentChatSessionsChanged(agentId?: string): void {
+  try {
+    window.dispatchEvent(
+      new CustomEvent(AGENT_CHAT_SESSIONS_EVENT, { detail: { agentId } }),
+    )
+  } catch {
+    /* jsdom / SSR */
+  }
+}
+
+export function saveAgentChatSessions(sessions: AgentChatSessionMap, agentId?: string): void {
   try {
     localStorage.setItem(AGENT_CHAT_SESSIONS_KEY, JSON.stringify(sessions))
   } catch {
     /* persistence is best-effort */
   }
+  emitAgentChatSessionsChanged(agentId)
 }
 
 export function persistableMessages(
-  messages: Array<{ key: string; role: 'user' | 'assistant'; text: string; streaming?: boolean }>,
+  messages: Array<{ key: string; role: string; text: string; streaming?: boolean }>,
 ): PersistedChatMessage[] {
   return messages
-    .filter((row) => row.text.length > 0 || !row.streaming)
-    .map((row) => ({ key: row.key, role: row.role, text: row.text }))
+    .filter(
+      (row) =>
+        (row.role === 'user' || row.role === 'assistant') &&
+        (row.text.length > 0 || !row.streaming),
+    )
+    .map((row) => ({ key: row.key, role: row.role as 'user' | 'assistant', text: row.text }))
 }
 
 export function getOrCreateAgentChatSession(agentId: string | null | undefined): AgentChatSession {
@@ -89,7 +106,7 @@ export function getOrCreateAgentChatSession(agentId: string | null | undefined):
     messages: [],
   }
   all[key] = created
-  saveAgentChatSessions(all)
+  saveAgentChatSessions(all, key)
   return created
 }
 
@@ -103,5 +120,5 @@ export function putAgentChatSession(
     conversationId: session.conversationId,
     messages: persistableMessages(session.messages),
   }
-  saveAgentChatSessions(all)
+  saveAgentChatSessions(all, key)
 }

--- a/webui/frontend/src/lib/chatTime.ts
+++ b/webui/frontend/src/lib/chatTime.ts
@@ -143,8 +143,57 @@ export function formatRailTimestamp(
   return `${stamp.weekday} ${stamp.day} ${stamp.month}`
 }
 
+export const PREVIEW_SNIPPET_MAX_CHARS = 100
+
+/**
+ * Normalizes whitespace and truncates preview text with an ellipsis if it exceeds maxChars.
+ */
+export function truncateSnippet(text: string, maxChars = PREVIEW_SNIPPET_MAX_CHARS): string {
+  const clean = text.replace(/\s+/g, ' ').trim()
+  if (clean.length <= maxChars) return clean
+  return `${clean.slice(0, maxChars).trimEnd()}…`
+}
+
+/**
+ * REQ-177: Selects the most recent message from a thread to display in the sidepane rail.
+ * Preference order:
+ * 1. Latest assistant reply with non-empty text (shows the agent's latest response).
+ * 2. Latest user message with non-empty text if no assistant reply exists yet.
+ * 3. Returns null if thread is empty or only contains status/empty messages.
+ */
+export function selectLatestMessage(
+  messages: ReadonlyArray<{ role?: string; text?: string; content?: string; key?: string }>,
+): { role: string; text: string; key?: string } | null {
+  if (!Array.isArray(messages) || messages.length === 0) return null
+
+  // 1. Prefer latest assistant message with non-empty text
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (m && m.role === 'assistant') {
+      const text = (m.text ?? m.content ?? '').trim()
+      if (text.length > 0) {
+        return { role: 'assistant', text, key: m.key }
+      }
+    }
+  }
+
+  // 2. Fallback to latest user message if no assistant message exists
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (m && m.role === 'user') {
+      const text = (m.text ?? m.content ?? '').trim()
+      if (text.length > 0) {
+        return { role: 'user', text, key: m.key }
+      }
+    }
+  }
+
+  return null
+}
+
 /**
  * Resolves the last message snippet and timestamp for a rail row.
+ * Prefers live thread activity from local chat sessions (REQ-177).
  */
 export function getRowLastMessage(
   id: string,
@@ -162,19 +211,9 @@ export function getRowLastMessage(
   }
 
   const rawSnippet =
-    (agentMeta?.last_message ?? agentMeta?.lastMessage ?? agentMeta?.snippet) as string | undefined
+    (agentMeta?.last_message ?? agentMeta?.lastMessage) as string | undefined
 
-  if (sessions && sessions.length > 0) {
-    const sorted = [...sessions].sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
-    const top = sorted[0]
-    if (top) {
-      return {
-        snippet: rawSnippet ?? top.snippet ?? null,
-        timestamp: parsedTime ?? top.updatedAt ?? top.startedAt ?? null,
-      }
-    }
-  }
-
+  // 1. Live thread activity in local chat sessions (REQ-177)
   try {
     if (typeof localStorage !== 'undefined') {
       const rawChats = localStorage.getItem('swarm_agent_chat_sessions')
@@ -182,15 +221,17 @@ export function getRowLastMessage(
         const parsed = JSON.parse(rawChats)
         const session = parsed?.[id]
         if (session && Array.isArray(session.messages) && session.messages.length > 0) {
-          const lastMsg = session.messages[session.messages.length - 1]
-          let ts = parsedTime
-          if (!ts && typeof lastMsg.key === 'string') {
-            const match = lastMsg.key.match(/-(\d{12,})$/)
-            if (match) ts = Number(match[1])
-          }
-          return {
-            snippet: rawSnippet ?? lastMsg.text ?? null,
-            timestamp: ts ?? null,
+          const selected = selectLatestMessage(session.messages)
+          if (selected) {
+            let ts = parsedTime
+            if (!ts && typeof selected.key === 'string') {
+              const match = selected.key.match(/-(\d{12,})$/)
+              if (match) ts = Number(match[1])
+            }
+            return {
+              snippet: rawSnippet ?? truncateSnippet(selected.text),
+              timestamp: ts ?? parsedTime ?? null,
+            }
           }
         }
       }
@@ -199,8 +240,21 @@ export function getRowLastMessage(
     /* storage unavailable */
   }
 
+  // 2. Scale-out multi-session fallback
+  if (sessions && sessions.length > 0) {
+    const sorted = [...sessions].sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
+    const top = sorted[0]
+    if (top) {
+      return {
+        snippet: rawSnippet ?? (top.snippet ? truncateSnippet(top.snippet) : null),
+        timestamp: parsedTime ?? top.updatedAt ?? top.startedAt ?? null,
+      }
+    }
+  }
+
+  // 3. Fallback to explicit metadata or placeholder description
   return {
-    snippet: rawSnippet ?? (agentMeta?.description as string) ?? null,
+    snippet: rawSnippet ?? (agentMeta?.snippet as string) ?? (agentMeta?.description as string) ?? null,
     timestamp: parsedTime,
   }
 }

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -21,6 +21,7 @@ import {
   openAgentEditor,
   type AgentSettingsChangedDetail,
 } from '../lib/agentSettings'
+import { persistableMessages, putAgentChatSession } from '../lib/agentChatSessions'
 import { useRailChrome } from '../components/RailChrome'
 import { ComputerControlStub } from '../components/ComputerControlStub'
 import { RemoteSelect } from '../components/RemoteSelect'
@@ -256,6 +257,44 @@ const ChatPage = () => {
   const lastUserTextRef = useRef('')
   /** Last hydrated agent or team thread; used to clear bubbles only on switch. */
   const lastHydratedAgentRef = useRef<string | null>(null)
+  const previewSyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // REQ-177: Sync active thread messages to localStorage so rail preview snippets update live.
+  // Throttled to 250ms during streaming, and immediate on turn completion / user send.
+  useEffect(() => {
+    if (!activeChatAgentId) return
+    const threadMessages = threads[threadKey]
+    if (threadMessages === undefined) return
+    const isStreaming = threadMessages.some((m) => m.streaming)
+    const sync = () => {
+      const persistable = persistableMessages(threadMessages)
+      putAgentChatSession(activeChatAgentId, {
+        conversationId,
+        messages: persistable,
+      })
+    }
+
+    if (isStreaming) {
+      if (!previewSyncTimerRef.current) {
+        previewSyncTimerRef.current = setTimeout(() => {
+          previewSyncTimerRef.current = null
+          sync()
+        }, 250)
+      }
+    } else {
+      if (previewSyncTimerRef.current) {
+        clearTimeout(previewSyncTimerRef.current)
+        previewSyncTimerRef.current = null
+      }
+      sync()
+    }
+    return () => {
+      if (previewSyncTimerRef.current) {
+        clearTimeout(previewSyncTimerRef.current)
+        previewSyncTimerRef.current = null
+      }
+    }
+  }, [activeChatAgentId, conversationId, threadKey, threads])
 
   const blueprintsQuery = useQuery({
     queryKey: ['blueprints'],


### PR DESCRIPTION
## Summary
Fixes #632 (REQ-177).

### Quoting Issue #632
> **Intent:** Rail rows reflect the latest chat activity at a glance.
>
> **Success:**
> 1. Second-row preview = truncated latest message text (prefer latest assistant reply if that matches product; else latest of either — document choice; Matthew said “most recent agent message” → prefer latest assistant text, fallback latest user if none).
> 2. Updates when a turn completes (and ideally mid-stream with throttle) without full page reload.
> 3. Empty thread: no stale leftover / placeholder OK.
> 4. Tests for update after mock final. `Fixes` this Issue.
>
> **Constraints:** UI + whatever store feeds the rail. Prefer agy. No secrets.
>
> **Owner:** agy. CoS: Open Swarm.

### Feasibility
- Fully feasible with zero runtime backend changes and zero new dependencies.
- Synchronizes active chat thread messages into `swarm_agent_chat_sessions` keyed by rail row id.
- Updates live with mid-stream throttle (250ms) and immediate commit upon completion / user sends.
- `getRowLastMessage` prefers latest assistant message text, falls back to latest user message, and truncates text with an ellipsis up to 100 characters.
- When a thread is empty or cleared, returns null / description placeholder with no stale leftover.
- Listens to `AGENT_CHAT_SESSIONS_EVENT` and `GENERATION_COMPLETE_EVENT` in `AgentSidebar` to re-render without page reloads.
- Disjoint file surface from PR #696 (`index.css`) and PR #698 (`AvatarStack.tsx`, `AgentAvatar.tsx`).

### Key Changes
- `webui/frontend/src/lib/chatTime.ts`: Adds `truncateSnippet`, `selectLatestMessage`, and updates `getRowLastMessage` to prefer live local chat sessions and latest assistant reply (fallback user).
- `webui/frontend/src/lib/agentChatSessions.ts`: Adds `AGENT_CHAT_SESSIONS_EVENT` and `emitAgentChatSessionsChanged`, dispatches on save, and filters non-chat (status) messages in `persistableMessages`.
- `webui/frontend/src/pages/ChatPage.tsx`: Adds syncing effect that saves active messages to `agentChatSessions` (throttled 250ms during streaming, immediate on completion).
- `webui/frontend/src/components/AgentSidebar.tsx`: Listens to `AGENT_CHAT_SESSIONS_EVENT` and `GENERATION_COMPLETE_EVENT` to update rail preview snippets live without reload.
- `webui/frontend/src/lib/__tests__/chatTimePreview.test.ts`: Vitest suite covering truncation, message role preference, live updates, and empty thread placeholder behavior.
- `tests/unit/test_req177_rail_preview_snippet.py`: Contract tests verifying exports and event bindings.