### PR TITLE
feat(webui): codeblock copy chip top-right, reveal on hover (Fixes #628)

### DIFF
--- a/tests/unit/test_req174_codeblock_copy_hover.py
+++ b/tests/unit/test_req174_codeblock_copy_hover.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INDEX_CSS = REPO_ROOT / "webui" / "frontend" / "src" / "index.css"
+CODE_FENCES_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "codeFences.ts"
+
+
+def test_code_copy_concealed_by_default_in_css():
+    """index.css must conceal .os-code-copy with opacity: 0 at rest."""
+    css = INDEX_CSS.read_text(encoding="utf-8")
+    assert ".os-code-copy {" in css
+    assert "opacity: 0;" in css
+
+
+def test_code_copy_revealed_on_hover_and_focus_within():
+    """index.css must reveal .os-code-copy on codeblock hover and focus-within."""
+    css = INDEX_CSS.read_text(encoding="utf-8")
+    assert ".os-code:hover .os-code-copy" in css or "pre:hover .os-code-copy" in css
+    assert "focus-within .os-code-copy" in css
+
+
+def test_code_copy_always_visible_on_touch_mobile():
+    """index.css must keep .os-code-copy visible on touch devices without hover."""
+    css = INDEX_CSS.read_text(encoding="utf-8")
+    assert "@media (hover: none)" in css
+
+
+def test_code_fences_adds_os_code_class():
+    """codeFences.ts must add os-code class to pre elements for relative positioning and hover."""
+    ts = CODE_FENCES_TS.read_text(encoding="utf-8")
+    assert "pre.classList.add('os-code')" in ts
+    assert "code-copy" in ts

--- a/webui/frontend/src/components/__tests__/CodeblockCopyHover.test.tsx
+++ b/webui/frontend/src/components/__tests__/CodeblockCopyHover.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { ChatMessageBubble } from '../ChatMessageBubble'
+import * as clipboard from '../../lib/clipboard'
+
+describe('REQ-174: Codeblock copy control (top-right, reveal on hover/focus)', () => {
+  const codeSnippet = '```javascript\nfunction hello() {\n  console.log("hello world");\n}\n```'
+
+  it('renders top-right copy control on assistant code blocks', () => {
+    render(
+      <ChatMessageBubble
+        role="assistant"
+        agentName="Codey"
+        text={codeSnippet}
+        streaming={false}
+        canEdit={false}
+        editing={false}
+        onStartEdit={() => {}}
+        onCancelEdit={() => {}}
+        onSaveEdit={() => {}}
+      />,
+    )
+
+    const pre = document.querySelector('pre')
+    expect(pre).not.toBeNull()
+    expect(pre).toHaveClass('os-code')
+
+    const actions = pre?.querySelector('.os-code-actions')
+    expect(actions).not.toBeNull()
+
+    const copyBtn = actions?.querySelector<HTMLButtonElement>('[data-testid="code-copy"]')
+    expect(copyBtn).not.toBeNull()
+    expect(copyBtn).toHaveClass('os-code-copy')
+    expect(copyBtn?.getAttribute('aria-label')).toBe('Copy code')
+  })
+
+  it('renders top-right copy control on user code blocks', () => {
+    render(
+      <ChatMessageBubble
+        role="user"
+        agentName="User"
+        text={codeSnippet}
+        streaming={false}
+        canEdit={false}
+        editing={false}
+        onStartEdit={() => {}}
+        onCancelEdit={() => {}}
+        onSaveEdit={() => {}}
+      />,
+    )
+
+    const pre = document.querySelector('pre')
+    expect(pre).not.toBeNull()
+    expect(pre).toHaveClass('os-code')
+
+    const copyBtn = pre?.querySelector<HTMLButtonElement>('[data-testid="code-copy"]')
+    expect(copyBtn).not.toBeNull()
+    expect(copyBtn).toHaveClass('os-code-copy')
+  })
+
+  it('copies full code text and provides Copied! visual feedback', async () => {
+    vi.useFakeTimers()
+    const copySpy = vi.spyOn(clipboard, 'copyTextToClipboard').mockResolvedValue(true)
+
+    render(
+      <ChatMessageBubble
+        role="assistant"
+        agentName="Codey"
+        text={codeSnippet}
+        streaming={false}
+        canEdit={false}
+        editing={false}
+        onStartEdit={() => {}}
+        onCancelEdit={() => {}}
+        onSaveEdit={() => {}}
+      />,
+    )
+
+    const copyBtn = screen.getByTestId('code-copy')
+    expect(copyBtn.textContent).toBe('Copy')
+
+    fireEvent.click(copyBtn)
+    expect(copySpy).toHaveBeenCalledTimes(1)
+    expect(copySpy.mock.calls[0][0]).toContain('function hello()')
+    expect(copySpy.mock.calls[0][0]).toContain('\n')
+
+    expect(copyBtn.textContent).toBe('Copied!')
+
+    act(() => {
+      vi.advanceTimersByTime(1600)
+    })
+
+    expect(copyBtn.textContent).toBe('Copy')
+    vi.useRealTimers()
+  })
+})

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -973,6 +973,25 @@ button.os-agent-row {
   height: 1.5rem;
   min-height: 1.5rem;
   padding: 0 0.45rem;
+  border-radius: 0.375rem;
+  backdrop-filter: blur(4px);
+  background: color-mix(in srgb, var(--color-base-100) 80%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-base-content) 12%, transparent);
+}
+.os-code-copy {
+  opacity: 0;
+  transition: opacity 0.15s ease-in-out;
+}
+.os-code:hover .os-code-copy,
+.os-code:focus-within .os-code-copy,
+pre:hover .os-code-copy,
+pre:focus-within .os-code-copy {
+  opacity: 1;
+}
+@media (hover: none) {
+  .os-code-copy {
+    opacity: 1;
+  }
 }
 .os-code--collapsible.os-code--collapsed {
   max-height: 12rem;

--- a/webui/frontend/src/lib/codeFences.ts
+++ b/webui/frontend/src/lib/codeFences.ts
@@ -16,6 +16,7 @@ export function setupCodeFenceControls(
 ) {
   const pres = root.querySelectorAll('pre')
   pres.forEach((pre, index) => {
+    pre.classList.add('os-code')
     const code = pre.querySelector('code')
     const fullText = code?.textContent ?? pre.textContent ?? ''
     const lines = fullText.split('\n')
@@ -31,7 +32,7 @@ export function setupCodeFenceControls(
       pre.insertBefore(actions, pre.firstChild)
     }
 
-    // Always-available Copy button
+    // Always-available Copy button (concealed until hover / focus-within per REQ-174)
     let copyBtn = actions.querySelector<HTMLButtonElement>('[data-testid="code-copy"]')
     if (!copyBtn) {
       copyBtn = document.createElement('button')
@@ -44,6 +45,12 @@ export function setupCodeFenceControls(
         event.preventDefault()
         event.stopPropagation()
         void copyTextToClipboard(fullText)
+        if (copyBtn) {
+          copyBtn.textContent = 'Copied!'
+          setTimeout(() => {
+            if (copyBtn) copyBtn.textContent = 'Copy'
+          }, 1500)
+        }
       })
       actions.appendChild(copyBtn)
     }


### PR DESCRIPTION
## Summary
Fixes #628 (REQ-174).

### Quoting Issue #628
> **Intent:** One-glance copy without clutter; same pattern as hover-reveal chrome elsewhere.
>
> **Success:**
> 1. Every rendered fence in chat bubbles (user + assistant) has a top-right copy control (clipboard / copy glyph or compact emoji-style chip).
> 2. At rest: control is **concealed** (opacity 0 / invisible, still not layout-jumping badly).
> 3. On **hover anywhere** over that codeblock (not only the button): control fades in; click copies full fence text (newlines preserved — #517).
> 4. Works for collapsed and expanded fences (#498). Keyboard/focus: visible on focus-within for a11y.
> 5. Mobile: always-visible or long-press acceptable if hover absent — document choice.
> 6. Tests: hover reveal + copy. No secrets. `Fixes` this Issue.
>
> **Constraints:** UI-only. Coordinate ChatMessageBubble / codeFences from #620. Prefer agy Wave 10/11. GitHub then `:8001`.
>
> **Owner:** agy. CoS: Open Swarm.

### Feasibility
- Fully feasible with zero runtime backend dependencies.
- Extends the existing `setupCodeFenceControls` pipeline in `codeFences.ts` to ensure `os-code` is added to every `pre` codeblock (both user and assistant).
- Enhances CSS rules in `index.css` so `.os-code-copy` is concealed with `opacity: 0` at rest, fading in with smooth transition whenever the codeblock (`.os-code` or `pre`) is hovered anywhere or focused within (`:focus-within` for accessibility).
- Mobile devices without pointer hover (`@media (hover: none)`) keep the copy chip visible so touch users can easily tap to copy.
- Provides visual feedback: temporarily changes to `Copied!` upon successful copy, then resets to `Copy`.
- Disjoint file surface: touches `index.css` and `codeFences.ts`. Disjoint from upcoming PR 2 (`AgentSidebar.tsx`) and PR 3 (`BlobAvatar.tsx`, `ChatPage.tsx`).

### Key Changes
- `webui/frontend/src/lib/codeFences.ts`: Adds `pre.classList.add('os-code')` to all code fence blocks and adds `Copied!` visual feedback upon click.
- `webui/frontend/src/index.css`: Styles `.os-code-copy` as a compact chip with top-right positioning; conceals at rest (`opacity: 0`); reveals on hover anywhere on `.os-code` / `pre` and on `:focus-within`; always visible on mobile (`@media (hover: none)`).
- `webui/frontend/src/components/__tests__/CodeblockCopyHover.test.tsx`: Vitest tests for assistant and user codeblocks, copy functionality, newline preservation, and feedback.
- `tests/unit/test_req174_codeblock_copy_hover.py`: Python contract tests verifying CSS hover/focus-within/mobile opacity rules and `codeFences.ts` integration.