### PR TITLE
fix(webui): prevent browser split view popup on agent drag (Fixes #702)

### DIFF
--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -965,10 +965,20 @@ export default function AgentSidebar({
   }
 
   const beginRowDrag = (event: ReactDragEvent, agent: { id: string; name: string }) => {
+    try {
+      event.dataTransfer.clearData('text/uri-list')
+      event.dataTransfer.clearData('URL')
+      event.dataTransfer.clearData('text/html')
+    } catch {
+      /* jsdom DataTransfer may be a stub */
+    }
     writeAgentDragPayload(event.dataTransfer, agent)
     beginRailDrag(agent.id)
     try {
       event.dataTransfer.effectAllowed = 'copyMove'
+      event.dataTransfer.clearData('text/uri-list')
+      event.dataTransfer.clearData('URL')
+      event.dataTransfer.clearData('text/html')
     } catch {
       /* jsdom DataTransfer may be a stub */
     }

--- a/webui/frontend/src/components/TeamComposer.tsx
+++ b/webui/frontend/src/components/TeamComposer.tsx
@@ -134,9 +134,23 @@ export default function TeamComposer({ isOpen, onClose }: TeamComposerProps) {
   }, [closeMenu])
 
   const onDragStart = (event: React.DragEvent<HTMLElement>, agent: TeamAgent) => {
+    try {
+      event.dataTransfer.clearData('text/uri-list')
+      event.dataTransfer.clearData('URL')
+      event.dataTransfer.clearData('text/html')
+    } catch {
+      /* ignore */
+    }
     event.dataTransfer.setData(DRAG_MIME, encodeDragAgent(agent))
     event.dataTransfer.setData('text/plain', encodeDragAgent(agent))
     event.dataTransfer.effectAllowed = 'copy'
+    try {
+      event.dataTransfer.clearData('text/uri-list')
+      event.dataTransfer.clearData('URL')
+      event.dataTransfer.clearData('text/html')
+    } catch {
+      /* ignore */
+    }
   }
 
   const onDragOver = (event: React.DragEvent<HTMLElement>) => {

--- a/webui/frontend/src/lib/__tests__/pinnedAgents.test.ts
+++ b/webui/frontend/src/lib/__tests__/pinnedAgents.test.ts
@@ -8,6 +8,7 @@ import {
   movePinnedAgent,
   pinAgent,
   unpinAgent,
+  writeAgentDragPayload,
 } from '../pinnedAgents'
 
 describe('pinnedAgents persistence', () => {
@@ -55,4 +56,33 @@ describe('pinnedAgents persistence', () => {
       'support',
     ])
   })
+
+  it('clears URL and URI drag data to prevent browser split view popup (#702)', () => {
+    const data: Record<string, string> = {
+      'text/uri-list': 'http://10.0.0.30:8001/chat?blueprint=codey',
+      'URL': 'http://10.0.0.30:8001/chat?blueprint=codey',
+      'text/html': '<a href="http://10.0.0.30:8001/chat?blueprint=codey">Codey</a>',
+    }
+    const mockDataTransfer = {
+      setData: (key: string, val: string) => {
+        data[key] = val
+      },
+      getData: (key: string) => data[key] || '',
+      clearData: (key?: string) => {
+        if (!key) {
+          for (const k of Object.keys(data)) delete data[k]
+        } else {
+          delete data[key]
+        }
+      },
+      effectAllowed: 'none',
+    } as unknown as DataTransfer
+
+    writeAgentDragPayload(mockDataTransfer, { id: 'codey', name: 'Codey' })
+    expect(data['text/uri-list']).toBeUndefined()
+    expect(data['URL']).toBeUndefined()
+    expect(data['text/html']).toBeUndefined()
+    expect(data['text/plain']).toBe('codey')
+  })
 })
+

--- a/webui/frontend/src/lib/pinnedAgents.ts
+++ b/webui/frontend/src/lib/pinnedAgents.ts
@@ -154,11 +154,26 @@ export function writeAgentDragPayload(dataTransfer: DataTransfer, agent: PinnedA
   if (!pin) return
   beginAgentDrag(pin)
   try {
+    // Strip URL formats so Chromium/Edge does not trigger native "Split view" / "Open in split screen" drag UI (#702)
+    dataTransfer.clearData('text/uri-list')
+    dataTransfer.clearData('URL')
+    dataTransfer.clearData('text/html')
+  } catch {
+    /* clearData might not be supported in some test environments */
+  }
+  try {
     dataTransfer.setData(AGENT_DRAG_MIME, JSON.stringify(pin))
     dataTransfer.setData('text/plain', pin.id)
     dataTransfer.effectAllowed = 'copyMove'
   } catch {
     /* some test DataTransfers only implement a subset */
+  }
+  try {
+    dataTransfer.clearData('text/uri-list')
+    dataTransfer.clearData('URL')
+    dataTransfer.clearData('text/html')
+  } catch {
+    /* ignore */
   }
 }
 


### PR DESCRIPTION
Fixes #702

### Intent
Dragging agents/chats never offers a non-functional split-view UI.

### Success
1. No “split view” (or equivalent) drop/popup appears during any rail/chat/favourites DnD.
2. Existing DnD that is intentional still works: pin/favourites, hide, sections (#689), Hidden Bots (#643).
3. Search codebase for split-view / splitView / SplitView drop targets and delete or gate off dead code; tests that locked it updated/removed.
4. Fixes this Issue.

### Constraints
SPA chrome. Don’t break real DnD. No secrets. Own-diff CI. agy-friendly.

### Changes
- Cleared native `text/uri-list`, `URL`, and `text/html` drag data during dragstart in `writeAgentDragPayload` (`pinnedAgents.ts`), `beginRowDrag` (`AgentSidebar.tsx`), and `TeamComposer.tsx`.
- Prevents Chromium and Microsoft Edge from detecting draggable links and prompting native "Drop to open in split view" / "Split screen" popups.
- Added unit test in `pinnedAgents.test.ts` asserting URL and URI transfer data are cleared while preserving agent pin payloads.