### PR TITLE
feat(webui): remotes popup server icons with red dot health status (REQ-195)

### DIFF
--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -87,6 +87,11 @@ import { fetchTeamRosters, teamHideId, type TeamRoster } from '../lib/teamRoster
 import { fetchConfiguredRemotes, remoteHideId, type RemoteEntry } from '../lib/remotesCatalog'
 import { configuredRemotes } from '../lib/remotes'
 import RemoteSessionsPopup from './RemoteSessionsPopup'
+import {
+  CHAT_CONNECTION_EVENT,
+  getChatConnection,
+  type ChatConnectionStatus,
+} from '../lib/chatConnection'
 import { selectStackedFaces } from '../lib/avatarStack'
 import {
   defaultSessionForRemote,
@@ -245,6 +250,22 @@ export default function AgentSidebar({
   const [hoveringHidden, setHoveringHidden] = useState(false)
   const [pluginsOpen, setPluginsOpen] = useState(false)
   const [remotesPopupOpen, setRemotesPopupOpen] = useState(false)
+  const [localWsStatus, setLocalWsStatus] = useState<ChatConnectionStatus>(() => getChatConnection())
+
+  useEffect(() => {
+    const handleStatus = (event: Event) => {
+      const customEvent = event as CustomEvent<ChatConnectionStatus>
+      if (customEvent.detail) {
+        setLocalWsStatus(customEvent.detail)
+      }
+    }
+    window.addEventListener(CHAT_CONNECTION_EVENT, handleStatus)
+    return () => {
+      window.removeEventListener(CHAT_CONNECTION_EVENT, handleStatus)
+    }
+  }, [])
+
+  const localWsDown = localWsStatus === 'closed' || localWsStatus === 'failed'
   const [hostname, setHostname] = useState(() => loadHostname())
   const [menu, setMenu] = useState<ContextMenuState | null>(null)
   const [settingsTick, setSettingsTick] = useState(0)
@@ -1931,7 +1952,7 @@ export default function AgentSidebar({
           <div className="relative os-rail-hostname-row">
             <button
               type="button"
-              className="os-rail-hostname-icon btn btn-ghost btn-xs btn-square h-5 w-5 min-h-0 text-base-content/60 hover:text-base-content"
+              className="os-rail-hostname-icon btn btn-ghost btn-xs btn-square h-5 w-5 min-h-0 text-base-content/60 hover:text-base-content relative"
               aria-label="Remote sessions"
               aria-expanded={remotesPopupOpen}
               aria-haspopup="menu"
@@ -1939,6 +1960,12 @@ export default function AgentSidebar({
               onClick={() => setRemotesPopupOpen((open) => !open)}
             >
               <Server className="h-3.5 w-3.5" aria-hidden="true" />
+              {localWsDown && (
+                <span
+                  data-testid="local-server-status-dot"
+                  className="absolute top-0.5 right-0.5 h-1.5 w-1.5 rounded-full bg-error ring-1 ring-base-100"
+                />
+              )}
             </button>
             <label className="sr-only" htmlFor="os-rail-hostname">
               Hostname

--- a/webui/frontend/src/components/RemoteSessionsPopup.tsx
+++ b/webui/frontend/src/components/RemoteSessionsPopup.tsx
@@ -1,6 +1,12 @@
-import { useEffect, useRef } from 'react'
-import type { RemoteConnection } from '../lib/api'
+import { useEffect, useRef, useState } from 'react'
+import { Server } from 'lucide-react'
+import { probeRemoteHealth, type RemoteConnection } from '../lib/api'
 import { remoteDisplayName } from '../lib/remotesCatalog'
+import {
+  CHAT_CONNECTION_EVENT,
+  getChatConnection,
+  type ChatConnectionStatus,
+} from '../lib/chatConnection'
 
 export interface RemoteSessionsPopupProps {
   isOpen: boolean
@@ -37,6 +43,10 @@ export default function RemoteSessionsPopup({
   onOpenSettingsRemotes,
 }: RemoteSessionsPopupProps) {
   const popupRef = useRef<HTMLDivElement | null>(null)
+  const [healthMap, setHealthMap] = useState<Record<string, 'pending' | 'ok' | 'failed'>>({})
+  const [wsStatus, setWsStatus] = useState<ChatConnectionStatus>(() => getChatConnection())
+
+  const browsable = remotes.filter(isBrowsableRemote)
 
   useEffect(() => {
     if (!isOpen) return
@@ -60,9 +70,56 @@ export default function RemoteSessionsPopup({
     }
   }, [isOpen, onClose])
 
+  useEffect(() => {
+    if (!isOpen) return
+    const handleStatus = (event: Event) => {
+      const customEvent = event as CustomEvent<ChatConnectionStatus>
+      if (customEvent.detail) {
+        setWsStatus(customEvent.detail)
+      }
+    }
+    window.addEventListener(CHAT_CONNECTION_EVENT, handleStatus)
+    return () => {
+      window.removeEventListener(CHAT_CONNECTION_EVENT, handleStatus)
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen || browsable.length === 0) return
+    let active = true
+
+    const initialMap: Record<string, 'pending' | 'ok' | 'failed'> = {}
+    for (const r of browsable) {
+      initialMap[r.id] = 'pending'
+    }
+    setHealthMap(initialMap)
+
+    for (const remote of browsable) {
+      probeRemoteHealth(remote.id)
+        .then((res) => {
+          if (!active) return
+          setHealthMap((prev) => ({
+            ...prev,
+            [remote.id]: res.ok ? 'ok' : 'failed',
+          }))
+        })
+        .catch(() => {
+          if (!active) return
+          setHealthMap((prev) => ({
+            ...prev,
+            [remote.id]: 'failed',
+          }))
+        })
+    }
+
+    return () => {
+      active = false
+    }
+  }, [isOpen, remotes])
+
   if (!isOpen) return null
 
-  const browsable = remotes.filter(isBrowsableRemote)
+  const localWsDown = wsStatus === 'closed' || wsStatus === 'failed'
 
   return (
     <div
@@ -73,8 +130,23 @@ export default function RemoteSessionsPopup({
       data-testid="remote-sessions-popup"
     >
       <div className="p-2">
-        <div className="px-2 py-1 font-semibold text-base-content/80 text-[11px] uppercase tracking-wider">
-          Remote sessions
+        <div className="px-2 py-1 font-semibold text-base-content/80 text-[11px] uppercase tracking-wider flex items-center justify-between">
+          <span>Remote sessions</span>
+          <span
+            className="flex items-center gap-1 text-[10px] lowercase font-normal tracking-normal text-base-content/60"
+            data-testid="popup-local-status"
+          >
+            <span className="relative inline-flex items-center">
+              <Server className="h-3 w-3 text-base-content/50" aria-hidden="true" />
+              {localWsDown && (
+                <span
+                  data-testid="popup-local-health-dot"
+                  className="absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-error ring-1 ring-base-100"
+                />
+              )}
+            </span>
+            <span>local</span>
+          </span>
         </div>
         {browsable.length === 0 ? (
           <div className="px-2 py-2 text-xs text-base-content/65" data-testid="remotes-empty-state">
@@ -96,6 +168,7 @@ export default function RemoteSessionsPopup({
               const raw = remote.ui_url?.trim() || remote.base_url?.trim() || ''
               const url = cleanRemoteUrl(raw)
               const label = remoteDisplayName(remote)
+              const isFailed = healthMap[remote.id] === 'failed'
               return (
                 <li key={remote.id} role="none">
                   <a
@@ -103,13 +176,27 @@ export default function RemoteSessionsPopup({
                     target="_blank"
                     rel="noopener noreferrer"
                     role="menuitem"
-                    className="flex flex-col items-start gap-0.5 py-1.5 px-2 rounded hover:bg-base-200"
+                    className="flex items-start gap-2 py-1.5 px-2 rounded hover:bg-base-200"
                     onClick={onClose}
                   >
-                    <span className="font-medium text-base-content">{label}</span>
-                    <span className="text-[11px] text-base-content/60 truncate max-w-[14rem]">
-                      {url}
+                    <span
+                      className="relative inline-flex shrink-0 mt-0.5"
+                      data-testid={`remote-server-icon-${remote.id}`}
+                    >
+                      <Server className="h-3.5 w-3.5 text-base-content/70" aria-hidden="true" />
+                      {isFailed && (
+                        <span
+                          data-testid={`remote-health-dot-${remote.id}`}
+                          className="absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-error ring-1 ring-base-100"
+                        />
+                      )}
                     </span>
+                    <div className="flex flex-col min-w-0 flex-1">
+                      <span className="font-medium text-base-content truncate">{label}</span>
+                      <span className="text-[11px] text-base-content/60 truncate max-w-[14rem]">
+                        {url}
+                      </span>
+                    </div>
                   </a>
                 </li>
               )

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../lib/railOrder'
 import { BUMP_COMPLETED_KEY } from '../../lib/settingsPrefs'
 import { saveAgentSessions, type AgentSession } from '../../lib/scaleOutSessions'
+import { publishChatConnection, resetChatConnection } from '../../lib/chatConnection'
 
 function blueprint(
   id: string,
@@ -395,6 +396,26 @@ describe('AgentSidebar Grok rail', () => {
 
     fireEvent.keyDown(window, { key: 'Escape' })
     expect(screen.queryByTestId('remote-sessions-popup')).toBeNull()
+  })
+
+  it('paints a red dot on rail-server-icon when local WS is disconnected (REQ-195)', async () => {
+    resetChatConnection()
+    renderSidebar()
+    await screen.findByRole('navigation', { name: 'Agent list' })
+    const serverBtn = screen.getByTestId('rail-server-icon')
+    expect(serverBtn).toBeInTheDocument()
+    expect(screen.queryByTestId('local-server-status-dot')).not.toBeInTheDocument()
+
+    act(() => {
+      publishChatConnection('closed')
+    })
+    expect(screen.getByTestId('local-server-status-dot')).toBeInTheDocument()
+
+    act(() => {
+      publishChatConnection('open')
+    })
+    expect(screen.queryByTestId('local-server-status-dot')).not.toBeInTheDocument()
+    resetChatConnection()
   })
 
   it('leaves the Hidden Bots area blank until something is hidden', async () => {

--- a/webui/frontend/src/components/__tests__/RemoteSessionsPopupHealth.test.tsx
+++ b/webui/frontend/src/components/__tests__/RemoteSessionsPopupHealth.test.tsx
@@ -1,0 +1,137 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import RemoteSessionsPopup from '../RemoteSessionsPopup'
+import type { RemoteConnection } from '../../lib/api'
+import {
+  publishChatConnection,
+  resetChatConnection,
+} from '../../lib/chatConnection'
+
+describe('REQ-195: RemoteSessionsPopup health indicators', () => {
+  beforeEach(() => {
+    resetChatConnection()
+  })
+
+  afterEach(() => {
+    resetChatConnection()
+    vi.unstubAllGlobals()
+  })
+
+  const testRemotes: RemoteConnection[] = [
+    {
+      id: 'remote-1',
+      title: 'Remote One',
+      base_url: 'http://10.0.0.10:8000',
+    },
+    {
+      id: 'remote-2',
+      title: 'Remote Two',
+      base_url: 'http://10.0.0.20:8000',
+    },
+  ]
+
+  it('renders a server icon for each browsable remote', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, state: 'healthy', detail: 'OK' }),
+      } as Response),
+    )
+
+    render(
+      <RemoteSessionsPopup
+        isOpen={true}
+        onClose={vi.fn()}
+        remotes={testRemotes}
+        onOpenSettingsRemotes={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByTestId('remote-server-icon-remote-1')).toBeInTheDocument()
+    expect(screen.getByTestId('remote-server-icon-remote-2')).toBeInTheDocument()
+  })
+
+  it('displays red-dot overlay when remote health fails, and no red-dot when ok', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/v1/remotes/remote-1/health/')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ ok: true, state: 'healthy', detail: 'OK' }),
+          } as Response
+        }
+        if (url.includes('/v1/remotes/remote-2/health/')) {
+          return {
+            ok: false,
+            status: 500,
+            json: async () => ({ ok: false, state: 'error', detail: 'Down' }),
+          } as Response
+        }
+        return {
+          ok: false,
+          status: 404,
+          json: async () => ({ error: 'not found' }),
+        } as Response
+      }),
+    )
+
+    render(
+      <RemoteSessionsPopup
+        isOpen={true}
+        onClose={vi.fn()}
+        remotes={testRemotes}
+        onOpenSettingsRemotes={vi.fn()}
+      />,
+    )
+
+    // remote-2 fails -> red dot shown
+    await waitFor(() => {
+      expect(screen.getByTestId('remote-health-dot-remote-2')).toBeInTheDocument()
+    })
+
+    // remote-1 succeeds -> no red dot
+    expect(screen.queryByTestId('remote-health-dot-remote-1')).not.toBeInTheDocument()
+  })
+
+  it('paints red-dot on local indicator when WS is disconnected and clears on reconnect', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, state: 'healthy', detail: 'OK' }),
+      } as Response),
+    )
+
+    render(
+      <RemoteSessionsPopup
+        isOpen={true}
+        onClose={vi.fn()}
+        remotes={testRemotes}
+        onOpenSettingsRemotes={vi.fn()}
+      />,
+    )
+
+    // Initially connecting/open: no red dot on local
+    expect(screen.queryByTestId('popup-local-health-dot')).not.toBeInTheDocument()
+
+    // Disconnect WS
+    act(() => {
+      publishChatConnection('closed')
+    })
+
+    expect(screen.getByTestId('popup-local-health-dot')).toBeInTheDocument()
+
+    // Reconnect WS
+    act(() => {
+      publishChatConnection('open')
+    })
+
+    expect(screen.queryByTestId('popup-local-health-dot')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #668

### Intent
Operators see at a glance which remotes are down and whether this host’s WS is dead, without leaving the popup.

### Success
1. Popup lists remotes with a compact server glyph per row (DaisyUI / existing icon language; match #622 glyph family).
2. On open, each remote is probed; failed / unreachable → red-dot overlay on that row’s glyph. Healthy → no red.
3. Local WS disconnect (same signal the rail/header already uses for Connected/Disconnected) paints a red-dot on the local server control; reconnect clears it.
4. No fake healthy: probe/auth failure ≠ green. Loading state is distinct from fail (spinner or muted, not red until fail confirmed).
5. RTL and/or e2e: mock remote fail → red-dot; mock WS down → local red-dot; mock OK → no red.

### Constraints
Prefer existing remotes health/computer-status/list APIs — do not invent a second auth path. No secrets in Issues/UI. Coordinate #372 WS hostname icon if still open. Own-diff CI. No Neon.