### PR TITLE
feat(webui): disable llm profiles save when catalog failed or empty (REQ-188B-3)

### DIFF
--- a/webui/frontend/src/components/SettingsSheet.tsx
+++ b/webui/frontend/src/components/SettingsSheet.tsx
@@ -1097,10 +1097,16 @@ function LlmProfilesPane() {
 
   const handleSave = async (event: FormEvent) => {
     event.preventDefault()
+    if (profilesQuery.isError || profiles.length === 0) {
+      return
+    }
     setSaving(true)
     try {
-      const saved = await patchLlmProfiles({
-        default_llm_profile: defaultId,
+      const payload: {
+        default_llm_profile?: string
+        override_per_task: boolean
+        task_llm_profiles: Partial<Record<LlmTaskClass, string>>
+      } = {
         override_per_task: overrideOn,
         task_llm_profiles: overrideOn
           ? {
@@ -1109,7 +1115,11 @@ function LlmProfilesPane() {
               delegation: taskMap.delegation || defaultId,
             }
           : taskMap,
-      })
+      }
+      if (defaultId.trim()) {
+        payload.default_llm_profile = defaultId.trim()
+      }
+      const saved = await patchLlmProfiles(payload)
       setDefaultId(saved.default_llm_profile || defaultId)
       setOverrideOn(Boolean(saved.override_per_task))
       setTaskMap({ ...saved.task_llm_profiles })
@@ -1250,7 +1260,12 @@ function LlmProfilesPane() {
         </Alert>
       ) : null}
 
-      <Button type="submit" variant="primary" size="sm" disabled={saving}>
+      <Button
+        type="submit"
+        variant="primary"
+        size="sm"
+        disabled={saving || profilesQuery.isPending || profilesQuery.isError || profiles.length === 0}
+      >
         {saving ? 'Saving…' : 'Save LLM profiles'}
       </Button>
     </form>

--- a/webui/frontend/src/components/__tests__/LLMProfilesSaveGuards.test.tsx
+++ b/webui/frontend/src/components/__tests__/LLMProfilesSaveGuards.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import SettingsSheet from '../SettingsSheet'
+import { ToastProvider } from '../DaisyUI'
+
+function renderSheet() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const onClose = vi.fn()
+  const view = render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <SettingsSheet
+          isOpen={true}
+          onClose={onClose}
+          initialSection="llm-profiles"
+        />
+      </ToastProvider>
+    </QueryClientProvider>,
+  )
+  return { ...view, onClose, client }
+}
+
+describe('LLMProfilesSaveGuards (REQ-188B-3)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('disables Save button when /v1/llm-profiles/ returns 500 error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: 'server error' }),
+      } as Response),
+    )
+
+    renderSheet()
+
+    expect(
+      await screen.findByText(/Could not load configured profiles/i, undefined, { timeout: 4000 }),
+    ).toBeInTheDocument()
+
+    const saveButton = screen.getByRole('button', { name: 'Save LLM profiles' })
+    expect(saveButton).toBeDisabled()
+  })
+
+  it('disables Save button when profiles catalog is empty', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          object: 'llm_profiles',
+          profiles: [],
+          default_llm_profile: 'default',
+          default_is_auto: true,
+          override_per_task: false,
+          task_llm_profiles: {},
+          auto_picks: {},
+          warnings: [],
+          routes: {},
+          task_classes: ['orchestration', 'auxiliary', 'delegation'],
+        }),
+      } as Response),
+    )
+
+    renderSheet()
+
+    expect(await screen.findByText(/No connected models yet/i)).toBeInTheDocument()
+
+    const saveButton = screen.getByRole('button', { name: 'Save LLM profiles' })
+    expect(saveButton).toBeDisabled()
+  })
+
+  it('enables Save button and sends PATCH with valid profiles', async () => {
+    const fetchMock = vi.fn().mockImplementation(async (input: RequestInfo, init?: RequestInit) => {
+      const url = String(input)
+      const method = (init?.method || 'GET').toUpperCase()
+      if (url.includes('/v1/llm-profiles') && method === 'PATCH') {
+        const body = JSON.parse(String(init?.body || '{}'))
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            object: 'llm_profiles',
+            profiles: [
+              { id: 'gpt-5.6-terra', object: 'llm_profile', source: 'config', owned_by: 'openai' },
+            ],
+            default_llm_profile: body.default_llm_profile || 'gpt-5.6-terra',
+            default_is_auto: false,
+            override_per_task: Boolean(body.override_per_task),
+            task_llm_profiles: body.task_llm_profiles || {},
+            auto_picks: { default: 'gpt-5.6-terra' },
+            warnings: [],
+            routes: {},
+            task_classes: ['orchestration', 'auxiliary', 'delegation'],
+          }),
+        } as Response
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          object: 'llm_profiles',
+          profiles: [
+            { id: 'gpt-5.6-terra', object: 'llm_profile', source: 'config', owned_by: 'openai' },
+          ],
+          default_llm_profile: 'gpt-5.6-terra',
+          default_is_auto: false,
+          override_per_task: false,
+          task_llm_profiles: {},
+          auto_picks: { default: 'gpt-5.6-terra' },
+          warnings: [],
+          routes: {},
+          task_classes: ['orchestration', 'auxiliary', 'delegation'],
+        }),
+      } as Response
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderSheet()
+
+    expect(await screen.findByRole('list', { name: 'Configured LLM profiles' })).toBeInTheDocument()
+
+    const saveButton = screen.getByRole('button', { name: 'Save LLM profiles' })
+    expect(saveButton).toBeEnabled()
+
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('LLM profiles saved')).toBeInTheDocument()
+    })
+
+    const patchCall = fetchMock.mock.calls.find(
+      (call) => String(call[0]).includes('/v1/llm-profiles') && call[1]?.method === 'PATCH',
+    )
+    expect(patchCall).toBeTruthy()
+    expect(JSON.parse(String(patchCall?.[1]?.body))).toMatchObject({
+      default_llm_profile: 'gpt-5.6-terra',
+      override_per_task: false,
+    })
+  })
+})


### PR DESCRIPTION
Fixes #665

### Intent
Settings → Show LLM profiles cannot delete `settings.default_llm_profile` because GET failed or no models are connected.

### Success
1. Save is disabled (or omitted) when `profilesQuery.isError` or when there is no connected model and the user has not explicitly chosen “clear default.”
2. PATCH with blank `default_llm_profile` does not pop a stored default unless the request is an explicit clear.
3. RTL: stub GET 500 → Save disabled; stub empty catalog → Save disabled (or no-ops without PATCH). Existing empty/error copy tests stay.

### Constraints
Own-diff CI. No secrets. Do not invent a second model list. Docker `:ro` 500 is separate (ADR-002 follow-up 2).