### PR TITLE
feat(webui): settings Definition honest empty state when no agent selected (REQ-188A-1, Fixes #653)

### DIFF
--- a/webui/frontend/src/components/DefinitionPane.tsx
+++ b/webui/frontend/src/components/DefinitionPane.tsx
@@ -112,6 +112,29 @@ export default function DefinitionPane({
     }
   }
 
+  if (!definitionId || !definitionId.trim()) {
+    return (
+      <section
+        id="os-definition-pane"
+        aria-labelledby={headingId}
+        className="space-y-4"
+        data-testid="definition-empty"
+      >
+        <div>
+          <h4 id={headingId} className="text-lg font-semibold">
+            Definition
+          </h4>
+          <p className="mt-1 text-sm text-base-content/70">
+            Select an agent, role, or team from the sidebar to inspect its definition and injected context.
+          </p>
+        </div>
+        <Alert type="info" icon={<AlertCircle className="h-5 w-5" />}>
+          <span className="text-sm">No definition selected.</span>
+        </Alert>
+      </section>
+    )
+  }
+
   return (
     <section
       id="os-definition-pane"

--- a/webui/frontend/src/components/__tests__/DefinitionPaneEmpty.test.tsx
+++ b/webui/frontend/src/components/__tests__/DefinitionPaneEmpty.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import DefinitionPane from '../DefinitionPane'
+import { ToastProvider } from '../DaisyUI'
+
+function renderPane(definitionId = '', kind: 'role' | 'blueprint' | 'team' = 'role') {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <DefinitionPane kind={kind} definitionId={definitionId} />
+      </ToastProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('REQ-188A-1: Settings Definition — empty untitled pane needs identity or honest empty', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders honest empty state with no fake worker recipe and no Save/Edit button when definitionId is empty', () => {
+    renderPane('')
+
+    expect(screen.getByTestId('definition-empty')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Definition' })).toBeInTheDocument()
+    expect(screen.getByText('No definition selected.')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Select an agent, role, or team from the sidebar/i),
+    ).toBeInTheDocument()
+
+    // Must not show fake worker blueprint recipe
+    expect(screen.queryByText(/This is a worker blueprint/i)).not.toBeInTheDocument()
+    expect(screen.queryByTestId('definition-explanation')).not.toBeInTheDocument()
+
+    // Must not show Edit code or Save button
+    expect(screen.queryByRole('button', { name: /edit code/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^Save$/i })).not.toBeInTheDocument()
+  })
+
+  it('renders normal definition view when a valid definitionId is provided', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          kind: 'role',
+          id: 'gate',
+          title: 'Gate',
+          role: 'gate',
+          explanation: 'Gate is a classifier.',
+          source: 'GATE_SOURCE',
+          injected: {
+            system_prompt: 'Gate prompt',
+            tools: {},
+            metadata: {},
+            handoff: '',
+            extra: '',
+          },
+          default_llm: { configured: false, model: null },
+        }),
+      } as Response),
+    )
+
+    renderPane('gate', 'role')
+
+    expect(screen.queryByTestId('definition-empty')).not.toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /edit code/i })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #653

## Quoted Issue

**Intent:** Parent #644 / PR #647. Gear→Definition with no definitionId shows blank heading, fake worker recipe, Save still shown.
**Success:** Selected identity or honest empty (no fake Save). No secrets.
**Constraints:** React 18 / DaisyUI 5 SPA chrome. Disjoint file surface.

## Summary of Changes
- In `DefinitionPane.tsx`, added an honest empty state when `definitionId` is empty, displaying a clean heading, informational message, and alert guiding the user to select an agent, role, or team from the sidebar.
- Eliminates the previous blank heading, fake worker recipe text, and inappropriate Edit/Save buttons when no agent is selected.
- Added comprehensive unit tests in `DefinitionPaneEmpty.test.tsx`.

Ready to squash. SHA: 33672e23cb3638df4bb966d00a5f4d784a94d427