### PR TITLE
fix(webui): open search palette when clicking search icon or collapsed rail (Fixes #703)

### DIFF
--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -1504,20 +1504,45 @@ export default function AgentSidebar({
           <label className="sr-only" htmlFor="os-rail-search">
             Search
           </label>
-          <div className="os-rail-search min-w-0 flex-1">
-            <Search className="h-3.5 w-3.5 shrink-0 text-base-content/40" aria-hidden="true" />
+          <div
+            className="os-rail-search min-w-0 flex-1 cursor-pointer"
+            data-testid="rail-search-trigger"
+            role="button"
+            tabIndex={0}
+            aria-label="Search"
+            onClick={openPalette}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault()
+                openPalette()
+              }
+            }}
+          >
+            <Search
+              className="h-3.5 w-3.5 shrink-0 text-base-content/40 cursor-pointer"
+              aria-hidden="true"
+              data-testid="rail-search-icon"
+              onClick={(event) => {
+                event.stopPropagation()
+                openPalette()
+              }}
+            />
             <input
               id="os-rail-search"
               type="search"
               className="os-rail-search__input"
               placeholder="Search"
               readOnly
+              tabIndex={isAvatarOnly ? -1 : 0}
               autoComplete="off"
               onFocus={(event) => {
                 event.currentTarget.blur()
                 openPalette()
               }}
-              onClick={openPalette}
+              onClick={(event) => {
+                event.stopPropagation()
+                openPalette()
+              }}
             />
             <kbd className="os-rail-search__kbd kbd kbd-xs">{searchShortcut}</kbd>
           </div>

--- a/webui/frontend/src/components/__tests__/AgentSidebarCollapsedSearch.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebarCollapsedSearch.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import AgentSidebar from '../AgentSidebar'
+
+describe('BUG #703: Collapsed rail search icon click opens Search palette', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ results: [] }),
+      } as Response),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('clicking the magnifying glass icon in expanded rail opens search palette', () => {
+    const onOpenSearch = vi.fn()
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AgentSidebar open={true} onOpenSearch={onOpenSearch} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    const searchIcon = screen.getByTestId('rail-search-icon')
+    fireEvent.click(searchIcon)
+    expect(onOpenSearch).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking search trigger in collapsed/avatar-only rail opens search palette', () => {
+    // Set rail width to avatar-only threshold (e.g. 68px)
+    localStorage.setItem('swarm_rail_width', '68')
+    const onOpenSearch = vi.fn()
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AgentSidebar open={true} onOpenSearch={onOpenSearch} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    const trigger = screen.getByTestId('rail-search-trigger')
+    expect(trigger).toHaveAttribute('role', 'button')
+    expect(trigger).toHaveAttribute('tabindex', '0')
+
+    const searchIcon = screen.getByTestId('rail-search-icon')
+    fireEvent.click(searchIcon)
+    expect(onOpenSearch).toHaveBeenCalledTimes(1)
+
+    // Also verify pressing Enter on the trigger opens search palette
+    fireEvent.keyDown(trigger, { key: 'Enter' })
+    expect(onOpenSearch).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## BUG — Search unusable when rail collapsed

Fixes #703

### Intent
Search remains reachable in icon-only / fully collapsed rail via the magnifier (and existing Ctrl-K if present).

### Success
1. Click magnifying-glass (or the collapsed search control) opens the same Search palette as focusing the expanded Search field / Ctrl-K.
2. Fully collapsed rail: Search is usable (opens palette; not a dead icon).
3. Expanded rail: icon click still opens/focuses Search (doesn’t no-op).
4. RTL both widths; `Fixes` this Issue.

### Constraints
SPA chrome. Don’t break DnD or + add-agent beside Search. No secrets. Own-diff CI. agy-friendly / priority polish.

Ready to squash. SHA: 50eba133