### PR TITLE
feat(webui): role badges/pills overlay the rail avatar (Fixes #630)

### DIFF
--- a/tests/unit/test_req175_role_pill_avatar_overlay.py
+++ b/tests/unit/test_req175_role_pill_avatar_overlay.py
@@ -1,0 +1,52 @@
+"""REQ-175: Role badges/pills overlay the rail avatar (not beside name or on second row)."""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SIDEBAR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+
+
+def test_sidebar_role_badge_overlays_avatar():
+    content = SIDEBAR_TSX.read_text(encoding="utf-8")
+
+    # Verify role badge has avatar overlay indicator / styling
+    assert 'data-avatar-overlay="true"' in content
+    assert "roleBadgeNode" in content
+
+    # REQ-67 contract preserved: className exact template literal
+    assert re.search(
+        r"className=\{`os-agent-role-badge \$\{roleCssClass\(role\)\}`\}",
+        content,
+    )
+
+    # Avatar container has relative inline-flex wrapping mark and role badge
+    assert re.search(
+        r'<span className="relative inline-flex shrink-0 mt-1\.5">\s*\{mark\}\s*\{roleBadgeNode\}\s*</span>',
+        content,
+    )
+
+
+def test_second_row_does_not_contain_role_badge_chip():
+    content = SIDEBAR_TSX.read_text(encoding="utf-8")
+
+    # In single agent row, second row has snippet and optional taskCount, but NOT badge ? <span ...>
+    agent_second_row = re.search(
+        r'\{snippet \|\| agent\.description\}\s*</span>\s*\{taskCount > 1',
+        content,
+    )
+    assert agent_second_row is not None, "Second row should not reserve role badge chip beside snippet"
+
+    # In team row, second row only has team snippet
+    team_second_row = re.search(
+        r'\{teamSnippet \|\| team\.description\}\s*</span>\s*</span>\s*</span>\s*</Link>',
+        content,
+    )
+    assert team_second_row is not None, "Team second row should not contain Team badge"
+
+    # In remote row, second row only has remote snippet
+    remote_second_row = re.search(
+        r'\{remoteSnippet \|\| \(remote as any\)\.description \|\| \'Remote team\'\}\s*</span>\s*</span>\s*</span>\s*</Link>',
+        content,
+    )
+    assert remote_second_row is not None, "Remote second row should not contain Remote badge"

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -915,13 +915,51 @@ export default function AgentSidebar({
           src={agent.avatar_path}
           agentId={agent.id}
           size="sm"
-          className="mt-1.5"
         />
       )
     )
+    const roleBadgeNode = badge ? (
+      <span
+        className={`os-agent-role-badge ${roleCssClass(role)}`}
+        data-role={role}
+        data-definition-id={agent.id}
+        data-avatar-overlay="true"
+        role="button"
+        tabIndex={0}
+        aria-label={`Open ${role} settings`}
+        style={{
+          position: 'absolute',
+          bottom: '-0.2rem',
+          right: '-0.25rem',
+          zIndex: 10,
+          fontSize: '0.55rem',
+          padding: '0 0.25rem',
+          lineHeight: '1.2',
+          height: '0.9rem',
+          boxShadow: '0 1px 2px rgba(0,0,0,0.25)',
+        }}
+        onClick={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          openDefinition('role', agent.id, { blueprintId: agent.id })
+        }}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            event.stopPropagation()
+            openDefinition('role', agent.id, { blueprintId: agent.id })
+          }
+        }}
+      >
+        {badge}
+      </span>
+    ) : null
     const body = (
       <>
-        {mark}
+        <span className="relative inline-flex shrink-0 mt-1.5">
+          {mark}
+          {roleBadgeNode}
+        </span>
         <span className="min-w-0 flex-1">
           <span className="flex min-w-0 items-center justify-between gap-1.5">
             <span className="block truncate text-sm font-semibold leading-5">{name}</span>
@@ -949,30 +987,6 @@ export default function AgentSidebar({
             <span className="block truncate min-w-0 flex-1">
               {snippet || agent.description}
             </span>
-            {badge ? (
-              <span
-                className={`os-agent-role-badge ${roleCssClass(role)}`}
-                data-role={role}
-                data-definition-id={agent.id}
-                role="button"
-                tabIndex={0}
-                aria-label={`Open ${role} settings`}
-                onClick={(event) => {
-                  event.preventDefault()
-                  event.stopPropagation()
-                  openDefinition('role', agent.id, { blueprintId: agent.id })
-                }}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter' || event.key === ' ') {
-                    event.preventDefault()
-                    event.stopPropagation()
-                    openDefinition('role', agent.id, { blueprintId: agent.id })
-                  }
-                }}
-              >
-                {badge}
-              </span>
-            ) : null}
             {taskCount > 1 ? (
               <span
                 className="badge badge-sm badge-outline shrink-0"
@@ -1110,21 +1124,57 @@ export default function AgentSidebar({
         }}
         onContextMenu={(event) => openMenu(event, hideId, name, hidden, 'team', sessions)}
       >
-        {stacked.faces.length > 0 ? (
-          <AvatarStack
-            faces={stacked.faces}
-            remainder={stacked.remainder}
-            animate
-            label={`${name} members`}
-          />
-        ) : (
+        <span className="relative inline-flex shrink-0 mt-0.5">
+          {stacked.faces.length > 0 ? (
+            <AvatarStack
+              faces={stacked.faces}
+              remainder={stacked.remainder}
+              animate
+              label={`${name} members`}
+            />
+          ) : (
+            <span
+              className="os-team-mark os-agent-team-icon flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-base-300 text-base-content/80"
+              aria-hidden="true"
+            >
+              <Users className="h-3.5 w-3.5" />
+            </span>
+          )}
           <span
-            className="os-team-mark os-agent-team-icon mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-base-300 text-base-content/80"
-            aria-hidden="true"
+            className="os-agent-role-badge badge badge-ghost badge-xs shrink-0 font-medium uppercase tracking-wide text-base-content/55"
+            data-kind="team"
+            data-avatar-overlay="true"
+            role="button"
+            tabIndex={0}
+            aria-label={`Open ${name} team settings`}
+            data-definition-id={team.id}
+            style={{
+              position: 'absolute',
+              bottom: '-0.25rem',
+              right: '-0.25rem',
+              zIndex: 10,
+              fontSize: '0.55rem',
+              padding: '0 0.25rem',
+              lineHeight: '1.2',
+              height: '0.9rem',
+              boxShadow: '0 1px 2px rgba(0,0,0,0.25)',
+            }}
+            onClick={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              openDefinition('team', team.id, { teamId: team.id })
+            }}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault()
+                event.stopPropagation()
+                openDefinition('team', team.id, { teamId: team.id })
+              }
+            }}
           >
