### PR TITLE
feat(webui): open Search palette filtered to hidden bots on Hidden Bots click (REQ-190)

### DIFF
--- a/webui/frontend/src/App.tsx
+++ b/webui/frontend/src/App.tsx
@@ -3,14 +3,14 @@ import { BrowserRouter as Router, Navigate, Route, Routes } from 'react-router-d
 import ChatPage from './pages/ChatPage'
 import AgentRouterPage from './pages/AgentRouterPage'
 import AgentSidebar from './components/AgentSidebar'
-import SearchPalette from './components/SearchPalette'
+import SearchPalette, { type SearchPaletteOptions } from './components/SearchPalette'
 import AgentEditor, { OPEN_AGENT_EDITOR_EVENT, type OpenAgentEditorDetail } from './components/AgentEditor'
 import SettingsSheet, {
   OPEN_SETTINGS_EVENT,
   type OpenSettingsDetail,
   type SettingsSection,
 } from './components/SettingsSheet'
-import { OPEN_LLM_PROFILES_EVENT } from './lib/chromeOverlay'
+import { OPEN_LLM_PROFILES_EVENT, OPEN_HIDDEN_EVENT } from './lib/chromeOverlay'
 import { RailChromeProvider, SwipeHint } from './components/RailChrome'
 import { ToastProvider } from './components/DaisyUI'
 import CommandPalette from './experimental/CommandPalette'
@@ -68,6 +68,7 @@ function App() {
   const [railOpen, setRailOpen] = useState(() => !isNarrowViewport())
   const [swipeHint, setSwipeHint] = useState(false)
   const [searchOpen, setSearchOpen] = useState(false)
+  const [searchOptions, setSearchOptions] = useState<SearchPaletteOptions | undefined>()
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [settingsDetail, setSettingsDetail] = useState<OpenSettingsDetail | null>(null)
   const [agentEditorOpen, setAgentEditorOpen] = useState(false)
@@ -126,7 +127,15 @@ function App() {
         setThemePreference(detail)
       }
     }
