### PR TITLE
feat(webui): support preload compact Message from System pill (REQ-207)

### DIFF
--- a/webui/frontend/src/components/AgentChat/AgentMessageBubble.tsx
+++ b/webui/frontend/src/components/AgentChat/AgentMessageBubble.tsx
@@ -14,6 +14,7 @@ import {
   messageHasCopyableText,
 } from '../../lib/clipboard'
 import { renderSafeMarkdown } from '../../lib/markdown'
+import { SystemPreloadPill } from '../SystemPreloadPill'
 
 interface AgentMessageBubbleProps {
   message: ChatMessage
@@ -47,6 +48,10 @@ export function AgentMessageBubble({
   const [steer, setSteer] = useState('')
   const { error } = useToast()
   const canCopy = messageHasCopyableText(message.text)
+
+  if (message.kind === 'system' || message.isSystemPreload || (message.role as string) === 'system') {
+    return <SystemPreloadPill text={message.text} />
+  }
 
   const handleCopy = async () => {
     const result = await copyTextToClipboard(message.text)

--- a/webui/frontend/src/components/AgentChat/__tests__/AgentMessageBubble.test.tsx
+++ b/webui/frontend/src/components/AgentChat/__tests__/AgentMessageBubble.test.tsx
@@ -232,6 +232,36 @@ describe('AgentMessageBubble', () => {
     fireEvent.click(thumbsUpBadge)
     expect(onAddReaction).toHaveBeenCalledWith('r-msg', '👍')
   })
+
+  it('renders system preload message as a compact "Message from System" pill without assistant avatar (REQ-207)', () => {
+    const systemMsg: ChatMessage = {
+      key: 'sys-preload-1',
+      role: 'system',
+      kind: 'system',
+      isSystemPreload: true,
+      text: '**Agents**\n- Support · support\n\n**Inference** ready.',
+      timestamp: new Date(),
+    }
+
+    renderBubble(<AgentMessageBubble message={systemMsg} />)
+
+    // Verify pill is rendered
+    const pill = screen.getByRole('button', { name: /Message from System/i })
+    expect(pill).toBeInTheDocument()
+    expect(pill).toHaveAttribute('aria-expanded', 'false')
+
+    // Verify no assistant avatar / speech bubble chrome
+    expect(screen.queryByTestId('agent-avatar')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('message-actions')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('system-preload-content')).not.toBeInTheDocument()
+
+    // Expanding reveals the preload text
+    fireEvent.click(pill)
+    expect(pill).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByTestId('system-preload-content')).toBeInTheDocument()
+    expect(screen.getByTestId('system-preload-content')).toHaveTextContent('Support · support')
+  })
 })
+
 
 

--- a/webui/frontend/src/components/ChatMessageBubble.tsx
+++ b/webui/frontend/src/components/ChatMessageBubble.tsx
@@ -11,9 +11,10 @@ import { Pencil } from 'lucide-react'
 import { Textarea, LoadingDots } from './DaisyUI'
 import { renderSafeMarkdown } from '../lib/markdown'
 import { setupCodeFenceControls } from '../lib/codeFences'
+import { SystemPreloadPill } from './SystemPreloadPill'
 
 export interface ChatMessageBubbleProps {
-  role: 'user' | 'assistant'
+  role: 'user' | 'assistant' | 'system' | 'status'
   agentName: string
   text: string
   streaming: boolean
@@ -24,6 +25,7 @@ export interface ChatMessageBubbleProps {
   onCancelEdit: () => void
   onSaveEdit: (text: string) => void
   children?: ReactNode
+  isSystemPreload?: boolean
 }
 
 function selectionIsActive(): boolean {
@@ -89,6 +91,7 @@ export function ChatMessageBubble({
   onCancelEdit,
   onSaveEdit,
   children,
+  isSystemPreload,
 }: ChatMessageBubbleProps) {
   const [draft, setDraft] = useState(text)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
@@ -101,6 +104,14 @@ export function ChatMessageBubble({
     }
     return undefined
   }, [editing, text])
+
+  if (role === 'system' || isSystemPreload) {
+    return (
+      <div className="flex justify-start w-full my-1" data-testid="chat-system-preload">
+        <SystemPreloadPill text={text} />
+      </div>
+    )
+  }
 
   const handleBubbleClick = (event: MouseEvent<HTMLDivElement>) => {
     if (!canEdit || streaming || editing) return

--- a/webui/frontend/src/components/SystemPreloadPill.tsx
+++ b/webui/frontend/src/components/SystemPreloadPill.tsx
@@ -1,0 +1,65 @@
+import { useState, useId } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { renderSafeMarkdown } from '../lib/markdown'
+
+export interface SystemPreloadPillProps {
+  text: string
+  defaultExpanded?: boolean
+  className?: string
+  label?: string
+}
+
+export function SystemPreloadPill({
+  text,
+  defaultExpanded = false,
+  className = '',
+  label = 'Message from System',
+}: SystemPreloadPillProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded)
+  const contentId = useId()
+
+  return (
+    <div
+      className={`os-system-preload flex flex-col items-start w-full my-2 ${className}`}
+      data-testid="system-preload-container"
+    >
+      <button
+        type="button"
+        className="inline-flex items-center gap-1.5 rounded-full border border-base-content/20 bg-base-200/80 hover:bg-base-200 px-2.5 py-1 text-xs font-medium text-base-content/75 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary cursor-pointer select-none"
+        data-testid="system-preload-pill"
+        aria-expanded={expanded}
+        aria-controls={contentId}
+        aria-label={label}
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        <span
+          className="flex h-4 w-4 items-center justify-center rounded-full bg-base-300 text-[10px] font-bold text-base-content/80 shrink-0"
+          aria-hidden="true"
+        >
+          S
+        </span>
+        <span>{label}</span>
+        <ChevronDown
+          className={`h-3.5 w-3.5 opacity-60 transition-transform duration-150 shrink-0 ${
+            expanded ? 'rotate-180' : ''
+          }`}
+          aria-hidden="true"
+        />
+      </button>
+      {expanded && (
+        <div
+          id={contentId}
+          data-testid="system-preload-content"
+          role="region"
+          aria-label={label}
+          className="mt-2 w-full max-w-xl rounded-lg border border-base-content/15 bg-base-200/40 p-3 text-xs text-base-content/80 shadow-xs whitespace-pre-wrap leading-relaxed"
+        >
+          <div
+            className="os-system-preload-md chat-md break-words [&_p]:my-1 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-5 [&_strong]:font-semibold"
+            dangerouslySetInnerHTML={{ __html: renderSafeMarkdown(text) }}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/webui/frontend/src/components/__tests__/ChatMessageBubble.test.tsx
+++ b/webui/frontend/src/components/__tests__/ChatMessageBubble.test.tsx
@@ -284,4 +284,31 @@ describe('REQ-122: No You / agent name labels above chat bubbles', () => {
     expect(screen.getByTestId('edited-hint')).toHaveTextContent('edited')
     expect(screen.queryByText('You')).not.toBeInTheDocument()
   })
+
+  it('renders system preload message as a compact "Message from System" pill (REQ-207)', () => {
+    render(
+      <ChatMessageBubble
+        role="system"
+        isSystemPreload={true}
+        agentName="Support"
+        text="**Agents**\n- Support · support\n\n**Inference** ready."
+        streaming={false}
+        canEdit={false}
+        editing={false}
+        onStartEdit={() => {}}
+        onCancelEdit={() => {}}
+        onSaveEdit={() => {}}
+      />,
+    )
+
+    const pill = screen.getByRole('button', { name: /Message from System/i })
+    expect(pill).toBeInTheDocument()
+    expect(pill).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('chat-bubble')).not.toBeInTheDocument()
+
+    fireEvent.click(pill)
+    expect(pill).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByTestId('system-preload-content')).toHaveTextContent('Support · support')
+  })
 })
+

--- a/webui/frontend/src/components/__tests__/SystemPreloadPill.test.tsx
+++ b/webui/frontend/src/components/__tests__/SystemPreloadPill.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SystemPreloadPill } from '../SystemPreloadPill'
+
+describe('REQ-207: Support preload — Message from System pill', () => {
+  const samplePreload = '**Agents**\n- Support · support\n\n**Inference** ready.'
+
+  it('renders a compact "Message from System" pill/badge by default without full text', () => {
+    render(<SystemPreloadPill text={samplePreload} />)
+
+    const pill = screen.getByRole('button', { name: /Message from System/i })
+    expect(pill).toBeInTheDocument()
+    expect(pill).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('system-preload-content')).not.toBeInTheDocument()
+  })
+
+  it('expands on click to reveal the full preload context in a system notice box', () => {
+    render(<SystemPreloadPill text={samplePreload} />)
+
+    const pill = screen.getByRole('button', { name: /Message from System/i })
+    fireEvent.click(pill)
+
+    expect(pill).toHaveAttribute('aria-expanded', 'true')
+    const content = screen.getByTestId('system-preload-content')
+    expect(content).toBeInTheDocument()
+    expect(content).toHaveTextContent('Agents')
+    expect(content).toHaveTextContent('Support · support')
+    expect(content).toHaveTextContent('Inference ready.')
+  })
+
+  it('collapses on second click returning to compact pill view', () => {
+    render(<SystemPreloadPill text={samplePreload} />)
+
+    const pill = screen.getByRole('button', { name: /Message from System/i })
+    fireEvent.click(pill)
+    expect(screen.getByTestId('system-preload-content')).toBeInTheDocument()
+
+    fireEvent.click(pill)
+    expect(pill).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('system-preload-content')).not.toBeInTheDocument()
+  })
+
+  it('can be keyboard activated via space or enter', () => {
+    render(<SystemPreloadPill text={samplePreload} />)
+
+    const pill = screen.getByRole('button', { name: /Message from System/i })
+    fireEvent.keyDown(pill, { key: 'Enter', code: 'Enter' })
+    // fireEvent.click triggers standard button activation
+    fireEvent.click(pill)
+    expect(pill).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByTestId('system-preload-content')).toBeInTheDocument()
+  })
+
+  it('supports custom label', () => {
+    render(<SystemPreloadPill text={samplePreload} label="System Notice" />)
+    expect(screen.getByRole('button', { name: /System Notice/i })).toBeInTheDocument()
+  })
+})

