### PR TITLE
fix(webui): chat history never scrolls under floating composer

### DIFF
--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -1263,6 +1263,14 @@ html[data-theme="light"] .os-code--collapsible.os-code--collapsed::after {
 .os-chat-transcript {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
+  /* #743: last-message clearance tracks live sticky composer height */
+  scroll-padding-bottom: var(--os-chat-composer-inset, 0px);
+}
+.os-chat-messages {
+  padding-bottom: var(--os-chat-composer-inset, 0px);
+}
+.os-chat-bottom-dock {
+  margin-top: calc(-1 * var(--os-chat-composer-inset, 0px));
 }
 @media (min-width: 640px) {
   .os-chat-transcript {

--- a/webui/frontend/src/lib/__tests__/composerInset.test.ts
+++ b/webui/frontend/src/lib/__tests__/composerInset.test.ts
@@ -58,9 +58,10 @@ describe('composerInset helpers (#743)', () => {
   })
 
   it('treats the user as pinned when remaining scroll is within inset slack', () => {
-    const el = { scrollHeight: 2000, scrollTop: 1900, clientHeight: 80 }
-    expect(isPinnedToTranscriptBottom(el, 96)).toBe(true)
-    expect(isPinnedToTranscriptBottom(el, 48)).toBe(false)
+    const nearBottom = { scrollHeight: 2000, scrollTop: 1920, clientHeight: 80 }
+    const scrolledUp = { scrollHeight: 2000, scrollTop: 1600, clientHeight: 80 }
+    expect(isPinnedToTranscriptBottom(nearBottom, 96)).toBe(true)
+    expect(isPinnedToTranscriptBottom(scrolledUp, 96)).toBe(false)
     expect(COMPOSER_PIN_SLACK_PX).toBe(48)
   })
 

--- a/webui/frontend/src/lib/__tests__/composerInset.test.ts
+++ b/webui/frontend/src/lib/__tests__/composerInset.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COMPOSER_INSET_VAR,
+  COMPOSER_PIN_SLACK_PX,
+  composerInsetCustomProperty,
+  isPinnedToTranscriptBottom,
+  measureComposerDockInset,
+  scrollTranscriptToBottom,
+} from '../composerInset'
+
+describe('composerInset helpers (#743)', () => {
+  it('measures dock height with ceil and ignores missing nodes', () => {
+    expect(measureComposerDockInset(null)).toBe(0)
+
+    const dock = document.createElement('div')
+    dock.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 320,
+        bottom: 87.4,
+        width: 320,
+        height: 87.4,
+        toJSON: () => ({}),
+      }) as DOMRect
+
+    expect(measureComposerDockInset(dock)).toBe(88)
+  })
+
+  it('falls back to offsetHeight when getBoundingClientRect height is 0', () => {
+    const dock = document.createElement('div')
+    Object.defineProperty(dock, 'offsetHeight', { value: 64, configurable: true })
+    dock.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+        toJSON: () => ({}),
+      }) as DOMRect
+
+    expect(measureComposerDockInset(dock)).toBe(64)
+  })
+
+  it('exposes the live inset as a CSS custom property', () => {
+    expect(composerInsetCustomProperty(96)).toEqual({
+      [COMPOSER_INSET_VAR]: '96px',
+    })
+    expect(composerInsetCustomProperty(-4)).toEqual({
+      [COMPOSER_INSET_VAR]: '0px',
+    })
+  })
+
+  it('treats the user as pinned when remaining scroll is within inset slack', () => {
+    const el = { scrollHeight: 2000, scrollTop: 1900, clientHeight: 80 }
+    expect(isPinnedToTranscriptBottom(el, 96)).toBe(true)
+    expect(isPinnedToTranscriptBottom(el, 48)).toBe(false)
+    expect(COMPOSER_PIN_SLACK_PX).toBe(48)
+  })
+
+  it('scrolls the transcript box to its end', () => {
+    const box = document.createElement('div')
+    Object.defineProperty(box, 'scrollHeight', { value: 2400, configurable: true })
+    box.scrollTop = 12
+    scrollTranscriptToBottom(box)
+    expect(box.scrollTop).toBe(2400)
+  })
+})

