### PR TITLE
feat(webui): REQ-216 normal avatar for 1-member remote and team rows

### DIFF
--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -1145,6 +1145,9 @@ export default function AgentSidebar({
     const active = selectedTeamId === team.id
     const sessions = sessionsForTeam(team)
     const stacked = selectStackedFaces(stackFacesForTeam(team))
+    const totalMembers = team.members ? team.members.length : (stacked.faces.length + (stacked.remainder || 0))
+    const singleMember = totalMembers === 1
+    const singleFace = stacked.faces[0]
     const dragging = draggingId === hideId
     const dropping = dropTargetId === hideId
     const { snippet: teamSnippet, timestamp: teamTime } = getRowLastMessage(
@@ -1185,13 +1188,20 @@ export default function AgentSidebar({
         }}
         onContextMenu={(event) => openMenu(event, hideId, name, hidden, 'team', sessions)}
       >
-        <span className="relative inline-flex shrink-0 mt-0.5">
-          {stacked.faces.length > 0 ? (
+        <span className={`relative inline-flex shrink-0 ${singleMember ? 'mt-1.5' : 'mt-0.5'}`}>
+          {totalMembers >= 2 ? (
             <AvatarStack
               faces={stacked.faces}
               remainder={stacked.remainder}
               animate
               label={`${name} members`}
+            />
+          ) : singleMember && singleFace ? (
+            <AgentAvatar
+              src={singleFace.avatarSrc || singleFace.src}
+              agentId={singleFace.id}
+              alt={singleFace.name || name}
+              size="sm"
             />
           ) : (
             <span
@@ -1276,6 +1286,9 @@ export default function AgentSidebar({
     const dragging = draggingId === hideId
     const sessions = sessionsForRemote(remote)
     const stacked = selectStackedFaces(stackFacesForRemote(remote))
+    const totalMembers = remote.agents ? remote.agents.length : (stacked.faces.length + (stacked.remainder || 0))
+    const singleMember = totalMembers === 1
+    const singleFace = stacked.faces[0]
     const { snippet: remoteSnippet, timestamp: remoteTime } = getRowLastMessage(
       hideId,
       sessions as any,
@@ -1324,13 +1337,29 @@ export default function AgentSidebar({
         }}
         onContextMenu={(event) => openMenu(event, hideId, name, hidden, 'remote', sessions)}
       >
-        <span className="relative inline-flex shrink-0 mt-0.5">
-          <AvatarStack
-            faces={stacked.faces}
-            remainder={stacked.remainder}
-            animate
-            label={`${name} members`}
-          />
+        <span className={`relative inline-flex shrink-0 ${singleMember ? 'mt-1.5' : 'mt-0.5'}`}>
+          {totalMembers >= 2 ? (
+            <AvatarStack
+              faces={stacked.faces}
+              remainder={stacked.remainder}
+              animate
+              label={`${name} members`}
+            />
+          ) : singleMember && singleFace ? (
+            <AgentAvatar
+              src={singleFace.avatarSrc || singleFace.src}
+              agentId={singleFace.id}
+              alt={singleFace.name || name}
+              size="sm"
+            />
+          ) : (
+            <span
+              className="os-team-mark os-agent-team-icon flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-base-300 text-base-content/80"
+              aria-hidden="true"
+            >
+              <Users className="h-3.5 w-3.5" />
+            </span>
+          )}
           <span
             className="os-agent-role-badge badge badge-ghost badge-xs shrink-0 font-medium uppercase tracking-wide text-base-content/55"
             data-kind="remote"

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -1512,16 +1512,16 @@ describe('AgentSidebar stacked avatars (REQ-68)', () => {
     expect(delays).toContain('0ms')
   })
 
-  it('keeps a single-agent remote as one avatar (no stack)', async () => {
+  it('keeps a single-agent remote as one normal avatar (no mini stack)', async () => {
     renderSidebar()
     const list = await screen.findByRole('navigation', { name: 'Agent list' })
     const hermes = await within(list).findByRole('link', { name: /Hermes \(remote\)/ })
     expect(hermes).toHaveAttribute('data-stack-count', '1')
     expect(hermes).toHaveAttribute('data-remainder', '0')
-    const stack = within(hermes).getByLabelText('Hermes members')
-    expect(stack).toHaveAttribute('data-avatar-stack', 'false')
+    expect(within(hermes).queryByLabelText('Hermes members')).not.toBeInTheDocument()
     expect(within(hermes).queryByText(/^\+\d+$/)).not.toBeInTheDocument()
-    expect(hermes.querySelectorAll('.os-avatar-stack__face')).toHaveLength(1)
+    expect(hermes.querySelector('[data-agent-avatar]')).toBeInTheDocument()
+    expect(hermes.querySelectorAll('.os-avatar-stack__face')).toHaveLength(0)
   })
 
   it('labels OpenMousBot (not OMB) and stacks CoS + workers; left-click opens directly, right-click Select Agent opens picker', async () => {

--- a/webui/frontend/src/components/__tests__/SingleMemberTeamAvatar.test.tsx
+++ b/webui/frontend/src/components/__tests__/SingleMemberTeamAvatar.test.tsx
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import AgentSidebar from '../AgentSidebar'
+
+describe('REQ-216: Remote/team stack — normal avatar if 1 member; mini stack only for 2+', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    localStorage.clear()
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    global.fetch = vi.fn().mockImplementation(async (input: RequestInfo) => {
+      const url = String(input)
+      if (url.includes('/v1/preferences')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            object: 'user_preferences',
+            principal: 'session:test',
+            guest: true,
+            empty: true,
+            favourites: [],
+            hidden_agents: [],
+          }),
+        } as Response
+      }
+      if (url.includes('team_rosters') || url.includes('team-rosters')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            object: 'list',
+            data: [
+              {
+                id: 'solo-team',
+                name: 'Solo Team',
+                description: 'Team with 1 member',
+                members: [{ id: 'solo-bot', name: 'Solo Bot', role: 'lead' }],
+              },
+              {
+                id: 'duo-team',
+                name: 'Duo Team',
+                description: 'Team with 2 members',
+                members: [
+                  { id: 'bot-1', name: 'Bot 1', role: 'lead' },
+                  { id: 'bot-2', name: 'Bot 2', role: 'worker' },
+                ],
+              },
+            ],
+          }),
+        } as Response
+      }
+      if (url.includes('remotes')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: [
+              {
+                id: 'hermes',
+                title: 'Hermes',
+                configured: true,
+                agents: [{ id: 'hermes-1', name: 'Hermes', started_at: '2026-09-03T00:00:00Z' }],
+              },
+              {
+                id: 'duo-remote',
+                title: 'Duo Remote',
+                configured: true,
+                agents: [
+                  { id: 'r1', name: 'R1', started_at: '2026-09-03T00:00:00Z' },
+                  { id: 'r2', name: 'R2', started_at: '2026-09-03T00:00:01Z' },
+                ],
+              },
+            ],
+          }),
+        } as Response
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ object: 'list', data: [] }),
+      } as Response
+    })
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('renders single normal-size avatar (no mini stack) when team has only 1 member', async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AgentSidebar open />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const solo = await within(list).findByRole('link', { name: /Solo Team \(team\)/ })
+
+    // Solo team has 1 member -> single normal-size avatar, no AvatarStack
+    expect(solo).toHaveAttribute('data-stack-count', '1')
+    expect(within(solo).queryByLabelText('Solo Team members')).not.toBeInTheDocument()
+    expect(solo.querySelector('[data-agent-avatar]')).toBeInTheDocument()
+    expect(solo.querySelectorAll('.os-avatar-stack__face')).toHaveLength(0)
+    expect(within(solo).queryByText(/^\+\d+$/)).not.toBeInTheDocument()
+  })
+
+  it('renders mini stacked avatars when team has 2 or more members', async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AgentSidebar open />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const duo = await within(list).findByRole('link', { name: /Duo Team \(team\)/ })
+
+    // Duo team has 2 members -> mini stacked avatars
+    expect(duo).toHaveAttribute('data-stack-count', '2')
+    const stack = within(duo).getByLabelText('Duo Team members')
+    expect(stack).toHaveAttribute('data-avatar-stack', 'true')
+    expect(duo.querySelectorAll('.os-avatar-stack__face')).toHaveLength(2)
+  })
+
+  it('renders single normal-size avatar (no mini stack) when remote has only 1 member', async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AgentSidebar open />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const hermes = await within(list).findByRole('link', { name: /Hermes \(remote\)/ })
+
+    // Hermes has 1 member -> single normal-size avatar
+    expect(hermes).toHaveAttribute('data-stack-count', '1')
+    expect(within(hermes).queryByLabelText('Hermes members')).not.toBeInTheDocument()
+    expect(hermes.querySelector('[data-agent-avatar]')).toBeInTheDocument()
+    expect(hermes.querySelectorAll('.os-avatar-stack__face')).toHaveLength(0)
+  })
+
+  it('renders mini stacked avatars when remote has 2 or more members', async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AgentSidebar open />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const duoRemote = await within(list).findByRole('link', { name: /Duo Remote \(remote\)/ })
+
+    // Duo remote has 2 members -> mini stacked avatars
+    expect(duoRemote).toHaveAttribute('data-stack-count', '2')
+    const stack = within(duoRemote).getByLabelText('Duo Remote members')
+    expect(stack).toHaveAttribute('data-avatar-stack', 'true')
+    expect(duoRemote.querySelectorAll('.os-avatar-stack__face')).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
Fixes #704

### Intent
One-member remotes/teams look and align like ordinary agent rows; multi-member keeps the stack.

### Success
1. Member count == 1 (remote or team): render single normal-size avatar (same size/alignment as a plain API/CLI agent row).
2. Member count >= 2: render mini stacked avatars (chrome per #701 when that lands).
3. Collapsed + expanded rail both align with neighbouring non-team rows for the 1-member case.
4. RTL; `Fixes` this Issue.

### Constraints
SPA chrome. Coordinate AvatarStack. No secrets. Own-diff CI. agy-friendly.

### Changes
- Updated `renderTeamLink` and `renderRemoteLink` in `AgentSidebar.tsx` to inspect total member count.
- When member count == 1, renders `<AgentAvatar size="sm">` with `mt-1.5` aligning identically with standard agent rows.
- When member count >= 2, keeps mini stacked avatars via `<AvatarStack>`.
- Added unit tests in `SingleMemberTeamAvatar.test.tsx` and updated existing Hermes test.

Ready to squash. SHA: 12154501