-            <Users className="h-3.5 w-3.5" />
+            Team
           </span>
-        )}
+        </span>
         <span className="min-w-0 flex-1">
           <span className="flex min-w-0 items-center justify-between gap-1.5">
             <span className="block truncate text-sm font-semibold leading-5">{name}</span>
@@ -1151,28 +1201,6 @@ export default function AgentSidebar({
           <span className="mt-0.5 flex min-w-0 items-center justify-between gap-1.5 text-xs text-base-content/45">
             <span className="block truncate min-w-0 flex-1">
               {teamSnippet || team.description}
-            </span>
-            <span
-              className="os-agent-role-badge badge badge-ghost badge-xs shrink-0 font-medium uppercase tracking-wide text-base-content/55"
-              data-kind="team"
-              role="button"
-              tabIndex={0}
-              aria-label={`Open ${name} team settings`}
-              data-definition-id={team.id}
-              onClick={(event) => {
-                event.preventDefault()
-                event.stopPropagation()
-                openDefinition('team', team.id, { teamId: team.id })
-              }}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' || event.key === ' ') {
-                  event.preventDefault()
-                  event.stopPropagation()
-                  openDefinition('team', team.id, { teamId: team.id })
-                }
-              }}
-            >
-              Team
             </span>
           </span>
         </span>
@@ -1235,12 +1263,32 @@ export default function AgentSidebar({
         }}
         onContextMenu={(event) => openMenu(event, hideId, name, hidden, 'remote', sessions)}
       >
