### PR TITLE
feat(webui): distinct loading and error states for remotes catalog (REQ-188A-4, Fixes #656)

### DIFF
--- a/webui/frontend/src/components/SettingsSheet.tsx
+++ b/webui/frontend/src/components/SettingsSheet.tsx
@@ -634,133 +634,154 @@ function RemotesCatalogPane() {
         </p>
       </div>
 
-      {configured.length > 0 ? (
-        <RemoteSelect
-          remotes={catalog}
-          value={selectedId}
-          onChange={setSelectedId}
-          label="Remote"
-        />
-      ) : null}
+      {remotesQuery.isPending ? (
+        <p className="text-sm text-base-content/60" data-testid="remotes-loading">
+          Loading remotes…
+        </p>
+      ) : remotesQuery.isError ? (
+        <div className="space-y-3" data-testid="remotes-error">
+          <Alert type="error" icon={<AlertCircle className="h-5 w-5" />}>
+            <span className="text-sm">Failed to load remotes catalog.</span>
+          </Alert>
+          <button
+            type="button"
+            className="btn btn-sm btn-outline"
+            onClick={() => void remotesQuery.refetch()}
+          >
+            Retry
+          </button>
+        </div>
+      ) : (
+        <>
+          {configured.length > 0 ? (
+            <RemoteSelect
+              remotes={catalog}
+              value={selectedId}
+              onChange={setSelectedId}
+              label="Remote"
+            />
+          ) : null}
 
-      {configured.length === 0 && !adding ? (
-        <Alert type="info" icon={<Server className="h-5 w-5" />}>
-          <span className="text-sm">No remotes configured yet.</span>
-        </Alert>
-      ) : configured.length === 0 ? null : (
-        <ul className="space-y-2 os-scrollable-picker-list" aria-label="Configured remotes">
-          {configured.map((remote) => {
-            const label = remoteKindLabel(remote.kind || remote.id, kinds)
-            return (
-              <li
-                key={remote.id}
-                className="flex items-start justify-between gap-3 rounded-lg border border-base-300 bg-base-200/60 px-3 py-2"
+          {configured.length === 0 && !adding ? (
+            <Alert type="info" icon={<Server className="h-5 w-5" />}>
+              <span className="text-sm">No remotes configured yet.</span>
+            </Alert>
+          ) : configured.length === 0 ? null : (
+            <ul className="space-y-2 os-scrollable-picker-list" aria-label="Configured remotes">
+              {configured.map((remote) => {
+                const label = remoteKindLabel(remote.kind || remote.id, kinds)
+                return (
+                  <li
+                    key={remote.id}
+                    className="flex items-start justify-between gap-3 rounded-lg border border-base-300 bg-base-200/60 px-3 py-2"
+                  >
+                    <div className="min-w-0">
+                      <p className="font-medium">{label}</p>
+                      <p className="truncate font-mono text-xs text-base-content/60">
+                        {remote.base_url || 'localhost'}
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="xs"
+                      onClick={() => removeMutation.mutate(remote.id)}
+                      disabled={removeMutation.isPending}
+                    >
+                      Remove
+                    </Button>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+
+          {selected ? <RemoteOperatePane remote={selected} /> : null}
+
+          {adding ? (
+            <form className="space-y-3 rounded-box border border-base-300 p-3" onSubmit={handleAdd}>
+              <Select
+                label="Kind"
+                name="remote-kind"
+                size="sm"
+                value={kind}
+                onChange={(event) => setKind(event.target.value)}
               >
-                <div className="min-w-0">
-                  <p className="font-medium">{label}</p>
-                  <p className="truncate font-mono text-xs text-base-content/60">
-                    {remote.base_url || 'localhost'}
-                  </p>
-                </div>
+                {unused.length === 0 ? (
+                  <option value="" disabled>
+                    All kinds added
+                  </option>
+                ) : (
+                  unused.map((item) => (
+                    <option key={item.id} value={item.id}>
+                      {item.label}
+                    </option>
+                  ))
+                )}
+              </Select>
+              <Input
+                label="URL"
+                name="remote-url"
+                value={baseUrl}
+                onChange={(event) => setBaseUrl(event.target.value)}
+                placeholder={kind === 'swarm' ? 'http://127.0.0.1:9' : 'http://127.0.0.1:8802'}
+                autoComplete="off"
+                spellCheck={false}
+              />
+              {kind === 'swarm' ? (
+                <p className="text-sm text-base-content/70">
+                  Nested open-swarm is another process (own DB). Do not add this
+                  instance as its own remote.
+                </p>
+              ) : null}
+              <Input
+                label="API key env (optional)"
+                name="remote-api-key-env"
+                value={apiKeyEnv}
+                onChange={(event) => setApiKeyEnv(event.target.value)}
+                placeholder="OMB_API_KEY"
+                autoComplete="off"
+                spellCheck={false}
+              />
+              <Input
+                label="API key"
+                name="remote-api-key"
+                type="password"
+                value={apiKey}
+                onChange={(event) => setApiKey(event.target.value)}
+                placeholder="${API_KEY}"
+                autoComplete="off"
+                spellCheck={false}
+              />
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="submit"
+                  variant="primary"
+                  size="sm"
+                  disabled={!kind || addMutation.isPending}
+                >
+                  Save remote
+                </Button>
                 <Button
                   type="button"
                   variant="ghost"
-                  size="xs"
-                  onClick={() => removeMutation.mutate(remote.id)}
-                  disabled={removeMutation.isPending}
+                  size="sm"
+                  onClick={() => {
+                    setAdding(false)
+                    setApiKey('')
+                  }}
                 >
-                  Remove
+                  Cancel
                 </Button>
-              </li>
-            )
-          })}
-        </ul>
-      )}
-
-      {selected ? <RemoteOperatePane remote={selected} /> : null}
-
-      {adding ? (
-        <form className="space-y-3 rounded-box border border-base-300 p-3" onSubmit={handleAdd}>
-          <Select
-            label="Kind"
-            name="remote-kind"
-            size="sm"
-            value={kind}
-            onChange={(event) => setKind(event.target.value)}
-          >
-            {unused.length === 0 ? (
-              <option value="" disabled>
-                All kinds added
-              </option>
-            ) : (
-              unused.map((item) => (
-                <option key={item.id} value={item.id}>
-                  {item.label}
-                </option>
-              ))
-            )}
-          </Select>
-          <Input
-            label="URL"
-            name="remote-url"
-            value={baseUrl}
-            onChange={(event) => setBaseUrl(event.target.value)}
-            placeholder={kind === 'swarm' ? 'http://127.0.0.1:9' : 'http://127.0.0.1:8802'}
-            autoComplete="off"
-            spellCheck={false}
-          />
-          {kind === 'swarm' ? (
-            <p className="text-sm text-base-content/70">
-              Nested open-swarm is another process (own DB). Do not add this
-              instance as its own remote.
-            </p>
-          ) : null}
-          <Input
-            label="API key env (optional)"
-            name="remote-api-key-env"
-            value={apiKeyEnv}
-            onChange={(event) => setApiKeyEnv(event.target.value)}
-            placeholder="OMB_API_KEY"
-            autoComplete="off"
-            spellCheck={false}
-          />
-          <Input
-            label="API key"
-            name="remote-api-key"
-            type="password"
-            value={apiKey}
-            onChange={(event) => setApiKey(event.target.value)}
-            placeholder="${API_KEY}"
-            autoComplete="off"
-            spellCheck={false}
-          />
-          <div className="flex flex-wrap gap-2">
-            <Button
-              type="submit"
-              variant="primary"
-              size="sm"
-              disabled={!kind || addMutation.isPending}
-            >
-              Save remote
+              </div>
+            </form>
+          ) : (
+            <Button type="button" variant="outline" size="sm" onClick={() => setAdding(true)}>
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Add remote
             </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                setAdding(false)
-                setApiKey('')
-              }}
-            >
-              Cancel
-            </Button>
-          </div>
-        </form>
-      ) : (
-        <Button type="button" variant="outline" size="sm" onClick={() => setAdding(true)}>
-          <Plus className="h-4 w-4" aria-hidden="true" />
-          Add remote
-        </Button>
+          )}
+        </>
       )}
     </div>
   )

--- a/webui/frontend/src/components/__tests__/RemotesCatalogFetchStates.test.tsx
+++ b/webui/frontend/src/components/__tests__/RemotesCatalogFetchStates.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import SettingsSheet from '../SettingsSheet'
+import { ToastProvider } from '../DaisyUI'
+
+function renderSheet() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const onClose = vi.fn()
+  const view = render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <SettingsSheet isOpen={true} onClose={onClose} />
+      </ToastProvider>
+    </QueryClientProvider>,
+  )
+  return { ...view, onClose, client }
+}
+
+describe('REQ-188A-4: Remotes distinct loading, error, and empty states', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows loading indicator when GET /v1/remotes/ is pending', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/v1/remotes/')) {
+          // Never resolving promise to simulate pending fetch
+          return new Promise(() => {})
+        }
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ object: 'list', data: [] }),
+        } as Response)
+      }),
+    )
+
+    renderSheet()
+    fireEvent.click(screen.getByRole('button', { name: 'Remotes' }))
+
+    expect(screen.getByTestId('remotes-loading')).toHaveTextContent('Loading remotes…')
+    expect(screen.queryByText('No remotes configured yet.')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('remotes-error')).not.toBeInTheDocument()
+  })
+
+  it('shows error banner with retry button when GET /v1/remotes/ fails', async () => {
+    let callCount = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/v1/remotes/')) {
+          callCount += 1
+          if (callCount <= 2) {
+            return {
+              ok: false,
+              status: 500,
+              statusText: 'Internal Server Error',
+              text: async () => 'Database unreachable',
+            } as Response
+          }
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'list',
+              kinds: [{ id: 'omb', label: 'OpenMousBot' }],
+              configured: [],
+              data: [],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ object: 'list', data: [] }),
+        } as Response
+      }),
+    )
+
+    renderSheet()
+    fireEvent.click(screen.getByRole('button', { name: 'Remotes' }))
+
+    const errorContainer = await screen.findByTestId('remotes-error', undefined, { timeout: 4000 })
+    expect(errorContainer).toHaveTextContent('Failed to load remotes catalog.')
+    expect(screen.queryByText('No remotes configured yet.')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('remotes-loading')).not.toBeInTheDocument()
+
+    // Test retry
+    const retryBtn = screen.getByRole('button', { name: 'Retry' })
+    fireEvent.click(retryBtn)
+
+    await waitFor(() => {
+      expect(screen.getByText('No remotes configured yet.')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('remotes-error')).not.toBeInTheDocument()
+  })
+
+  it('shows honest empty state when GET /v1/remotes/ succeeds with zero configured remotes', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/v1/remotes/')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'list',
+              kinds: [{ id: 'omb', label: 'OpenMousBot' }],
+              configured: [],
+              data: [],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ object: 'list', data: [] }),
+        } as Response
+      }),
+    )
+
+    renderSheet()
+    fireEvent.click(screen.getByRole('button', { name: 'Remotes' }))
+
+    expect(await screen.findByText('No remotes configured yet.')).toBeInTheDocument()
+    expect(screen.queryByTestId('remotes-loading')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('remotes-error')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Add remote/i })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #656

## Description
Implements REQ-188A-4:
- Distinguishes pending/loading, error/failed, and healthy empty states in the Remotes pane in `SettingsSheet.tsx`.
- When GET `/v1/remotes/` is pending, renders `Loading remotes…`.
- When GET `/v1/remotes/` fails, renders an error Alert with a `Retry` button that triggers query refetch.
- When GET `/v1/remotes/` succeeds with 0 configured remotes, renders the informative `No remotes configured yet.` empty state.
- Adds comprehensive unit tests in `RemotesCatalogFetchStates.test.tsx`.

**Intent:** Avoid conflating a pending or broken fetch of /v1/remotes/ with a healthy empty catalog.

**Success:**
Distinct loading, error, and empty states.

**Constraints:** DaisyUI 5 / React SPA chrome only. Own-diff CI.

Ready to squash. SHA: db2cd86f607a5ce6e3cbda46ee7d3b470b1d952d