### PR TITLE
feat(webui): vertically align collapsed sidepane unpinned Support-role and peer rows (REQ-196)

### DIFF
--- a/webui/frontend/src/components/__tests__/CollapsedRailAlignment.test.tsx
+++ b/webui/frontend/src/components/__tests__/CollapsedRailAlignment.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+describe('REQ-196: Collapsed sidepane vertical alignment for Support and peer rows', () => {
+  it('defines vertical centering, matching row heights, and hides role badge in avatar-only mode', () => {
+    const cssPath = path.resolve(__dirname, '../../index.css')
+    const css = fs.readFileSync(cssPath, 'utf8')
+
+    // Expect .os-agent-sidebar--avatar-only .os-agent-row to have centering and height
+    const avatarOnlyRowMatch = css.match(
+      /\.os-agent-sidebar--avatar-only\s+\.os-agent-row\s*\{([^}]+)\}/
+    )
+    expect(avatarOnlyRowMatch).toBeTruthy()
+    const rowRules = avatarOnlyRowMatch![1]
+    expect(rowRules).toMatch(/justify-content:\s*center/)
+    expect(rowRules).toMatch(/align-items:\s*center/)
+    expect(rowRules).toMatch(/height:\s*2\.75rem/)
+
+    // Expect .os-agent-sidebar--avatar-only .os-agent-row__avatar-slot to center and reset margin
+    const avatarSlotMatch = css.match(
+      /\.os-agent-sidebar--avatar-only\s+\.os-agent-row__avatar-slot\s*\{([^}]+)\}/
+    )
+    expect(avatarSlotMatch).toBeTruthy()
+    const slotRules = avatarSlotMatch![1]
+    expect(slotRules).toMatch(/margin-top:\s*0/)
+    expect(slotRules).toMatch(/align-self:\s*center/)
+
+    // Expect .os-agent-sidebar--avatar-only .os-agent-role-badge to be hidden
+    const roleBadgeMatch = css.match(
+      /\.os-agent-sidebar--avatar-only\s+\.os-agent-role-badge\s*\{([^}]+)\}/
+    )
+    expect(roleBadgeMatch).toBeTruthy()
+    const badgeRules = roleBadgeMatch![1]
+    expect(badgeRules).toMatch(/display:\s*none/)
+  })
+})

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -689,10 +689,27 @@ button.os-agent-row {
 .os-agent-role-badge[data-kind="team"] { color: #6b7c8a; }
 
 /* REQ-116: Avatar-only rail mode when width <= AVATAR_ONLY_THRESHOLD */
+/* REQ-196: Collapsed sidepane — Support-role unpinned row vertically aligned with peers */
 .os-agent-sidebar--avatar-only .os-agent-row {
   justify-content: center;
+  align-items: center;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
+  min-height: 2.75rem;
+  height: 2.75rem;
+}
+.os-agent-sidebar--avatar-only .os-agent-row-wrap {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+}
+.os-agent-sidebar--avatar-only .os-agent-row__avatar-slot {
+  margin-top: 0;
+  align-self: center;
+}
+.os-agent-sidebar--avatar-only .os-agent-role-badge {
+  display: none;
 }
 .os-agent-sidebar--avatar-only .os-agent-row > span.flex-1,
 .os-agent-sidebar--avatar-only .os-agent-row__label-col {


### PR DESCRIPTION
Fixes #669

### Quoted Intent, Success, Constraints from #669
> **Intent:** Every collapsed-rail agent row (pinned or unpinned, any role) shares the same vertical center / row height so the list looks even.
>
> **Success:**
> 1. Collapsed sidepane: Support-role unpinned row aligns vertically with neighbouring non-Support rows (avatar centers and row boxes match).
> 2. No role (Support or other) adds extra top/bottom offset that shifts only that row.
> 3. Pinned + unpinned both checked; team/remote rows still OK.
> 4. Screenshot or RTL layout assert acceptable; `Fixes` this Issue.
>
> **Constraints:** SPA/DaisyUI chrome. Coordinate #630 (pills on small avatar — fix alignment there if that’s the cause). No secrets. Own-diff CI. agy-friendly.

### Changes
- Updated `.os-agent-sidebar--avatar-only .os-agent-row` to use consistent `align-items: center`, `justify-content: center`, and matching fixed height `2.75rem`.
- Reset `margin-top: 0` and `align-self: center` on `.os-agent-sidebar--avatar-only .os-agent-row__avatar-slot` across all rows.
- Set `display: none` for `.os-agent-role-badge` in collapsed rail mode (matching `.os-fav-tile__badge` hiding), preventing role text chips from shifting or offsetting Support or role rows.
- Added test in `webui/frontend/src/components/__tests__/CollapsedRailAlignment.test.tsx`.

Ready to squash. SHA: 6af7e9b1ebae1dfec8938173663aeaf090b8ef47