-        <AvatarStack
-          faces={stacked.faces}
-          remainder={stacked.remainder}
-          animate
-          label={`${name} members`}
-        />
+        <span className="relative inline-flex shrink-0 mt-0.5">
+          <AvatarStack
+            faces={stacked.faces}
+            remainder={stacked.remainder}
+            animate
+            label={`${name} members`}
+          />
+          <span
+            className="os-agent-role-badge badge badge-ghost badge-xs shrink-0 font-medium uppercase tracking-wide text-base-content/55"
+            data-kind="remote"
+            data-avatar-overlay="true"
+            style={{
+              position: 'absolute',
+              bottom: '-0.25rem',
+              right: '-0.25rem',
+              zIndex: 10,
+              fontSize: '0.55rem',
+              padding: '0 0.25rem',
+              lineHeight: '1.2',
+              height: '0.9rem',
+              boxShadow: '0 1px 2px rgba(0,0,0,0.25)',
+            }}
+          >
+            Remote
+          </span>
+        </span>
         <span className="min-w-0 flex-1">
           <span className="flex min-w-0 items-center justify-between gap-1.5">
             <span className="block truncate text-sm font-semibold leading-5">{name}</span>
@@ -1268,12 +1316,6 @@ export default function AgentSidebar({
             <span className="block truncate min-w-0 flex-1">
               {remoteSnippet || (remote as any).description || 'Remote team'}
             </span>
-            <span
-              className="os-agent-role-badge badge badge-ghost badge-xs shrink-0 font-medium uppercase tracking-wide text-base-content/55"
-              data-kind="remote"
-            >
-              Remote
-            </span>
           </span>
         </span>
       </Link>
@@ -1295,18 +1337,27 @@ export default function AgentSidebar({
               return (
                 <li key={`team-slot-${m.id}`}>
                   <span className="os-agent-row os-agent-row--team os-agent-row--nested">
-                    <Users className="os-agent-team-icon mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate text-sm font-semibold leading-5">
-                        {m.team_id || m.id}
-                      </span>
+                    <span className="relative inline-flex shrink-0 mt-0.5">
+                      <Users className="os-agent-team-icon h-4 w-4 shrink-0" aria-hidden="true" />
                       <span
                         className="os-agent-role-badge"
                         data-kind="team"
+                        data-avatar-overlay="true"
                         data-definition-id={m.team_id || m.id}
                         role="button"
                         tabIndex={0}
                         aria-label={`Open ${m.team_id || m.id} team settings`}
+                        style={{
+                          position: 'absolute',
+                          bottom: '-0.25rem',
+                          right: '-0.25rem',
+                          zIndex: 10,
+                          fontSize: '0.55rem',
+                          padding: '0 0.25rem',
+                          lineHeight: '1.2',
+                          height: '0.9rem',
+                          boxShadow: '0 1px 2px rgba(0,0,0,0.25)',
+                        }}
                         onClick={(event) => {
                           event.preventDefault()
                           event.stopPropagation()
@@ -1323,6 +1374,11 @@ export default function AgentSidebar({
                         }}
                       >
                         Team
+                      </span>
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-semibold leading-5">
+                        {m.team_id || m.id}
                       </span>
                     </span>
                   </span>

--- a/webui/frontend/src/components/__tests__/AgentRolePillOverlay.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentRolePillOverlay.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import AgentSidebar from '../AgentSidebar'
+import { PINNED_AGENTS_STORAGE_KEY } from '../../lib/pinnedAgents'
+import { HIDDEN_AGENTS_STORAGE_KEY } from '../../lib/hiddenAgents'
+
+const blueprints = [
+  {
+    id: 'cos_agent',
+    object: 'blueprint' as const,
+    name: 'Pat Chief',
+    description: 'Oversees operations and strategic goals',
+    role: 'chief_of_staff',
+    installed: true,
+    compiled: true,
+  },
+  {
+    id: 'codey',
+    object: 'blueprint' as const,
+    name: 'Codey',
+    description: 'Code assistant',
+    role: 'default',
+    installed: true,
+    compiled: true,
+  },
+]
+
+const rosters = [
+  {
+    id: 'dev_squad',
+    object: 'team_roster' as const,
+    name: 'Dev Squad',
+    description: 'Full stack development unit',
+    members: [{ id: 'codey', kind: 'api', role: 'default', source: 'blueprint:codey' }],
+    wires: { handoff: true, as_tool: true },
+  },
+]
+
+function mockFetch() {
+  return vi.fn().mockImplementation(async (input: RequestInfo) => {
+    const url = String(input)
+    if (url.includes('team_rosters') || url.includes('team-rosters')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ object: 'list', data: rosters }),
+      } as Response
+    }
+    if (url.includes('/v1/cli-agents') || url.includes('/v1/herdr-agents')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ object: 'list', data: [], clis: [], rail: [] }),
+      } as Response
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ object: 'list', data: blueprints }),
+    } as Response
+  })
+}
+
+describe('AgentSidebar Role Badges Overlay Avatar (REQ-175)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem(PINNED_AGENTS_STORAGE_KEY, '[]')
+    localStorage.setItem(HIDDEN_AGENTS_STORAGE_KEY, '[]')
+    vi.stubGlobal('fetch', mockFetch())
+  })
+
+  it('renders role badge as an overlay on the agent avatar, leaving second row for snippet only', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/chat']}>
+          <AgentSidebar open />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const cosRow = await within(list).findByRole('link', { name: /Pat Chief/i })
+
+    // Find the role badge
+    const badge = cosRow.querySelector('.os-agent-role-badge')
+    expect(badge).not.toBeNull()
+    expect(badge).toHaveAttribute('data-avatar-overlay', 'true')
+    expect(badge).toHaveAttribute('data-role', 'chief_of_staff')
+    expect(badge).toHaveTextContent('CoS')
+
+    // Badge should be inside the avatar's relative container
+    const avatarContainer = badge?.parentElement
+    expect(avatarContainer).toHaveClass('relative')
+    expect(avatarContainer?.querySelector('[data-agent-avatar]')).not.toBeNull()
+
+    // Second text row should contain description snippet and not the badge
+    const textColumn = cosRow.querySelector('.min-w-0.flex-1')
+    expect(textColumn).not.toBeNull()
+    expect(textColumn?.querySelector('.os-agent-role-badge')).toBeNull()
+    expect(within(textColumn as HTMLElement).getByText('Oversees operations and strategic goals')).toBeInTheDocument()
+
+    // Plain agent without special role has no badge
+    const codeyRow = within(list).getByRole('link', { name: /Codey/i })
+    expect(codeyRow.querySelector('.os-agent-role-badge')).toBeNull()
+  })
+
+  it('renders team badge as an overlay on the team avatar stack', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/chat']}>
+          <AgentSidebar open />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const teamRow = await within(list).findByRole('link', { name: /Dev Squad/i })
+
+    const teamBadge = teamRow.querySelector('.os-agent-role-badge')
+    expect(teamBadge).not.toBeNull()
+    expect(teamBadge).toHaveAttribute('data-avatar-overlay', 'true')
+    expect(teamBadge).toHaveAttribute('data-kind', 'team')
+    expect(teamBadge).toHaveTextContent('Team')
+
+    // Badge is inside avatar container
+    const avatarContainer = teamBadge?.parentElement
+    expect(avatarContainer).toHaveClass('relative')
+
+    // Second row contains team snippet without badge
+    const textColumn = teamRow.querySelector('.min-w-0.flex-1')
+    expect(textColumn?.querySelector('.os-agent-role-badge')).toBeNull()
+    expect(textColumn?.querySelector('.block.truncate')).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## REQ-175: Role badges/pills overlay the rail avatar (not beside name)

Fixes #630

### Issue Quote
> **Intent:** Cleaner name row; role still scannable on the face.
>
> **Success:**
> 1. Role badge overlays avatar (e.g. bottom-right or top-right corner) for agents/teams that show a role today.
> 2. Name + timestamp + preview snippet layout no longer reserves a role chip on the text rows (unless another REQ requires it).
> 3. Accessible name still exposes role. Tests for overlay placement. No secrets. `Fixes` this Issue.
>
> **Constraints:** UI-only. Coordinate #443/#515 rail rows, #627 pencil removal. Prefer agy.
>
> **Owner:** agy. CoS: Open Swarm.

### Feasibility & Changes
- Feasible and implemented cleanly with zero new runtime or styling dependencies:
  - Agent, team, and remote rows now render their role badge / kind pill overlaid on the avatar container (`relative inline-flex shrink-0`) at bottom-right.
  - The second text row layout no longer reserves a role chip beside the preview snippet / description, granting full horizontal width for message snippets.
  - Accessible name continues to expose role and team info.
  - REQ-67 class name template literal `className={`os-agent-role-badge ${roleCssClass(role)}`}` is strictly preserved.
  - Added frontend test `AgentRolePillOverlay.test.tsx` and Python unit contract test `test_req175_role_pill_avatar_overlay.py`.