--- a/webui/frontend/src/lib/composerInset.ts
+++ b/webui/frontend/src/lib/composerInset.ts
@@ -1,0 +1,36 @@
+/** Live bottom inset so the sticky composer never covers transcript content. */
+
+export const COMPOSER_INSET_VAR = '--os-chat-composer-inset'
+
+/** Slack used when deciding whether the user is still pinned to the bottom. */
+export const COMPOSER_PIN_SLACK_PX = 48
+
+export function measureComposerDockInset(dock: Element | null): number {
+  if (!dock) return 0
+  const box = dock.getBoundingClientRect()
+  const height = box.height || (dock instanceof HTMLElement ? dock.offsetHeight : 0)
+  return Math.max(0, Math.ceil(height))
+}
+
+export function composerInsetCustomProperty(insetPx: number): {
+  [COMPOSER_INSET_VAR]: string
+} {
+  return { [COMPOSER_INSET_VAR]: `${Math.max(0, insetPx)}px` }
+}
+
+export function isPinnedToTranscriptBottom(
+  el: { scrollHeight: number; scrollTop: number; clientHeight: number },
+  insetPx: number,
+  slackPx = COMPOSER_PIN_SLACK_PX,
+): boolean {
+  const threshold = Math.max(slackPx, insetPx)
+  return el.scrollHeight - el.scrollTop - el.clientHeight < threshold
+}
+
+export function scrollTranscriptToBottom(box: HTMLElement | null, listEnd?: HTMLElement | null) {
+  if (box) {
+    box.scrollTop = box.scrollHeight
+    return
+  }
+  listEnd?.scrollIntoView({ block: 'end' })
+}

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -1,9 +1,11 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type ChangeEvent,
   type FormEvent,
   type KeyboardEvent,
@@ -48,6 +50,12 @@ import {
   type ConversationSummary,
 } from '../lib/agentChat'
 import { canEditAgentMessages, classifyAgentKind, type AgentKind } from '../lib/agentKind'
