### PR TITLE
feat(webui): chat right-click reply with composer quote strip (REQ-198, Fixes #673)

### DIFF
--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Layers, Mic, PanelLeft, Pencil, Plus, Settings } from 'lucide-react'
+import { Layers, Mic, PanelLeft, Pencil, Plus, Reply, Settings } from 'lucide-react'
 import AgentAvatar from '../components/AgentAvatar'
 import { TOAST_KIND_WS_DISCONNECT, useToast } from '../components/DaisyUI'
 import ThemeToggle from '../components/ThemeToggle'
@@ -155,6 +155,19 @@ export {
   formatTokenCount,
 } from '../lib/chatMeter'
 
+interface ReplyTarget {
+  key: string
+  role: string
+  speaker: string
+  text: string
+}
+
+interface MessageContextMenuState {
+  x: number
+  y: number
+  message: ChatMessage
+}
+
 const ChatPage = () => {
   const [searchParams, setSearchParams] = useSearchParams()
   const { addToast, dismissByKind } = useToast()
@@ -184,6 +197,8 @@ const ChatPage = () => {
     Record<string, ConversationSummary[]>
   >({})
   const [input, setInput] = useState('')
+  const [replyTarget, setReplyTarget] = useState<ReplyTarget | null>(null)
+  const [contextMenu, setContextMenu] = useState<MessageContextMenuState | null>(null)
   const [slashDismissed, setSlashDismissed] = useState(false)
   const [slashSelectedIndex, setSlashSelectedIndex] = useState(0)
   const [recentSlashIds, setRecentSlashIds] = useState<string[]>(() => getRecentSlashIds())
@@ -295,6 +310,38 @@ const ChatPage = () => {
       }
     }
   }, [activeChatAgentId, conversationId, threadKey, threads])
