### PR TITLE
feat(webui): tighter chat bubble margins and transcript width (Fixes #649)

### DIFF
--- a/tests/unit/test_req192_tighter_bubble_margins.py
+++ b/tests/unit/test_req192_tighter_bubble_margins.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+def test_req192_chat_transcript_classes_and_tighter_margins():
+    repo_root = Path(__file__).resolve().parents[2]
+    chat_page_tsx = repo_root / "webui" / "frontend" / "src" / "pages" / "ChatPage.tsx"
+    index_css = repo_root / "webui" / "frontend" / "src" / "index.css"
+
+    assert chat_page_tsx.exists()
+    assert index_css.exists()
+
+    tsx_content = chat_page_tsx.read_text(encoding="utf-8")
+    css_content = index_css.read_text(encoding="utf-8")
+
+    # Verifies transcript container uses tightened padding and os-chat-transcript class
+    assert "os-chat-transcript" in tsx_content
+    assert "px-2 py-3 sm:px-3" in tsx_content
+    assert "px-4 py-4" not in tsx_content
+
+    # Verifies CSS rules tighten horizontal margins and column gaps
+    assert ".os-chat-transcript" in css_content
+    assert "column-gap: 0.25rem;" in css_content
+    assert "max-width: 95%;" in css_content
+
+    # Verifies status lines remain centered
+    assert ".os-chat-status" in css_content
+    assert "justify-content: center;" in css_content
+    assert "text-align: center;" in css_content

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -1116,6 +1116,26 @@ html[data-theme="light"] .os-code--collapsible.os-code--collapsed::after {
   opacity: 0.5;
 }
 
+/* REQ-192: Tighter chat bubble margins — less wasted side gap (Grok transcript layout) */
+.os-chat-transcript {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+@media (min-width: 640px) {
+  .os-chat-transcript {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+}
+.os-chat-transcript .chat {
+  column-gap: 0.25rem;
+  padding-block: 0.15rem;
+}
+.os-chat-transcript .chat-start .chat-bubble,
+.os-chat-transcript .chat-end .chat-bubble {
+  max-width: 95%;
+}
+
 .os-chat-footer {
   display: flex;
   align-items: center;

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -1523,7 +1523,7 @@ const ChatPage = () => {
 
       <div
         ref={scrollBoxRef}
-        className="min-h-0 flex-1 space-y-1 overflow-y-auto px-4 py-4 focus:outline focus:outline-2 focus:outline-primary"
+        className="os-chat-transcript min-h-0 flex-1 space-y-1 overflow-y-auto px-2 py-3 sm:px-3 focus:outline focus:outline-2 focus:outline-primary"
         aria-live="polite"
         role="log"
         aria-label="Conversation"

--- a/webui/frontend/src/pages/__tests__/TighterChatBubbleMargins.test.tsx
+++ b/webui/frontend/src/pages/__tests__/TighterChatBubbleMargins.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import { ToastProvider } from '../../components/DaisyUI'
+import ChatPage from '../ChatPage'
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  url: string
+  readyState = 0
+  onopen: ((e?: unknown) => void) | null = null
+  onclose: ((e?: unknown) => void) | null = null
+  onmessage: ((e: { data: string }) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  open() {
+    this.readyState = 1
+    this.onopen?.()
+  }
+
+  emitMessage(data: Record<string, unknown>) {
+    this.onmessage?.({ data: JSON.stringify(data) })
+  }
+}
+
+describe('REQ-192: Tighter chat bubble margins and transcript width', () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ results: [] }),
+      } as Response),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders transcript container with os-chat-transcript and tightened padding classes', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    render(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/chat']}>
+            <ChatPage />
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+
+    const transcript = screen.getByRole('log', { name: 'Conversation' })
+    expect(transcript).toBeInTheDocument()
+    expect(transcript).toHaveClass('os-chat-transcript')
+    expect(transcript).toHaveClass('px-2')
+    expect(transcript).toHaveClass('sm:px-3')
+    expect(transcript).toHaveClass('py-3')
+    expect(transcript).not.toHaveClass('px-4')
+  })
+
+  it('renders messages and status lines within tightened transcript', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    render(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/chat']}>
+            <ChatPage />
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    const ws = MockWebSocket.instances[0]
+    await act(async () => {
+      ws?.open()
+    })
+
+    // Emit user echo and assistant message
+    await act(async () => {
+      ws?.onmessage?.(
+        new MessageEvent('message', {
+          data: '<div id="message-list" hx-swap-oob="beforeend"><div class="user-message">Hello from user</div></div>',
+        }),
+      )
+      ws?.onmessage?.(
+        new MessageEvent('message', {
+          data: '<div id="message-list" hx-swap-oob="beforeend"><div id="message-response-abc123" class="assistant-message"></div></div>',
+        }),
+      )
+      ws?.onmessage?.(
+        new MessageEvent('message', {
+          data: '<div id="message-response-abc123" class="assistant-message" hx-swap-oob="true">Hello from assistant</div>',
+        }),
+      )
+    })
+
+    const transcript = screen.getByRole('log', { name: 'Conversation' })
+    expect(transcript.querySelector('.chat-bubble')).toBeInTheDocument()
+    expect(transcript.querySelector('.chat-start')).toBeInTheDocument()
+    expect(transcript.querySelector('.chat-end')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
Fixes #649.

### Quoted Issue
> **Intent:** Less wasted chrome; denser transcript like Grok.
> 
> **Success:**
> 1. Measurably smaller left/right inset for user and assistant bubbles (document before/after px or Tailwind classes).
> 2. Still works on mobile (no overflow under rail). Status/centred lines remain centred.
> 3. Visual/CSS test or class assert. `Fixes` this Issue.
> 
> **Constraints:** UI-only. Prefer agy. Coordinate #464 if colours land same wave. No secrets.
> **Owner:** agy. CoS: Open Swarm.

### Feasibility & Changes
- Measurably tightened chat bubble horizontal spacing to reduce wasted chrome and produce a denser Grok-like transcript:
  - **Before:**
    - Container padding: `px-4` (`1rem` = 16px)
    - DaisyUI `.chat` column-gap: `0.75rem` (12px)
    - Bubble left/right outer inset: `16px + 12px = 28px`
    - Bubble max width: `90%`
  - **After:**
    - Container padding: `px-2` (`0.5rem` = 8px) on mobile, `sm:px-3` (`0.75rem` = 12px) on desktop (`-50%` mobile, `-25%` desktop)
    - DaisyUI `.chat` column-gap: `0.25rem` (4px, `-66.7%`)
    - Bubble left/right outer inset: `12px` on mobile (`-57%`), `16px` on desktop (`-43%`)
    - Bubble max width: `95%` (allowing denser width without going edge-flush)
- Mobile layout remains fully responsive without overflow under the rail.
- Full-pane centered status / info lines (`.os-chat-status`) preserve their centered layout (`justify-content: center`).
- Added frontend RTL test in `webui/frontend/src/pages/__tests__/TighterChatBubbleMargins.test.tsx` and Python unit test in `tests/unit/test_req192_tighter_bubble_margins.py`.

Ready to squash. SHA: 02743582