### PR TITLE
feat(webui): update blueprint copy to honest viewing instead of editing on read-only pre (REQ-188A-3)

### DIFF
--- a/webui/frontend/src/components/SettingsSheet.tsx
+++ b/webui/frontend/src/components/SettingsSheet.tsx
@@ -424,7 +424,7 @@ export function BlueprintEditorPane({ blueprintId }: { blueprintId: string }) {
         <p className="mt-1 text-sm text-base-content/70">
           {blueprintId ? (
             <>
-              Editing <span className="font-medium">{label}</span>
+              Viewing <span className="font-medium">{label}</span>
               {isExampleRole(role) ? (
                 <>
                   {' '}
@@ -433,7 +433,7 @@ export function BlueprintEditorPane({ blueprintId }: { blueprintId: string }) {
               ) : (
                 '.'
               )}{' '}
-              This editor opens the Python/API recipe (tools, prompts, code) — not the Teams roster.
+              This view displays the Python/API recipe (tools, prompts, code) — not the Teams roster.
             </>
           ) : (
             'Select a roled agent in the rail to open its blueprint.'

--- a/webui/frontend/src/components/__tests__/BlueprintViewingCopy.test.tsx
+++ b/webui/frontend/src/components/__tests__/BlueprintViewingCopy.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, expect, it } from 'vitest'
+import { BlueprintEditorPane } from '../SettingsSheet'
+import { ToastProvider } from '../DaisyUI'
+
+describe('REQ-188A-3: Blueprints must not claim Editing on read-only pre', () => {
+  it('renders honest Viewing copy instead of claiming Editing on read-only recipe', () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    render(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <BlueprintEditorPane blueprintId="support" />
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    // Should NOT claim "Editing Support"
+    expect(screen.queryByText(/Editing Support/i)).toBeNull()
+
+    // Should display honest "Viewing Support"
+    const desc = screen.getByText(/Viewing/i)
+    expect(desc).toHaveTextContent('Viewing Support')
+    expect(desc).toHaveTextContent('This view displays the Python/API recipe')
+  })
+})


### PR DESCRIPTION
Fixes #655

### Quoted Intent, Success, Constraints from #655
> **Intent:** Ensure Blueprint view in Settings does not claim "Editing" when displaying read-only recipe.
>
> **Success:**
> 1. Inspect/View copy or real editor+Save.
> 2. Copy states Viewing/Inspecting instead of Editing.
> 3. `Fixes` this Issue.
>
> **Constraints:** SPA chrome. No secrets. Own-diff CI. agy-friendly.

### Changes
- In `SettingsSheet.tsx`: updated Blueprint pane copy from `Editing {label}` to `Viewing {label}`, and updated explanatory text from `This editor opens...` to `This view displays the Python/API recipe (tools, prompts, code) — not the Teams roster.`
- Added unit test in `webui/frontend/src/components/__tests__/BlueprintViewingCopy.test.tsx` verifying honest viewing copy.

Ready to squash. SHA: 4ca57177573f0c13bb1fe578c7c9448834710ddf