### PR TITLE
feat(webui): chat pane background non-selectable with no focus outline (Fixes #681)

### DIFF
--- a/webui/frontend/src/components/ChatMessageBubble.tsx
+++ b/webui/frontend/src/components/ChatMessageBubble.tsx
@@ -164,7 +164,7 @@ export function ChatMessageBubble({
         </div>
       ) : (
         <div
-          className={`chat-bubble ${
+          className={`chat-bubble select-text ${
             role === 'user' ? 'bg-neutral text-neutral-content' : 'bg-base-200 text-base-content'
           } ${canEdit && !streaming ? 'cursor-pointer' : ''}`}
           data-testid="chat-bubble"

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -1523,7 +1523,7 @@ const ChatPage = () => {
 
       <div
         ref={scrollBoxRef}
-        className="os-chat-transcript min-h-0 flex-1 space-y-1 overflow-y-auto px-2 py-3 sm:px-3 focus:outline focus:outline-2 focus:outline-primary"
+        className="os-chat-transcript min-h-0 flex-1 space-y-1 overflow-y-auto px-2 py-3 sm:px-3 select-none outline-none focus:outline-none"
         aria-live="polite"
         role="log"
         aria-label="Conversation"

--- a/webui/frontend/src/pages/__tests__/ChatPageNoSelectBg.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPageNoSelectBg.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import { ToastProvider } from '../../components/DaisyUI'
+import ChatPage from '../ChatPage'
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  url: string
+  readyState = 0
+  onopen: ((e?: unknown) => void) | null = null
+  onclose: ((e?: unknown) => void) | null = null
+  onmessage: ((e: MessageEvent) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  open() {
+    this.readyState = 1
+    this.onopen?.()
+  }
+}
+
+describe('REQ-204: Chat pane no focus outline / chrome on empty background', () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ results: [] }),
+      } as Response),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders transcript container with select-none, outline-none, focus:outline-none and without focus:outline-primary', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    render(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/chat']}>
+            <ChatPage />
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+
+    const transcript = screen.getByRole('log', { name: 'Conversation' })
+    expect(transcript).toBeInTheDocument()
+    expect(transcript).toHaveClass('os-chat-transcript')
+    expect(transcript).toHaveClass('select-none')
+    expect(transcript).toHaveClass('outline-none')
+    expect(transcript).toHaveClass('focus:outline-none')
+    expect(transcript).not.toHaveClass('focus:outline-primary')
+    expect(transcript).not.toHaveClass('focus:outline-2')
+  })
+
+  it('renders chat message bubbles with select-text class for copyable text', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    render(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/chat']}>
+            <ChatPage />
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    const ws = MockWebSocket.instances[0]
+    await act(async () => {
+      ws?.open()
+    })
+
+    await act(async () => {
+      ws?.onmessage?.(
+        new MessageEvent('message', {
+          data: '<div id="message-list" hx-swap-oob="beforeend"><div class="user-message">Hello from user</div></div>',
+        }),
+      )
+      ws?.onmessage?.(
+        new MessageEvent('message', {
+          data: '<div id="message-list" hx-swap-oob="beforeend"><div id="message-response-abc123" class="assistant-message"></div></div>',
+        }),
+      )
+      ws?.onmessage?.(
+        new MessageEvent('message', {
+          data: '<div id="message-response-abc123" class="assistant-message" hx-swap-oob="true">Hello from assistant</div>',
+        }),
+      )
+    })
+
+    const transcript = screen.getByRole('log', { name: 'Conversation' })
+    const bubbles = transcript.querySelectorAll('.chat-bubble')
+    expect(bubbles.length).toBeGreaterThan(0)
+    for (const bubble of bubbles) {
+      expect(bubble).toHaveClass('select-text')
+    }
+  })
+})


### PR DESCRIPTION
## REQ-204 — Chat background not selectable / no blue focus bars

Fixes #681

### Intent
Clicks on the transcript chrome/background don’t look like a selected region or focused box; only message text (and intentional controls) remain selectable.

### Success
1. Clicking empty chat background does not show blue top/bottom focus (or selection) bars on the scroll pane.
2. User cannot drag-select the empty background as a highlight slab (user-select none on the pane chrome / empty regions).
3. Bubble message text remains selectable/copyable; composer and inputs stay focusable as today.
4. Right-click Reply (#673) still works on bubbles.
5. Screenshot or RTL; Fixes this Issue.

### Constraints
SPA chrome. Prefer `user-select: none` on container + `user-select: text` on bubble content; kill outline on non-interactive pane focus if that’s the blue bars. No secrets. Own-diff CI. agy-friendly.

Ready to squash. SHA: cc440fb6