### PR TITLE
feat(webui): remove mystery navbar You / Default dropdown (Fixes #744)

### DIFF
--- a/tests/unit/test_req186_navbar_dropdown.py
+++ b/tests/unit/test_req186_navbar_dropdown.py
@@ -9,10 +9,13 @@ CHAT_PAGE_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "pages" / "ChatPage.t
 def test_navbar_no_mystery_api_or_model_dropdown():
     content = CHAT_PAGE_TSX.read_text(encoding="utf-8")
 
-    # The mystery "You" and "Default" controls were api-model-select and the blueprint picker (availableApiAgents)
+    # The mystery "You" and "Default" controls were api-model-select, api-select, and the blueprint picker (availableApiAgents)
     assert 'data-testid="api-model-select"' not in content, "api-model-select must be removed from navbar"
+    assert 'data-testid="api-select"' not in content, "api-select must be removed from navbar"
     assert "availableApiAgents" not in content, "availableApiAgents blueprint picker must be removed from navbar"
+    assert "isNamedApiAgent" not in content, "isNamedApiAgent should not be in ChatPage"
 
-    # fetchModels and modelsQuery should no longer be in ChatPage
+    # fetchModels, fetchLlmProfiles, and modelsQuery should no longer be in ChatPage
     assert "fetchModels" not in content, "fetchModels should not be imported in ChatPage"
+    assert "fetchLlmProfiles" not in content, "fetchLlmProfiles should not be imported in ChatPage"
     assert "modelsQuery" not in content, "modelsQuery should not be present in ChatPage"

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -34,8 +34,7 @@ import {
   getRecentSlashIds,
   recordRecentSlashId,
 } from '../lib/slashMenu'
-import { fetchConfigOptions, fetchBlueprints, fetchCliAgents, fetchCliModels, fetchLlmProfiles, fetchRemotes } from '../lib/api'
-import { profileIds } from '../lib/llmProfiles'
+import { fetchConfigOptions, fetchBlueprints, fetchCliAgents, fetchCliModels, fetchRemotes } from '../lib/api'
 import {
   agentIdFromBlueprint,
   appendAgentMessage,
@@ -421,7 +420,6 @@ const ChatPage = () => {
         })),
   )
 
-  const isNamedApiAgent = selectedBlueprint === 'api_agent'
   const isApiAgent = Boolean(
     !teamFromUrl &&
       !remoteFromUrl &&
@@ -429,13 +427,6 @@ const ChatPage = () => {
       !isRemoteAgent &&
       !isCliAgent,
   )
-
-  const llmProfilesQuery = useQuery({
-    queryKey: ['llm-profiles'],
-    queryFn: fetchLlmProfiles,
-    enabled: Boolean(isNamedApiAgent || isApiAgent),
-    retry: 1,
-  })
 
   const discoveredClis = useMemo(
     () => discoverChatClis(cliQuery.data, searchParams.get('cli') || selectedCli?.cli),
@@ -464,22 +455,6 @@ const ChatPage = () => {
     if (fromParam && availableCliModels.includes(fromParam)) return fromParam
     return availableCliModels[0] || 'default'
   }, [searchParams, availableCliModels])
-
-  const availableApiModels = useMemo(() => {
-    if (isNamedApiAgent) {
-      const ids = profileIds(llmProfilesQuery.data)
-      const fallback = llmProfilesQuery.data?.default_llm_profile
-      const list = ids.length ? ids : fallback ? [fallback] : []
-      return list.length ? list : ['default']
-    }
-    return ['default']
-  }, [isNamedApiAgent, llmProfilesQuery.data])
-
-  const currentApiModel = useMemo(() => {
-    const fromParam = (searchParams.get('model') ?? '').trim()
-    if (fromParam && availableApiModels.includes(fromParam)) return fromParam
-    return availableApiModels[0] || 'default'
-  }, [searchParams, availableApiModels])
   const recordDropdownChange = useCallback(
     (kind: DropdownKind, fromLabel: string, toLabel: string) => {
       if (!shouldRecordDropdownChange(fromLabel, toLabel)) return
@@ -1607,33 +1582,6 @@ const ChatPage = () => {
                 ))}
               </select>
             </>
-          ) : null}
-          {isNamedApiAgent ? (
-            <select
-              className="select select-sm h-8 max-w-[10rem] border border-base-300 bg-base-100"
-              value={currentApiModel}
-              aria-label="API"
-              data-testid="api-select"
-              onChange={(e) => {
-                const nextModel = e.target.value
-                const prev = currentApiModel
-                setSearchParams(
-                  (prevParams) => {
-                    const nextParams = new URLSearchParams(prevParams)
-                    nextParams.set('model', nextModel)
-                    return nextParams
-                  },
-                  { replace: true },
-                )
-                recordDropdownChange('api', prev, nextModel)
-              }}
-            >
-              {availableApiModels.map((m) => (
-                <option key={m} value={m}>
-                  {m}
-                </option>
-              ))}
-            </select>
           ) : null}
           <div
             className="flex items-center gap-2"

--- a/webui/frontend/src/pages/__tests__/NavbarMysteryDropdown.test.tsx
+++ b/webui/frontend/src/pages/__tests__/NavbarMysteryDropdown.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import ChatPage from '../ChatPage'
+import { ToastProvider } from '../../components/DaisyUI'
+
+describe('REQ-186 / Fixes #744: No mystery navbar You / Default dropdown', () => {
+  let client: QueryClient
+
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+    client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/v1/blueprints')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'list',
+              data: [
+                { id: 'api_agent', name: 'api_agent', object: 'blueprint' },
+                { id: 'codey', name: 'Codey', object: 'blueprint' },
+              ],
+            }),
+          } as Response
+        }
+        if (url.includes('/v1/cli-agents')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              clis: ['grok', 'agy'],
+              native_consensus: {},
+              catalog: {},
+            }),
+          } as Response
+        }
+        if (url.includes('/v1/remotes')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'list',
+              kinds: [],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({}),
+        } as Response
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not render api-select or api-model-select when api_agent is active', async () => {
+    render(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/chat?blueprint=api_agent']}>
+            <Routes>
+              <Route path="/chat" element={<ChatPage />} />
+            </Routes>
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    expect(screen.queryByTestId('api-select')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('api-model-select')).not.toBeInTheDocument()
+    expect(screen.queryByRole('combobox', { name: 'API' })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #744

### Intent
Top navbar must not show a mystery You / Default (or equivalent orphan identity/profile) dropdown.

### Success
1. The You / Default control is gone from the top navbar (and any twin that shows the same meaningless labels).
2. What the control was: leftover `api-select` rendered when `isNamedApiAgent` was active (`api_agent` blueprint). LLM profile configuration lives in Settings → Show LLM profiles and Agent Editor, not top navbar.
3. Kept legitimate CLI/model pickers; only removed the mystery api-select control.
4. Added RTL test `NavbarMysteryDropdown.test.tsx` and updated `test_req186_navbar_dropdown.py` asserting absence of `api-select`, `api-model-select`, and `isNamedApiAgent`.

### Constraints
React 18 + Vite + Tailwind 4 + DaisyUI 5. Surgical removal. Own-diff CI.