### PR TITLE
fix(webui): update top navbar title on agent rename in real time (Fixes #697)

### DIFF
--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -98,7 +98,7 @@ import {
 import { isExperimentalEnabled } from '../experimental/flags'
 import { ChatMessageActions } from '../experimental/ChatMessageActions'
 import { agentRole, exampleRoleAgents, isChiefOfStaff, isExampleRole } from '../lib/agentRoles'
-import { assignedBlueprintId, AGENT_EDITS_CHANGED_EVENT } from '../lib/agentEdits'
+import { assignedBlueprintId, AGENT_EDITS_CHANGED_EVENT, editedAgentLabel } from '../lib/agentEdits'
 import {
   agentLabel,
   defaultBlueprintId,
@@ -324,19 +324,18 @@ const ChatPage = () => {
   const selectedCli = cliAgents.find((row) => row.id === selectedBlueprint)
   const selectedAgent = blueprints.find((bp) => bp.id === selectedBlueprint)
   const runtimeBlueprint = teamFromUrl ? '' : assignedBlueprintId(selectedBlueprint)
+  const fallbackAgentName =
+    selectedAgent?.name ||
+    selectedCli?.name ||
+    (selectedBlueprint === SUPPORT_AGENT_ID ? 'Support' : selectedBlueprint)
   const selectedAgentName = teamFromUrl
     ? selectedTeamSession?.name || selectedTeam?.name || teamFromUrl
     : remoteFromUrl
       ? selectedRemoteSession?.name || selectedRemote?.title || remoteFromUrl
-      : selectedBlueprint === 'api_agent'
-        ? 'api_agent'
-        : selectedCli
-        ? selectedCli.name
-        : selectedAgent
-          ? agentLabel(selectedAgent)
-          : selectedBlueprint === SUPPORT_AGENT_ID
-            ? 'Support'
-            : selectedBlueprint
+      : editedAgentLabel({
+          id: selectedBlueprint,
+          name: fallbackAgentName,
+        })
   const signInHref = chatLoginHref(searchParams)
 
   const isRemoteBackedTeam = Boolean(

--- a/webui/frontend/src/pages/__tests__/ChatPageNavbarRename.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPageNavbarRename.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import { ToastProvider } from '../../components/DaisyUI'
+import { saveAgentEdit } from '../../lib/agentEdits'
+import ChatPage from '../ChatPage'
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  url: string
+  readyState = 0
+  onopen: ((e?: unknown) => void) | null = null
+  onclose: ((e?: unknown) => void) | null = null
+  onmessage: ((e: MessageEvent) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  open() {
+    this.readyState = 1
+    this.onopen?.()
+  }
+}
+
+describe('BUG #697: Agent rename updates rail and top navbar in real time', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    Element.prototype.scrollIntoView = vi.fn()
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ results: [] }),
+      } as Response),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('updates top navbar agent title immediately when selected agent is renamed', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    render(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/chat?blueprint=support']}>
+            <ChatPage />
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+
+    // Initially says Support
+    const headerIdentity = screen.getByTestId('selected-agent-header')
+    expect(headerIdentity).toHaveTextContent('Support')
+
+    // Now rename agent via saveAgentEdit (as done in right sidepane editor)
+    await act(async () => {
+      saveAgentEdit('support', { name: 'Super Concierge' })
+    })
+
+    // Navbar title updates immediately on the same frame without reselecting
+    expect(headerIdentity).toHaveTextContent('Super Concierge')
+    expect(screen.getByRole('button', { name: 'Open Super Concierge definition' })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## BUG — Navbar title stale after rename

Fixes #697

### Intent
One rename SoT — rail, navbar (and any “Current Agent” chrome) stay in sync while editing.

### Success
1. With agent A selected, change display name in the right editor → top navbar title / picker face updates **immediately** (same frame/reactivity as the left rail).
2. Switching away and back still shows the new name (persist already OK if rail is correct).
3. RTL: edit name → assert navbar text matches without reselect.
4. `Fixes` this Issue.

### Constraints
SPA chrome. Shared store / event — don’t fork a second name cache for navbar. No secrets. Own-diff CI. agy-friendly.

Ready to squash. SHA: b5970b7e