### PR TITLE
feat(webui): shared left vertical alignment for unpinned agent labels (REQ-217)

### DIFF
--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -1017,11 +1017,11 @@ export default function AgentSidebar({
     ) : null
     const body = (
       <>
-        <span className="relative inline-flex shrink-0 mt-1.5">
+        <span className="os-agent-row__avatar-slot relative inline-flex shrink-0 items-center justify-center">
           {mark}
           {roleBadgeNode}
         </span>
-        <span className="min-w-0 flex-1">
+        <span className="os-agent-row__label-col min-w-0 flex-1">
           <span className="flex min-w-0 items-center justify-between gap-1.5">
             <span className="block truncate text-sm font-semibold leading-5">{name}</span>
             <span className="flex items-center gap-1 shrink-0">
@@ -1188,7 +1188,7 @@ export default function AgentSidebar({
         }}
         onContextMenu={(event) => openMenu(event, hideId, name, hidden, 'team', sessions)}
       >
-        <span className={`relative inline-flex shrink-0 ${singleMember ? 'mt-1.5' : 'mt-0.5'}`}>
+        <span className="os-agent-row__avatar-slot relative inline-flex shrink-0 items-center justify-center">
           {totalMembers >= 2 ? (
             <AvatarStack
               faces={stacked.faces}
@@ -1246,7 +1246,7 @@ export default function AgentSidebar({
             Team
           </span>
         </span>
-        <span className="min-w-0 flex-1">
+        <span className="os-agent-row__label-col min-w-0 flex-1">
           <span className="flex min-w-0 items-center justify-between gap-1.5">
             <span className="block truncate text-sm font-semibold leading-5">{name}</span>
             <span className="flex items-center gap-1 shrink-0">
@@ -1337,7 +1337,7 @@ export default function AgentSidebar({
         }}
         onContextMenu={(event) => openMenu(event, hideId, name, hidden, 'remote', sessions)}
       >
-        <span className={`relative inline-flex shrink-0 ${singleMember ? 'mt-1.5' : 'mt-0.5'}`}>
+        <span className="os-agent-row__avatar-slot relative inline-flex shrink-0 items-center justify-center">
           {totalMembers >= 2 ? (
             <AvatarStack
               faces={stacked.faces}
@@ -1379,7 +1379,7 @@ export default function AgentSidebar({
             Remote
           </span>
         </span>
-        <span className="min-w-0 flex-1">
+        <span className="os-agent-row__label-col min-w-0 flex-1">
           <span className="flex min-w-0 items-center justify-between gap-1.5">
             <span className="block truncate text-sm font-semibold leading-5">{name}</span>
             <span className="flex items-center gap-1 shrink-0">
@@ -1427,7 +1427,7 @@ export default function AgentSidebar({
               return (
                 <li key={`team-slot-${m.id}`}>
                   <span className="os-agent-row os-agent-row--team os-agent-row--nested">
-                    <span className="relative inline-flex shrink-0 mt-0.5">
+                    <span className="os-agent-row__avatar-slot relative inline-flex shrink-0 items-center justify-center">
                       <Users className="os-agent-team-icon h-4 w-4 shrink-0" aria-hidden="true" />
                       <span
                         className="os-agent-role-badge"
@@ -1466,7 +1466,7 @@ export default function AgentSidebar({
                         Team
                       </span>
                     </span>
-                    <span className="min-w-0 flex-1">
+                    <span className="os-agent-row__label-col min-w-0 flex-1">
                       <span className="block truncate text-sm font-semibold leading-5">
                         {m.team_id || m.id}
                       </span>

--- a/webui/frontend/src/components/__tests__/UnpinnedLabelAlignment.test.tsx
+++ b/webui/frontend/src/components/__tests__/UnpinnedLabelAlignment.test.tsx
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import AgentSidebar from '../AgentSidebar'
+
+describe('REQ-217: Unpinned agent labels — shared left vertical alignment', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    localStorage.clear()
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    global.fetch = vi.fn().mockImplementation(async (input: RequestInfo) => {
+      const url = String(input)
+      if (url.includes('/v1/preferences')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            object: 'user_preferences',
+            principal: 'session:test',
+            guest: true,
+            empty: true,
+            favourites: [],
+            hidden_agents: [],
+          }),
+        } as Response
+      }
+      if (url.includes('team_rosters') || url.includes('team-rosters')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            object: 'list',
+            data: [
+              {
+                id: 'solo-team',
+                name: 'Solo Team',
+                description: 'Team with 1 member',
+                members: [{ id: 'solo-bot', name: 'Solo Bot', role: 'lead' }],
+              },
+              {
+                id: 'multi-team',
+                name: 'Multi Team',
+                description: 'Team with 2 members',
+                members: [
+                  { id: 'bot-1', name: 'Bot 1', role: 'lead' },
+                  { id: 'bot-2', name: 'Bot 2', role: 'worker' },
+                ],
+              },
+            ],
+          }),
+        } as Response
+      }
+      if (url.includes('remotes')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            object: 'list',
+            data: [
+              {
+                id: 'remote-1',
+                title: 'Remote Cluster',
+                configured: true,
+                endpoint: 'http://localhost:9000',
+                agents: ['r1', 'r2'],
+              },
+            ],
+          }),
+        } as Response
+      }
+      if (url.includes('blueprints')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            object: 'list',
+            data: [
+              { id: 'codey', name: 'Codey', role: 'default', description: 'Writes code' },
+              { id: 'tester', name: 'Tester', role: 'support', description: 'Tests code' },
+            ],
+          }),
+        } as Response
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ object: 'list', data: [] }),
+      } as Response
+    })
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('renders all unpinned rows with shared os-agent-row__avatar-slot and os-agent-row__label-col', async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AgentSidebar open />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const codeyRow = await within(list).findByRole('link', { name: /codey/i })
+    const testerRow = await within(list).findByRole('link', { name: /tester/i })
+    const soloTeamRow = await within(list).findByRole('link', { name: /solo team/i })
+    const multiTeamRow = await within(list).findByRole('link', { name: /multi team/i })
+    const remoteRow = await within(list).findByRole('link', { name: /remote cluster/i })
+
+    const rows = [codeyRow, testerRow, soloTeamRow, multiTeamRow, remoteRow]
+
+    for (const row of rows) {
+      expect(row.className).toContain('os-agent-row')
+      const avatarSlot = row.querySelector('.os-agent-row__avatar-slot')
+      expect(avatarSlot).toBeInTheDocument()
+
+      const labelCol = row.querySelector('.os-agent-row__label-col')
+      expect(labelCol).toBeInTheDocument()
+
+      // The label column starts immediately after the avatar slot in the DOM
+      expect(avatarSlot?.nextElementSibling).toBe(labelCol)
+    }
+  })
+})

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -515,6 +515,23 @@ html[data-theme="light"] #root {
   color: color-mix(in srgb, var(--color-base-content) 90%, transparent);
   transition: background-color 0.15s ease;
 }
