### PR TITLE
feat(webui): remotes Add env name only and remove live api key posting (REQ-188A-5, Fixes #657)

### DIFF
--- a/webui/frontend/src/components/SettingsSheet.tsx
+++ b/webui/frontend/src/components/SettingsSheet.tsx
@@ -545,7 +545,6 @@ function RemotesCatalogPane() {
   const [adding, setAdding] = useState(false)
   const [kind, setKind] = useState('')
   const [baseUrl, setBaseUrl] = useState('')
-  const [apiKey, setApiKey] = useState('')
   const [apiKeyEnv, setApiKeyEnv] = useState('')
   const [selectedId, setSelectedId] = useState('')
 
@@ -573,7 +572,6 @@ function RemotesCatalogPane() {
         kind,
         ...(baseUrl.trim() ? { base_url: baseUrl.trim() } : {}),
         ...(apiKeyEnv.trim() ? { api_key_env: apiKeyEnv.trim() } : {}),
-        ...(apiKey.trim() ? { api_key: apiKey.trim() } : {}),
       }),
     onSuccess: (created) => {
       queryClient.setQueryData(['settings-remotes'], (prev: Awaited<ReturnType<typeof fetchRemotes>> | undefined) => ({
@@ -586,7 +584,6 @@ function RemotesCatalogPane() {
       void queryClient.invalidateQueries({ queryKey: ['configured-remotes'] })
       setAdding(false)
       setBaseUrl('')
-      setApiKey('')
       setApiKeyEnv('')
       setKind('')
       setSelectedId(created.id)
@@ -743,16 +740,6 @@ function RemotesCatalogPane() {
                 autoComplete="off"
                 spellCheck={false}
               />
-              <Input
-                label="API key"
-                name="remote-api-key"
-                type="password"
-                value={apiKey}
-                onChange={(event) => setApiKey(event.target.value)}
-                placeholder="${API_KEY}"
-                autoComplete="off"
-                spellCheck={false}
-              />
               <div className="flex flex-wrap gap-2">
                 <Button
                   type="submit"
@@ -768,7 +755,6 @@ function RemotesCatalogPane() {
                   size="sm"
                   onClick={() => {
                     setAdding(false)
-                    setApiKey('')
                   }}
                 >
                   Cancel

--- a/webui/frontend/src/components/__tests__/RemotesAddEnvOnly.test.tsx
+++ b/webui/frontend/src/components/__tests__/RemotesAddEnvOnly.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import SettingsSheet from '../SettingsSheet'
+import { ToastProvider } from '../DaisyUI'
+
+function renderSheet() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const onClose = vi.fn()
+  const view = render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <SettingsSheet isOpen={true} onClose={onClose} />
+      </ToastProvider>
+    </QueryClientProvider>,
+  )
+  return { ...view, onClose, client }
+}
+
+describe('REQ-188A-5: Remotes Add must not post live api_key (env name only)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('provides api_key_env input and no live api_key password input', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/v1/remotes/')) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'list',
+              kinds: [
+                { id: 'omb', label: 'OpenMousBot' },
+                { id: 'herdr', label: 'Herdr' },
+              ],
+              configured: [],
+              data: [],
+            }),
+          } as Response)
+        }
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ object: 'list', data: [] }),
+        } as Response)
+      }),
+    )
+
+    renderSheet()
+    fireEvent.click(screen.getByRole('button', { name: 'Remotes' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('No remotes configured yet.')).toBeInTheDocument()
+    })
+
+    // Click "Add remote" button to open add form
+    const addBtn = screen.getByRole('button', { name: /Add remote/i })
+    fireEvent.click(addBtn)
+
+    // Verify "API key env (optional)" exists
+    expect(screen.getByLabelText(/API key env/i)).toBeInTheDocument()
+
+    // Verify live "API key" password field does NOT exist
+    expect(screen.queryByLabelText(/^API key$/i)).not.toBeInTheDocument()
+  })
+
+  it('posts only kind, url, and api_key_env without live api_key payload', async () => {
+    let postPayload: any = null
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo, init?: RequestInit) => {
+        const url = String(input)
+        if (url.includes('/v1/remotes/') && init?.method === 'POST') {
+          postPayload = JSON.parse(String(init.body))
+          return {
+            ok: true,
+            status: 201,
+            json: async () => ({
+              id: 'omb',
+              kind: 'omb',
+              base_url: 'http://127.0.0.1:8802',
+              api_key_env: 'OMB_KEY_VAR',
+            }),
+          } as Response
+        }
+        if (url.includes('/v1/remotes/')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'list',
+              kinds: [{ id: 'omb', label: 'OpenMousBot' }],
+              configured: [],
+              data: [],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ object: 'list', data: [] }),
+        } as Response
+      }),
+    )
+
+    renderSheet()
+    fireEvent.click(screen.getByRole('button', { name: 'Remotes' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('No remotes configured yet.')).toBeInTheDocument()
+    })
+
+    const addBtn = screen.getByRole('button', { name: /Add remote/i })
+    fireEvent.click(addBtn)
+
+    const kindSelect = screen.getByLabelText(/Kind/i)
+    fireEvent.change(kindSelect, { target: { value: 'omb' } })
+
+    const envInput = screen.getByLabelText(/API key env/i)
+    fireEvent.change(envInput, { target: { value: 'OMB_KEY_VAR' } })
+
+    const saveBtn = screen.getByRole('button', { name: 'Save remote' })
+    fireEvent.click(saveBtn)
+
+    await waitFor(() => {
+      expect(postPayload).not.toBeNull()
+    })
+
+    expect(postPayload.kind).toBe('omb')
+    expect(postPayload.api_key_env).toBe('OMB_KEY_VAR')
+    expect(postPayload).not.toHaveProperty('api_key')
+  })
+})


### PR DESCRIPTION
Fixes #657

## Quoted Issue

**Intent:** Parent #644 / #647. Add posts live api_key vs env-name-only contract.
**Success:** Never send token; env name only. No secrets in repo.
**Constraints:** React 18 / DaisyUI 5 SPA chrome. Disjoint file surface.

## Summary of Changes
- Removed the live `API key` password input and state from `RemotesCatalogPane` in `webui/frontend/src/components/SettingsSheet.tsx`.
- `createRemote` payload now only passes `api_key_env` (if set) and no longer sends live `api_key` tokens.
- Added comprehensive unit tests in `webui/frontend/src/components/__tests__/RemotesAddEnvOnly.test.tsx` verifying that only `api_key_env` is rendered and submitted.

Ready to squash. SHA: 264fe0b56316f2bc966f101e51c0c1256c4dd760