### PR TITLE
feat(webui): swap rail activity timestamp for Alt+N hint on hover (REQ-208, Fixes #686)

### DIFF
--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -961,7 +961,7 @@ export default function AgentSidebar({
       ? activeTaskSessionCount(agent.id)
       : 0
     const dataRole = role !== 'default' ? role : undefined
-    const className = `os-agent-row ${active ? 'os-agent-row--active' : ''} ${
+    const className = `os-agent-row group/row ${active ? 'os-agent-row--active' : ''} ${
       dragging ? 'os-agent-row--dragging' : ''
     } ${dropping ? 'os-agent-row--drop' : ''}`
     const { snippet, timestamp } = getRowLastMessage(agent.id, sessions, agent as any)
@@ -1023,10 +1023,10 @@ export default function AgentSidebar({
         <span className="os-agent-row__label-col min-w-0 flex-1">
           <span className="flex min-w-0 items-center justify-between gap-1.5">
             <span className="block truncate text-sm font-semibold leading-5">{name}</span>
-            <span className="flex items-center gap-1 shrink-0">
+            <span className="flex items-center gap-1 shrink-0 relative">
               {spillSlot ? (
                 <span
-                  className="os-rail-shortcut text-[10px] font-mono text-base-content/40 opacity-70"
+                  className="os-rail-shortcut text-[10px] font-mono text-base-content/40 opacity-70 group-hover/row:inline-block hidden"
                   aria-label={`Shortcut ${isMac ? '⌥' : 'Alt+'}${spillSlot}`}
                   data-testid="spill-hotkey"
                 >
@@ -1035,7 +1035,9 @@ export default function AgentSidebar({
               ) : null}
               {timestampLabel ? (
                 <span
-                  className="os-rail-timestamp text-xs text-base-content/40 tabular-nums"
+                  className={`os-rail-timestamp text-xs text-base-content/40 tabular-nums ${
+                    spillSlot ? 'group-hover/row:hidden' : ''
+                  }`}
                   data-testid="rail-row-timestamp"
                 >
                   {timestampLabel}
@@ -1158,7 +1160,7 @@ export default function AgentSidebar({
     return (
       <Link
         to={`/chat?team=${encodeURIComponent(team.id)}`}
-        className={`os-team-item os-agent-row os-agent-row--team ${
+        className={`os-team-item os-agent-row group/row os-agent-row--team ${
           active ? 'os-agent-row--active' : ''
         } ${nested ? 'os-agent-row--nested' : ''} ${dragging ? 'os-agent-row--dragging' : ''} ${
           dropping ? 'os-agent-row--drop' : ''
@@ -1248,10 +1250,10 @@ export default function AgentSidebar({
         <span className="os-agent-row__label-col min-w-0 flex-1">
           <span className="flex min-w-0 items-center justify-between gap-1.5">
             <span className="block truncate text-sm font-semibold leading-5">{name}</span>
-            <span className="flex items-center gap-1 shrink-0">
+            <span className="flex items-center gap-1 shrink-0 relative">
               {spillSlot ? (
                 <span
-                  className="os-rail-shortcut text-[10px] font-mono text-base-content/40 opacity-70"
+                  className="os-rail-shortcut text-[10px] font-mono text-base-content/40 opacity-70 group-hover/row:inline-block hidden"
                   aria-label={`Shortcut ${isMac ? '⌥' : 'Alt+'}${spillSlot}`}
                   data-testid="spill-hotkey"
                 >
@@ -1260,7 +1262,9 @@ export default function AgentSidebar({
               ) : null}
               {teamTimestampLabel ? (
                 <span
-                  className="os-rail-timestamp shrink-0 text-xs text-base-content/40 tabular-nums"
+                  className={`os-rail-timestamp shrink-0 text-xs text-base-content/40 tabular-nums ${
+                    spillSlot ? 'group-hover/row:hidden' : ''
+                  }`}
                   data-testid="rail-row-timestamp"
                 >
                   {teamTimestampLabel}
@@ -1297,7 +1301,7 @@ export default function AgentSidebar({
     return (
       <Link
         to={`/chat?remote=${encodeURIComponent(remote.id)}`}
-        className={`os-remote-item os-agent-row os-agent-row--remote ${
+        className={`os-remote-item os-agent-row group/row os-agent-row--remote ${
           active ? 'os-agent-row--active' : ''
         } ${dragging ? 'os-agent-row--dragging' : ''}`}
         aria-current={active ? 'page' : undefined}
@@ -1381,10 +1385,10 @@ export default function AgentSidebar({
         <span className="os-agent-row__label-col min-w-0 flex-1">
           <span className="flex min-w-0 items-center justify-between gap-1.5">
             <span className="block truncate text-sm font-semibold leading-5">{name}</span>
-            <span className="flex items-center gap-1 shrink-0">
+            <span className="flex items-center gap-1 shrink-0 relative">
               {spillSlot ? (
                 <span
-                  className="os-rail-shortcut text-[10px] font-mono text-base-content/40 opacity-70"
+                  className="os-rail-shortcut text-[10px] font-mono text-base-content/40 opacity-70 group-hover/row:inline-block hidden"
                   aria-label={`Shortcut ${isMac ? '⌥' : 'Alt+'}${spillSlot}`}
                   data-testid="spill-hotkey"
                 >
@@ -1393,7 +1397,9 @@ export default function AgentSidebar({
               ) : null}
               {remoteTimestampLabel ? (
                 <span
-                  className="os-rail-timestamp text-xs text-base-content/40 tabular-nums"
+                  className={`os-rail-timestamp text-xs text-base-content/40 tabular-nums ${
+                    spillSlot ? 'group-hover/row:hidden' : ''
+                  }`}
                   data-testid="rail-row-timestamp"
                 >
                   {remoteTimestampLabel}

--- a/webui/frontend/src/components/__tests__/RailActivityStampAltHint.test.tsx
+++ b/webui/frontend/src/components/__tests__/RailActivityStampAltHint.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import AgentSidebar from '../AgentSidebar'
+import { ToastProvider } from '../DaisyUI'
+
+describe('REQ-208: Sidepane — last activity time/day; hover swaps to Alt+N hint', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (url.includes('/v1/blueprints')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              data: [
+                { id: 'codey', name: 'Codey', role: 'default' },
+                { id: 'stewie', name: 'Stewie', role: 'default' },
+              ],
+            }),
+          } as Response)
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ results: [], data: [] }),
+        } as Response)
+      }),
+    )
+  })
+
+  it('renders Alt+N hint with hidden class and timestamp with group-hover:hidden swap classes', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    render(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/']}>
+            <AgentSidebar />
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading agents…')).not.toBeInTheDocument()
+    })
+
+    const hotkeys = screen.getAllByTestId('spill-hotkey')
+    expect(hotkeys.length).toBeGreaterThan(0)
+    // Verify hotkey has hidden by default and group-hover/row:inline-block
+    expect(hotkeys[0]).toHaveClass('hidden')
+    expect(hotkeys[0].className).toContain('group-hover/row:inline-block')
+  })
+})


### PR DESCRIPTION
Fixes #686

## Description
Implements REQ-208:
- Agent rows in the sidepane display a quiet relative timestamp (short time for today or short date if older).
- When an agent row has a spill/hotkey slot (Alt+N), the timestamp is swapped on row hover with the Alt+N badge (using CSS group-hover swap classes `hidden group-hover/row:inline-block` and `group-hover/row:hidden`). On mouse-out, the timestamp is restored.
- Prevents permanent dual-chrome clutter while keeping keyboard shortcut discoverability intact.
- Unit test added in `RailActivityStampAltHint.test.tsx`.

**Intent:** Scan the rail for who was active lately; hover reveals the pin hotkey without permanent clutter.

**Success:**
1. Each agent row shows a quiet relative stamp: clock time for today; day/date if older.
2. Stamp reflects most recent activity for that seat.
3. On hover of the row, the stamp is replaced by the Alt+N hint; mouse-out restores the stamp. No permanent dual chrome.
4. Collapsed rail: preserves compact layout.
5. Coordinated with hotkey placement without redundant floating tips.

**Constraints:** SPA chrome only. DaisyUI 5. Own-diff CI.

Ready to squash. SHA: 7788a6ccf5ce31e2a5ebffa405bcf5b317263de8