### PR TITLE
feat(webui): rail unread blue dot in place of timestamp with mark as unread (REQ-210, Fixes #690)

### DIFF
--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -9,8 +9,14 @@ import {
 } from 'react'
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Eye, EyeOff, Pencil, Pin, PinOff, Plug, Plus, Search, Server, Users, X } from 'lucide-react'
+import { Circle, Eye, EyeOff, Pencil, Pin, PinOff, Plug, Plus, Search, Server, Users, X } from 'lucide-react'
 import AddAgentWizard, { type AgentKind } from './AddAgentWizard'
+import {
+  UNREAD_CHANGED_EVENT,
+  loadUnreadAgentIds,
+  markAgentRead,
+  markAgentUnread,
+} from '../lib/unreadAgents'
 import {
   fetchBlueprints,
   fetchCliAgents,
@@ -262,6 +268,30 @@ export default function AgentSidebar({
   const searchShortcut = searchShortcutLabel()
   const [addWizardOpen, setAddWizardOpen] = useState(false)
   const sessionsByAgent = useMemo(() => loadAllAgentSessions(), [sessionTick])
+  const [unreadIds, setUnreadIds] = useState<string[]>(() => loadUnreadAgentIds())
+  const currentTargetId = selectedTeamId || selectedRemoteId || selectedId
+  const prevTargetRef = useRef(currentTargetId)
+
+  useEffect(() => {
+    const onUnreadChange = () => {
+      setUnreadIds(loadUnreadAgentIds())
+    }
+    window.addEventListener(UNREAD_CHANGED_EVENT, onUnreadChange)
+    window.addEventListener('storage', onUnreadChange)
+    return () => {
+      window.removeEventListener(UNREAD_CHANGED_EVENT, onUnreadChange)
+      window.removeEventListener('storage', onUnreadChange)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (currentTargetId && currentTargetId !== prevTargetRef.current) {
+      if (unreadIds.includes(currentTargetId)) {
+        setUnreadIds(markAgentRead(currentTargetId))
+      }
+      prevTargetRef.current = currentTargetId
+    }
+  }, [currentTargetId, unreadIds])
 
   const [railWidth, setRailWidth] = useState(() => loadRailWidth())
   const [isResizing, setIsResizing] = useState(false)
@@ -682,15 +712,18 @@ export default function AgentSidebar({
 
   useEffect(() => {
     const onComplete = (event: Event) => {
-      if (!bumpCompleted) return
       const agentId = generationCompleteAgentId(event)
+      if (agentId && agentId !== currentTargetId) {
+        setUnreadIds(markAgentUnread(agentId))
+      }
+      if (!bumpCompleted) return
       if (!agentId || !visibleRowIds.includes(agentId)) return
       const base = mergeRailOrder(railOrder, visibleRowIds)
       persistVisibleOrder(bumpRailIdToTop(base, agentId))
     }
     window.addEventListener(GENERATION_COMPLETE_EVENT, onComplete)
     return () => window.removeEventListener(GENERATION_COMPLETE_EVENT, onComplete)
-  }, [bumpCompleted, visibleRowIds, railOrder, persistVisibleOrder])
+  }, [bumpCompleted, visibleRowIds, railOrder, persistVisibleOrder, currentTargetId])
   useEffect(() => {
     if (!menu) return
     const onKey = (event: KeyboardEvent) => {
@@ -966,6 +999,7 @@ export default function AgentSidebar({
     } ${dropping ? 'os-agent-row--drop' : ''}`
     const { snippet, timestamp } = getRowLastMessage(agent.id, sessions, agent as any)
     const timestampLabel = formatRailTimestamp(timestamp)
+    const unread = unreadIds.includes(agent.id)
     const mark = (
       scaleOut ? (
         // Teams/remotes (#398) must not be stacked here — import AvatarStack there.
@@ -1033,7 +1067,15 @@ export default function AgentSidebar({
                   {isMac ? `⌥${spillSlot}` : `Alt+${spillSlot}`}
                 </span>
               ) : null}
-              {timestampLabel ? (
+              {unread ? (
+                <span
+                  className={`os-rail-unread-dot inline-block h-2 w-2 rounded-full bg-sky-500 shrink-0 ${
+                    spillSlot ? 'group-hover/row:hidden' : ''
+                  }`}
+                  aria-label="Unread"
+                  data-testid="rail-unread-dot"
+                />
+              ) : timestampLabel ? (
                 <span
                   className={`os-rail-timestamp text-xs text-base-content/40 tabular-nums ${
                     spillSlot ? 'group-hover/row:hidden' : ''
@@ -1157,6 +1199,7 @@ export default function AgentSidebar({
       team as any,
     )
     const teamTimestampLabel = formatRailTimestamp(teamTime)
+    const unread = unreadIds.includes(hideId)
     return (
       <Link
         to={`/chat?team=${encodeURIComponent(team.id)}`}
@@ -1260,7 +1303,15 @@ export default function AgentSidebar({
                   {isMac ? `⌥${spillSlot}` : `Alt+${spillSlot}`}
                 </span>
               ) : null}
-              {teamTimestampLabel ? (
+              {unread ? (
+                <span
+                  className={`os-rail-unread-dot inline-block h-2 w-2 rounded-full bg-sky-500 shrink-0 ${
+                    spillSlot ? 'group-hover/row:hidden' : ''
+                  }`}
+                  aria-label="Unread"
+                  data-testid="rail-unread-dot"
+                />
+              ) : teamTimestampLabel ? (
                 <span
                   className={`os-rail-timestamp shrink-0 text-xs text-base-content/40 tabular-nums ${
                     spillSlot ? 'group-hover/row:hidden' : ''
@@ -1298,6 +1349,7 @@ export default function AgentSidebar({
       remote as any,
     )
     const remoteTimestampLabel = formatRailTimestamp(remoteTime)
+    const unread = unreadIds.includes(hideId)
     return (
       <Link
         to={`/chat?remote=${encodeURIComponent(remote.id)}`}
@@ -1395,7 +1447,15 @@ export default function AgentSidebar({
                   {isMac ? `⌥${spillSlot}` : `Alt+${spillSlot}`}
                 </span>
               ) : null}
-              {remoteTimestampLabel ? (
+              {unread ? (
+                <span
+                  className={`os-rail-unread-dot inline-block h-2 w-2 rounded-full bg-sky-500 shrink-0 ${
+                    spillSlot ? 'group-hover/row:hidden' : ''
+                  }`}
+                  aria-label="Unread"
+                  data-testid="rail-unread-dot"
+                />
+              ) : remoteTimestampLabel ? (
                 <span
                   className={`os-rail-timestamp text-xs text-base-content/40 tabular-nums ${
                     spillSlot ? 'group-hover/row:hidden' : ''
@@ -1630,13 +1690,21 @@ export default function AgentSidebar({
             const role = live ? agentRole(live) : 'default'
             const badge = live ? roleBadgeLabel(role) : ''
             const pinActive = Boolean(selectedId && selectedId === pin.id)
-            const pinClass = `os-fav-tile ${
+            const pinUnread = unreadIds.includes(pin.id)
+            const pinClass = `os-fav-tile group/tile ${
               draggingId === pin.id ? 'os-fav-tile--dragging' : ''
             } ${dropTargetId === pin.id ? 'os-fav-tile--drop' : ''} ${
               pinActive ? 'os-fav-tile--active' : ''
             }`
             const pinFace = (
               <>
+                {pinUnread && (
+                  <span
+                    className="os-rail-unread-dot absolute top-1.5 right-1.5 h-2 w-2 rounded-full bg-sky-500 z-10 group-hover/tile:hidden"
+                    aria-label="Unread"
+                    data-testid="rail-unread-dot"
+                  />
+                )}
                 {badge ? (
                   <span
                     className={`os-fav-tile__badge os-agent-role-badge ${roleCssClass(role)}`}
@@ -2010,6 +2078,22 @@ export default function AgentSidebar({
               Hide from sidebar
             </button>
           )}
+          <button
+            type="button"
+            role="menuitem"
+            className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-base-300/50"
+            onClick={() => {
+              if (unreadIds.includes(menu.agentId)) {
+                setUnreadIds(markAgentRead(menu.agentId))
+              } else {
+                setUnreadIds(markAgentUnread(menu.agentId))
+              }
+              closeMenu()
+            }}
+          >
+            <Circle className="h-4 w-4" aria-hidden="true" />
+            {unreadIds.includes(menu.agentId) ? 'Mark as read' : 'Mark as unread'}
+          </button>
           <button
             type="button"
             role="menuitem"

--- a/webui/frontend/src/components/__tests__/RailUnreadDot.test.tsx
+++ b/webui/frontend/src/components/__tests__/RailUnreadDot.test.tsx
@@ -1,0 +1,135 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import AgentSidebar from '../AgentSidebar'
+import { ToastProvider } from '../DaisyUI'
+import { markAgentUnread, UNREAD_AGENTS_STORAGE_KEY } from '../../lib/unreadAgents'
+import { GENERATION_COMPLETE_EVENT } from '../../lib/railOrder'
+
+describe('REQ-210: Unread blue dot (replaces timestamp) + Mark as unread', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (url.includes('/v1/blueprints')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              data: [
+                { id: 'codey', name: 'Codey', role: 'default' },
+                { id: 'stewie', name: 'Stewie', role: 'default' },
+              ],
+            }),
+          } as Response)
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ results: [], data: [] }),
+        } as Response)
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function renderRail(initialRoute = '/chat?blueprint=codey') {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    return render(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={[initialRoute]}>
+            <Routes>
+              <Route path="/chat" element={<AgentSidebar />} />
+              <Route path="/" element={<AgentSidebar />} />
+            </Routes>
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+  }
+
+  it('renders blue dot in place of timestamp for unread agent seat', async () => {
+    markAgentUnread('stewie')
+
+    renderRail('/chat?blueprint=codey')
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading agents…')).not.toBeInTheDocument()
+    })
+
+    // Find unread dots
+    const unreadDots = await screen.findAllByTestId('rail-unread-dot')
+    expect(unreadDots.length).toBeGreaterThan(0)
+
+    // Verify stewie row has unread dot with group-hover/row:hidden class for Alt swap
+    const stewieRow = screen.getByRole('link', { name: /stewie/i })
+    const dotInStewie = stewieRow.querySelector('[data-testid="rail-unread-dot"]')
+    expect(dotInStewie).toBeInTheDocument()
+    expect(dotInStewie?.className).toContain('group-hover/row:hidden')
+    expect(dotInStewie?.className).toContain('bg-sky-500')
+
+    // Verify timestamp is replaced (no rail-row-timestamp inside stewie row)
+    const timestampInStewie = stewieRow.querySelector('[data-testid="rail-row-timestamp"]')
+    expect(timestampInStewie).toBeNull()
+  })
+
+  it('context menu provides Mark as unread and restores blue dot', async () => {
+    renderRail('/chat?blueprint=codey')
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading agents…')).not.toBeInTheDocument()
+    })
+
+    // Initially stewie is read
+    const stewieRow = screen.getByRole('link', { name: /stewie/i })
+    expect(stewieRow.querySelector('[data-testid="rail-unread-dot"]')).toBeNull()
+
+    // Right-click stewie to open context menu
+    fireEvent.contextMenu(stewieRow)
+
+    const markUnreadItem = await screen.findByRole('menuitem', { name: /mark as unread/i })
+    expect(markUnreadItem).toBeInTheDocument()
+
+    // Click Mark as unread
+    act(() => {
+      fireEvent.click(markUnreadItem)
+    })
+
+    // Verify blue dot is now rendered
+    await waitFor(() => {
+      expect(stewieRow.querySelector('[data-testid="rail-unread-dot"]')).toBeInTheDocument()
+    })
+
+    // Verify stored in localStorage
+    expect(localStorage.getItem(UNREAD_AGENTS_STORAGE_KEY)).toContain('stewie')
+  })
+
+  it('new inbound activity via generation complete sets unread on unselected agent', async () => {
+    renderRail('/chat?blueprint=codey')
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading agents…')).not.toBeInTheDocument()
+    })
+
+    const stewieRow = screen.getByRole('link', { name: /stewie/i })
+    expect(stewieRow.querySelector('[data-testid="rail-unread-dot"]')).toBeNull()
+
+    // Dispatch generation complete for stewie while codey is selected
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(GENERATION_COMPLETE_EVENT, { detail: { agentId: 'stewie' } }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(stewieRow.querySelector('[data-testid="rail-unread-dot"]')).toBeInTheDocument()
+    })
+  })
+})

--- a/webui/frontend/src/lib/unreadAgents.ts
+++ b/webui/frontend/src/lib/unreadAgents.ts
@@ -1,0 +1,74 @@
+/**
+ * REQ-210: Unread blue dot (replaces timestamp) + Mark as unread.
+ *
+ * Persists unread agent seat IDs in localStorage ('swarm_unread_agents').
+ * Dispatches 'swarm:unread-changed' on mutation so rail and other UI components update.
+ */
+
+export const UNREAD_AGENTS_STORAGE_KEY = 'swarm_unread_agents'
+export const UNREAD_CHANGED_EVENT = 'swarm:unread-changed'
+
+export function parseUnreadAgentIds(raw: string | null): string[] {
+  if (!raw) return []
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((id): id is string => typeof id === 'string' && id.length > 0)
+  } catch {
+    return []
+  }
+}
+
+export function loadUnreadAgentIds(): string[] {
+  try {
+    return parseUnreadAgentIds(localStorage.getItem(UNREAD_AGENTS_STORAGE_KEY))
+  } catch {
+    return []
+  }
+}
+
+export function saveUnreadAgentIds(ids: string[]): string[] {
+  const unique = Array.from(new Set(ids.filter((id) => typeof id === 'string' && id.length > 0)))
+  try {
+    localStorage.setItem(UNREAD_AGENTS_STORAGE_KEY, JSON.stringify(unique))
+  } catch {
+    /* storage quota / unavailable */
+  }
+  try {
+    window.dispatchEvent(
+      new CustomEvent(UNREAD_CHANGED_EVENT, { detail: { unreadIds: unique } }),
+    )
+  } catch {
+    /* non-browser environment */
+  }
+  return unique
+}
+
+export function isAgentUnread(id: string, currentUnread?: string[]): boolean {
+  if (!id) return false
+  const list = currentUnread ?? loadUnreadAgentIds()
+  return list.includes(id)
+}
+
+export function markAgentUnread(id: string): string[] {
+  if (!id) return loadUnreadAgentIds()
+  const current = loadUnreadAgentIds()
+  if (current.includes(id)) return current
+  return saveUnreadAgentIds([...current, id])
+}
+
+export function markAgentRead(id: string): string[] {
+  if (!id) return loadUnreadAgentIds()
+  const current = loadUnreadAgentIds()
+  if (!current.includes(id)) return current
+  return saveUnreadAgentIds(current.filter((item) => item !== id))
+}
+
+export function toggleAgentUnread(id: string): string[] {
+  if (!id) return loadUnreadAgentIds()
+  const current = loadUnreadAgentIds()
+  if (current.includes(id)) {
+    return markAgentRead(id)
+  }
+  return markAgentUnread(id)
+}


### PR DESCRIPTION
Fixes #690

## Quoted Issue

**Intent:** If the user has not yet read messages from an agent, the sidepane shows a blue dot in place of the activity timestamp (#686). Opening that agent’s chat clears the unread state (dot → timestamp again). Right-click → Mark as unread restores the blue dot.
**Success:**
1. Unread seat: blue dot occupies the timestamp slot (replaces time/day stamp).
2. Browsing to that agent’s chat marks read and restores normal stamp.
3. Right-click menu includes Mark as unread (and Mark as read); restores dot even if chat was just viewed.
4. New inbound activity while seat is not selected sets unread.
5. Pinned tiles + section rows both show indicator.
6. Persist unread flags (localStorage).
**Constraints:** SPA chrome. Quiet Grok-ish blue. Hover Alt+N swap (#686): when unread, hover shows Alt hint instead of the dot.

## Summary of Changes
- Added `unreadAgents.ts` helper managing localStorage persistence (`swarm_unread_agents`) and custom `swarm:unread-changed` events.
- In `AgentSidebar.tsx`, replaced the timestamp slot on agent/team/remote rows with `os-rail-unread-dot` (`bg-sky-500`) when unread.
- Hover over row with Alt+N slot reveals Alt hint and hides unread dot (`group-hover/row:hidden`), smoothly swapping on hover and restoring on mouseout.
- Added unread dot to pinned favourite tiles.
- Inbound generation complete events on non-selected seats automatically mark them unread.
- Added 'Mark as unread' / 'Mark as read' action to agent right-click context menu.
- Added comprehensive unit tests in `RailUnreadDot.test.tsx`.

Ready to squash. SHA: e787c4be94b48bfcf1526b3fdbb34f537caa12c9