+import {
+  composerInsetCustomProperty,
+  isPinnedToTranscriptBottom,
+  measureComposerDockInset,
+  scrollTranscriptToBottom,
+} from '../lib/composerInset'
 import {
   buildDisplayItems,
   contextTextsForMeter,
@@ -257,9 +265,11 @@ const ChatPage = () => {
   conversationIdRef.current = conversationId
   const listEndRef = useRef<HTMLDivElement | null>(null)
   const scrollBoxRef = useRef<HTMLDivElement | null>(null)
+  const bottomDockRef = useRef<HTMLDivElement | null>(null)
   const composerRef = useRef<HTMLTextAreaElement | null>(null)
   const plusRef = useRef<HTMLDivElement | null>(null)
   const composerWrapRef = useRef<HTMLDivElement | null>(null)
+  const [composerInsetPx, setComposerInsetPx] = useState(0)
   /** Monotonic counter for collision-free user-echo keys. */
   const userKeyCounterRef = useRef(0)
   const prevStatusRef = useRef<ConnectionStatus>('connecting')
@@ -916,11 +926,31 @@ const ChatPage = () => {
   }, [status])
 
   const pinnedToBottomRef = useRef(true)
+
+  const applyComposerInset = useCallback(() => {
+    const next = measureComposerDockInset(bottomDockRef.current)
+    setComposerInsetPx((prev) => (prev === next ? prev : next))
+  }, [])
+
+  useLayoutEffect(() => {
+    applyComposerInset()
+  }, [applyComposerInset, messages, replyTarget, input])
+
+  useLayoutEffect(() => {
+    const dock = bottomDockRef.current
+    if (!dock || typeof ResizeObserver === 'undefined') return undefined
+    const observer = new ResizeObserver(() => {
+      applyComposerInset()
+    })
+    observer.observe(dock)
+    return () => observer.disconnect()
+  }, [applyComposerInset])
+
   useEffect(() => {
     if (pinnedToBottomRef.current) {
-      listEndRef.current?.scrollIntoView({ block: 'end' })
+      scrollTranscriptToBottom(scrollBoxRef.current, listEndRef.current)
     }
-  }, [messages])
+  }, [messages, composerInsetPx])
 
   useEffect(() => {
     const wasOpen = prevStatusRef.current === 'open'
@@ -1662,6 +1692,7 @@ const ChatPage = () => {
       <div
         ref={scrollBoxRef}
         className="os-chat-transcript min-h-0 flex-1 space-y-1 overflow-y-auto px-2 py-3 sm:px-3 select-none outline-none focus:outline-none flex flex-col justify-between relative"
+        style={composerInsetCustomProperty(composerInsetPx) as CSSProperties}
         aria-live="polite"
         role="log"
         aria-label="Conversation"
@@ -1673,13 +1704,13 @@ const ChatPage = () => {
               : agentKind
         }
         data-messages-editable={messagesEditable && !isCliAgent && agentKind !== 'remote' ? 'true' : 'false'}
+        data-composer-inset={composerInsetPx}
         tabIndex={0}
         onScroll={(e) => {
-          const el = e.currentTarget
-          pinnedToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 48
+          pinnedToBottomRef.current = isPinnedToTranscriptBottom(e.currentTarget, composerInsetPx)
         }}
       >
-        <div className="space-y-1 flex-1 pb-4" data-testid="chat-messages-container">
+        <div className="os-chat-messages space-y-1 flex-1" data-testid="chat-messages-container">
         {messages.length === 0 ? (
           <div className="flex h-full min-h-64 flex-col items-center justify-center gap-2 text-center text-base-content/45">
             <p className="text-sm">Message {selectedAgentName}</p>
@@ -1789,7 +1820,8 @@ const ChatPage = () => {
         </div>
 
         <div
-          className="os-chat-bottom-dock sticky bottom-0 z-20 mt-auto -mx-2 sm:-mx-3 -mb-3 bg-base-100/95 backdrop-blur-xs border-t border-base-content/5"
+          ref={bottomDockRef}
+          className="os-chat-bottom-dock sticky bottom-0 z-20 -mx-2 sm:-mx-3 -mb-3 bg-base-100 border-t border-base-content/5"
           data-testid="chat-bottom-dock"
         >
           {streamingMessage ? (

--- a/webui/frontend/src/pages/__tests__/ChatComposerInset.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatComposerInset.test.tsx
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ToastProvider } from '../../components/DaisyUI'
+import ChatPage from '../ChatPage'
+import { COMPOSER_INSET_VAR } from '../../lib/composerInset'
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  static instances: MockWebSocket[] = []
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  url: string
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  send() {}
+  close() {}
+
+  open() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+}
+
+let dockHeight = 72
+let resizeCallback: ResizeObserverCallback | null = null
+
+class MockResizeObserver {
+  constructor(cb: ResizeObserverCallback) {
+    resizeCallback = cb
+  }
+  observe() {
+    resizeCallback?.([], this as unknown as ResizeObserver)
+  }
+  unobserve() {}
+  disconnect() {}
+}
+
+function mockDockRect() {
+  const original = HTMLElement.prototype.getBoundingClientRect
+  HTMLElement.prototype.getBoundingClientRect = function () {
+    if (this.getAttribute('data-testid') === 'chat-bottom-dock') {
+      return {
+        x: 0,
+        y: 520,
+        top: 520,
+        left: 0,
+        right: 400,
+        bottom: 520 + dockHeight,
+        width: 400,
+        height: dockHeight,
+        toJSON: () => ({}),
+      } as DOMRect
+    }
+    return original.call(this)
+  }
+  return () => {
+    HTMLElement.prototype.getBoundingClientRect = original
+  }
+}
+
+function renderChat() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>
+        <MemoryRouter initialEntries={['/chat?blueprint=support']}>
+          <ChatPage />
+        </MemoryRouter>
+      </ToastProvider>
+    </QueryClientProvider>,
+  )
+}
+
+function deliverTurn(ws: MockWebSocket, text: string, id: string) {
+  ws.onmessage?.(
+    new MessageEvent('message', {
+      data: `<div id="message-list" hx-swap-oob="beforeend"><div class="user-message">${text}?</div></div>`,
+    }),
+  )
+  ws.onmessage?.(
+    new MessageEvent('message', {
+      data: `<div id="message-list" hx-swap-oob="beforeend"><div id="${id}" class="assistant-message"></div></div>`,
+    }),
+  )
+  ws.onmessage?.(
+    new MessageEvent('message', {
+      data: `<div id="${id}" class="assistant-message" hx-swap-oob="true">${text}</div>`,
+    }),
+  )
+}
+
+async function openAndStream(count = 1) {
+  const ws = MockWebSocket.instances[0]
+  expect(ws).toBeDefined()
+  await act(async () => {
+    ws.open()
+  })
+  await act(async () => {
+    for (let i = 0; i < count; i += 1) {
+      deliverTurn(ws, `Transcript line ${i + 1}`, `message-response-inset-${i}`)
+    }
+  })
+  return ws
+}
+
+describe('REQ #743: chat history never scrolls under floating composer', () => {
+  let restoreRect: () => void
+
+  beforeEach(() => {
+    dockHeight = 72
+    resizeCallback = null
+    MockWebSocket.instances = []
+    window.HTMLElement.prototype.scrollIntoView = vi.fn()
+    restoreRect = mockDockRect()
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.stubGlobal('ResizeObserver', MockResizeObserver)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [{ id: 'support', name: 'Support', description: 'Support agent' }],
+        }),
+      }),
+    )
+  })
+
+  afterEach(() => {
+    restoreRect()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps the sticky composer dock and insets the message list to the live dock height', async () => {
+    renderChat()
+    await openAndStream(1)
+
+    const scrollPane = screen.getByRole('log', { name: 'Conversation' })
+    const bottomDock = screen.getByTestId('chat-bottom-dock')
+    const messages = screen.getByTestId('chat-messages-container')
+
+    expect(scrollPane).toContainElement(bottomDock)
+    expect(bottomDock).toHaveClass('sticky')
+    expect(bottomDock).toHaveClass('bottom-0')
+    expect(scrollPane).toHaveAttribute('data-composer-inset', '72')
+    expect(scrollPane.style.getPropertyValue(COMPOSER_INSET_VAR)).toBe('72px')
+    expect(messages).toHaveClass('os-chat-messages')
+    expect(messages.className).not.toMatch(/\bpb-24\b|\bpb-32\b|\bh-96\b/)
+  })
+
+  it('tracks a taller composer (quote strip) without a stale fixed pixel inset', async () => {
+    renderChat()
+    const ws = await openAndStream(1)
+
+    const bubble = await screen.findByText('Transcript line 1')
+    fireEvent.contextMenu(bubble, { clientX: 80, clientY: 80 })
+    fireEvent.click(await screen.findByTestId('context-menu-reply'))
+    expect(await screen.findByTestId('composer-reply-strip')).toBeInTheDocument()
+
+    dockHeight = 148
+    await act(async () => {
+      resizeCallback?.([], {} as ResizeObserver)
+    })
+
+    const scrollPane = screen.getByRole('log', { name: 'Conversation' })
+    expect(scrollPane).toHaveAttribute('data-composer-inset', '148')
+    expect(scrollPane.style.getPropertyValue(COMPOSER_INSET_VAR)).toBe('148px')
+    expect(ws).toBeDefined()
+  })
+
+  it('includes the working-avatar band in the inset while streaming', async () => {
+    renderChat()
+    const ws = MockWebSocket.instances[0]
+    await act(async () => {
+      ws.open()
+      ws.onmessage?.(
+        new MessageEvent('message', {
+          data: '<div id="message-list" hx-swap-oob="beforeend"><div id="message-response-work-inset" class="assistant-message"></div></div>',
+        }),
+      )
+    })
+
+    expect(screen.getByTestId('composer-working-indicator')).toBeInTheDocument()
+    dockHeight = 104
+    await act(async () => {
+      resizeCallback?.([], {} as ResizeObserver)
+    })
+
+    const scrollPane = screen.getByRole('log', { name: 'Conversation' })
+    expect(Number(scrollPane.getAttribute('data-composer-inset'))).toBe(104)
+    expect(Number(scrollPane.getAttribute('data-composer-inset'))).toBeGreaterThan(72)
+  })
+
+  it('scrolls a long transcript to the end so the last bubble sits above the composer inset', async () => {
+    renderChat()
+    const scrollPane = screen.getByRole('log', { name: 'Conversation' })
+    let scrollTopValue = 0
+    Object.defineProperty(scrollPane, 'scrollHeight', { configurable: true, value: 4000 })
+    Object.defineProperty(scrollPane, 'clientHeight', { configurable: true, value: 600 })
+    Object.defineProperty(scrollPane, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTopValue,
+      set: (value: number) => {
+        scrollTopValue = value
+      },
+    })
+
+    await openAndStream(12)
+
+    expect(scrollTopValue).toBe(4000)
+    expect(screen.getByText('Transcript line 12')).toBeInTheDocument()
+    expect(scrollPane).toHaveAttribute('data-composer-inset', '72')
+  })
+
+  it('idle short chat only reserves the measured composer inset, not a huge empty gap', async () => {
+    dockHeight = 68
+    renderChat()
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+
+    const scrollPane = screen.getByRole('log', { name: 'Conversation' })
+    const messages = screen.getByTestId('chat-messages-container')
+    expect(scrollPane).toHaveAttribute('data-composer-inset', '68')
+    expect(messages).toHaveClass('os-chat-messages')
+    expect(screen.getByText(/Message Support/i)).toBeInTheDocument()
+    expect(Number(scrollPane.getAttribute('data-composer-inset'))).toBeLessThan(120)
+  })
+})

