### PR TITLE
feat(webui): label token popup seat as Current Agent (Fixes #682)

### DIFF
--- a/webui/frontend/src/components/TokenDiagnosticsModal.tsx
+++ b/webui/frontend/src/components/TokenDiagnosticsModal.tsx
@@ -64,7 +64,10 @@ export function TokenDiagnosticsModal({
         {/* Session Metadata */}
         <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-base-content/70">
           <div>
-            Agent: <span className="font-medium text-base-content">{agentName || '—'}</span>
+            Current Agent:{' '}
+            <span className="font-medium text-base-content" data-testid="diag-current-agent">
+              {agentName || '—'}
+            </span>
           </div>
           <div>
             Session:{' '}

--- a/webui/frontend/src/components/__tests__/TokenDiagnosticsModal.test.tsx
+++ b/webui/frontend/src/components/__tests__/TokenDiagnosticsModal.test.tsx
@@ -36,7 +36,8 @@ describe('TokenDiagnosticsModal (REQ-115)', () => {
 
     expect(screen.getByTestId('token-diagnostics-modal')).toBeInTheDocument()
     expect(screen.getByText('Session Token Diagnostics')).toBeInTheDocument()
-    expect(screen.getByText('Stewie')).toBeInTheDocument()
+    expect(screen.getByText(/Current Agent:/i)).toBeInTheDocument()
+    expect(screen.getByTestId('diag-current-agent')).toHaveTextContent('Stewie')
     expect(screen.getByTestId('diag-session-id')).toHaveTextContent('conv-test-123')
     expect(screen.getByTestId('diag-context-usage')).toHaveTextContent('4.2k / 128k tok')
 
@@ -47,6 +48,33 @@ describe('TokenDiagnosticsModal (REQ-115)', () => {
     expect(screen.getByTestId('diag-tool-calls')).toHaveTextContent('5')
     expect(screen.getByTestId('diag-message-count')).toHaveTextContent('8')
     expect(screen.getByTestId('diag-estimated-cost')).toHaveTextContent('—')
+  })
+
+  it('updates Current Agent dynamically when agent changes without sticky name', () => {
+    const { rerender } = render(
+      <TokenDiagnosticsModal
+        isOpen={true}
+        onClose={vi.fn()}
+        agentName="FirstAgent"
+        conversationId="conv-test-123"
+        tokenCount={100}
+      />
+    )
+
+    expect(screen.getByTestId('diag-current-agent')).toHaveTextContent('FirstAgent')
+
+    rerender(
+      <TokenDiagnosticsModal
+        isOpen={true}
+        onClose={vi.fn()}
+        agentName="SwitchedAgent"
+        conversationId="conv-test-123"
+        tokenCount={120}
+      />
+    )
+
+    expect(screen.getByTestId('diag-current-agent')).toHaveTextContent('SwitchedAgent')
+    expect(screen.queryByText('FirstAgent')).not.toBeInTheDocument()
   })
 
   it('handles empty/unknown fields with honest placeholders', () => {


### PR DESCRIPTION
## REQ-205 — Token popup “Current Agent”

Fixes #682

### Intent
Token breakdown copy always reflects the **active** agent, not a stale name from an earlier seat in the same thread.

### Success
1. Token popup (and any heading inside it) uses **Current Agent** (or equivalent) instead of a label that freezes the agent that opened the thread.
2. If the popup shows an agent display name, it is the **currently selected** rail/navbar agent and updates on switch without implying history ownership.
3. Switching agents mid-chat then opening the popup does not claim the previous agent’s identity for the meter.
4. `Fixes` this Issue. RTL or screenshot OK.

### Constraints
SPA chrome. Coordinate #677 placement. No secrets. Own-diff CI. agy-friendly.

Ready to squash. SHA: 7b1f2eba