### PR TITLE
feat(webui): REQ-215 team stack mini-avatars bg-matching border

### DIFF
--- a/webui/frontend/src/components/AvatarStack.tsx
+++ b/webui/frontend/src/components/AvatarStack.tsx
@@ -1,4 +1,4 @@
-import { agentMarkColor, agentMarkIndex } from '../lib/hiddenAgents'
+import { agentMarkIndex } from '../lib/hiddenAgents'
 import AgentAvatar from './AgentAvatar'
 import {
   STACK_FACE_LIMIT,
@@ -78,7 +78,7 @@ export default function AvatarStack({
           data-role={face.role}
           title={face.name}
           style={{
-            backgroundColor: agentMarkColor(face.markId || face.id),
+            backgroundColor: 'transparent',
             overflow: 'hidden',
             ...(animate
               ? { animationDelay: `${stackAnimationDelayMs(face.startedAt, origin)}ms` }
@@ -91,6 +91,7 @@ export default function AvatarStack({
             alt={face.name || face.id}
             size="xs"
             className="w-full h-full flex items-center justify-center pointer-events-none"
+            style={{ background: 'transparent' }}
           />
         </span>
       ))}

--- a/webui/frontend/src/components/__tests__/AvatarStackBorder.test.tsx
+++ b/webui/frontend/src/components/__tests__/AvatarStackBorder.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import AvatarStack from '../AvatarStack'
+
+describe('REQ-215: Team stack mini-avatars — border matching bg, not grey circle', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders stacked mini avatars with transparent background instead of grey/mark colored disc', () => {
+    render(
+      <AvatarStack
+        faces={[
+          { id: 'codey', name: 'Codey', startedAt: 100 },
+          { id: 'stewie', name: 'Stewie', startedAt: 200 },
+        ]}
+      />,
+    )
+
+    const stackedAvatars = screen.getAllByTestId('os-stacked-avatar')
+    expect(stackedAvatars).toHaveLength(2)
+
+    for (const el of stackedAvatars) {
+      // Must not sit on a filled grey or mark-color disc plate
+      expect(el.style.backgroundColor).toBe('transparent')
+      // Must have the stacked face classes for outline / border matching background
+      expect(el).toHaveClass('os-stacked-avatar')
+      expect(el).toHaveClass('os-avatar-stack__face')
+      expect(el).toHaveClass('os-stacked-avatar--stacked')
+    }
+  })
+
+  it('renders clean outline with transparent container for custom upload avatars', () => {
+    render(
+      <AvatarStack
+        faces={[
+          {
+            id: 'custom-lead',
+            name: 'Custom Lead',
+            startedAt: 100,
+            avatarSrc: 'https://example.com/lead.png',
+          },
+        ]}
+      />,
+    )
+
+    const el = screen.getByTestId('os-stacked-avatar')
+    expect(el.style.backgroundColor).toBe('transparent')
+
+    const img = screen.getByRole('img', { hidden: true })
+    expect(img).toHaveAttribute('src', 'https://example.com/lead.png')
+  })
+
+  it('renders clean outline with transparent container for Blobs avatars', () => {
+    render(
+      <AvatarStack
+        faces={[
+          { id: 'blob-bot', name: 'Blob Bot', startedAt: 150 },
+        ]}
+      />,
+    )
+
+    const el = screen.getByTestId('os-stacked-avatar')
+    expect(el.style.backgroundColor).toBe('transparent')
+
+    const svg = el.querySelector('svg[data-avatar-theme="blobs"]')
+    expect(svg).not.toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #701

### Intent
Stacked team faces look like overlapping avatars with a bg-matching outline, not grey discs.

### Success
1. Mini stacked avatars have no grey circular fill behind/around them.
2. Each mini has a thin border/outline whose colour matches the sidepane/card background (adapts if theme changes).
3. Overlap / z-order still readable; works for Blobs and custom uploads.
4. Pinned multi-avatar stacks use the same treatment if they share the component.
5. Screenshot RTL; `Fixes` this Issue.

### Constraints
SPA chrome. Coordinate AvatarStack from #637. No secrets. Own-diff CI. agy-friendly.

### Changes
- Updated `AvatarStack.tsx` to remove `backgroundColor: agentMarkColor(...)` and use `transparent`, eliminating the filled colored/grey circular plate behind mini stacked avatars.
- Ensured nested `AgentAvatar` has a transparent background.
- Preserved `.os-avatar-stack__face` / `.os-stacked-avatar` border matching container background (`var(--color-base-100)`), adapting dynamically to theme.
- Added comprehensive unit tests in `AvatarStackBorder.test.tsx`.

Ready to squash. SHA: 9bb5666e