### PR TITLE
feat(webui): render real agent avatars in search palette (REQ-199)

### DIFF
--- a/webui/frontend/src/components/SearchPalette.tsx
+++ b/webui/frontend/src/components/SearchPalette.tsx
@@ -20,6 +20,7 @@ import { exampleRoleAgents } from '../lib/agentRoles'
 import { agentLabel } from '../lib/supportAgent'
 import { dispatchToggleTheme } from '../lib/theme'
 import { searchShortcutLabel } from '../lib/keybindingTips'
+import AgentAvatar from './AgentAvatar'
 
 export const SEARCH_PALETTE_TABS = [
   'All',
@@ -48,6 +49,8 @@ interface PaletteRow {
   href?: string
   overlay?: ChromeOverlay
   action?: () => void
+  agentId?: string
+  avatarPath?: string | null
 }
 
 export interface SearchPaletteProps {
@@ -82,6 +85,8 @@ export default function SearchPalette({ open, onClose }: SearchPaletteProps) {
       name: agentLabel(agent),
       description: agent.description || `${agentLabel(agent)} agent`,
       href: `/chat?blueprint=${encodeURIComponent(agent.id)}`,
+      agentId: agent.id,
+      avatarPath: agent.avatar_path,
     }))
     const actionRows: PaletteRow[] = [
       {
@@ -300,7 +305,13 @@ export default function SearchPalette({ open, onClose }: SearchPaletteProps) {
                 onMouseDown={(event) => event.preventDefault()}
                 onClick={() => choose(row)}
               >
-                <RowIcon tab={row.tab} id={row.id} />
+                <RowIcon
+                  tab={row.tab}
+                  id={row.id}
+                  agentId={row.agentId}
+                  avatarPath={row.avatarPath}
+                  name={row.name}
+                />
                 <span className="min-w-0 flex-1">
                   <span className="os-search-row__name">{row.name}</span>
                   <span className="os-search-row__desc">{row.description}</span>
@@ -321,12 +332,34 @@ export default function SearchPalette({ open, onClose }: SearchPaletteProps) {
   )
 }
 
-function RowIcon({ tab, id }: { tab: PaletteRow['tab']; id: string }) {
+function RowIcon({
+  tab,
+  id,
+  agentId,
+  avatarPath,
+  name,
+}: {
+  tab: PaletteRow['tab']
+  id: string
+  agentId?: string
+  avatarPath?: string | null
+  name?: string
+}) {
   if (tab === 'Bots') {
-    const mark = agentMarkIndex(id.replace(/^bot-/, ''))
+    const botId = agentId || id.replace(/^bot-/, '')
+    const mark = agentMarkIndex(botId)
     return (
-      <span className="os-search-row__icon" data-mark={String(mark)} aria-hidden="true">
-        <Bot className="h-4 w-4" />
+      <span
+        className="os-search-row__icon os-search-row__icon--avatar flex items-center justify-center shrink-0 !bg-transparent rounded-full overflow-hidden"
+        data-mark={String(mark)}
+        aria-hidden="true"
+      >
+        <AgentAvatar
+          src={avatarPath}
+          agentId={botId}
+          alt={name || botId}
+          size="sm"
+        />
       </span>
     )
   }

--- a/webui/frontend/src/components/__tests__/SearchPalette.test.tsx
+++ b/webui/frontend/src/components/__tests__/SearchPalette.test.tsx
@@ -249,4 +249,20 @@ describe('SearchPalette choose + actions (REQ-5c #322)', () => {
     expect(assign).not.toHaveBeenCalled()
     expect(screen.getByTestId('palette-loc')).toHaveTextContent('/')
   })
+
+  it('renders real agent avatars in search results instead of default bot icon (REQ-199)', async () => {
+    renderPalette()
+    const codeyRow = await screen.findByRole('option', { name: /Codey/i })
+    expect(codeyRow).toBeInTheDocument()
+
+    const avatarSlot = codeyRow.querySelector('.os-search-row__icon--avatar')
+    expect(avatarSlot).toBeInTheDocument()
+
+    // Real avatar component is rendered inside (e.g. data-agent-avatar)
+    const avatar = avatarSlot?.querySelector('[data-agent-avatar]')
+    expect(avatar).toBeInTheDocument()
+
+    // No generic Bot lucide icon inside the bot avatar slot
+    expect(avatarSlot?.querySelector('.lucide-bot')).toBeNull()
+  })
 })


### PR DESCRIPTION
Fixes #674

## REQ-199: Search palette — real agent avatars (not default bot icon)

> **Intent:**
> Search results match the rail visually so operators recognise agents by face, not a generic glyph.
>
> **Success:**
> 1. Every agent (and team member row if listed) in Search shows the same avatar asset the rail would for that seat.
> 2. Default bot icon only when the agent truly has no avatar configured (same fallback as rail).
> 3. Hidden-filtered Search (#646) also uses real avatars.
> 4. RTL or screenshot; Fixes this Issue.
>
> **Constraints:**
> - SPA chrome; reuse existing avatar component/theme store (coordinate #662 one avatar-theme store). No secrets. Own-diff CI. agy Wave 11/16 friendly.

Ready to squash. SHA: 7b5c1966a3d99d146db7bafe0e9d6d8a39a0efb9