### PR TITLE
fix(webui): small working avatar above composer, hover label only

### DIFF
--- a/webui/frontend/src/components/AgentAvatar.tsx
+++ b/webui/frontend/src/components/AgentAvatar.tsx
@@ -68,20 +68,17 @@ export default function AgentAvatar({
       <div
         className={`avatar ${className}`.trim()}
         data-agent-avatar="custom"
+        data-avatar-size={size}
         aria-hidden={alt ? undefined : true}
         style={style}
       >
-        <div
-          className={`os-agent-avatar os-agent-avatar--${size} rounded-full`}
-          style={size === 'xs' ? { width: '100%', height: '100%' } : undefined}
-        >
+        <div className={`os-agent-avatar os-agent-avatar--${size} rounded-full`}>
           <img
             src={customSrc}
             alt={alt}
             draggable={false}
             data-agent-avatar="custom"
             onError={() => setBroken(true)}
-            style={size === 'xs' ? { width: '100%', height: '100%', objectFit: 'cover' } : undefined}
           />
         </div>
       </div>
@@ -95,6 +92,7 @@ export default function AgentAvatar({
         className={`avatar ${className}`.trim()}
         data-agent-avatar="default"
         data-avatar-theme="blobs"
+        data-avatar-size={size}
         data-eye-state={active ? 'active' : 'idle'}
         aria-hidden={alt ? undefined : true}
         style={style}
@@ -104,7 +102,6 @@ export default function AgentAvatar({
           active={active}
           size={size}
           className=""
-          style={size === 'xs' ? { width: '100%', height: '100%' } : undefined}
         />
       </div>
     )
@@ -115,19 +112,16 @@ export default function AgentAvatar({
     <div
       className={`avatar ${className}`.trim()}
       data-agent-avatar="default"
+      data-avatar-size={size}
       aria-hidden={alt ? undefined : true}
       style={style}
     >
-      <div
-        className={`os-agent-avatar os-agent-avatar--${size} rounded-full`}
-        style={size === 'xs' ? { width: '100%', height: '100%' } : undefined}
-      >
+      <div className={`os-agent-avatar os-agent-avatar--${size} rounded-full`}>
         <img
           src={DEFAULT_AGENT_AVATAR_SRC}
           alt={alt}
           draggable={false}
           data-agent-avatar="default"
-          style={size === 'xs' ? { width: '100%', height: '100%', objectFit: 'cover' } : undefined}
         />
       </div>
     </div>

--- a/webui/frontend/src/components/BlobAvatar.tsx
+++ b/webui/frontend/src/components/BlobAvatar.tsx
@@ -88,10 +88,7 @@ export default function BlobAvatar({
       data-blob-shape={spec.shape}
       data-eye-state={eyeState}
       data-agent-id={agentId}
-      style={{
-        ...(size === 'xs' ? { width: '100%', height: '100%' } : {}),
-        ...style,
-      }}
+      style={style}
     >
       <BlobShapePath shape={spec.shape} color={spec.color} />
       <g

--- a/webui/frontend/src/components/__tests__/AgentAvatar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentAvatar.test.tsx
@@ -1,5 +1,7 @@
 import { afterEach, describe, it, expect } from 'vitest'
 import { fireEvent, render } from '@testing-library/react'
+import fs from 'node:fs'
+import path from 'node:path'
 import AgentAvatar, {
   DEFAULT_AGENT_AVATAR_SRC,
   agentAvatarKind,
@@ -97,5 +99,35 @@ describe('AgentAvatar', () => {
       'default',
     )
     expect(container.querySelector('img')).toHaveAttribute('src', DEFAULT_AGENT_AVATAR_SRC)
+  })
+
+  it('caps xs so it cannot fill an unbounded flex parent (#736)', () => {
+    const css = fs.readFileSync(path.resolve(__dirname, '../../index.css'), 'utf8')
+    expect(css).toMatch(/\.os-agent-avatar--xs\s*\{[^}]*max-width:\s*1\.5rem/)
+    expect(css).toMatch(/\.os-blob-avatar--xs\s*\{[^}]*max-width:\s*1\.5rem/)
+
+    const { container } = render(
+      <div style={{ display: 'flex', width: 400, height: 400 }}>
+        <AgentAvatar agentId="codey" size="xs" />
+      </div>,
+    )
+    const face = container.querySelector('[data-agent-avatar]')
+    expect(face).toHaveAttribute('data-avatar-size', 'xs')
+    const blob = container.querySelector('.os-blob-avatar')
+    expect(blob).toHaveClass('os-blob-avatar--xs')
+    expect(blob).not.toHaveStyle({ width: '100%', height: '100%' })
+  })
+
+  it('sizes a custom xs face with the capped class instead of 100% fill', () => {
+    const { container } = render(
+      <div style={{ display: 'flex', width: 400, height: 400 }}>
+        <AgentAvatar src="/avatars/codey_avatar.png" size="xs" alt="Codey" />
+      </div>,
+    )
+    const inner = container.querySelector('.os-agent-avatar')
+    expect(inner).toHaveClass('os-agent-avatar--xs')
+    expect(inner).not.toHaveStyle({ width: '100%', height: '100%' })
+    const img = container.querySelector('img')
+    expect(img).not.toHaveStyle({ width: '100%', height: '100%' })
   })
 })

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -248,6 +248,13 @@ html:not([data-theme="light"]) .os-chat-md a,
   height: 100%;
   object-fit: cover;
 }
+/* xs must stay capped — never inherit 100% of an unbounded flex parent (#736). */
+.os-agent-avatar--xs {
+  width: 1.5rem;
+  height: 1.5rem;
+  max-width: 1.5rem;
+  max-height: 1.5rem;
+}
 .os-agent-avatar--sm { width: 1.75rem; height: 1.75rem; }
 .os-agent-avatar--md { width: 2rem; height: 2rem; }
 .os-agent-avatar--lg { width: 2.5rem; height: 2.5rem; }
@@ -331,6 +338,12 @@ html:not([data-theme="light"]) .os-chat-md a,
   display: block;
   flex: 0 0 auto;
   overflow: visible;
+}
+.os-blob-avatar--xs {
+  width: 1.5rem;
+  height: 1.5rem;
+  max-width: 1.5rem;
+  max-height: 1.5rem;
 }
 .os-blob-avatar--sm {
   width: 2.15rem;
@@ -1273,6 +1286,30 @@ html[data-theme="light"] .os-code--collapsible.os-code--collapsed::after {
   padding: 0.35rem 1.1rem 0.7rem;
   font-size: 0.7rem;
   color: color-mix(in srgb, var(--color-base-content) 50%, transparent);
+}
+
+/* REQ-41 / #736: small working avatar immediately above the composer, no footer gap. */
+.os-composer-working {
+  display: flex;
+  align-items: center;
+  padding: 0.35rem 1.1rem 0;
+  min-height: 0;
+  line-height: 0;
+}
+.os-composer-working__tip {
+  display: inline-flex;
+  line-height: 0;
+}
+.os-composer-working__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  max-width: 1.5rem;
+  max-height: 1.5rem;
+  flex: 0 0 auto;
+  overflow: hidden;
 }
 
 /* REQ-143 / REQ-46: info/status/system chrome is full-pane centred — not a bubble. */

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -92,9 +92,9 @@ import {
 import {
   CONTEXT_METER_TOKENS,
   estimateTokensInContext,
-  formatElapsed,
   formatTokenCount,
 } from '../lib/chatMeter'
+import { workingLabel } from '../lib/chatBubble'
 import { isExperimentalEnabled } from '../experimental/flags'
 import { ChatMessageActions } from '../experimental/ChatMessageActions'
 import { agentRole, exampleRoleAgents, isChiefOfStaff, isExampleRole } from '../lib/agentRoles'
@@ -207,7 +207,6 @@ const ChatPage = () => {
   const [memberTarget, setMemberTarget] = useState(ALL_MEMBERS_TARGET)
   const [connectAttempt, setConnectAttempt] = useState(0)
   const [authRejected, setAuthRejected] = useState(false)
-  const [nowMs, setNowMs] = useState(() => Date.now())
   const [plusOpen, setPlusOpen] = useState(false)
   const [editingKey, setEditingKey] = useState<string | null>(null)
   const [agentKind, setAgentKind] = useState<AgentKind>(() =>
@@ -268,7 +267,6 @@ const ChatPage = () => {
   const backoffAttemptRef = useRef(0)
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const intentionalCloseRef = useRef(false)
-  const streamStartedAtRef = useRef<number | null>(null)
   const lastUserTextRef = useRef('')
   /** Last hydrated agent or team thread; used to clear bubbles only on switch. */
   const lastHydratedAgentRef = useRef<string | null>(null)
@@ -1192,17 +1190,6 @@ const ChatPage = () => {
       }
     }
   }, [streamingMessage, activeChatAgentId])
-  useEffect(() => {
-    if (!streamingMessage) {
-      streamStartedAtRef.current = null
-      return
-    }
-    if (streamStartedAtRef.current == null) {
-      streamStartedAtRef.current = Date.now()
-    }
-    const timer = window.setInterval(() => setNowMs(Date.now()), 1000)
-    return () => window.clearInterval(timer)
-  }, [streamingMessage])
 
   const handleCompact = useCallback(async () => {
     setPlusOpen(false)
@@ -1339,12 +1326,8 @@ const ChatPage = () => {
     () => messages.filter((m) => m.role === 'assistant').length,
     [messages],
   )
-  const streamElapsed =
-    streamingMessage && streamStartedAtRef.current != null
-      ? formatElapsed(nowMs - streamStartedAtRef.current)
-      : null
-
   const composerPlaceholder = replyTarget ? 'Reply…' : 'Message …'
+  const workingTip = workingLabel(selectedAgentName)
 
   const statusLabel = useMemo(() => {
     if (status === 'open') return ''
@@ -1809,6 +1792,27 @@ const ChatPage = () => {
           className="os-chat-bottom-dock sticky bottom-0 z-20 mt-auto -mx-2 sm:-mx-3 -mb-3 bg-base-100/95 backdrop-blur-xs border-t border-base-content/5"
           data-testid="chat-bottom-dock"
         >
+          {streamingMessage ? (
+            <div
+              className="os-composer-working"
+              data-testid="composer-working-indicator"
+              role="status"
+              aria-live="polite"
+              aria-label={workingTip}
+            >
+              <span className="tooltip tooltip-top os-composer-working__tip" data-tip={workingTip}>
+                <span className="os-composer-working__avatar">
+                  <AgentAvatar
+                    src={selectedAgent?.avatar_path}
+                    agentId={teamFromUrl || agentIdFromBlueprint(selectedBlueprint)}
+                    active={true}
+                    size="xs"
+                    className="shrink-0"
+                  />
+                </span>
+              </span>
+            </div>
+          ) : null}
           <form onSubmit={handleSend} className="os-composer-wrap">
             <div className="relative" ref={composerWrapRef}>
               <ComposerSlashPopup
@@ -1930,23 +1934,6 @@ const ChatPage = () => {
               Send
             </button>
           </form>
-
-          <footer className="os-chat-footer" aria-live="polite">
-            {streamingMessage ? (
-              <span className="flex items-center gap-1.5 min-w-0 truncate" data-testid="composer-working-indicator">
-                <AgentAvatar
-                  src={selectedAgent?.avatar_path}
-                  agentId={teamFromUrl || agentIdFromBlueprint(selectedBlueprint)}
-                  active={true}
-                  size="xs"
-                  className="shrink-0"
-                />
-                <span className="truncate">
-                  {selectedAgentName} · {streamElapsed ?? '0s'}
-                </span>
-              </span>
-            ) : null}
-          </footer>
         </div>
       </div>
 

--- a/webui/frontend/src/pages/__tests__/ComposerWorkingIndicator.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ComposerWorkingIndicator.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import ChatPage from '../ChatPage'
+import { ToastProvider } from '../../components/DaisyUI'
+import { resetConversationThreads } from '../../lib/chatMeter'
+import { workingLabel } from '../../lib/chatBubble'
+
+type WsHandler = ((ev?: Event) => void) | null
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  static instances: MockWebSocket[] = []
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: WsHandler = null
+  onmessage: WsHandler = null
+  onclose: WsHandler = null
+  send = vi.fn()
+  close = vi.fn()
+  url: string
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+}
+
+function renderChat(initialEntry = '/chat?blueprint=codey') {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <ChatPage />
+        </MemoryRouter>
+      </ToastProvider>
+    </QueryClientProvider>,
+  )
+}
+
+async function openSocket() {
+  await act(async () => {
+    MockWebSocket.instances[0]?.open()
+  })
+}
+
+async function startStream(id = 'message-response-work1') {
+  const ws = MockWebSocket.instances[0]!
+  await act(async () => {
+    ws.onmessage?.(
+      new MessageEvent('message', {
+        data: `<div id="message-list" hx-swap-oob="beforeend"><div id="${id}" class="assistant-message"></div></div>`,
+      }),
+    )
+  })
+}
+
+async function finishStream(id = 'message-response-work1', text = 'done') {
+  const ws = MockWebSocket.instances[0]!
+  await act(async () => {
+    ws.onmessage?.(
+      new MessageEvent('message', {
+        data: `<div id="${id}" class="assistant-message" hx-swap-oob="true">${text}</div>`,
+      }),
+    )
+  })
+}
+
+describe('REQ-41 / #736: composer working indicator', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [{ id: 'codey', name: 'Codey', description: 'Code assistant' }],
+        }),
+      } as Response),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    resetConversationThreads()
+  })
+
+  it('shows no composer working avatar while idle', async () => {
+    renderChat()
+    await openSocket()
+
+    expect(screen.queryByTestId('composer-working-indicator')).not.toBeInTheDocument()
+    const dock = screen.getByTestId('chat-bottom-dock')
+    expect(dock.querySelector('.os-chat-footer')).toBeNull()
+    expect(dock.querySelector('form')?.nextElementSibling).toBeNull()
+  })
+
+  it('places a small avatar-only indicator above the composer while streaming', async () => {
+    renderChat()
+    await openSocket()
+    await screen.findByRole('button', { name: /Open Codey definition/i })
+    await startStream()
+
+    const indicator = screen.getByTestId('composer-working-indicator')
+    const composer = screen.getByRole('textbox', { name: 'Chat message' })
+    const dock = screen.getByTestId('chat-bottom-dock')
+
+    expect(dock).toContainElement(indicator)
+    expect(dock).toContainElement(composer)
+    expect(indicator.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(dock.querySelector('.os-chat-footer')).toBeNull()
+    expect(dock.querySelector('form')?.nextElementSibling).toBeNull()
+
+    expect(indicator).toHaveClass('os-composer-working')
+    expect(indicator).not.toHaveTextContent(/is working/)
+    expect(indicator).not.toHaveTextContent('·')
+    expect(indicator).toHaveAttribute('aria-label', workingLabel('Codey'))
+
+    const tip = indicator.querySelector('.tooltip')
+    expect(tip).toHaveAttribute('data-tip', workingLabel('Codey'))
+
+    const avatar = indicator.querySelector('[data-agent-avatar]')
+    expect(avatar).toBeTruthy()
+    expect(avatar).toHaveAttribute('data-avatar-size', 'xs')
+    const sized = indicator.querySelector('.os-blob-avatar--xs, .os-agent-avatar--xs')
+    expect(sized).toBeTruthy()
+    expect(sized).not.toHaveStyle({ width: '100%', height: '100%' })
+  })
+
+  it('exposes the working label only as a hover tooltip', async () => {
+    renderChat()
+    await openSocket()
+    await screen.findByRole('button', { name: /Open Codey definition/i })
+    await startStream()
+
+    const indicator = screen.getByTestId('composer-working-indicator')
+    const tip = indicator.querySelector('.tooltip')
+    expect(tip).toHaveAttribute('data-tip', workingLabel('Codey'))
+    expect(screen.queryByText(/Codey is working/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Codey ·/)).not.toBeInTheDocument()
+
+    fireEvent.mouseEnter(tip!)
+    expect(tip).toHaveAttribute('data-tip', workingLabel('Codey'))
+    expect(indicator).not.toHaveTextContent(/is working/)
+  })
+
+  it('removes the indicator completely when the stream finishes', async () => {
+    renderChat()
+    await openSocket()
+    await startStream()
+    expect(screen.getByTestId('composer-working-indicator')).toBeInTheDocument()
+
+    await finishStream()
+    expect(screen.queryByTestId('composer-working-indicator')).not.toBeInTheDocument()
+
+    const dock = screen.getByTestId('chat-bottom-dock')
+    expect(dock.querySelector('.os-chat-footer')).toBeNull()
+    expect(dock.querySelector('form')?.nextElementSibling).toBeNull()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #736

**Feasibility:** Confirmed on `main` — ChatPage rendered the working indicator in a padded footer *below* the form with always-on `{name} · {elapsed}`, and `AgentAvatar`/`BlobAvatar` `size="xs"` forced `width/height: 100%` with no `--xs` size cap, so a flex footer grew the face to fill the dock.

## Issue (quoted)

**Intent:** While the agent is working, the composer-adjacent working indicator must be a small avatar **above** the input (hover label only). Today it renders as a huge avatar **below** the message field with an always-visible `{agent} · Ns` caption, breaking the chat layout.

**Success:**
1. Working indicator sits **immediately above** the composer (same band as jump-to-bottom / prior #355), never below the input and never in a large empty footer gap.
2. Avatar size matches other in-chat / rail avatar chrome (roughly header / bubble scale — **not** ~5–10× header size). Cap max dimension in CSS if the component can inherit unbounded size from a flex parent.
3. Default chrome is **avatar only**. No always-on `{Agent} · Ns` / `{Agent} is working` text beside or under it. Hover (tooltip) may show `{Agent} is working` (or elapsed) per #355.
4. When work finishes, the indicator is fully removed (no leftover giant node or spacer).
5. Does not collide with sticky composer / full-height scroll from #726 / #678.
6. Tests: idle = no composer working avatar; working = small avatar above input, no visible label until hover; completion removes it; layout does not reserve a tall empty band under the composer.

**Constraints:** React 18 + Vite + Tailwind 4 + DaisyUI 5. Likely the WorkingAvatar / streaming indicator near ChatComposer — check flex/height inheritance after sticky-composer layout. GitHub PR with `Fixes #N`. Wave discipline: one focused PR. Preview FF by engineer after squash. Do not re-open #355; this is a new bugfix.

**Owner:** Cursor cloud implement; open-swarm engineer squash + FF `:8001` on Matthew GO.

## What changed

- Relocated `composer-working-indicator` into the sticky bottom dock **above** the composer form; removed the always-rendered `os-chat-footer` under the input (that padding was the tall empty gap).
- Default chrome is the capped `xs` avatar only. `{Agent} is working` is a DaisyUI hover tooltip (`data-tip`) / `aria-label`, not visible text.
- `AgentAvatar` and `BlobAvatar` no longer set `width/height: 100%` for `xs`. New `.os-agent-avatar--xs` / `.os-blob-avatar--xs` (and a wrapping `.os-composer-working__avatar`) cap at `1.5rem`.
- Dropped the elapsed-seconds ticker that existed only to feed the always-on caption.
- Tests cover idle / working / hover tooltip / completion / no footer spacer, plus xs size-cap on `AgentAvatar`.

Does not re-open #355.

## Verification

Own-diff Vitest: `ComposerWorkingIndicator`, `AgentAvatar` xs cap, sticky-dock / reply-strip / avatar-stack suites — pass.

Playwright against Vite with this change (not the snapshot Django `:8000` dist): streaming avatar is **24×24** above the input (header 44×44), no visible `{name} · Ns`, no `os-chat-footer`, dock gap under the form is 0; completion removes the indicator.

Six `ChatPage.test.tsx` failures also fail on `origin/main` (stale heading/avatar/remotes assertions). Not worsened here.

[Idle composer — no working avatar, no footer gap](https://cursor.com/agents/bc-8545be42-b33c-4c39-ace6-9c02596d518f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworking_indicator_idle.png)
[Working: small avatar immediately above composer, no always-on label](https://cursor.com/agents/bc-8545be42-b33c-4c39-ace6-9c02596d518f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworking_indicator_above_composer.png)
[After completion the indicator is gone](https://cursor.com/agents/bc-8545be42-b33c-4c39-ace6-9c02596d518f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworking_indicator_removed_after_complete.png)
[working_indicator_flow.mp4](https://cursor.com/agents/bc-8545be42-b33c-4c39-ace6-9c02596d518f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fworking_indicator_flow.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8545be42-b33c-4c39-ace6-9c02596d518f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8545be42-b33c-4c39-ace6-9c02596d518f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