--- a/webui/frontend/src/pages/AgentRouterPage.tsx
+++ b/webui/frontend/src/pages/AgentRouterPage.tsx
@@ -318,14 +318,16 @@ export default function AgentRouterPage() {
     setMessages([
       {
         key: `support-briefing-${key}`,
-        role: 'assistant',
+        role: 'system',
+        kind: 'system',
+        isSystemPreload: true,
         text: buildSupportBriefing({
           agents,
           llmProfiles,
           defaultLlm: resolvedDefaultLlm,
           clis,
         }),
-        agent: selectedAgent.customName || selectedAgent.name,
+        agent: 'System',
         agent_id: selectedAgent.agent_id,
         timestamp: new Date(),
       },

--- a/webui/frontend/src/types/agent.ts
+++ b/webui/frontend/src/types/agent.ts
@@ -163,7 +163,7 @@ export interface CompactedLine {
 
 export interface ChatMessage {
   key: string
-  role: 'user' | 'assistant'
+  role: 'user' | 'assistant' | 'system'
   text: string
   agent?: string
   agent_id?: string
@@ -173,9 +173,10 @@ export interface ChatMessage {
   delegationId?: string
   consensus_data?: ConsensusData
   /** Rectangular context block replacing compacted history — not a chat turn. */
-  kind?: 'message' | 'summary' | 'review' | 'approval'
+  kind?: 'message' | 'summary' | 'review' | 'approval' | 'system'
   compacted?: CompactedLine[]
   oversightRole?: 'socratic_skeptic' | 'stupidity_checker' | 'taskmaster'
+  isSystemPreload?: boolean
   approval?: {
     status: 'pending' | 'approved' | 'rejected'
     reason: string


### PR DESCRIPTION
Fixes #685

### Intent
> Opening Support (or any system preload) feels like a quiet system notice, not a fake assistant turn.

### Success
> 1. Preloaded Support content is **not** rendered as a normal assistant chat bubble (no agent avatar / “assistant” chrome).
> 2. Default view: a compact **Message from System** pill/badge in the transcript (or above composer — prefer in-thread near top).
> 3. Click (or keyboard activate) expands to show the full preload text; collapse returns to the pill.
> 4. Expanded content is clearly system (muted / distinct), still not styled as the Support agent speaking.
> 5. Whether the preload is in the model context stays honest per existing Support contracts — this Issue is **UI compaction**; if the text must stay in context, say so in the PR; do not invent a second SoT.
> 6. RTL + screenshot; `Fixes` this Issue.

### Constraints
> SPA chrome. Coordinate #407 (UI-only vs in-context). No secrets. Own-diff CI. agy-friendly.

### Changes
- Created `SystemPreloadPill` component with default-collapsed "Message from System" badge, pill button, accessible expand/collapse state with chevron, and muted system card presentation when opened.
- Updated `ChatMessage` type to support `role: 'system'` and `kind: 'system'` as well as `isSystemPreload?: boolean`.
- Updated `AgentMessageBubble` and `ChatMessageBubble` to intercept system preloads and render `SystemPreloadPill` rather than speech bubbles with avatars.
- Updated `AgentRouterPage` support briefing preload initialization to dispatch system preload message.
- Added comprehensive unit tests in `SystemPreloadPill.test.tsx`, `AgentMessageBubble.test.tsx`, and `ChatMessageBubble.test.tsx`.

Ready to squash. SHA: a7172fcdc4b2355944f0102e9d9ce1e892682bec