### PR TITLE
fix(webui): remove leftover navbar You/Default API profile dropdown (Fixes #744)

### DIFF
--- a/tests/unit/test_req133_cli_api_dropdowns_models.py
+++ b/tests/unit/test_req133_cli_api_dropdowns_models.py
@@ -20,18 +20,18 @@ def test_chat_page_renders_cli_and_api_dropdowns_with_models():
     assert "isApiAgent" in tsx
     assert "showRemotesControl" in tsx
 
-    # CLI controls
+    # CLI controls (legitimate host-CLI + model override; keep these)
     assert 'data-testid="cli-select"' in tsx
     assert 'aria-label="CLI"' in tsx
     assert 'data-testid="cli-model-select"' in tsx
 
-    # API controls
-    assert 'data-testid="api-select"' in tsx
-    assert 'aria-label="API"' in tsx
+    # API identity/profile navbar dropdown was a mystery You/Default control
+    # (REQ-186 / #642 / #744). LLM profiles live in Settings / Agent Editor.
+    assert 'data-testid="api-select"' not in tsx
+    assert 'data-testid="api-model-select"' not in tsx
 
     # Status tracking on change
     assert "recordDropdownChange('cli'" in tsx
-    assert "recordDropdownChange('api'" in tsx
     assert "recordDropdownChange('model'" in tsx
 
 

--- a/tests/unit/test_req186_navbar_dropdown.py
+++ b/tests/unit/test_req186_navbar_dropdown.py
@@ -1,4 +1,4 @@
-"""REQ-186: Remove mystery navbar You / Default dropdown."""
+"""REQ-186 / #744: Remove mystery navbar You / Default dropdown."""
 
 from pathlib import Path
 
@@ -9,10 +9,18 @@ CHAT_PAGE_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "pages" / "ChatPage.t
 def test_navbar_no_mystery_api_or_model_dropdown():
     content = CHAT_PAGE_TSX.read_text(encoding="utf-8")
 
-    # The mystery "You" and "Default" controls were api-model-select and the blueprint picker (availableApiAgents)
+    # #679 removed api-model-select + availableApiAgents but left api-select on
+    # api_agent (LLM profile ids / "default"). That leftover is the regression.
+    assert 'data-testid="api-select"' not in content, "api-select must stay out of the navbar"
     assert 'data-testid="api-model-select"' not in content, "api-model-select must be removed from navbar"
     assert "availableApiAgents" not in content, "availableApiAgents blueprint picker must be removed from navbar"
+    assert "availableApiModels" not in content, "navbar must not list LLM profiles as a model dropdown"
+    assert "currentApiModel" not in content, "navbar must not keep an API model select value"
 
     # fetchModels and modelsQuery should no longer be in ChatPage
     assert "fetchModels" not in content, "fetchModels should not be imported in ChatPage"
+    assert "fetchLlmProfiles" not in content, "LLM profiles belong in Settings / Agent Editor, not ChatPage navbar"
     assert "modelsQuery" not in content, "modelsQuery should not be present in ChatPage"
+
+    # Do not resurrect a cryptic dual-dropdown (#676 cascading picker is a later REQ).
+    assert 'aria-label="API"' not in content, "navbar must not expose an unlabeled API identity/profile select"

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -34,8 +34,7 @@ import {
   getRecentSlashIds,
   recordRecentSlashId,
 } from '../lib/slashMenu'
-import { fetchConfigOptions, fetchBlueprints, fetchCliAgents, fetchCliModels, fetchLlmProfiles, fetchRemotes } from '../lib/api'
-import { profileIds } from '../lib/llmProfiles'
+import { fetchConfigOptions, fetchBlueprints, fetchCliAgents, fetchCliModels, fetchRemotes } from '../lib/api'
 import {
   agentIdFromBlueprint,
   appendAgentMessage,
@@ -366,7 +365,9 @@ const ChatPage = () => {
   const selectedRemote = remotes.find((remote) => remote.id === remoteFromUrl) ?? null
   const selectedRemoteSession = selectedRemote?.agents.find((agent) => agent.id === sessionFromUrl)
   const selectedTeamSession = selectedTeam?.members.find((member) => member.id === sessionFromUrl)
-  const selectedCli = cliAgents.find((row) => row.id === selectedBlueprint)
+  // api_agent is also listed on the CLI rail (kind=api). Do not treat it as a
+  // host-CLI seat — that reintroduced CLI chrome beside the mystery API picker.
+  const selectedCli = cliAgents.find((row) => row.id === selectedBlueprint && row.kind === 'cli')
   const selectedAgent = blueprints.find((bp) => bp.id === selectedBlueprint)
   const runtimeBlueprint = teamFromUrl ? '' : assignedBlueprintId(selectedBlueprint)
   const fallbackAgentName =
@@ -407,8 +408,10 @@ const ChatPage = () => {
 
   const showRemotesControl = isRemoteAgent || isRemoteBackedTeam
 
+  const isNamedApiAgent = selectedBlueprint === 'api_agent'
   const isCliAgent = Boolean(
-    !teamFromUrl &&
+    !isNamedApiAgent &&
+      !teamFromUrl &&
       !remoteFromUrl &&
       !isRemoteBackedTeam &&
       !isRemoteAgent &&
@@ -421,7 +424,6 @@ const ChatPage = () => {
         })),
   )
 
-  const isNamedApiAgent = selectedBlueprint === 'api_agent'
   const isApiAgent = Boolean(
     !teamFromUrl &&
       !remoteFromUrl &&
@@ -429,13 +431,6 @@ const ChatPage = () => {
       !isRemoteAgent &&
       !isCliAgent,
   )
-
-  const llmProfilesQuery = useQuery({
-    queryKey: ['llm-profiles'],
-    queryFn: fetchLlmProfiles,
-    enabled: Boolean(isNamedApiAgent || isApiAgent),
-    retry: 1,
-  })
 
   const discoveredClis = useMemo(
     () => discoverChatClis(cliQuery.data, searchParams.get('cli') || selectedCli?.cli),
@@ -465,21 +460,6 @@ const ChatPage = () => {
     return availableCliModels[0] || 'default'
   }, [searchParams, availableCliModels])
 
-  const availableApiModels = useMemo(() => {
-    if (isNamedApiAgent) {
-      const ids = profileIds(llmProfilesQuery.data)
-      const fallback = llmProfilesQuery.data?.default_llm_profile
-      const list = ids.length ? ids : fallback ? [fallback] : []
-      return list.length ? list : ['default']
-    }
-    return ['default']
-  }, [isNamedApiAgent, llmProfilesQuery.data])
-
-  const currentApiModel = useMemo(() => {
-    const fromParam = (searchParams.get('model') ?? '').trim()
-    if (fromParam && availableApiModels.includes(fromParam)) return fromParam
-    return availableApiModels[0] || 'default'
-  }, [searchParams, availableApiModels])
   const recordDropdownChange = useCallback(
     (kind: DropdownKind, fromLabel: string, toLabel: string) => {
       if (!shouldRecordDropdownChange(fromLabel, toLabel)) return
@@ -1607,33 +1587,6 @@ const ChatPage = () => {
                 ))}
               </select>
             </>
-          ) : null}
-          {isNamedApiAgent ? (
-            <select
-              className="select select-sm h-8 max-w-[10rem] border border-base-300 bg-base-100"
-              value={currentApiModel}
-              aria-label="API"
-              data-testid="api-select"
-              onChange={(e) => {
-                const nextModel = e.target.value
-                const prev = currentApiModel
-                setSearchParams(
-                  (prevParams) => {
-                    const nextParams = new URLSearchParams(prevParams)
-                    nextParams.set('model', nextModel)
-                    return nextParams
-                  },
-                  { replace: true },
-                )
-                recordDropdownChange('api', prev, nextModel)
-              }}
-            >
-              {availableApiModels.map((m) => (
-                <option key={m} value={m}>
-                  {m}
-                </option>
-              ))}
-            </select>
           ) : null}
           <div
             className="flex items-center gap-2"

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -2591,6 +2591,7 @@ describe('ChatPage dropdown status lines (REQ-46)', () => {
 
     expect(await screen.findByRole('combobox', { name: 'CLI' })).toBeInTheDocument()
     expect(await screen.findByRole('combobox', { name: 'Model' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'grok' })).toBeInTheDocument()
     expect(screen.queryByRole('combobox', { name: 'API' })).not.toBeInTheDocument()
     expect(screen.queryByRole('combobox', { name: 'Remote' })).not.toBeInTheDocument()
   })
@@ -2604,10 +2605,123 @@ describe('ChatPage dropdown status lines (REQ-46)', () => {
       MockWebSocket.instances[0]?.open()
     })
 
-    expect(screen.queryByRole('combobox', { name: 'API' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('combobox', { name: 'Model' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('combobox', { name: 'CLI' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('combobox', { name: 'Remote' })).not.toBeInTheDocument()
+    const header = screen.getByRole('banner')
+    expect(within(header).queryByRole('combobox', { name: 'API' })).not.toBeInTheDocument()
+    expect(within(header).queryByRole('combobox', { name: 'Model' })).not.toBeInTheDocument()
+    expect(within(header).queryByRole('combobox', { name: 'CLI' })).not.toBeInTheDocument()
+    expect(within(header).queryByRole('combobox', { name: 'Remote' })).not.toBeInTheDocument()
+    expect(within(header).queryByTestId('api-select')).not.toBeInTheDocument()
+    expect(within(header).queryByRole('option', { name: 'You' })).not.toBeInTheDocument()
+    expect(within(header).queryByRole('option', { name: 'Default' })).not.toBeInTheDocument()
+  })
+
+  it('does not render You/Default profile dropdown on api_agent even when the CLI rail lists it (REQ-186 / #744)', async () => {
+    const store = { messages: [] as { role: string; content: string }[] }
+    MockWebSocket.instances = []
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/chat/thread/')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              agent_id: 'api_agent',
+              conversation_id: 'api_agent',
+              messages: store.messages,
+            }),
+          } as Response
+        }
+        if (url.includes('/v1/cli-agents')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              clis: ['grok', 'agy'],
+              rail: [
+                {
+                  id: 'cli_agent',
+                  object: 'cli.agent',
+                  name: 'cli_agent',
+                  cli: 'grok',
+                  kind: 'cli',
+                  description: 'Host CLI',
+                  installed: true,
+                },
+                {
+                  id: 'api_agent',
+                  object: 'cli.agent',
+                  name: 'api_agent',
+                  cli: '',
+                  kind: 'api',
+                  description: 'LiteLLM',
+                  installed: true,
+                },
+              ],
+            }),
+          } as Response
+        }
+        if (url.includes('/v1/llm-profiles')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'llm_profiles',
+              profiles: [
+                { id: 'You', object: 'llm_profile', source: 'config', owned_by: 'user' },
+                { id: 'Default', object: 'llm_profile', source: 'config', owned_by: 'openai' },
+              ],
+              default_llm_profile: 'Default',
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: [{ id: 'api_agent', name: 'API agent', description: 'LiteLLM' }],
+          }),
+        } as Response
+      }),
+    )
+
+    renderChat('/chat?blueprint=api_agent')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+
+    const header = screen.getByRole('banner')
+    expect(within(header).queryByRole('combobox', { name: 'API' })).not.toBeInTheDocument()
+    expect(within(header).queryByRole('combobox', { name: 'CLI' })).not.toBeInTheDocument()
+    expect(within(header).queryByRole('combobox', { name: 'Model' })).not.toBeInTheDocument()
+    expect(within(header).queryByTestId('api-select')).not.toBeInTheDocument()
+    expect(within(header).queryByRole('option', { name: 'You' })).not.toBeInTheDocument()
+    expect(within(header).queryByRole('option', { name: 'Default' })).not.toBeInTheDocument()
+  })
+
+  it('still forwards ?model= on API agent send without a navbar profile picker', async () => {
+    const store = { messages: [] as { role: string; content: string }[] }
+    stubWithThreadStore(store)
+
+    renderChat('/chat?blueprint=codey&model=gpt-4')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+
+    const composer = await screen.findByRole('textbox', { name: 'Chat message' })
+    fireEvent.change(composer, { target: { value: 'use override' } })
+    fireEvent.click(screen.getByRole('button', { name: /^Send$/i }))
+
+    const ws = MockWebSocket.instances[0]!
+    expect(ws.send).toHaveBeenCalled()
+    expect(JSON.parse(String(ws.send.mock.calls[0][0]))).toMatchObject({
+      message: 'use override',
+      blueprint: 'codey',
+      params: { model: 'gpt-4' },
+    })
   })
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #744

