### PR TITLE
feat(webui): token counter in top navbar beside model picker (REQ-201)

### DIFF
--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -1431,6 +1431,28 @@ const ChatPage = () => {
           </div>
         </div>
         <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="btn btn-ghost btn-xs h-auto p-1 gap-1.5 font-normal text-inherit hover:bg-base-300/40 normal-case shrink-0"
+            aria-label="Session token usage"
+            data-testid="token-meter-button"
+            onClick={() => setTokenDiagOpen(true)}
+          >
+            <div
+              className="h-1 w-14 overflow-hidden rounded-full bg-base-300"
+              role="meter"
+              aria-label="Tokens in context"
+              aria-valuemin={0}
+              aria-valuemax={CONTEXT_METER_TOKENS}
+              aria-valuenow={tokenCount}
+            >
+              <div
+                className="h-full rounded-full bg-base-content/45"
+                style={{ width: `${Math.max(tokenCount > 0 ? 4 : 0, tokenPct)}%` }}
+              />
+            </div>
+            <span className="tabular-nums whitespace-nowrap text-xs">{formatTokenCount(tokenCount)} tok</span>
+          </button>
           {showRemotesControl ? (
             <RemoteSelect
               remotes={remotesQuery.data}
@@ -1811,28 +1833,6 @@ const ChatPage = () => {
           </form>
 
           <footer className="os-chat-footer" aria-live="polite">
-            <button
-              type="button"
-              className="btn btn-ghost btn-xs h-auto p-0.5 gap-1.5 font-normal text-inherit hover:bg-base-300/40 normal-case"
-              aria-label="Session token usage"
-              data-testid="token-meter-button"
-              onClick={() => setTokenDiagOpen(true)}
-            >
-              <div
-                className="h-1 w-16 overflow-hidden rounded-full bg-base-300"
-                role="meter"
-                aria-label="Tokens in context"
-                aria-valuemin={0}
-                aria-valuemax={CONTEXT_METER_TOKENS}
-                aria-valuenow={tokenCount}
-              >
-                <div
-                  className="h-full rounded-full bg-base-content/45"
-                  style={{ width: `${Math.max(tokenCount > 0 ? 4 : 0, tokenPct)}%` }}
-                />
-              </div>
-              <span className="tabular-nums whitespace-nowrap">{formatTokenCount(tokenCount)} tok</span>
-            </button>
             {streamingMessage ? (
               <span className="flex items-center gap-1.5 min-w-0 truncate" data-testid="composer-working-indicator">
                 <AgentAvatar

--- a/webui/frontend/src/pages/__tests__/ChatScrollBottom.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatScrollBottom.test.tsx
@@ -69,12 +69,14 @@ describe('REQ-202: Chat scrollbar to page bottom; composer inside pane but non-s
     expect(bottomDock).toHaveClass('sticky')
     expect(bottomDock).toHaveClass('bottom-0')
 
-    // Both the composer input and the token footer live inside this sticky dock
+    // The composer input lives inside this sticky dock
     const composerInput = screen.getByRole('textbox', { name: 'Chat message' })
     expect(bottomDock).toContainElement(composerInput)
 
+    // Token meter lives in top navbar header per REQ-201
     const tokenButton = screen.getByTestId('token-meter-button')
-    expect(bottomDock).toContainElement(tokenButton)
+    const header = screen.getByRole('banner')
+    expect(header).toContainElement(tokenButton)
 
     // Messages container has bottom padding so last message remains readable above dock
     const messagesContainer = screen.getByTestId('chat-messages-container')

--- a/webui/frontend/src/pages/__tests__/ChatTokenMeterNavbar.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatTokenMeterNavbar.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import { ToastProvider } from '../../components/DaisyUI'
+import ChatPage from '../ChatPage'
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  url: string
+  readyState = 0
+  onopen: ((e?: unknown) => void) | null = null
+  onclose: ((e?: unknown) => void) | null = null
+  onmessage: ((e: MessageEvent) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  open() {
+    this.readyState = 1
+    this.onopen?.()
+  }
+}
+
+describe('REQ-201: Token counter in top navbar beside agent/model picker', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    Element.prototype.scrollIntoView = vi.fn()
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ results: [] }),
+      } as Response),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders token counter in top navbar header and removes duplicate from composer footer', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    render(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/chat?blueprint=support']}>
+            <ChatPage />
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+
+    const tokenButton = screen.getByTestId('token-meter-button')
+    expect(tokenButton).toBeInTheDocument()
+
+    // Token button is inside the top header (navbar)
+    const header = screen.getByRole('banner')
+    expect(header).toContainElement(tokenButton)
+
+    // No token meter button exists inside the bottom dock footer
+    const bottomDock = screen.getByTestId('chat-bottom-dock')
+    expect(bottomDock.querySelector('[data-testid="token-meter-button"]')).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #677

### Quoted Intent, Success, Constraints from #677
> **Intent:** Token count stays visible in a stable top-navbar slot beside the agent/model/effort control when switching agents.
>
> **Success:**
> 1. Token meter (`{n} tok` / existing quiet tabular style) lives in the **top navbar**, immediately **beside** the cascading picker (#676) — left or right of that control group, same row.
> 2. Removed from under-composer footer if still there; do not leave a duplicate meter.
> 3. If #338 left a centered meter in chat header only, relocate or merge so there is **one** meter next to the picker.
> 4. Same screen position across agents; name length does not shove tokens off-row.
> 5. `Fixes` this Issue. Coordinate #676 so both land as one navbar cluster if possible.
>
> **Constraints:** SPA chrome. Quiet Grok-ish styling. No secrets. Own-diff CI. **Priority for next agy wave**.

### Changes
- In `ChatPage.tsx`: moved `data-testid="token-meter-button"` into the top navbar control cluster (`.os-chat-header` right flex container) immediately preceding the dropdown controls.
- Removed duplicate token meter from `footer.os-chat-footer` under the composer.
- Added unit test in `webui/frontend/src/pages/__tests__/ChatTokenMeterNavbar.test.tsx` and updated `ChatScrollBottom.test.tsx`.

Ready to squash. SHA: b11a394c8e7e174092b77a76059e7fce9525e648