-    const onOpenSearch = () => setSearchOpen(true)
+    const onOpenSearch = (event: Event) => {
+      const detail = (event as CustomEvent<SearchPaletteOptions>).detail
+      setSearchOptions(detail)
+      setSearchOpen(true)
+    }
+    const onOpenHidden = () => {
+      setSearchOptions({ filterHidden: true, tab: 'Bots' })
+      setSearchOpen(true)
+    }
     const onOpenSettings = (event: Event) => {
       const detail = (event as CustomEvent<OpenSettingsDetail>).detail ?? {}
       setSettingsDetail(detail)
@@ -151,6 +160,7 @@ function App() {
     window.addEventListener(THEME_TOGGLE_EVENT, onToggle)
     window.addEventListener(THEME_SET_EVENT, onSet)
     window.addEventListener('swarm:open-search', onOpenSearch)
+    window.addEventListener(OPEN_HIDDEN_EVENT, onOpenHidden)
     window.addEventListener(OPEN_SETTINGS_EVENT, onOpenSettings)
     window.addEventListener(OPEN_LLM_PROFILES_EVENT, onOpenLlmProfiles)
     window.addEventListener(OPEN_AGENT_EDITOR_EVENT, onOpenAgentEditor)
@@ -159,6 +169,7 @@ function App() {
       window.removeEventListener(THEME_TOGGLE_EVENT, onToggle)
       window.removeEventListener(THEME_SET_EVENT, onSet)
       window.removeEventListener('swarm:open-search', onOpenSearch)
+      window.removeEventListener(OPEN_HIDDEN_EVENT, onOpenHidden)
       window.removeEventListener(OPEN_SETTINGS_EVENT, onOpenSettings)
       window.removeEventListener(OPEN_LLM_PROFILES_EVENT, onOpenLlmProfiles)
       window.removeEventListener(OPEN_AGENT_EDITOR_EVENT, onOpenAgentEditor)
@@ -169,7 +180,14 @@ function App() {
     <Router>
       <ToastProvider>
         {SHOW_COMMAND_PALETTE && <CommandPalette />}
-        <SearchPalette open={searchOpen} onClose={() => setSearchOpen(false)} />
+        <SearchPalette
+          open={searchOpen}
+          options={searchOptions}
+          onClose={() => {
+            setSearchOpen(false)
+            setSearchOptions(undefined)
+          }}
+        />
         <SettingsSheet
           isOpen={settingsOpen}
           onClose={() => setSettingsOpen(false)}

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -236,7 +236,6 @@ export default function AgentSidebar({
     hasHiddenAgentsStorage() ? loadHiddenAgentIds() : null,
   )
   const [pins, setPins] = useState<PinnedAgent[]>(() => loadOrSeedPinnedAgents())
-  const [hiddenOpen, setHiddenOpen] = useState(false)
   const [hoveringHidden, setHoveringHidden] = useState(false)
   const [pluginsOpen, setPluginsOpen] = useState(false)
   const [remotesPopupOpen, setRemotesPopupOpen] = useState(false)
@@ -1817,10 +1816,9 @@ export default function AgentSidebar({
               type="button"
               className="os-hide-drop__action os-hidden-bots-row group"
               aria-haspopup="dialog"
-              aria-expanded={hiddenOpen}
               aria-label={`Hidden Bots ${hiddenCount} (${hiddenCount} hidden)`}
               data-testid="os-hidden-bots-button"
-              onClick={() => setHiddenOpen(true)}
+              onClick={() => openSearchPalette({ filterHidden: true })}
               onMouseEnter={() => setHoveringHidden(true)}
               onMouseLeave={() => setHoveringHidden(false)}
             >
@@ -1908,82 +1906,6 @@ export default function AgentSidebar({
           </div>
         </div>
       </aside>
-
-      {hiddenOpen && (
-        <>
-          <button
-            type="button"
-            className="fixed inset-0 z-50 bg-black/45"
-            aria-label="Close hidden agents"
-            onClick={() => setHiddenOpen(false)}
-          />
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="os-hidden-agents-title"
-            className="fixed left-1/2 top-1/2 z-50 w-[20rem] max-w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-base-300 bg-base-100 p-4 shadow-2xl"
-          >
-            <div className="mb-3 flex items-center justify-between gap-2">
-              <h2 id="os-hidden-agents-title" className="text-sm font-semibold">
-                Hidden agents
-              </h2>
-              <button
-                type="button"
-                className="btn btn-ghost btn-xs btn-circle"
-                aria-label="Close hidden agents"
-                onClick={() => setHiddenOpen(false)}
-              >
-                <X className="h-4 w-4" aria-hidden="true" />
-              </button>
-            </div>
-            {hiddenCount === 0 ? (
-              <p className="text-sm text-base-content/60">No hidden agents.</p>
-            ) : (
-              <ul className="space-y-1">
-                {hiddenTeams.map((team) => (
-                  <li key={teamHideId(team.id)} className="flex items-center gap-2">
-                    <span className="min-w-0 flex-1 truncate text-sm">{team.name || team.id}</span>
-                    <button
-                      type="button"
-                      className="btn btn-ghost btn-xs"
-                      aria-label={`Unhide ${team.name || team.id}`}
-                      onClick={() => unhideAgent(teamHideId(team.id))}
-                    >
-                      Unhide
-                    </button>
-                  </li>
-                ))}
-                {hiddenRemotes.map((remote) => (
-                  <li key={remoteHideId(remote.id)} className="flex items-center gap-2">
-                    <span className="min-w-0 flex-1 truncate text-sm">{remote.title}</span>
-                    <button
-                      type="button"
-                      className="btn btn-ghost btn-xs"
-                      aria-label={`Unhide ${remote.title}`}
-                      onClick={() => unhideAgent(remoteHideId(remote.id))}
-                    >
-                      Unhide
-                    </button>
-                  </li>
-                ))}
-                {hiddenAgents.map((agent) => (
-                  <li key={agent.id} className="flex items-center gap-2">
-                    <span className="min-w-0 flex-1 truncate text-sm">{agentLabel(agent)}</span>
-                    <button
-                      type="button"
-                      className="btn btn-ghost btn-xs"
-                      aria-label={`Unhide ${agentLabel(agent)}`}
-                      onClick={() => unhideAgent(agent.id)}
-                    >
-                      Unhide
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        </>
-      )}
 
       {pluginsOpen && (
         <>

--- a/webui/frontend/src/components/SearchPalette.tsx
+++ b/webui/frontend/src/components/SearchPalette.tsx
@@ -15,7 +15,7 @@ import {
 import { fetchBlueprints } from '../lib/api'
 import { openChromeOverlay, type ChromeOverlay } from '../lib/chromeOverlay'
 import { openSettingsSheet } from './SettingsSheet'
-import { agentMarkIndex } from '../lib/hiddenAgents'
+import { agentMarkIndex, loadHiddenAgentIds, unhideAgentId } from '../lib/hiddenAgents'
 import { exampleRoleAgents } from '../lib/agentRoles'
 import { agentLabel } from '../lib/supportAgent'
 import { dispatchToggleTheme } from '../lib/theme'
@@ -37,8 +37,14 @@ export type SearchPaletteTab = (typeof SEARCH_PALETTE_TABS)[number]
 
 export const OPEN_SEARCH_EVENT = 'swarm:open-search'
 
-export function openSearchPalette(): void {
-  window.dispatchEvent(new CustomEvent(OPEN_SEARCH_EVENT))
+export interface SearchPaletteOptions {
+  filterHidden?: boolean
+  tab?: SearchPaletteTab
+  query?: string
+}
+
+export function openSearchPalette(options?: SearchPaletteOptions): void {
+  window.dispatchEvent(new CustomEvent(OPEN_SEARCH_EVENT, { detail: options }))
 }
 
 interface PaletteRow {
@@ -56,15 +62,18 @@ interface PaletteRow {
 export interface SearchPaletteProps {
   open: boolean
   onClose: () => void
+  options?: SearchPaletteOptions
 }
 
 function shortcutLabel(index: number): string {
   return `⌃${index + 1}`
 }
 
-export default function SearchPalette({ open, onClose }: SearchPaletteProps) {
+export default function SearchPalette({ open, onClose, options }: SearchPaletteProps) {
   const [query, setQuery] = useState('')
   const [tab, setTab] = useState<SearchPaletteTab>('All')
+  const [hiddenOnly, setHiddenOnly] = useState(false)
+  const [hiddenIds, setHiddenIds] = useState<string[]>(() => loadHiddenAgentIds())
   const [activeIdx, setActiveIdx] = useState(0)
   const inputRef = useRef<HTMLInputElement | null>(null)
   const dialogRef = useRef<HTMLDivElement | null>(null)
@@ -129,7 +138,10 @@ export default function SearchPalette({ open, onClose }: SearchPaletteProps) {
         tab: 'Actions',
         name: 'Hidden Bots',
         description: 'Unhide agents without leaving chat',
-        overlay: 'hidden',
+        action: () => {
+          setHiddenOnly(true)
+          setTab('Bots')
+        },
       },
       {
         id: 'action-computer',
@@ -152,25 +164,53 @@ export default function SearchPalette({ open, onClose }: SearchPaletteProps) {
   const visible = useMemo(() => {
     const q = query.trim().toLowerCase()
     return rows.filter((row) => {
-      if (tab !== 'All' && row.tab !== tab) return false
+      if (hiddenOnly) {
+        if (row.tab !== 'Bots') return false
+        if (!row.agentId || !hiddenIds.includes(row.agentId)) return false
+      } else {
+        if (tab !== 'All' && row.tab !== tab) return false
+      }
       if (!q) return true
       return (
         row.name.toLowerCase().includes(q) ||
         row.description.toLowerCase().includes(q)
       )
     })
-  }, [query, rows, tab])
+  }, [query, rows, tab, hiddenOnly, hiddenIds])
 
   useEffect(() => {
     setActiveIdx(0)
-  }, [query, tab, open])
+  }, [query, tab, open, hiddenOnly])
 
   useEffect(() => {
     if (!open) return
-    setQuery('')
-    setTab('All')
+    const ids = loadHiddenAgentIds()
+    setHiddenIds(ids)
+    if (options?.filterHidden) {
+      setHiddenOnly(true)
+      setTab('Bots')
+    } else {
+      setHiddenOnly(false)
+      setTab(options?.tab || 'All')
+    }
+    setQuery(options?.query || '')
     requestAnimationFrame(() => inputRef.current?.focus())
-  }, [open])
+  }, [open, options])
+
+  useEffect(() => {
+    const handleOpen = (e: Event) => {
+      const detail = (e as CustomEvent<SearchPaletteOptions>).detail
+      if (detail?.filterHidden) {
+        setHiddenOnly(true)
+        setTab('Bots')
+      } else if (detail?.tab) {
+        setTab(detail.tab)
+      }
+      if (detail?.query !== undefined) setQuery(detail.query)
+    }
+    window.addEventListener(OPEN_SEARCH_EVENT, handleOpen)
+    return () => window.removeEventListener(OPEN_SEARCH_EVENT, handleOpen)
+  }, [])
 
   const choose = useCallback(
     (row: PaletteRow | undefined) => {
@@ -283,6 +323,26 @@ export default function SearchPalette({ open, onClose }: SearchPaletteProps) {
           })}
         </div>
 
+        {hiddenOnly && (
+          <div
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-base-200/50 border-b border-base-300 text-xs text-base-content/70"
+            data-testid="hidden-filter-indicator"
+          >
+            <span className="font-semibold text-primary">Filter:</span>
+            <span className="inline-flex items-center gap-1 rounded bg-base-300 px-2 py-0.5 font-medium text-base-content">
+              Hidden only
+              <button
+                type="button"
+                className="cursor-pointer hover:opacity-75 ml-0.5"
+                aria-label="Clear hidden filter"
+                onClick={() => setHiddenOnly(false)}
+              >
+                ×
+              </button>
+            </span>
+          </div>
+        )}
+
         <ul
           id="os-search-results"
           role="listbox"
@@ -290,7 +350,12 @@ export default function SearchPalette({ open, onClose }: SearchPaletteProps) {
           className="os-search-palette__list"
         >
           {visible.length === 0 ? (
-            <li className="os-search-empty">No results</li>
+            <li
+              className="os-search-empty"
+              data-testid={hiddenOnly ? 'search-empty-hidden' : undefined}
+            >
+              {hiddenOnly ? 'No hidden agents found' : 'No results'}
+            </li>
           ) : (
             visible.map((row, idx) => (
               <li
@@ -316,6 +381,22 @@ export default function SearchPalette({ open, onClose }: SearchPaletteProps) {
                   <span className="os-search-row__name">{row.name}</span>
                   <span className="os-search-row__desc">{row.description}</span>
                 </span>
+                {row.agentId && hiddenIds.includes(row.agentId) && (
+                  <button
+                    type="button"
+                    className="btn btn-ghost btn-xs text-xs z-10 mr-1"
+                    data-testid={`unhide-${row.agentId}`}
+                    aria-label={`Unhide ${row.name}`}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      const next = unhideAgentId(row.agentId!, hiddenIds)
+                      setHiddenIds(next)
+                      window.dispatchEvent(new Event('storage'))
+                    }}
+                  >
+                    Unhide
+                  </button>
+                )}
                 {idx < 9 && <kbd className="os-search-shortcut">{shortcutLabel(idx)}</kbd>}
               </li>
             ))

--- a/webui/frontend/src/components/__tests__/HiddenBotsSearch.test.tsx
+++ b/webui/frontend/src/components/__tests__/HiddenBotsSearch.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import SearchPalette, { OPEN_SEARCH_EVENT, openSearchPalette } from '../SearchPalette'
+import { HIDDEN_AGENTS_STORAGE_KEY } from '../../lib/hiddenAgents'
+
+function renderPalette(options?: { filterHidden?: boolean; tab?: any; query?: string }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const onClose = vi.fn()
+  const res = render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <SearchPalette open={true} onClose={onClose} options={options} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+  return { ...res, onClose }
+}
+
+describe('REQ-190: Hidden Bots opens Search palette filtered to hidden', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/v1/blueprints')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              data: [
+                { id: 'gate', name: 'Gate Agent', description: 'Safety gate', role: 'gate' },
+                { id: 'skeptic', name: 'Skeptic Agent', description: 'Reviewer', role: 'skeptic' },
+                { id: 'codey', name: 'Codey', description: 'Developer agent' },
+              ],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [] }),
+        } as Response
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it('openSearchPalette dispatches OPEN_SEARCH_EVENT with options', () => {
+    const spy = vi.fn()
+    window.addEventListener(OPEN_SEARCH_EVENT, spy)
+    openSearchPalette({ filterHidden: true })
+    expect(spy).toHaveBeenCalled()
+    const event = spy.mock.calls[0][0] as CustomEvent
+    expect(event.detail).toEqual({ filterHidden: true })
+    window.removeEventListener(OPEN_SEARCH_EVENT, spy)
+  })
+
+  it('displays Hidden only filter indicator and shows only hidden bots when filterHidden is true', async () => {
+    localStorage.setItem(HIDDEN_AGENTS_STORAGE_KEY, JSON.stringify(['gate', 'skeptic']))
+    renderPalette({ filterHidden: true })
+
+    const indicator = await screen.findByTestId('hidden-filter-indicator')
+    expect(indicator).toBeInTheDocument()
+    expect(indicator).toHaveTextContent('Hidden only')
+
+    // Gate and Skeptic should be shown
+    expect(await screen.findByText('Gate Agent')).toBeInTheDocument()
+    expect(screen.getByText('Skeptic Agent')).toBeInTheDocument()
+
+    // Codey (not hidden) should NOT be shown
+    expect(screen.queryByText('Codey')).not.toBeInTheDocument()
+  })
+
+  it('allows filtering within hidden bots via search input', async () => {
+    localStorage.setItem(HIDDEN_AGENTS_STORAGE_KEY, JSON.stringify(['gate', 'skeptic']))
+    renderPalette({ filterHidden: true })
+
+    await screen.findByText('Gate Agent')
+    const input = screen.getByRole('combobox', { name: 'Search' })
+    fireEvent.change(input, { target: { value: 'skep' } })
+
+    expect(screen.getByText('Skeptic Agent')).toBeInTheDocument()
+    expect(screen.queryByText('Gate Agent')).not.toBeInTheDocument()
+  })
+
+  it('displays Unhide button on hidden bot rows and clicking it unhides the agent', async () => {
+    localStorage.setItem(HIDDEN_AGENTS_STORAGE_KEY, JSON.stringify(['gate', 'skeptic']))
+    renderPalette({ filterHidden: true })
+
+    await screen.findByText('Gate Agent')
+    const unhideGateBtn = screen.getByTestId('unhide-gate')
+    expect(unhideGateBtn).toBeInTheDocument()
+
+    fireEvent.click(unhideGateBtn)
+
+    // Gate should now be removed from hidden list in localStorage
+    const remaining = JSON.parse(localStorage.getItem(HIDDEN_AGENTS_STORAGE_KEY) || '[]')
+    expect(remaining).not.toContain('gate')
+    expect(remaining).toContain('skeptic')
+
+    // Gate should disappear from the filtered list
+    expect(screen.queryByText('Gate Agent')).not.toBeInTheDocument()
+    expect(screen.getByText('Skeptic Agent')).toBeInTheDocument()
+  })
+
+  it('displays honest empty state when hidden set is empty', async () => {
+    localStorage.setItem(HIDDEN_AGENTS_STORAGE_KEY, JSON.stringify([]))
+    renderPalette({ filterHidden: true })
+
+    const empty = await screen.findByTestId('search-empty-hidden')
+    expect(empty).toBeInTheDocument()
+    expect(empty).toHaveTextContent('No hidden agents found')
+  })
+
+  it('clears hidden filter when clicking the × button on filter indicator', async () => {
+    localStorage.setItem(HIDDEN_AGENTS_STORAGE_KEY, JSON.stringify(['gate']))
+    renderPalette({ filterHidden: true })
+
+    const indicator = await screen.findByTestId('hidden-filter-indicator')
+    const clearBtn = within(indicator).getByRole('button', { name: /Clear hidden filter/i })
+    fireEvent.click(clearBtn)
+
+    // Filter indicator should disappear
+    expect(screen.queryByTestId('hidden-filter-indicator')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #646

### Intent
> One Search surface; Hidden Bots is a filter preset, not a second list widget.

### Success
> 1. Activating Hidden Bots opens the **existing Search palette** (or equivalent) with filter = **hidden only** (pre-applied; user can type to narrow further).
> 2. No separate tall popup listing all hidden names as the primary UI.
> 3. Unhide / select from results works; Esc closes; chat stays mounted.
> 4. Empty hidden set: honest empty state in the palette.
> 5. Tests: click Hidden Bots → palette open + hidden filter. `Fixes` this Issue.

### Constraints
> Reuse SearchPalette. Prefer agy. Coordinate #643 DnD highlight on the row. No secrets. GitHub then `:8001`.

### Changes
- Replaced the unwieldy tall popup modal in `AgentSidebar` with a call to `openSearchPalette({ filterHidden: true })`.
- Added support for `filterHidden` option in `SearchPalette` and wired `App.tsx` overlay listener.
- Rendered a "Filter: Hidden only" removable chip indicator when filtered to hidden bots.
- Filtered palette bot results strictly to hidden agent IDs, with live in-palette typing filter support.
- Added an "Unhide" button directly on hidden bot rows in the search results to easily unhide agents.
- Provided an honest empty state ("No hidden agents found") when the hidden set is empty or no matches exist.
- Added comprehensive unit tests in `HiddenBotsSearch.test.tsx`.

Ready to squash. SHA: 2254a4a814bd4337d1f3dc1b4aae0e8efec9be92