### PR TITLE
feat(webui): visible error UI with retry when /v1/system/ fails (REQ-188C-2)

### DIFF
--- a/webui/frontend/src/components/SettingsSheet.tsx
+++ b/webui/frontend/src/components/SettingsSheet.tsx
@@ -978,7 +978,7 @@ function SystemPane() {
     staleTime: 0,
     refetchOnMount: 'always',
   })
-  const facts = storeQuery.isError || !storeQuery.data ? EMPTY_LOCAL_STORE : storeQuery.data
+  const facts = storeQuery.data || EMPTY_LOCAL_STORE
   const sizeLabel =
     facts.created && facts.size_bytes > 0
       ? facts.size_label || formatStoreSize(facts.size_bytes)
@@ -998,6 +998,21 @@ function SystemPane() {
       </div>
       {storeQuery.isPending ? (
         <p className="text-sm text-base-content/60">Loading local database…</p>
+      ) : storeQuery.isError ? (
+        <div className="space-y-3" data-testid="system-store-error">
+          <Alert type="error" icon={<AlertCircle className="h-5 w-5" />}>
+            <span className="text-sm">
+              Failed to load local database facts. Check local daemon connection.
+            </span>
+          </Alert>
+          <button
+            type="button"
+            className="btn btn-sm btn-outline"
+            onClick={() => void storeQuery.refetch()}
+          >
+            Retry
+          </button>
+        </div>
       ) : (
         <dl className="space-y-3 text-sm">
           <div className="rounded-lg border border-base-300 bg-base-200/60 px-3 py-2">

--- a/webui/frontend/src/components/__tests__/SettingsSheet.test.tsx
+++ b/webui/frontend/src/components/__tests__/SettingsSheet.test.tsx
@@ -569,7 +569,17 @@ describe('SettingsSheet', () => {
   it('shows 0 and not created yet when the local store is missing', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockRejectedValue(new Error('offline')),
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          created: false,
+          size_bytes: 0,
+          path: '',
+          conversation_count: 0,
+          message_count: 0,
+        }),
+      } as Response),
     )
     renderSheet()
     fireEvent.click(screen.getByRole('button', { name: 'System' }))

--- a/webui/frontend/src/components/__tests__/SettingsSystemErrorState.test.tsx
+++ b/webui/frontend/src/components/__tests__/SettingsSystemErrorState.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import SettingsSheet from '../SettingsSheet'
+import { ToastProvider } from '../DaisyUI'
+
+describe('REQ-188C-2: Settings System must not look empty when /v1/system/ fails', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders visible error UI with retry button when GET /v1/system/ fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('Internal server error 500')),
+    )
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    render(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <SettingsSheet isOpen={true} onClose={vi.fn()} initialSection="system" />
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    // Should display the error UI
+    const errorContainer = await screen.findByTestId('system-store-error')
+    expect(errorContainer).toBeInTheDocument()
+    expect(errorContainer).toHaveTextContent(/Failed to load local database facts/i)
+
+    // Should have retry button
+    const retryBtn = screen.getByRole('button', { name: 'Retry' })
+    expect(retryBtn).toBeInTheDocument()
+
+    // Must NOT paint false "not created yet" or "0 B"
+    expect(screen.queryByText('not created yet')).toBeNull()
+  })
+
+  it('renders 0 and not created yet when local store returns honest missing 200 (created: false)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          created: false,
+          size_bytes: 0,
+          path: '',
+          conversation_count: 0,
+          message_count: 0,
+        }),
+      } as Response),
+    )
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    render(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <SettingsSheet isOpen={true} onClose={vi.fn()} initialSection="system" />
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    const notCreated = await screen.findAllByText('not created yet')
+    expect(notCreated.length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('Conversations').closest('div')).toHaveTextContent('0')
+    expect(screen.getByText('Messages').closest('div')).toHaveTextContent('0')
+    expect(screen.queryByTestId('system-store-error')).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #661

### Quoted Intent, Success, Constraints from #661
> **Intent:** Operators can tell a missing local store from a failed System fetch. Missing store stays `0` / “not created yet”. Errors are visible and retryable.
>
> **Success:**
> 1. Fetch/auth failure on `GET /v1/system/` does **not** paint `EMPTY_LOCAL_STORE` / “not created yet”.
> 2. Error UI is visible and offers retry (or equivalent).
> 3. Happy missing store (`created: false`, 200) still shows `0` / “not created yet” (#377 Success #4).
> 4. Vitest no longer asserts empty copy on fetch reject as “missing store”.
>
> **Constraints:** Keep the pane read-only (no vacuum/export here). No secrets. Do not reopen #377’s “do not say Django”. Frontend must handle both 5xx and honest empty 200.

### Changes
- In `SettingsSheet.tsx`: updated `SystemPane` so fetch/auth failure on `storeQuery.isError` displays an `Alert` error container (`data-testid="system-store-error"`) with a "Retry" button instead of masking errors as `EMPTY_LOCAL_STORE` / "not created yet".
- Preserved honest empty representation (`0 B`, `not created yet`, `0` counts) when the backend returns 200 with `created: false`.
- Updated test in `SettingsSheet.test.tsx` and added unit tests in `webui/frontend/src/components/__tests__/SettingsSystemErrorState.test.tsx`.

Ready to squash. SHA: 30fb5fc45e9a4f48b94fdb202868ef6c3b69a19d