### PR TITLE
feat(webui): honest Settings Retention status linking to server dashboard (REQ-188B-1, Fixes #663)

### DIFF
--- a/webui/frontend/e2e/settings-sheet.spec.ts
+++ b/webui/frontend/e2e/settings-sheet.spec.ts
@@ -139,13 +139,11 @@ test('gear opens a DaisyUI modal-end settings sheet over chat', async ({ page })
   await expect(sections.getByRole('button', { name: 'System' })).toBeVisible()
 
   await sections.getByRole('button', { name: 'Retention' }).click()
-  await expect(page.getByRole('radiogroup', { name: 'Retention mode' })).toHaveClass(/join/)
-  await page.getByRole('radio', { name: 'Trash' }).click()
-  await page.getByRole('button', { name: 'Save retention' }).click()
-  await expect(page.getByText('Retention saved')).toBeVisible()
-  await expect
-    .poll(() => page.evaluate(() => localStorage.getItem('swarm_retention_mode')))
-    .toBe('trash')
+  await expect(page.getByRole('heading', { name: 'Retention' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Save retention' })).toHaveCount(0)
+  await expect(
+    page.getByRole('link', { name: 'Server retention dashboard' }),
+  ).toHaveAttribute('href', '/settings/#chat-retention-title')
 
   await page.getByRole('button', { name: 'Hostname' }).click()
   await page.getByRole('textbox', { name: 'Hostname override' }).fill('swarm.example.com')

--- a/webui/frontend/src/components/SettingsSheet.tsx
+++ b/webui/frontend/src/components/SettingsSheet.tsx
@@ -40,15 +40,10 @@ import { roleDisplayName } from '../lib/safety'
 import type { DefinitionKind } from '../lib/definitionExplain'
 import { PYTHON_CODE_CLASS, highlightPython } from '../lib/highlightPython'
 import {
-  RETENTION_MODES,
-  RETENTION_MODE_LABELS,
   detectedHostname,
   loadBumpCompleted,
   loadHostnameOverride,
-  loadRetentionMode,
   saveBumpCompleted,
-  saveRetentionMode,
-  type RetentionMode,
 } from '../lib/settingsPrefs'
 import { agentLabel, catalogLabel } from '../lib/supportAgent'
 import { applyHostnameOverride, fetchUserPrefs, saveUserPrefs } from '../lib/userPrefs'
@@ -122,7 +117,6 @@ export default function SettingsSheet({
   const { success } = useToast()
   const [section, setSection] = useState<SettingsSection>('retention')
   const [hostname, setHostname] = useState(() => loadHostnameOverride())
-  const [retention, setRetention] = useState<RetentionMode>(() => loadRetentionMode())
   const [selectedBlueprintId, setSelectedBlueprintId] = useState(blueprintId || '')
   const [bumpCompleted, setBumpCompleted] = useState(() => loadBumpCompleted())
   const resolvedDefinitionId = definitionId || teamId || blueprintId || ''
@@ -139,7 +133,6 @@ export default function SettingsSheet({
       }
       setHostname(loadHostnameOverride())
     })
-    setRetention(loadRetentionMode())
     setBumpCompleted(loadBumpCompleted())
     if (initialSection) {
       setSection(initialSection)
@@ -159,12 +152,6 @@ export default function SettingsSheet({
     setHostname(next)
     void saveUserPrefs({ hostname_override: next })
     success('Hostname saved', 'Override stored for this account.')
-  }
-
-  const handleSaveRetention = (event: FormEvent) => {
-    event.preventDefault()
-    saveRetentionMode(retention)
-    success('Retention saved', `${RETENTION_MODE_LABELS[retention]} mode stored in this browser.`)
   }
 
   return (
@@ -288,13 +275,7 @@ export default function SettingsSheet({
             />
           )}
           {section === 'remotes' && <RemotesCatalogPane startAdding={initialAddRemote} />}
-          {section === 'retention' && (
-            <RetentionPane
-              value={retention}
-              onChange={setRetention}
-              onSave={handleSaveRetention}
-            />
-          )}
+          {section === 'retention' && <RetentionPane />}
           {section === 'hostname' && (
             <HostnamePane
               value={hostname}
@@ -781,44 +762,29 @@ function RemotesCatalogPane({ startAdding = false }: { startAdding?: boolean }) 
   )
 }
 
-function RetentionPane({
-  value,
-  onChange,
-  onSave,
-}: {
-  value: RetentionMode
-  onChange: (mode: RetentionMode) => void
-  onSave: (event: FormEvent) => void
-}) {
+function RetentionPane() {
   return (
-    <form className="space-y-4" onSubmit={onSave}>
+    <div className="space-y-4" data-testid="settings-retention-pane">
       <div>
         <h4 className="text-lg font-semibold">Retention</h4>
         <p className="mt-1 text-sm text-base-content/70">
-          How this browser keeps chat leftovers. Saved locally until a storage
-          API is wired.
+          Chat retention, archiving, and trash pruning are managed by the server storage engine.
         </p>
       </div>
-      <fieldset className="space-y-2">
-        <legend className="text-sm font-medium">Mode</legend>
-        <div className="join" role="radiogroup" aria-label="Retention mode">
-          {RETENTION_MODES.map((mode) => (
-            <input
-              key={mode}
-              className="join-item btn"
-              type="radio"
-              name="retention-mode"
-              aria-label={RETENTION_MODE_LABELS[mode]}
-              checked={value === mode}
-              onChange={() => onChange(mode)}
-            />
-          ))}
+      <div className="rounded-box border border-base-300 bg-base-200/50 p-4 space-y-3">
+        <p className="text-sm text-base-content/80">
+          To inspect chat disk usage, archive old sessions, or empty trash, open the server retention dashboard.
+        </p>
+        <div>
+          <a
+            href="/settings/#chat-retention-title"
+            className="btn btn-sm btn-outline gap-2"
+          >
+            Server retention dashboard
+          </a>
         </div>
-      </fieldset>
-      <Button type="submit" variant="primary" size="sm">
-        Save retention
-      </Button>
-    </form>
+      </div>
+    </div>
   )
 }
 

--- a/webui/frontend/src/components/__tests__/SettingsSheet.test.tsx
+++ b/webui/frontend/src/components/__tests__/SettingsSheet.test.tsx
@@ -86,7 +86,7 @@ describe('SettingsSheet', () => {
     expect(localStorage.getItem(BUMP_COMPLETED_KEY)).toBe('0')
   })
 
-  it('shows remotes empty state and join radios for retention', async () => {
+  it('shows remotes empty state and honest server link for retention', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -122,12 +122,10 @@ describe('SettingsSheet', () => {
     expect(screen.getByText(/do not add this instance as its own remote/i)).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Retention' }))
-    const group = screen.getByRole('radiogroup', { name: 'Retention mode' })
-    expect(group).toHaveClass('join')
-    expect(screen.getByRole('radio', { name: 'Count' })).toBeChecked()
-    expect(screen.getByRole('radio', { name: 'Disk' })).toHaveClass('join-item')
-    expect(screen.getByRole('radio', { name: 'Archive' })).toBeInTheDocument()
-    expect(screen.getByRole('radio', { name: 'Trash' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Retention' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Save retention' })).not.toBeInTheDocument()
+    const link = screen.getByRole('link', { name: /Server retention dashboard/i })
+    expect(link).toHaveAttribute('href', '/settings/#chat-retention-title')
   })
 
   it('LLM profiles shows the empty-models copy when /v1/llm-profiles/ returns none', async () => {
@@ -315,12 +313,14 @@ describe('SettingsSheet', () => {
     expect(screen.queryByText(/\bOMB\b/)).not.toBeInTheDocument()
   })
 
-  it('persists retention via join radios and shows a save toast', async () => {
+  it('shows honest retention pane linking to server dashboard without placebo save button (REQ-188B-1)', async () => {
     renderSheet()
-    fireEvent.click(screen.getByRole('radio', { name: 'Archive' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Save retention' }))
-    expect(localStorage.getItem(RETENTION_MODE_KEY)).toBe('archive')
-    expect(await screen.findByText('Retention saved')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retention' }))
+    expect(screen.getByRole('heading', { name: 'Retention' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Save retention' })).not.toBeInTheDocument()
+    const link = screen.getByRole('link', { name: /Server retention dashboard/i })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/settings/#chat-retention-title')
   })
 
   it('persists a hostname override and toasts on save', async () => {


### PR DESCRIPTION
Fixes #663
Refs #644

### Intent
The Settings → Retention pane must either perform the same archive / trash / disk jobs as Django `/settings/` or stop presenting a Save that cannot.

### Success
1. Choosing a mode + Save either (a) calls the existing chat-retention API (`/settings/chats/action/` or a `/v1/` twin) and changes `$SWARM_CHAT_DIR` the way the operator dump does, or (b) the pane is reduced to a read-only status + link to `#chat-retention-title` with no fake Save.
2. `swarm_retention_mode` is not a second SoT. If a mode enum stays, something in `chat_store` / Settings dashboard reads it.
3. RTL + API tests: Save trash/archive → JSON thread moves; or Save control is gone and the link is present.
4. e2e no longer treats localStorage write as success.

### Constraints
Do not fight #579 (it leaves retention local on purpose). No secrets. No Neon. Own-diff CI. Refs #644; do not Fixes #644.

### Changes
- Replaced placebo Retention form and fake "Save retention" button in `SettingsSheet.tsx` with an honest read-only status card explaining retention behavior.
- Provided direct link to `/settings/#chat-retention-title` (Server retention dashboard) where real chat retention / archive / trash management operates.
- Updated `SettingsSheet.test.tsx` and Playwright `e2e/settings-sheet.spec.ts` to assert that the fake Save control is gone and the server retention link is present.