+
+  useEffect(() => {
+    setReplyTarget(null)
+    setContextMenu(null)
+  }, [threadKey])
+
+  useEffect(() => {
+    if (!contextMenu) return
+    const handleKeyDown = (e: globalThis.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setContextMenu(null)
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [contextMenu])
+
+  const handleBubbleContextMenu = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>, message: ChatMessage) => {
+      if (message.streaming) return
+      if (typeof window !== 'undefined' && window.getSelection && !window.getSelection()?.isCollapsed) {
+        return
+      }
+      event.preventDefault()
+      setContextMenu({
+        x: event.clientX,
+        y: event.clientY,
+        message,
+      })
+    },
+    [],
+  )
 
   const blueprintsQuery = useQuery({
     queryKey: ['blueprints'],
@@ -1029,8 +1076,14 @@ const ChatPage = () => {
 
   const handleSend = (event: FormEvent) => {
     event.preventDefault()
-    sendText(input)
+    if (!canSend) return
+    const quotePrefix = replyTarget ? (replyTarget.speaker ? `> **${replyTarget.speaker}**: ` : `> `) : ''
+    const textToSend = replyTarget
+      ? `${quotePrefix}${replyTarget.text.replace(/\r\n/g, '\n').split('\n').join('\n> ')}\n\n${input}`
+      : input
+    sendText(textToSend)
     setInput('')
+    setReplyTarget(null)
   }
 
   // Dynamic skills loading for slash catalog (REQ-169)
@@ -1234,16 +1287,28 @@ const ChatPage = () => {
       }
     }
 
-    if (event.key === 'Escape' && input.length > 0) {
-      event.preventDefault()
-      setInput('')
-      return
+    if (event.key === 'Escape') {
+      if (replyTarget) {
+        event.preventDefault()
+        setReplyTarget(null)
+        return
+      }
+      if (input.length > 0) {
+        event.preventDefault()
+        setInput('')
+        return
+      }
     }
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault()
-      if (status === 'open') {
-        sendText(input)
+      if (status === 'open' && input.trim().length > 0) {
+        const quotePrefix = replyTarget ? (replyTarget.speaker ? `> **${replyTarget.speaker}**: ` : `> `) : ''
+        const textToSend = replyTarget
+          ? `${quotePrefix}${replyTarget.text.replace(/\r\n/g, '\n').split('\n').join('\n> ')}\n\n${input}`
+          : input
+        sendText(textToSend)
         setInput('')
+        setReplyTarget(null)
       }
     }
   }
@@ -1279,7 +1344,7 @@ const ChatPage = () => {
       ? formatElapsed(nowMs - streamStartedAtRef.current)
       : null
 
-  const composerPlaceholder = 'Message …'
+  const composerPlaceholder = replyTarget ? 'Reply…' : 'Message …'
 
   const statusLabel = useMemo(() => {
     if (status === 'open') return ''
@@ -1680,7 +1745,10 @@ const ChatPage = () => {
               !message.streaming &&
               (message.role === 'user' || message.role === 'assistant')
             return (
-              <div key={message.key}>
+              <div
+                key={message.key}
+                onContextMenu={(e) => handleBubbleContextMenu(e, message)}
+              >
                 <ChatMessageBubble
                   role={message.role}
                   agentName={selectedAgentName}
@@ -1752,79 +1820,110 @@ const ChatPage = () => {
                 onSelectItem={handleSelectSlashItem}
                 recentIds={recentSlashIds}
               />
-              <div className="os-composer">
-                <div className="relative" ref={plusRef}>
+              <div className={`os-composer ${replyTarget ? 'os-composer--reply flex-col items-stretch !rounded-2xl !p-2' : ''}`}>
+                {replyTarget && (
+                  <div
+                    className="flex items-center justify-between gap-2 px-2.5 py-1 text-xs text-base-content/70 border-b border-base-content/10 mb-1 w-full"
+                    data-testid="composer-reply-strip"
+                  >
+                    <div className="flex items-center gap-1.5 min-w-0 flex-1">
+                      <Reply className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden="true" />
+                      <span className="truncate" title={replyTarget.text}>
+                        {replyTarget.speaker ? (
+                          <strong className="font-semibold text-base-content/90 mr-1">
+                            {replyTarget.speaker}:
+                          </strong>
+                        ) : null}
+                        <span className="opacity-75">
+                          {replyTarget.text.replace(/\s+/g, ' ').slice(0, 100)}
+                        </span>
+                      </span>
+                    </div>
+                    <button
+                      type="button"
+                      className="btn btn-ghost btn-xs btn-circle h-5 w-5 min-h-0 text-base-content/60 hover:text-base-content"
+                      aria-label="Dismiss reply"
+                      data-testid="dismiss-reply-button"
+                      onClick={() => setReplyTarget(null)}
+                    >
+                      ×
+                    </button>
+                  </div>
+                )}
+                <div className={`flex items-center gap-1.5 min-h-0 ${replyTarget ? 'w-full' : 'flex-1'}`}>
+                  <div className="relative" ref={plusRef}>
+                    <button
+                      type="button"
+                      className="os-composer__icon"
+                      aria-label="Add"
+                      aria-haspopup="menu"
+                      aria-expanded={plusOpen}
+                      onClick={() => setPlusOpen((value) => !value)}
+                    >
+                      <Plus className="h-4 w-4" aria-hidden="true" />
+                    </button>
+                    {plusOpen && (
+                      <ul
+                        role="menu"
+                        aria-label="Chat actions"
+                        className="os-plus-menu"
+                      >
+                        <li role="none">
+                          <button
+                            type="button"
+                            role="menuitem"
+                            className="os-plus-menu__item"
+                            onClick={() => {
+                              void handleCompact()
+                            }}
+                          >
+                            <Layers className="h-4 w-4" aria-hidden="true" />
+                            Compact
+                          </button>
+                        </li>
+                      </ul>
+                    )}
+                  </div>
+                  <textarea
+                    ref={composerRef}
+                    rows={1}
+                    className="os-composer__input"
+                    placeholder={composerPlaceholder}
+                    value={input}
+                    onChange={handleInputChange}
+                    onKeyDown={handleComposerKeyDown}
+                    disabled={status !== 'open'}
+                    aria-label="Chat message"
+                    aria-haspopup="listbox"
+                    aria-expanded={isSlashOpen}
+                    aria-controls={isSlashOpen ? 'composer-slash-menu' : undefined}
+                  />
+                  {!input ? (
+                    <kbd
+                      className="os-composer__hint kbd kbd-xs"
+                      data-testid="composer-send-hint"
+                      title="Enter to send"
+                    >
+                      ↵
+                    </kbd>
+                  ) : (
+                    <kbd
+                      className="os-composer__hint kbd kbd-xs"
+                      data-testid="composer-clear-hint"
+                      title="Esc to clear"
+                    >
+                      Esc
+                    </kbd>
+                  )}
                   <button
                     type="button"
                     className="os-composer__icon"
-                    aria-label="Add"
-                    aria-haspopup="menu"
-                    aria-expanded={plusOpen}
-                    onClick={() => setPlusOpen((value) => !value)}
+                    aria-label="Voice input"
+                    onClick={handleMic}
                   >
-                    <Plus className="h-4 w-4" aria-hidden="true" />
+                    <Mic className="h-4 w-4" aria-hidden="true" />
                   </button>
-                  {plusOpen && (
-                    <ul
-                      role="menu"
-                      aria-label="Chat actions"
-                      className="os-plus-menu"
-                    >
-                      <li role="none">
-                        <button
-                          type="button"
-                          role="menuitem"
-                          className="os-plus-menu__item"
-                          onClick={() => {
-                            void handleCompact()
-                          }}
-                        >
-                          <Layers className="h-4 w-4" aria-hidden="true" />
-                          Compact
-                        </button>
-                      </li>
-                    </ul>
-                  )}
                 </div>
-                <textarea
-                  ref={composerRef}
-                  rows={1}
-                  className="os-composer__input"
-                  placeholder={composerPlaceholder}
-                  value={input}
-                  onChange={handleInputChange}
-                  onKeyDown={handleComposerKeyDown}
-                  disabled={status !== 'open'}
-                  aria-label="Chat message"
-                  aria-haspopup="listbox"
-                  aria-expanded={isSlashOpen}
-                  aria-controls={isSlashOpen ? 'composer-slash-menu' : undefined}
-                />
-                {!input ? (
-                  <kbd
-                    className="os-composer__hint kbd kbd-xs"
-                    data-testid="composer-send-hint"
-                    title="Enter to send"
-                  >
-                    ↵
-                  </kbd>
-                ) : (
-                  <kbd
-                    className="os-composer__hint kbd kbd-xs"
-                    data-testid="composer-clear-hint"
-                    title="Esc to clear"
-                  >
-                    Esc
-                  </kbd>
-                )}
-                <button
-                  type="button"
-                  className="os-composer__icon"
-                  aria-label="Voice input"
-                  onClick={handleMic}
-                >
-                  <Mic className="h-4 w-4" aria-hidden="true" />
-                </button>
               </div>
             </div>
             <button type="submit" className="sr-only" disabled={!canSend}>
@@ -1850,6 +1949,51 @@ const ChatPage = () => {
           </footer>
         </div>
       </div>
+
+      {contextMenu && (
+        <>
+          <div
+            className="fixed inset-0 z-40"
+            data-testid="context-menu-backdrop"
+            onClick={() => setContextMenu(null)}
+            onContextMenu={(e) => {
+              e.preventDefault()
+              setContextMenu(null)
+            }}
+          />
+          <div
+            role="menu"
+            aria-label="Message actions"
+            data-testid="message-context-menu"
+            className="fixed z-50 min-w-32 rounded-lg border border-base-300 bg-base-100 p-1 shadow-xl text-sm"
+            style={{
+              left: `${Math.min(contextMenu.x, typeof window !== 'undefined' ? window.innerWidth - 150 : 0)}px`,
+              top: `${Math.min(contextMenu.y, typeof window !== 'undefined' ? window.innerHeight - 80 : 0)}px`,
+            }}
+          >
+            <button
+              type="button"
+              role="menuitem"
+              className="flex w-full items-center gap-2 rounded px-3 py-1.5 text-left text-sm hover:bg-base-200 cursor-pointer"
+              data-testid="context-menu-reply"
+              onClick={() => {
+                setReplyTarget({
+                  key: contextMenu.message.key,
+                  role: contextMenu.message.role,
+                  speaker:
+                    contextMenu.message.role === 'user' ? 'You' : selectedAgentName,
+                  text: contextMenu.message.text,
+                })
+                setContextMenu(null)
+                composerRef.current?.focus()
+              }}
+            >
+              <Reply className="h-4 w-4 opacity-70" aria-hidden="true" />
+              Reply
+            </button>
+          </div>
+        </>
+      )}
 
       <TokenDiagnosticsModal
         isOpen={tokenDiagOpen}

--- a/webui/frontend/src/pages/__tests__/ChatReplyQuoteStrip.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatReplyQuoteStrip.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ToastProvider } from '../../components/DaisyUI'
+import ChatPage from '../ChatPage'
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  static instances: MockWebSocket[] = []
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  sentFrames: string[] = []
+
+  send = vi.fn((data: string) => {
+    this.sentFrames.push(data)
+  })
+  close = vi.fn(() => {
+    this.readyState = 3
+    this.onclose?.(new CloseEvent('close', { code: 1000 }))
+  })
+
+  url: string
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+}
+
+function deliverMockMessage(ws: MockWebSocket, text: string, id = 'message-response-1') {
+  ws.onmessage?.(
+    new MessageEvent('message', {
+      data: `<div id="message-list" hx-swap-oob="beforeend"><div id="${id}" class="assistant-message"></div></div>`,
+    }),
+  )
+  ws.onmessage?.(
+    new MessageEvent('message', {
+      data: `<div id="${id}" class="assistant-message" hx-swap-oob="true">${text}</div>`,
+    }),
+  )
+}
+
+describe('REQ-198: Chat right-click Reply — quote strip in composer, sent with user message', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    window.HTMLElement.prototype.scrollIntoView = vi.fn()
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/v1/blueprints')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              data: [{ id: 'support', name: 'Support', description: 'Support agent' }],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [] }),
+        } as Response
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('right-clicking a message opens context menu with Reply option, arming reply strip in composer', async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/chat?blueprint=support']}>
+            <ChatPage />
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    const ws = MockWebSocket.instances[0]
+    expect(ws).toBeDefined()
+
+    await act(async () => {
+      ws.open()
+      deliverMockMessage(ws, 'Checking the compact/compress Issues — sounds like it is ready')
+    })
+
+    const bubble = await screen.findByText(/Checking the compact\/compress Issues/i)
+    expect(bubble).toBeInTheDocument()
+
+    // Right-click on message bubble
+    fireEvent.contextMenu(bubble, { clientX: 200, clientY: 300 })
+
+    // Context menu should appear with Reply
+    const contextMenu = await screen.findByTestId('message-context-menu')
+    expect(contextMenu).toBeInTheDocument()
+    const replyBtn = screen.getByTestId('context-menu-reply')
+    expect(replyBtn).toBeInTheDocument()
+
+    // Click Reply
+    fireEvent.click(replyBtn)
+
+    // Context menu should close
+    expect(screen.queryByTestId('message-context-menu')).not.toBeInTheDocument()
+
+    // Reply strip should appear in composer
+    const replyStrip = await screen.findByTestId('composer-reply-strip')
+    expect(replyStrip).toBeInTheDocument()
+    expect(replyStrip).toHaveTextContent(/Checking the compact\/compress Issues/)
+
+    // Composer placeholder should be "Reply…"
+    const input = screen.getByRole('textbox', { name: 'Chat message' })
+    expect(input).toHaveAttribute('placeholder', 'Reply…')
+
+    // Dismiss with ×
+    const dismissBtn = screen.getByTestId('dismiss-reply-button')
+    fireEvent.click(dismissBtn)
+
+    // Reply strip is gone, placeholder restores to "Message …"
+    expect(screen.queryByTestId('composer-reply-strip')).not.toBeInTheDocument()
+    expect(input).toHaveAttribute('placeholder', 'Message …')
+  })
+
+  it('sending a message while reply is armed sends structured quote block on the wire', async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/chat?blueprint=support']}>
+            <ChatPage />
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    const ws = MockWebSocket.instances[0]
+    expect(ws).toBeDefined()
+
+    await act(async () => {
+      ws.open()
+      deliverMockMessage(ws, 'Existing answer text')
+    })
+
+    const bubble = await screen.findByText(/Existing answer text/i)
+    fireEvent.contextMenu(bubble, { clientX: 100, clientY: 100 })
+
+    const replyBtn = await screen.findByTestId('context-menu-reply')
+    fireEvent.click(replyBtn)
+
+    const input = screen.getByRole('textbox', { name: 'Chat message' })
+    fireEvent.change(input, { target: { value: 'Here is my followup' } })
+
+    // Send the message
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: false })
+
+    expect(ws.sentFrames.length).toBeGreaterThan(0)
+    const lastSent = JSON.parse(ws.sentFrames[ws.sentFrames.length - 1])
+    expect(lastSent.message).toContain('> **Support**: Existing answer text')
+    expect(lastSent.message).toContain('Here is my followup')
+
+    // Reply strip should be disarmed after send
+    expect(screen.queryByTestId('composer-reply-strip')).not.toBeInTheDocument()
+    expect(input).toHaveAttribute('placeholder', 'Message …')
+  })
+})


### PR DESCRIPTION
Fixes #673

## Description
Implements REQ-198:
- Right-clicking any chat bubble opens a context menu with **Reply**.
- Selecting Reply arms a quote strip at the top of the composer card displaying the reply icon, speaker, and snippet of the quoted message, with an `×` dismiss button.
- When armed, composer placeholder becomes `Reply…`.
- Sending the message prepends a markdown blockquote with the quoted message on the wire (`> **Speaker**: Quoted text\n\nUser message`) and automatically clears the reply state.
- Clicking `×` or pressing Escape disarms the reply state without sending.
- Respects active user text selection by keeping native context menu accessible when selecting text.
- Adds comprehensive unit tests in `ChatReplyQuoteStrip.test.tsx`.

**Intent:** Right-click anywhere in the chat pane; on a bubble, Reply quotes that message into the composer so the agent receives the quote with the user's send.

**Success:**
1. Right-click a user or assistant bubble → Reply available.
2. Armed reply shows the strip in the input card; × clears it.
3. On send, the agent receives the quoted message(s) alongside the new user text in markdown blockquote format.
4. Dismiss → send without quote.
5. Fixes this Issue.

**Constraints:** SPA chrome + chat send path. DaisyUI 5. Own-diff CI.

Ready to squash. SHA: b6caa7275fcb090715c806e86c5c61ae524096d0