--- a/webui/frontend/src/pages/__tests__/ChatScrollBottom.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatScrollBottom.test.tsx
@@ -78,9 +78,10 @@ describe('REQ-202: Chat scrollbar to page bottom; composer inside pane but non-s
     const header = screen.getByRole('banner')
     expect(header).toContainElement(tokenButton)
 
-    // Messages container has bottom padding so last message remains readable above dock
+    // Messages container uses a live composer inset (not a stale fixed pb-* guess)
     const messagesContainer = screen.getByTestId('chat-messages-container')
     expect(scrollPane).toContainElement(messagesContainer)
-    expect(messagesContainer.className).toContain('pb-4')
+    expect(messagesContainer).toHaveClass('os-chat-messages')
+    expect(scrollPane).toHaveAttribute('data-composer-inset')
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #743

**Feasibility:** Yes — measure the sticky dock live and apply that height as the message-list inset + scroll-padding; keep the #726 composer.

## Intent
The message input floats over the chat pane (sticky / docked), but the scrollable chat history must **never** actually scroll behind that input. There must be a bottom gap/inset in the scrollable region so the last messages remain fully visible above the composer.

## Success
1. Composer remains floating / sticky at the bottom of the chat pane (does not scroll away with history) — keep the #726 dock behaviour.
2. The scrollable message list has a **bottom inset** (padding, spacer, or scroll-padding) at least as tall as the composer (including any working-avatar band above it when present) so content cannot sit under the input.
3. Scrolling to the bottom (jump-to-bottom, new messages, session load) leaves the last message **fully visible above** the composer — no clipping, no bleed under the input chrome.
4. Growing composer (multi-line, quote strip from #673/#735, attachments) still keeps the inset correct — inset tracks composer height, not a fixed pixel guess that goes stale.
5. Visual: no message bubbles, timestamps, or “Message from …” pills peeking out from under the composer edge.
6. Tests: with a long transcript, scroll-to-bottom leaves last bubble fully above the composer; with tall composer (multi-line / quote strip), same invariant; idle short chat has no unnecessary huge empty gap beyond the needed inset.

## Constraints
React 18 + Vite + Tailwind 4 + DaisyUI 5. Builds on #678 / #726 — do not rip out sticky composer; fix the missing content inset. Account for #737 working-avatar-above-composer when that band is visible. GitHub PR with `Fixes #N`. Wave discipline: one focused PR. Preview FF by engineer after squash on Matthew GO.

## Owner
Cursor cloud implement; open-swarm engineer squash + FF `:8001` on Matthew GO.

## Root cause
#726 put the composer in a `sticky bottom-0` dock inside the transcript. Sticky overlays the scrollport, `scrollIntoView({ block: 'end' })` aligned the last message with the viewport bottom (under the dock), and `pb-4` was a stale fixed gap that did not track quote-strip / working-avatar / multi-line height. Semi-transparent dock chrome let bubbles peek under the edge.

## Fix
- Measure `chat-bottom-dock` with `ResizeObserver` / `useLayoutEffect`.
- Set `--os-chat-composer-inset` on the transcript.
- Message list `padding-bottom` equals that inset; dock `margin-top` is the negative inset so the reserved band sits under the floating composer (no double gap).
- `scroll-padding-bottom` + scroll-to-end use the same live height.
- Dock background is opaque `bg-base-100` so nothing peeks through.

## Own-diff verification
`vitest` on inset + adjacent chat suites: 5 files / 17 tests passed (`composerInset`, `ChatComposerInset`, `ChatScrollBottom`, `ComposerWorkingIndicator`, `ChatReplyQuoteStrip`).

`ChatPage.test.tsx` still has pre-existing main failures (header “Chat” heading, remotes dropdown, blob eye-state, “Manage Teams” copy) unrelated to this inset. Type-check on main already red; this PR does not add new ChatPage TS errors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb73fd54-d2fd-4c6f-8bd7-c89da36240f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb73fd54-d2fd-4c6f-8bd7-c89da36240f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

