### PR TITLE
fix(webui): bind remote agents to a real remote instead of No remotes

### DIFF
--- a/webui/frontend/src/App.tsx
+++ b/webui/frontend/src/App.tsx
@@ -196,6 +196,7 @@ function App() {
           initialSection={settingsDetail?.section}
           definitionKind={settingsDetail?.definitionKind}
           definitionId={settingsDetail?.definitionId}
+          initialAddRemote={settingsDetail?.addRemote}
         />
         <AgentEditor
           isOpen={agentEditorOpen}

--- a/webui/frontend/src/components/AddAgentWizard.tsx
+++ b/webui/frontend/src/components/AddAgentWizard.tsx
@@ -417,7 +417,7 @@ export default function AddAgentWizard({
       } else if (selectedKind === 'remote') {
         if (configuredRemoteRows.length > 0) {
           const picked = configuredRemoteRows.find((row) => row.id === pickedRemoteId)
-          if (!picked) throw new Error('Pick a remote')
+          if (!picked) throw new Error('Select a configured remote')
           saveAgentRemoteBinding(picked.id, {
             id: picked.id,
             kind: picked.kind || picked.id,

--- a/webui/frontend/src/components/AddAgentWizard.tsx
+++ b/webui/frontend/src/components/AddAgentWizard.tsx
@@ -1,4 +1,4 @@
-import { useState, useId, useMemo } from 'react'
+import { useState, useId, useMemo, useEffect } from 'react'
 import { Terminal, Bot, Globe, ArrowLeft, Plus, ExternalLink, Edit3 } from 'lucide-react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Modal, Button, Alert } from './DaisyUI'
@@ -9,9 +9,14 @@ import {
   fetchBlueprints,
   fetchCliAgents,
   fetchCustomBlueprints,
+  fetchRemotes,
 } from '../lib/api'
 import { OPENMOUSBOT_LABEL } from '../lib/remotesCatalog'
 import { loadAgentEdit, saveAgentEdit } from '../lib/agentEdits'
+import { RemoteSelect } from './RemoteSelect'
+import { openSettingsSheet } from './SettingsSheet'
+import { configuredRemotes } from '../lib/remotes'
+import { remotesListForSelect, saveAgentRemoteBinding } from '../lib/agentRemote'
 
 export type AgentKind = 'cli' | 'api' | 'remote'
 
@@ -78,6 +83,7 @@ export default function AddAgentWizard({
   const [remoteKind, setRemoteKind] = useState<'omb' | 'generic'>('omb')
   const [remoteBaseUrl, setRemoteBaseUrl] = useState('')
   const [remoteApiKey, setRemoteApiKey] = useState('')
+  const [pickedRemoteId, setPickedRemoteId] = useState('')
 
   // Queries for existing agents
   const blueprintsQuery = useQuery({
@@ -101,6 +107,23 @@ export default function AddAgentWizard({
     retry: 1,
   })
 
+  const remotesQuery = useQuery({
+    queryKey: ['remotes-list'],
+    queryFn: fetchRemotes,
+    enabled: isOpen,
+    retry: 1,
+  })
+  const remotesCatalog = remotesListForSelect(remotesQuery.data)
+  const configuredRemoteRows = configuredRemotes(remotesCatalog)
+
+  useEffect(() => {
+    if (!isOpen || selectedKind !== 'remote' || step !== 'configure') return
+    if (remotesQuery.isPending) return
+    if (configuredRemoteRows.length === 0) {
+      openSettingsSheet({ section: 'remotes', addRemote: true })
+    }
+  }, [isOpen, selectedKind, step, remotesQuery.isPending, configuredRemoteRows.length])
+
   const resetFormFields = () => {
     setError(null)
     setFolderError(null)
@@ -115,6 +138,7 @@ export default function AddAgentWizard({
     setRemoteKind('omb')
     setRemoteBaseUrl('')
     setRemoteApiKey('')
+    setPickedRemoteId('')
     setEditingAgentId(null)
   }
 
@@ -391,23 +415,43 @@ export default function AddAgentWizard({
           setStep('manage')
         }
       } else if (selectedKind === 'remote') {
-        const baseUrl = remoteBaseUrl.trim()
-        if (!baseUrl) throw new Error('Base URL is required')
+        if (configuredRemoteRows.length > 0) {
+          const picked = configuredRemoteRows.find((row) => row.id === pickedRemoteId)
+          if (!picked) throw new Error('Pick a remote')
+          saveAgentRemoteBinding(picked.id, {
+            id: picked.id,
+            kind: picked.kind || picked.id,
+          })
+          onCreated?.({
+            id: picked.id,
+            name: picked.label || picked.title || picked.id,
+            kind: 'remote',
+          })
+          handleClose()
+        } else {
+          const baseUrl = remoteBaseUrl.trim()
+          if (!baseUrl) throw new Error('Base URL is required')
 
-        const created = await createRemote({
-          kind: remoteKind === 'omb' ? 'omb' : 'remote',
-          base_url: baseUrl,
-          ...(remoteApiKey.trim() ? { api_key: remoteApiKey.trim() } : {}),
-        })
+          const created = await createRemote({
+            kind: remoteKind === 'omb' ? 'omb' : 'remote',
+            base_url: baseUrl,
+            ...(remoteApiKey.trim() ? { api_key: remoteApiKey.trim() } : {}),
+          })
 
-        await queryClient.invalidateQueries({ queryKey: ['configured-remotes'] })
-        await queryClient.invalidateQueries({ queryKey: ['settings-remotes'] })
-        onCreated?.({
-          id: created.id,
-          name: remoteKind === 'omb' ? OPENMOUSBOT_LABEL : created.id,
-          kind: 'remote',
-        })
-        handleClose()
+          saveAgentRemoteBinding(created.id, {
+            id: created.id,
+            kind: created.kind || created.id,
+          })
+          await queryClient.invalidateQueries({ queryKey: ['configured-remotes'] })
+          await queryClient.invalidateQueries({ queryKey: ['settings-remotes'] })
+          await queryClient.invalidateQueries({ queryKey: ['remotes-list'] })
+          onCreated?.({
+            id: created.id,
+            name: remoteKind === 'omb' ? OPENMOUSBOT_LABEL : created.id,
+            kind: 'remote',
+          })
+          handleClose()
+        }
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save agent')
@@ -789,53 +833,65 @@ export default function AddAgentWizard({
             ) : null}
 
             {selectedKind === 'remote' ? (
-              <>
-                <div className="space-y-1">
-                  <label className="block text-xs font-medium text-base-content/80">
-                    Remote Type <span className="text-error">*</span>
-                  </label>
-                  <select
-                    className="select select-sm select-bordered w-full"
-                    value={remoteKind}
-                    onChange={(e) => setRemoteKind(e.target.value as 'omb' | 'generic')}
-                    aria-label="Remote type"
-                    data-testid="select-remote-kind"
-                  >
-                    <option value="omb">{OPENMOUSBOT_LABEL}</option>
-                    <option value="generic">Generic Remote Agent</option>
-                  </select>
-                </div>
-                <div className="space-y-1">
-                  <label className="block text-xs font-medium text-base-content/80">
-                    Base URL <span className="text-error">*</span>
-                  </label>
-                  <input
-                    type="url"
-                    className="input input-sm input-bordered w-full font-mono text-xs"
-                    placeholder="http://localhost:8000"
-                    value={remoteBaseUrl}
-                    onChange={(e) => setRemoteBaseUrl(e.target.value)}
-                    required
-                    autoFocus
-                    aria-label="Base URL"
-                    data-testid="input-remote-url"
-                  />
-                </div>
-                <div className="space-y-1">
-                  <label className="block text-xs font-medium text-base-content/80">
-                    API Key / Token (optional)
-                  </label>
-                  <input
-                    type="password"
-                    className="input input-sm input-bordered w-full text-xs"
-                    placeholder="Optional authorization token"
-                    value={remoteApiKey}
-                    onChange={(e) => setRemoteApiKey(e.target.value)}
-                    aria-label="API Key"
-                    data-testid="input-remote-key"
-                  />
-                </div>
-              </>
+              configuredRemoteRows.length > 0 ? (
+                <RemoteSelect
+                  remotes={remotesCatalog}
+                  value={pickedRemoteId}
+                  onChange={setPickedRemoteId}
+                  label="Remote"
+                />
+              ) : (
+                <>
+                  <p className="text-xs text-base-content/60" data-testid="remote-empty-add-hint">
+                    No remotes configured yet. Add one here, or finish Add remote in Settings.
+                  </p>
+                  <div className="space-y-1">
+                    <label className="block text-xs font-medium text-base-content/80">
+                      Remote Type <span className="text-error">*</span>
+                    </label>
+                    <select
+                      className="select select-sm select-bordered w-full"
+                      value={remoteKind}
+                      onChange={(e) => setRemoteKind(e.target.value as 'omb' | 'generic')}
+                      aria-label="Remote type"
+                      data-testid="select-remote-kind"
+                    >
+                      <option value="omb">{OPENMOUSBOT_LABEL}</option>
+                      <option value="generic">Generic Remote Agent</option>
+                    </select>
+                  </div>
+                  <div className="space-y-1">
+                    <label className="block text-xs font-medium text-base-content/80">
+                      Base URL <span className="text-error">*</span>
+                    </label>
+                    <input
+                      type="url"
+                      className="input input-sm input-bordered w-full font-mono text-xs"
+                      placeholder="http://localhost:8000"
+                      value={remoteBaseUrl}
+                      onChange={(e) => setRemoteBaseUrl(e.target.value)}
+                      required
+                      autoFocus
+                      aria-label="Base URL"
+                      data-testid="input-remote-url"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <label className="block text-xs font-medium text-base-content/80">
+                      API Key / Token (optional)
+                    </label>
+                    <input
+                      type="password"
+                      className="input input-sm input-bordered w-full text-xs"
+                      placeholder="Optional authorization token"
+                      value={remoteApiKey}
+                      onChange={(e) => setRemoteApiKey(e.target.value)}
+                      aria-label="API Key"
+                      data-testid="input-remote-key"
+                    />
+                  </div>
+                </>
+              )
             ) : null}
 
             <div className="flex items-center justify-end gap-2 pt-2">

--- a/webui/frontend/src/components/AgentEditor.tsx
+++ b/webui/frontend/src/components/AgentEditor.tsx
@@ -7,9 +7,17 @@ import {
   fetchCliModels,
   fetchLlmProfiles,
   fetchModels,
+  fetchRemotes,
   type AgentRole,
   type Blueprint,
 } from '../lib/api'
+import { RemoteSelect } from './RemoteSelect'
+import { configuredRemotes } from '../lib/remotes'
+import {
+  loadAgentRemoteBinding,
+  remotesListForSelect,
+  saveAgentRemoteBinding,
+} from '../lib/agentRemote'
 import {
   assignedBlueprintId,
   loadAgentEdit,
@@ -73,6 +81,7 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
   const [profileOverride, setProfileOverride] = useState('')
   const [newChatPerTask, setNewChatPerTask] = useState(false)
   const [savingSettings, setSavingSettings] = useState(false)
+  const [boundRemoteId, setBoundRemoteId] = useState('')
 
   const blueprintsQuery = useQuery({
     queryKey: ['blueprints'],
@@ -136,6 +145,19 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
     retry: 1,
   })
 
+  const remotesQuery = useQuery({
+    queryKey: ['remotes-list'],
+    queryFn: fetchRemotes,
+    enabled: Boolean(isOpen && agentKind === 'remote'),
+    retry: 1,
+  })
+  const remotesCatalog = remotesListForSelect(
+    remotesQuery.data,
+    null,
+    boundRemoteId ? loadAgentRemoteBinding(id) : null,
+  )
+  const configuredRemoteRows = configuredRemotes(remotesCatalog)
+
   const catalogAgentIds = useMemo(
     () => new Set(catalog.map((item) => item.id.toLowerCase())),
     [catalog],
@@ -166,6 +188,7 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
     setLlmOverride(edit.llmOverride || '')
     setCliOverride(edit.cliOverride || '')
     setProfileOverride(edit.profileOverride || '')
+    setBoundRemoteId(loadAgentRemoteBinding(id)?.id || '')
 
     let cancelled = false
     ;(async () => {
@@ -273,9 +296,45 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
 
         {/* LLM Override Picker by Kind (REQ-124) */}
         {agentKind === 'remote' && (
-          <div className="rounded-box border border-base-300 bg-base-200/40 p-3 opacity-60">
-            <span className="text-sm font-semibold text-base-content/70">LLM override</span>
-            <p className="text-xs text-base-content/60 mt-1">Remotes keep their own models</p>
+          <div className="space-y-3">
+            {configuredRemoteRows.length === 0 ? (
+              <div className="rounded-box border border-base-300 bg-base-200/40 p-3">
+                <span className="text-sm font-semibold">Remote</span>
+                <p className="text-xs text-base-content/60 mt-1">
+                  Add a remote before this agent is usable.
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="mt-2"
+                  onClick={() => {
+                    onClose()
+                    openSettingsSheet({ section: 'remotes', addRemote: true })
+                  }}
+                >
+                  Add remote
+                </Button>
+              </div>
+            ) : (
+              <RemoteSelect
+                remotes={remotesCatalog}
+                value={boundRemoteId}
+                onChange={(nextId) => {
+                  setBoundRemoteId(nextId)
+                  const remote = configuredRemoteRows.find((row) => row.id === nextId)
+                  saveAgentRemoteBinding(
+                    id,
+                    remote ? { id: remote.id, kind: remote.kind || remote.id } : null,
+                  )
+                }}
+                label="Remote"
+              />
+            )}
+            <div className="rounded-box border border-base-300 bg-base-200/40 p-3 opacity-60">
+              <span className="text-sm font-semibold text-base-content/70">LLM override</span>
+              <p className="text-xs text-base-content/60 mt-1">Remotes keep their own models</p>
+            </div>
           </div>
         )}
 

--- a/webui/frontend/src/components/RemoteSelect.tsx
+++ b/webui/frontend/src/components/RemoteSelect.tsx
@@ -5,6 +5,7 @@ import {
   configuredRemotes,
   remoteKinds,
   remoteOptionLabel,
+  remoteSelectPlaceholder,
 } from '../lib/remotes'
 import type { RemotesListResponse } from '../lib/api'
 
@@ -54,7 +55,7 @@ export function RemoteSelect({
       }}
     >
       <option value="" disabled>
-        {configured.length === 0 ? 'No remotes' : 'Remote'}
+        {remoteSelectPlaceholder(configured.length, selected)}
       </option>
       {configured.map((remote) => (
         <option key={remote.id} value={remote.id}>

--- a/webui/frontend/src/components/SettingsSheet.tsx
+++ b/webui/frontend/src/components/SettingsSheet.tsx
@@ -82,6 +82,8 @@ export interface OpenSettingsDetail {
   teamId?: string
   definitionKind?: DefinitionKind
   definitionId?: string
+  /** Open the Remotes pane already on the add form (zero-remotes bind path). */
+  addRemote?: boolean
 }
 
 export function openSettingsSheet(detail?: OpenSettingsDetail): void {
@@ -96,6 +98,7 @@ export interface SettingsSheetProps {
   initialSection?: SettingsSection | null
   definitionKind?: DefinitionKind | null
   definitionId?: string | null
+  initialAddRemote?: boolean
 }
 
 /**
@@ -114,6 +117,7 @@ export default function SettingsSheet({
   initialSection,
   definitionKind,
   definitionId,
+  initialAddRemote = false,
 }: SettingsSheetProps) {
   const { success } = useToast()
   const [section, setSection] = useState<SettingsSection>('retention')
@@ -283,7 +287,7 @@ export default function SettingsSheet({
               onSelect={setSelectedBlueprintId}
             />
           )}
-          {section === 'remotes' && <RemotesCatalogPane />}
+          {section === 'remotes' && <RemotesCatalogPane startAdding={initialAddRemote} />}
           {section === 'retention' && (
             <RetentionPane
               value={retention}
@@ -539,10 +543,10 @@ function ModuleLink({
   )
 }
 
-function RemotesCatalogPane() {
+function RemotesCatalogPane({ startAdding = false }: { startAdding?: boolean }) {
   const { success, error: toastError } = useToast()
   const queryClient = useQueryClient()
-  const [adding, setAdding] = useState(false)
+  const [adding, setAdding] = useState(startAdding)
   const [kind, setKind] = useState('')
   const [baseUrl, setBaseUrl] = useState('')
   const [apiKey, setApiKey] = useState('')
@@ -566,6 +570,10 @@ function RemotesCatalogPane() {
   useEffect(() => {
     if (!selectedId && configured[0]) setSelectedId(configured[0].id)
   }, [selectedId, configured])
+
+  useEffect(() => {
+    if (startAdding) setAdding(true)
+  }, [startAdding])
 
   const addMutation = useMutation({
     mutationFn: () =>

--- a/webui/frontend/src/components/__tests__/AddAgentWizard.test.tsx
+++ b/webui/frontend/src/components/__tests__/AddAgentWizard.test.tsx
@@ -386,7 +386,7 @@ describe('AddAgentWizard (REQ-109, REQ-165, REQ-167)', () => {
     expect(screen.queryByTestId('input-remote-url')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('submit-create-agent'))
-    expect(await screen.findByText(/Pick a remote/i)).toBeInTheDocument()
+    expect(await screen.findByText(/Select a configured remote/i)).toBeInTheDocument()
     expect(createRemoteSpy).not.toHaveBeenCalled()
 
     fireEvent.change(select, { target: { value: 'omb' } })

--- a/webui/frontend/src/components/__tests__/AddAgentWizard.test.tsx
+++ b/webui/frontend/src/components/__tests__/AddAgentWizard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import AddAgentWizard from '../AddAgentWizard'
@@ -43,6 +43,12 @@ describe('AddAgentWizard (REQ-109, REQ-165, REQ-167)', () => {
       native_consensus: {},
       catalog: {},
       rail: [],
+    })
+    vi.spyOn(api, 'fetchRemotes').mockResolvedValue({
+      object: 'list',
+      kinds: [{ id: 'omb', label: 'OpenMousBot' }],
+      configured: [],
+      data: [],
     })
   })
 
@@ -353,5 +359,46 @@ describe('AddAgentWizard (REQ-109, REQ-165, REQ-167)', () => {
       })
       expect(onClose).toHaveBeenCalled()
     })
+  })
+
+  it('requires picking a configured remote when remotes already exist', async () => {
+    vi.spyOn(api, 'fetchRemotes').mockResolvedValue({
+      object: 'list',
+      kinds: [{ id: 'omb', label: 'OpenMousBot' }],
+      configured: [
+        {
+          id: 'omb',
+          kind: 'omb',
+          label: 'OpenMousBot',
+          title: 'OpenMousBot',
+          host_label: '',
+          base_url: 'http://127.0.0.1:8802',
+          source: 'config',
+        },
+      ],
+    })
+    const createRemoteSpy = vi.spyOn(api, 'createRemote')
+    const { onCreated, onClose } = renderWizard()
+
+    fireEvent.click(screen.getByTestId('kind-option-remote'))
+    const select = await screen.findByRole('combobox', { name: 'Remote' })
+    expect(within(select).getByRole('option', { name: 'Pick a remote' })).toBeInTheDocument()
+    expect(screen.queryByTestId('input-remote-url')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('submit-create-agent'))
+    expect(await screen.findByText(/Pick a remote/i)).toBeInTheDocument()
+    expect(createRemoteSpy).not.toHaveBeenCalled()
+
+    fireEvent.change(select, { target: { value: 'omb' } })
+    fireEvent.click(screen.getByTestId('submit-create-agent'))
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith({
+        id: 'omb',
+        name: 'OpenMousBot',
+        kind: 'remote',
+      })
+      expect(onClose).toHaveBeenCalled()
+    })
+    expect(createRemoteSpy).not.toHaveBeenCalled()
   })
 })

--- a/webui/frontend/src/components/__tests__/AgentEditor.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentEditor.test.tsx
@@ -6,6 +6,7 @@ import AgentEditor from '../AgentEditor'
 import SettingsSheet, { OPEN_SETTINGS_EVENT, type OpenSettingsDetail } from '../SettingsSheet'
 import { ToastProvider } from '../DaisyUI'
 import { AGENT_EDITS_KEY, assignedBlueprintId } from '../../lib/agentEdits'
+import { AGENT_REMOTE_BINDINGS_KEY } from '../../lib/agentRemote'
 
 const catalog = [
   {
@@ -114,6 +115,7 @@ function EditorThenSettings({ agentId = 'support' }: { agentId?: string }) {
 describe('AgentEditor (REQ-58)', () => {
   afterEach(() => {
     localStorage.removeItem(AGENT_EDITS_KEY)
+    localStorage.removeItem(AGENT_REMOTE_BINDINGS_KEY)
     vi.unstubAllGlobals()
   })
 
@@ -212,6 +214,47 @@ describe('AgentEditor (REQ-58)', () => {
       expect(within(dialog).getByText(/Remotes keep their own models/i)).toBeInTheDocument()
       expect(within(dialog).queryByRole('combobox', { name: /CLI override/i })).not.toBeInTheDocument()
       expect(within(dialog).queryByRole('combobox', { name: /API profile override/i })).not.toBeInTheDocument()
+    })
+
+    it('remote agent: requires picking a configured remote', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+          const url = String(input)
+          if (url.includes('/v1/remotes')) {
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                object: 'list',
+                kinds: [{ id: 'omb', label: 'OpenMousBot' }],
+                configured: [
+                  {
+                    id: 'omb',
+                    kind: 'omb',
+                    label: 'OpenMousBot',
+                    title: 'OpenMousBot',
+                    host_label: '',
+                    base_url: 'http://127.0.0.1:8802',
+                    source: 'config',
+                  },
+                ],
+              }),
+            } as Response
+          }
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ object: 'list', data: catalog }),
+          } as Response
+        }),
+      )
+      renderEditor({ agentId: 'remote-omb' })
+      const dialog = await screen.findByRole('dialog', { name: /Edit /i, hidden: true })
+      const select = await within(dialog).findByRole('combobox', { name: 'Remote' })
+      expect(within(select).getByRole('option', { name: 'Pick a remote' })).toBeInTheDocument()
+      expect(within(select).getByRole('option', { name: 'OpenMousBot' })).toBeInTheDocument()
+      expect(within(select).queryByRole('option', { name: 'No remotes' })).not.toBeInTheDocument()
     })
 
     it('CLI agent: renders CLIs and models, not agents from catalog', async () => {

--- a/webui/frontend/src/components/__tests__/RemoteSelect.test.tsx
+++ b/webui/frontend/src/components/__tests__/RemoteSelect.test.tsx
@@ -45,6 +45,16 @@ describe('RemoteSelect', () => {
     expect(within(select).getByRole('option', { name: 'OpenMousBot' })).toBeInTheDocument()
     expect(within(select).queryByRole('option', { name: 'OMB' })).not.toBeInTheDocument()
     expect(select.textContent).not.toMatch(/\bOMB\b/)
+    expect(within(select).getByRole('option', { name: 'Pick a remote' })).toBeInTheDocument()
+    expect(within(select).queryByRole('option', { name: 'No remotes' })).not.toBeInTheDocument()
+  })
+
+  it('shows the bound remote name instead of No remotes', () => {
+    render(<RemoteSelect remotes={ONE} value="omb" onChange={vi.fn()} />)
+    const select = screen.getByRole('combobox', { name: 'Remote' })
+    expect(select).toHaveValue('omb')
+    expect(within(select).getByRole('option', { name: 'OpenMousBot' })).toBeInTheDocument()
+    expect(within(select).queryByRole('option', { name: 'No remotes' })).not.toBeInTheDocument()
   })
 
   it('Add remote opens Settings remotes', () => {

--- a/webui/frontend/src/lib/__tests__/agentRemote.test.ts
+++ b/webui/frontend/src/lib/__tests__/agentRemote.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  AGENT_REMOTE_BINDINGS_KEY,
+  isRemoteKindAgent,
+  loadAgentRemoteBinding,
+  remotesListForSelect,
+  resolveBoundRemoteId,
+  saveAgentRemoteBinding,
+} from '../agentRemote'
+import { configuredRemotes, remoteSelectPlaceholder } from '../remotes'
+import { STARTER_REMOTE_ID } from '../starter-agents'
+
+const OMB = {
+  id: 'omb',
+  kind: 'omb',
+  label: 'OpenMousBot',
+  title: 'OpenMousBot',
+  host_label: '',
+  base_url: 'http://127.0.0.1:8802',
+  source: 'config',
+}
+
+describe('agentRemote binding (Issue #745)', () => {
+  afterEach(() => {
+    localStorage.removeItem(AGENT_REMOTE_BINDINGS_KEY)
+  })
+
+  it('persists id+kind and clears on empty', () => {
+    expect(loadAgentRemoteBinding('starter-remote')).toBeNull()
+    expect(saveAgentRemoteBinding('starter-remote', { id: 'omb', kind: 'omb' })).toEqual({
+      id: 'omb',
+      kind: 'omb',
+    })
+    expect(loadAgentRemoteBinding('starter-remote')).toEqual({ id: 'omb', kind: 'omb' })
+    expect(JSON.parse(localStorage.getItem(AGENT_REMOTE_BINDINGS_KEY) || '{}')).toEqual({
+      'starter-remote': { id: 'omb', kind: 'omb' },
+    })
+    saveAgentRemoteBinding('starter-remote', null)
+    expect(loadAgentRemoteBinding('starter-remote')).toBeNull()
+  })
+
+  it('resolves URL remotes as already bound', () => {
+    expect(
+      resolveBoundRemoteId({
+        remoteFromUrl: 'omb',
+        persisted: null,
+        configuredIds: [],
+      }),
+    ).toBe('omb')
+  })
+
+  it('returns empty for stale persisted ids when remotes exist', () => {
+    expect(
+      resolveBoundRemoteId({
+        persisted: { id: 'gone', kind: 'hermes' },
+        configuredIds: ['omb'],
+      }),
+    ).toBe('')
+  })
+
+  it('keeps a live persisted binding', () => {
+    expect(
+      resolveBoundRemoteId({
+        persisted: { id: 'omb', kind: 'omb' },
+        configuredIds: ['omb', 'hermes'],
+      }),
+    ).toBe('omb')
+  })
+
+  it('injects a bound remote into the select catalog', () => {
+    const catalog = remotesListForSelect(
+      { object: 'list', kinds: [], configured: [] },
+      [],
+      { id: 'omb', kind: 'omb', title: 'OpenMousBot' },
+    )
+    expect(configuredRemotes(catalog).map((row) => row.id)).toEqual(['omb'])
+    expect(catalog.configured?.[0]?.kind).toBe('omb')
+  })
+
+  it('merges Settings configured remotes without treating a rail array as empty', () => {
+    const catalog = remotesListForSelect({ object: 'list', configured: [OMB] }, [
+      { id: 'omb', kind: 'omb', title: 'OpenMousBot', configured: true, agents: [] },
+    ])
+    expect(configuredRemotes(catalog)).toHaveLength(1)
+    expect(remoteSelectPlaceholder(configuredRemotes(catalog).length, 'omb')).toBe('Remote')
+    expect(remoteSelectPlaceholder(1, '')).toBe('Pick a remote')
+    expect(remoteSelectPlaceholder(0, '')).toBe('No remotes')
+  })
+
+  it('recognizes remote-kind agents including the starter seat', () => {
+    expect(isRemoteKindAgent({ remoteFromUrl: 'omb' })).toBe(true)
+    expect(isRemoteKindAgent({ blueprintId: STARTER_REMOTE_ID })).toBe(true)
+    expect(isRemoteKindAgent({ selectedKind: 'remote' })).toBe(true)
+    expect(isRemoteKindAgent({ blueprintId: 'codey' })).toBe(false)
+    expect(isRemoteKindAgent({ blueprintId: 'cli:grok', agentKind: 'cli' })).toBe(false)
+  })
+})

--- a/webui/frontend/src/lib/__tests__/remotes.test.ts
+++ b/webui/frontend/src/lib/__tests__/remotes.test.ts
@@ -3,6 +3,7 @@ import {
   configuredRemotes,
   remoteKindLabel,
   remoteKinds,
+  remoteSelectPlaceholder,
   unusedRemoteKinds,
 } from '../remotes'
 
@@ -76,5 +77,23 @@ describe('remotes catalog (REQ-59)', () => {
       ],
     }
     expect(configuredRemotes(listed)).toEqual([])
+  })
+
+  it('treats a configured array payload as remotes, not an empty catalog', () => {
+    const rows = configuredRemotes([
+      {
+        id: 'omb',
+        kind: 'omb',
+        label: 'OpenMousBot',
+        title: 'OpenMousBot',
+        host_label: '',
+        base_url: 'http://127.0.0.1:8802',
+        source: 'config',
+      },
+    ])
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe('omb')
+    expect(remoteSelectPlaceholder(rows.length, '')).toBe('Pick a remote')
+    expect(remoteSelectPlaceholder(0, '')).toBe('No remotes')
   })
 })

--- a/webui/frontend/src/lib/__tests__/remotesCatalog.test.ts
+++ b/webui/frontend/src/lib/__tests__/remotesCatalog.test.ts
@@ -44,6 +44,22 @@ describe('remotesCatalog (REQ-68)', () => {
     expect(JSON.stringify(rail)).not.toMatch(/\bOMB\b/)
   })
 
+  it('parses a configured-only list payload used by Settings / RemoteSelect', () => {
+    const rail = parseRailRemotes({
+      object: 'list',
+      configured: [
+        {
+          id: 'omb',
+          kind: 'omb',
+          title: 'OpenMousBot',
+          source: 'config',
+        },
+      ],
+    })
+    expect(rail.map((row) => row.id)).toEqual(['omb'])
+    expect(rail[0]?.configured).toBe(true)
+  })
+
   it('ignores blueprint-shaped GET payloads so a mixed mock cannot poison the rail', () => {
     expect(
       parseRailRemotes({

--- a/webui/frontend/src/lib/agentRemote.ts
+++ b/webui/frontend/src/lib/agentRemote.ts
@@ -1,0 +1,206 @@
+/**
+ * Per-agent remote binding (id + kind). A remote-kind agent chats through a
+ * concrete configured remote — never an empty "No remotes" catalog (Issue #745).
+ */
+
+import type { RemoteConnection, RemotesListResponse } from './api'
+import { configuredRemotes, remoteKindLabel, remoteKinds } from './remotes'
+import { STARTER_REMOTE_ID } from './starter-agents'
+import type { RemoteEntry } from './remotesCatalog'
+
+export const AGENT_REMOTE_BINDINGS_KEY = 'swarm_agent_remote_bindings'
+export const AGENT_REMOTE_BINDINGS_CHANGED_EVENT = 'swarm:agent-remote-bindings-changed'
+
+export interface AgentRemoteBinding {
+  id: string
+  kind: string
+}
+
+type BindingMap = Record<string, AgentRemoteBinding>
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function readMap(): BindingMap {
+  try {
+    const raw = localStorage.getItem(AGENT_REMOTE_BINDINGS_KEY)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    const rec = asRecord(parsed)
+    if (!rec) return {}
+    const map: BindingMap = {}
+    for (const [agentId, value] of Object.entries(rec)) {
+      const binding = parseBinding(value)
+      if (binding) map[agentId] = binding
+    }
+    return map
+  } catch {
+    return {}
+  }
+}
+
+function writeMap(map: BindingMap): void {
+  try {
+    localStorage.setItem(AGENT_REMOTE_BINDINGS_KEY, JSON.stringify(map))
+  } catch {
+    /* persistence is best-effort */
+  }
+}
+
+function emitChange(agentId: string): void {
+  try {
+    window.dispatchEvent(
+      new CustomEvent(AGENT_REMOTE_BINDINGS_CHANGED_EVENT, { detail: { agentId } }),
+    )
+  } catch {
+    /* jsdom / detached window */
+  }
+}
+
+export function parseBinding(value: unknown): AgentRemoteBinding | null {
+  const rec = asRecord(value)
+  if (!rec) return null
+  const id = typeof rec.id === 'string' ? rec.id.trim() : ''
+  if (!id) return null
+  const kind = typeof rec.kind === 'string' && rec.kind.trim() ? rec.kind.trim() : id
+  return { id, kind }
+}
+
+export function loadAgentRemoteBinding(agentId: string): AgentRemoteBinding | null {
+  if (!agentId) return null
+  return readMap()[agentId] ?? null
+}
+
+export function saveAgentRemoteBinding(
+  agentId: string,
+  binding: AgentRemoteBinding | null,
+): AgentRemoteBinding | null {
+  if (!agentId) return null
+  const map = readMap()
+  if (!binding?.id) {
+    delete map[agentId]
+    writeMap(map)
+    emitChange(agentId)
+    return null
+  }
+  const next: AgentRemoteBinding = {
+    id: binding.id.trim(),
+    kind: (binding.kind || binding.id).trim(),
+  }
+  map[agentId] = next
+  writeMap(map)
+  emitChange(agentId)
+  return next
+}
+
+function asConnection(
+  remote: Pick<RemoteConnection, 'id'> &
+    Partial<RemoteConnection> & { title?: string; kind?: string },
+): RemoteConnection {
+  const id = remote.id
+  const kind = remote.kind || id
+  const title = remote.title || remote.label || remoteKindLabel(kind)
+  return {
+    id,
+    kind,
+    label: remote.label || title,
+    title,
+    host_label: remote.host_label || '',
+    base_url: remote.base_url || '',
+    source: remote.source || 'config',
+  }
+}
+
+/**
+ * Normalize Settings list + rail entries + an optional bound remote into the
+ * shape RemoteSelect expects. Bound remotes stay visible even when the
+ * configured catalog is empty or stale.
+ */
+export function remotesListForSelect(
+  list?: RemotesListResponse | RemoteConnection[] | null,
+  rail?: RemoteEntry[] | null,
+  bound?: AgentRemoteBinding | { id: string; kind?: string; title?: string } | null,
+): RemotesListResponse {
+  const fromList = configuredRemotes(list)
+  const seen = new Set(fromList.map((remote) => remote.id))
+  const merged = [...fromList]
+
+  for (const entry of rail ?? []) {
+    if (!entry?.id || seen.has(entry.id)) continue
+    if (!entry.configured && bound?.id !== entry.id) continue
+    seen.add(entry.id)
+    merged.push(
+      asConnection({
+        id: entry.id,
+        kind: entry.kind,
+        title: entry.title,
+        label: entry.title,
+      }),
+    )
+  }
+
+  if (bound?.id && !seen.has(bound.id)) {
+    merged.unshift(
+      asConnection({
+        id: bound.id,
+        kind: bound.kind || bound.id,
+        title: 'title' in bound ? bound.title : undefined,
+      }),
+    )
+  }
+
+  const kinds = remoteKinds(Array.isArray(list) ? undefined : list)
+  return {
+    object: 'list',
+    kinds,
+    configured: merged,
+    data: merged,
+  }
+}
+
+/**
+ * Resolve the remote id the navbar should show.
+ * URL remotes are already bound. Persisted / agent remote_id must still exist
+ * in the catalog — stale ids become an empty repair state ("Pick a remote").
+ */
+export function resolveBoundRemoteId(options: {
+  remoteFromUrl?: string
+  persisted?: AgentRemoteBinding | null
+  agentRemoteId?: string
+  configuredIds: Iterable<string>
+}): string {
+  const url = (options.remoteFromUrl || '').trim()
+  if (url) return url
+  const configured = new Set(
+    [...options.configuredIds].map((id) => id.trim()).filter(Boolean),
+  )
+  const agent = (options.agentRemoteId || '').trim()
+  if (agent && configured.has(agent)) return agent
+  const persisted = (options.persisted?.id || '').trim()
+  if (persisted && configured.has(persisted)) return persisted
+  return ''
+}
+
+export function isRemoteKindAgent(options: {
+  remoteFromUrl?: string
+  agentKind?: string
+  blueprintId?: string
+  selectedKind?: string
+  agentType?: string
+  remote?: string
+  tags?: string[]
+}): boolean {
+  if (options.remoteFromUrl) return true
+  if (options.agentKind === 'remote' || options.selectedKind === 'remote') return true
+  if (options.agentType === 'remote') return true
+  if (options.remote) return true
+  if (options.blueprintId === STARTER_REMOTE_ID) return true
+  const id = (options.blueprintId || '').toLowerCase()
+  if (id.startsWith('remote:') || id.startsWith('placeholder:remote:') || id.startsWith('remote-')) {
+    return true
+  }
+  return Boolean(options.tags?.includes('remote'))
+}

--- a/webui/frontend/src/lib/remotes.ts
+++ b/webui/frontend/src/lib/remotes.ts
@@ -50,12 +50,24 @@ export function remoteKinds(response?: RemotesListResponse | null): RemoteKind[]
 /**
  * Only remotes the user (or env) has added. Defaults / unused kinds stay out.
  */
-export function configuredRemotes(response?: RemotesListResponse | null): RemoteConnection[] {
+export function configuredRemotes(
+  response?: RemotesListResponse | RemoteConnection[] | null,
+): RemoteConnection[] {
   if (!response) return []
+  if (Array.isArray(response)) {
+    return response.filter((remote) => Boolean(remote?.id))
+  }
   if (Array.isArray(response.configured)) {
     return response.configured
   }
   return (response.data ?? []).filter((remote) => remote.source && remote.source !== 'default')
+}
+
+/** Empty catalog vs remotes-exist-but-unbound. Never "No remotes" while remotes exist. */
+export function remoteSelectPlaceholder(configuredCount: number, selectedId = ''): string {
+  if (configuredCount === 0) return 'No remotes'
+  if (!selectedId) return 'Pick a remote'
+  return 'Remote'
 }
 
 export function unusedRemoteKinds(

--- a/webui/frontend/src/lib/remotesCatalog.ts
+++ b/webui/frontend/src/lib/remotesCatalog.ts
@@ -141,7 +141,11 @@ export function parseRemotes(payload: unknown): RemoteEntry[] {
   }
   const rec = asRecord(payload)
   if (!rec) return []
-  const list = Array.isArray(rec.data) ? rec.data : null
+  const list = Array.isArray(rec.data)
+    ? rec.data
+    : Array.isArray(rec.configured)
+      ? rec.configured
+      : null
   if (!list) return []
   return list.map(parseRemote).filter((row): row is RemoteEntry => row !== null)
 }

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -80,6 +80,15 @@ import {
   teamThreadId,
 } from '../lib/teamRosters'
 import { fetchConfiguredRemotes, remoteHideId } from '../lib/remotesCatalog'
+import { configuredRemotes } from '../lib/remotes'
+import {
+  AGENT_REMOTE_BINDINGS_CHANGED_EVENT,
+  isRemoteKindAgent,
+  loadAgentRemoteBinding,
+  remotesListForSelect,
+  resolveBoundRemoteId,
+  saveAgentRemoteBinding,
+} from '../lib/agentRemote'
 import {
   publishChatConnection,
   type ChatConnectionStatus,
@@ -253,6 +262,7 @@ const ChatPage = () => {
   const summaryMap = useMemo(() => summariesById(summaries), [summaries])
 
   const wsRef = useRef<WebSocket | null>(null)
+  const emptyRemoteOpenedForRef = useRef('')
   const conversationIdRef = useRef(conversationId)
   conversationIdRef.current = conversationId
   const listEndRef = useRef<HTMLDivElement | null>(null)
@@ -358,6 +368,11 @@ const ChatPage = () => {
     queryFn: fetchConfiguredRemotes,
     retry: 1,
   })
+  const remotesListQuery = useQuery({
+    queryKey: ['remotes-list'],
+    queryFn: fetchRemotes,
+    retry: 1,
+  })
   const blueprints = exampleRoleAgents(blueprintsQuery.data?.data ?? [])
   const cliAgents = cliQuery.data?.rail ?? []
   const teams = teamsQuery.data ?? []
@@ -396,16 +411,34 @@ const ChatPage = () => {
     ),
   )
 
-  const isRemoteAgent = Boolean(
-    remoteFromUrl ||
-      selectedRemote ||
-      agentKind === 'remote' ||
-      selectedAgent?.kind === 'remote' ||
-      (selectedAgent as { agent_type?: string })?.agent_type === 'remote' ||
-      Boolean((selectedAgent as { remote?: string })?.remote),
-  )
+  const isRemoteAgent = isRemoteKindAgent({
+    remoteFromUrl,
+    agentKind,
+    blueprintId: selectedBlueprint,
+    selectedKind: (selectedAgent as { kind?: string } | undefined)?.kind,
+    agentType: (selectedAgent as { agent_type?: string })?.agent_type,
+    remote: (selectedAgent as { remote?: string })?.remote,
+    tags: (selectedAgent as { tags?: string[] })?.tags,
+  }) || Boolean(selectedRemote)
 
   const showRemotesControl = isRemoteAgent || isRemoteBackedTeam
+  const bindingAgentId = remoteFromUrl || (showRemotesControl ? selectedBlueprint : '')
+  const persistedRemote = bindingAgentId ? loadAgentRemoteBinding(bindingAgentId) : null
+  const remotesCatalog = remotesListForSelect(
+    remotesListQuery.data,
+    remotes,
+    remoteFromUrl
+      ? {
+          id: remoteFromUrl,
+          kind: selectedRemote?.kind || persistedRemote?.kind || remoteFromUrl,
+          title: selectedRemote?.title,
+        }
+      : persistedRemote,
+  )
+  const configuredRemoteRows = configuredRemotes(remotesCatalog)
+  const remotesCatalogReady = !remotesListQuery.isPending && !remotesQuery.isPending
+  const showEmptyRemoteChrome =
+    showRemotesControl && remotesCatalogReady && configuredRemoteRows.length === 0
 
   const isCliAgent = Boolean(
     !teamFromUrl &&
@@ -528,8 +561,39 @@ const ChatPage = () => {
   useEffect(() => {
     const onEdits = () => setEditsTick((tick) => tick + 1)
     window.addEventListener(AGENT_EDITS_CHANGED_EVENT, onEdits)
-    return () => window.removeEventListener(AGENT_EDITS_CHANGED_EVENT, onEdits)
+    window.addEventListener(AGENT_REMOTE_BINDINGS_CHANGED_EVENT, onEdits)
+    return () => {
+      window.removeEventListener(AGENT_EDITS_CHANGED_EVENT, onEdits)
+      window.removeEventListener(AGENT_REMOTE_BINDINGS_CHANGED_EVENT, onEdits)
+    }
   }, [])
+
+  useEffect(() => {
+    if (!showRemotesControl) return
+    setSelectedRemoteId(
+      resolveBoundRemoteId({
+        remoteFromUrl,
+        persisted: persistedRemote,
+        agentRemoteId: (selectedAgent as { remote_id?: string })?.remote_id,
+        configuredIds: configuredRemoteRows.map((row) => row.id),
+      }),
+    )
+  }, [
+    showRemotesControl,
+    remoteFromUrl,
+    bindingAgentId,
+    persistedRemote,
+    selectedAgent,
+    remotesCatalog,
+  ])
+
+  useEffect(() => {
+    if (!showEmptyRemoteChrome) return
+    const key = bindingAgentId || selectedBlueprint
+    if (!key || emptyRemoteOpenedForRef.current === key) return
+    emptyRemoteOpenedForRef.current = key
+    openSettingsSheet({ section: 'remotes', addRemote: true })
+  }, [showEmptyRemoteChrome, bindingAgentId, selectedBlueprint])
 
   useEffect(() => {
     if (teamFromUrl) {
@@ -1501,11 +1565,38 @@ const ChatPage = () => {
             </div>
             <span className="tabular-nums whitespace-nowrap text-xs">{formatTokenCount(tokenCount)} tok</span>
           </button>
-          {showRemotesControl ? (
+          {showEmptyRemoteChrome ? (
+            <button
+              type="button"
+              className="btn btn-sm h-8 border border-base-300 bg-base-100"
+              onClick={() => openSettingsSheet({ section: 'remotes', addRemote: true })}
+            >
+              Add remote
+            </button>
+          ) : showRemotesControl ? (
             <RemoteSelect
-              remotes={remotesQuery.data}
+              remotes={remotesCatalog}
               value={selectedRemoteId}
-              onChange={setSelectedRemoteId}
+              onChange={(nextId) => {
+                setSelectedRemoteId(nextId)
+                const remote = configuredRemoteRows.find((row) => row.id === nextId)
+                if (bindingAgentId && remote) {
+                  saveAgentRemoteBinding(bindingAgentId, {
+                    id: remote.id,
+                    kind: remote.kind || remote.id,
+                  })
+                } else if (bindingAgentId && !nextId) {
+                  saveAgentRemoteBinding(bindingAgentId, null)
+                }
+                if (remoteFromUrl && nextId && nextId !== remoteFromUrl) {
+                  setSearchParams((prev) => {
+                    const params = new URLSearchParams(prev)
+                    params.set('remote', nextId)
+                    params.delete('session')
+                    return params
+                  })
+                }
+              }}
               size="sm"
               className="h-8 max-w-[10rem]"
             />

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -1391,10 +1391,12 @@ describe('ChatPage remotes dropdown (REQ-59)', () => {
     MockWebSocket.instances = []
     Element.prototype.scrollIntoView = vi.fn()
     vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    window.localStorage.clear()
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    window.localStorage.clear()
   })
 
   it('lists only configured remotes plus Add remote on remote agents', async () => {
@@ -1442,12 +1444,147 @@ describe('ChatPage remotes dropdown (REQ-59)', () => {
     const options = within(select)
       .getAllByRole('option')
       .map((opt) => opt.textContent)
+    expect(select).toHaveValue('omb')
     expect(options).toContain('OpenMousBot')
     expect(options).toContain('Add remote')
     expect(options).not.toContain('Hermes')
     expect(options).not.toContain('Rakazo')
     expect(options).not.toContain('OMB')
+    expect(options).not.toContain('No remotes')
     expect(select.textContent).not.toMatch(/\bOMB\b/)
+  })
+
+  it('shows the bound remote name for a remote agent (Issue #745)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/v1/remotes') || url.includes('remotes_catalog')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'list',
+              kinds: [{ id: 'omb', label: 'OpenMousBot' }],
+              configured: [
+                {
+                  id: 'omb',
+                  kind: 'omb',
+                  label: 'OpenMousBot',
+                  title: 'OpenMousBot',
+                  host_label: '',
+                  base_url: 'http://127.0.0.1:8802',
+                  source: 'config',
+                },
+              ],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [] }),
+        } as Response
+      }),
+    )
+    renderChat('/chat?remote=omb')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+    const select = await screen.findByRole('combobox', { name: 'Remote' })
+    expect(select).toHaveValue('omb')
+    expect(within(select).getByRole('option', { name: 'OpenMousBot' })).toBeInTheDocument()
+    expect(within(select).queryByRole('option', { name: 'No remotes' })).not.toBeInTheDocument()
+  })
+
+  it('opens Add remote instead of No remotes chrome when none are configured', async () => {
+    const opened: unknown[] = []
+    const listener = (event: Event) => opened.push((event as CustomEvent).detail)
+    window.addEventListener('swarm:open-settings', listener)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/v1/remotes') || url.includes('remotes_catalog')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'list',
+              kinds: [{ id: 'omb', label: 'OpenMousBot' }],
+              configured: [],
+              data: [],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [] }),
+        } as Response
+      }),
+    )
+    renderChat('/chat?blueprint=starter-remote')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Add remote' })).toBeInTheDocument()
+    })
+    expect(screen.queryByRole('combobox', { name: 'Remote' })).not.toBeInTheDocument()
+    expect(screen.queryByText('No remotes')).not.toBeInTheDocument()
+    expect(opened).toContainEqual({ section: 'remotes', addRemote: true })
+    window.removeEventListener('swarm:open-settings', listener)
+  })
+
+  it('offers Pick a remote when remotes exist but the agent is unbound', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/v1/remotes') || url.includes('remotes_catalog')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'list',
+              kinds: [
+                { id: 'hermes', label: 'Hermes' },
+                { id: 'omb', label: 'OpenMousBot' },
+              ],
+              configured: [
+                {
+                  id: 'omb',
+                  kind: 'omb',
+                  label: 'OpenMousBot',
+                  title: 'OpenMousBot',
+                  host_label: '',
+                  base_url: 'http://127.0.0.1:8802',
+                  source: 'config',
+                },
+              ],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [] }),
+        } as Response
+      }),
+    )
+    renderChat('/chat?blueprint=starter-remote')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+    const select = await screen.findByRole('combobox', { name: 'Remote' })
+    const options = within(select)
+      .getAllByRole('option')
+      .map((opt) => opt.textContent)
+    expect(select).toHaveValue('')
+    expect(options).toContain('Pick a remote')
+    expect(options).toContain('OpenMousBot')
+    expect(options).not.toContain('No remotes')
   })
 
   it('hides the Remotes control on local API and CLI agents', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Feasibility:** Surgical bind + empty-state fix — ChatPage was passing a rail `RemoteEntry[]` into `RemoteSelect` (expects a remotes list), so the navbar always rendered the empty-catalog “No remotes” label.

## Intent

Choosing a remote agent means chatting through a concrete configured remote. Never leave the user on a dead “No remotes” control as if that were a valid runtime for that agent.

## Success

1. A **remote-kind** agent always has a **bound remote** (id + kind). Create/edit flow for remote agents **requires** picking an existing configured remote (or inline “Add remote” that completes binding before the agent is usable).
2. Navbar remote control for a remote agent shows the **bound remote’s name/kind** (e.g. Hermes / OpenMousBot), not “No remotes”.
3. If **zero** remotes are configured system-wide: selecting or creating a remote agent opens **Add remote** / Settings Remotes with a clear empty state — do **not** park a remote agent on a “No remotes” dropdown as the primary chrome.
4. If remotes exist but this agent’s binding is missing/stale: show an honest repair state (“Pick a remote”) listing configured remotes — never the empty-catalog “No remotes” label while remotes actually exist.
5. Non-remote agents still omit the remotes control entirely (keep #522).
6. Tests: remote agent with binding → control shows that remote; zero remotes → create/select remote agent forces add/bind path, no durable “No remotes” agent chrome; remotes exist + unbound agent → pick-from-list repair, not “No remotes”; local CLI/API agents → no RemoteSelect.

## Constraints

React 18 + Vite + Tailwind 4 + DaisyUI 5. Align with remotes opt-in (#384), remotes-only-on-remote-agents (#522), persist dropdown (#636), add-agent Remote tab (#640), Remote abstract harness (#680). Prefer surgical bind + empty-state fix over redesign. GitHub PR with `Fixes #N`. Wave discipline: one focused PR. Preview FF by engineer after squash on Matthew GO. No secrets in Issues/PRs.

## Owner

Cursor cloud implement; open-swarm engineer squash + FF `:8001` on Matthew GO.

## Fix

- Normalize Settings list + rail entries + bound remote into the `RemoteSelect` catalog.
- Persist per-agent `id`+`kind` (`swarm_agent_remote_bindings`).
- Navbar shows the bound name; empty catalog uses an **Add remote** button and opens Settings Remotes (add form); unbound + remotes exist uses **Pick a remote**.
- Add-agent / editor require a configured remote (or complete Add remote).

Fixes #745

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6326fab1-b603-4cab-b60a-76f4e9a83afd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6326fab1-b603-4cab-b60a-76f4e9a83afd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

