### PR TITLE
feat(webui): activate blob eyes wandering while agent is streaming (Fixes #631)

### DIFF
--- a/tests/unit/test_req176_blob_eyes_active.py
+++ b/tests/unit/test_req176_blob_eyes_active.py
@@ -1,0 +1,39 @@
+"""REQ-176: Blob eyes must wander while agent is working/streaming."""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHAT_PAGE_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "pages" / "ChatPage.tsx"
+BLOB_AVATAR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "BlobAvatar.tsx"
+INDEX_CSS = REPO_ROOT / "webui" / "frontend" / "src" / "index.css"
+
+
+def test_chat_page_blob_eyes_active_when_streaming():
+    content = CHAT_PAGE_TSX.read_text(encoding="utf-8")
+
+    # Header passes active only when streaming, not merely because ws status is open
+    assert "active={Boolean(streamingMessage)}" in content
+    assert "active={Boolean(streamingMessage || status === 'open')}" not in content
+
+    # Composer / footer working indicator renders working avatar with active={true}
+    assert 'data-testid="composer-working-indicator"' in content
+    assert re.search(
+        r'<AgentAvatar[^>]+active=\{true\}[^>]*size="xs"',
+        content,
+    )
+
+
+def test_blob_avatar_sets_eye_state_active_or_idle():
+    content = BLOB_AVATAR_TSX.read_text(encoding="utf-8")
+
+    assert "const eyeState: BlobEyeState = active ? 'active' : 'idle'" in content
+    assert 'data-eye-state={eyeState}' in content
+
+
+def test_css_animates_active_blob_eyes():
+    css = INDEX_CSS.read_text(encoding="utf-8")
+
+    assert '.os-blob-avatar[data-eye-state="active"] .os-blob-eyes' in css
+    assert "animation: os-blob-wander" in css
+    assert "@keyframes os-blob-wander" in css

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -1309,7 +1309,7 @@ const ChatPage = () => {
             <AgentAvatar
               src={selectedAgent?.avatar_path}
               agentId={agentIdFromBlueprint(selectedBlueprint)}
-              active={Boolean(streamingMessage || status === 'open')}
+              active={Boolean(streamingMessage)}
               size="lg"
               className="os-chat-header__avatar"
             />
@@ -1761,8 +1761,17 @@ const ChatPage = () => {
           <span className="tabular-nums whitespace-nowrap">{formatTokenCount(tokenCount)} tok</span>
         </button>
         {streamingMessage ? (
-          <span className="min-w-0 truncate">
-            {selectedAgentName} · {streamElapsed ?? '0s'}
+          <span className="flex items-center gap-1.5 min-w-0 truncate" data-testid="composer-working-indicator">
+            <AgentAvatar
+              src={selectedAgent?.avatar_path}
+              agentId={teamFromUrl || agentIdFromBlueprint(selectedBlueprint)}
+              active={true}
+              size="xs"
+              className="shrink-0"
+            />
+            <span className="truncate">
+              {selectedAgentName} · {streamElapsed ?? '0s'}
+            </span>
           </span>
         ) : null}
       </footer>

--- a/webui/frontend/src/pages/__tests__/BlobEyesActive.test.tsx
+++ b/webui/frontend/src/pages/__tests__/BlobEyesActive.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import AgentAvatar from '../../components/AgentAvatar'
+import { ToastProvider } from '../../components/DaisyUI/Toast'
+import ChatPage from '../ChatPage'
+
+describe('REQ-176: Blob eyes wander while agent is working/streaming', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem('swarm:avatar-theme', 'blobs')
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  it('sets data-eye-state to active when active=true and idle when active=false on AgentAvatar', () => {
+    const { container: idleContainer } = render(
+      <AgentAvatar agentId="codey" active={false} size="lg" />,
+    )
+    const idleSvg = idleContainer.querySelector('.os-blob-avatar')
+    expect(idleSvg).toHaveAttribute('data-eye-state', 'idle')
+
+    const { container: activeContainer } = render(
+      <AgentAvatar agentId="codey" active={true} size="lg" />,
+    )
+    const activeSvg = activeContainer.querySelector('.os-blob-avatar')
+    expect(activeSvg).toHaveAttribute('data-eye-state', 'active')
+  })
+
+  it('leaves header blob eyes idle when connected but not streaming', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    // Mock WebSocket to connect cleanly
+    class MockWs {
+      static OPEN = 1
+      readyState = 1
+      onopen: ((ev?: Event) => void) | null = null
+      onmessage: ((ev?: Event) => void) | null = null
+      onclose: ((ev?: Event) => void) | null = null
+      send = vi.fn()
+      close = vi.fn()
+      addEventListener = vi.fn()
+      removeEventListener = vi.fn()
+    }
+    vi.stubGlobal('WebSocket', MockWs as any)
+
+    render(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/chat?blueprint=codey']}>
+            <ChatPage />
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    // Header avatar should have idle eye state when no streaming message is present
+    const headerAvatar = document.querySelector('.os-chat-header__avatar .os-blob-avatar')
+    if (headerAvatar) {
+      expect(headerAvatar).toHaveAttribute('data-eye-state', 'idle')
+    }
+
+    // Composer working indicator should not be visible when idle
+    expect(screen.queryByTestId('composer-working-indicator')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## REQ-176: Blob eyes wander while agent is working/streaming

Fixes #631

### Issue Quote
> **Intent:** When an agent is generating, its blob eyes visibly wander (header + rail selected/working indicators).
>
> **Success:**
> 1. While assistant is streaming / working avatar shown: blob eyes animate (`active`).
> 2. Rail row for that agent (if visible) also shows active eyes when that agent is the one working (or at least the chat header + composer working avatar).
> 3. Idle agents stay idle. Bland-static theme unaffected.
> 4. Visual/RTL test or CSS assert on `data-eye-state=active` during stream. `Fixes` this Issue.
>
> **Constraints:** Fix wiring first before redesigning animation. Prefer agy. No secrets.
>
> **Owner:** agy. CoS: Open Swarm.

### Feasibility & Changes
- Feasible and implemented cleanly:
  - Header `AgentAvatar` now receives `active={Boolean(streamingMessage)}` rather than checking `status === 'open'`, ensuring idle agents remain idle and only animate when actively streaming.
  - Added working avatar with `active={true}` to the footer / composer working indicator when streaming is in progress.
  - Added unit test `BlobEyesActive.test.tsx` verifying active and idle eye state behavior.
  - Added Python unit contract test `test_req176_blob_eyes_active.py` asserting proper prop wiring, eye-state assignment, and CSS animations.