**Feasibility:** Surgical — delete leftover `api-select` and stop treating `api_agent` as a CLI seat; LLM profiles stay in Settings / Agent Editor.

### Quoted issue context

**Intent:** Top navbar must not show a mystery You / Default (or equivalent orphan identity/profile) dropdown. Matthew only wants chrome he understands (tokens, model/agent pickers that are real, theme, settings, etc.).

**Success:**
1. The You / Default control is gone from the top navbar (and any twin that shows the same meaningless labels).
2. PR names what the control was (e.g. API agent / LLM profile leftover) and where that function lives now if still needed (Settings LLM profiles / Agent Editor — not the navbar).
3. Do not replace it with another cryptic dual-dropdown. Keep legitimate model picker (e.g. `grok`) if that is a real model override; only remove the You/Default mystery control.
4. Tests assert the control is absent; update any tests that reintroduced it after #679. `Fixes` this Issue.
5. No regression of #642 contract (`test_req186_navbar_dropdown` or successor).

**Constraints:** React 18 + Vite + Tailwind 4 + DaisyUI 5. Prefer surgical remove over redesign. Do not break Settings LLM profiles (#358) or agent model override. Related open work: #676 cascading picker must not reintroduce You/Default. GitHub PR with `Fixes #N`. Wave discipline: one focused PR. Preview FF by engineer after squash on Matthew GO.

**Owner:** Cursor cloud implement; open-swarm engineer squash + FF `:8001` on Matthew GO.

### What the control was / where it lives now

- **What it was:** Navbar `api-select` on the named `api_agent` rail seat. #621 added it as a LiteLLM profile picker (ids / fallback `"default"`). Combined with `api_agent` living on the CLI rail (`kind: api`), `selectedCli` was truthy so ChatPage also painted the host-CLI dropdown (`grok`). Live chrome was token counter + `grok` + a mystery You/Default profile menu — the #642 / #679 leftover.
- **#679 gap:** That PR removed `api-model-select` and `availableApiAgents` (blueprint “You” + model “Default”) but left `api-select`. `test_req186_navbar_dropdown.py` did not forbid `api-select`; `test_req133` still required it, so the leftover could not regress-fail.
- **Where the function lives now:** Settings → LLM profiles (#358) and Agent Editor model override (#511). Not the navbar. URL `?model=` is still forwarded on API-agent send.

### Changes

- Remove `api-select` and unused ChatPage LLM-profile query/hooks (`fetchLlmProfiles`, `availableApiModels`, `currentApiModel`).
- Do not treat `api_agent` as a CLI seat (`selectedCli` requires `kind === 'cli'`; `isCliAgent` excludes `api_agent`) so grok does not appear beside a profile picker on that row.
- Keep real CLI + model dropdowns on `cli_agent` (including `grok`).
- Restore/strengthen REQ-186 contract; stop REQ-133 from requiring navbar `api-select`.
- Frontend tests: absence of You/Default / API combobox on `codey` and `api_agent` (with rail + profile fixtures); `?model=` still sent; CLI picker kept.

Does not implement #676 cascading picker.

### Verification

`api_agent` navbar — identity + token counter only (no You/Default, no API select, no grok):

[api_agent navbar without You/Default dropdown](https://cursor.com/agents/bc-7a861606-1373-4d91-8c3c-260fc122ba43/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi-agent-navbar.png)

`cli_agent` navbar — legitimate `grok` CLI picker kept; no You/Default identity menu:

[cli_agent navbar with grok CLI picker](https://cursor.com/agents/bc-7a861606-1373-4d91-8c3c-260fc122ba43/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcli-agent-navbar.png)

Contract tests: pytest REQ-186/133 and Vitest navbar cases all passed.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a861606-1373-4d91-8c3c-260fc122ba43?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a861606-1373-4d91-8c3c-260fc122ba43&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