+/* REQ-217: Unpinned agent labels — shared left vertical alignment across all avatar treatments */
+.os-agent-row__avatar-slot {
+  width: 2.25rem;
+  min-width: 2.25rem;
+  max-width: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  position: relative;
+  align-self: flex-start;
+  margin-top: 0.125rem;
+}
+.os-agent-row__label-col {
+  min-width: 0;
+  flex: 1 1 0%;
+}
 button.os-agent-row {
   width: 100%;
   background: transparent;
@@ -620,7 +637,8 @@ button.os-agent-row {
   padding-left: 0.25rem;
   padding-right: 0.25rem;
 }
-.os-agent-sidebar--avatar-only .os-agent-row > span.flex-1 {
+.os-agent-sidebar--avatar-only .os-agent-row > span.flex-1,
+.os-agent-sidebar--avatar-only .os-agent-row__label-col {
   display: none;
 }
 .os-agent-sidebar--avatar-only .os-fav-grid {


### PR DESCRIPTION
Fixes #705

## REQ-217: Unpinned agent labels — shared left vertical alignment

> **Intent:**
> Scanning the unpinned list, names form one clean left-aligned column.
>
> **Success:**
> 1. Unpinned rows share a common content grid: avatar slot (fixed width) + label column starting at the same x for every row.
> 2. Variable avatar treatments (1-up, stack, role overlay) do not shift the name left edge.
> 3. Activity stamp / unread / Alt hint stay on the right without shoving names.
> 4. Collapsed icon-only mode exempt or documented; expanded list must align.
> 5. Screenshot with mixed row types; Fixes this Issue. May close or absorb #669 if this fully fixes Support offset.
>
> **Constraints:**
> - SPA chrome. Pair with REQ-216. No secrets. Own-diff CI. agy-friendly.

Ready to squash. SHA: a207abe1161d9a2468307ba91811a21f7ae6e849