### PR TITLE
feat(webui): live hostname sync between Settings sheet and rail (REQ-188B-2, Fixes #664)

### DIFF
--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -42,7 +42,13 @@ import {
   loadOrSeedHiddenAgentIds,
   unhideAgentId,
 } from '../lib/hiddenAgents'
-import { defaultHostname, loadHostname, saveHostname } from '../lib/hostname'
+import {
+  defaultHostname,
+  loadHostname,
+  saveHostname,
+  HOSTNAME_CHANGED_EVENT,
+  dispatchHostnameChanged,
+} from '../lib/hostname'
 import {
   GENERATION_COMPLETE_EVENT,
   applyRailOrder,
@@ -59,6 +65,7 @@ import {
 import {
   BUMP_COMPLETED_EVENT,
   loadBumpCompleted,
+  saveHostnameOverride,
 } from '../lib/settingsPrefs'
 import { computeRailHotkeyTargets } from '../lib/railHotkeys'
 import {
@@ -263,6 +270,20 @@ export default function AgentSidebar({
     return () => {
       window.removeEventListener(CHAT_CONNECTION_EVENT, handleStatus)
     }
+  }, [])
+
+  useEffect(() => {
+    const onHostnameChanged = (event: Event) => {
+      const custom = event as CustomEvent<{ hostname?: string }>
+      const updated = custom.detail?.hostname
+      if (typeof updated === 'string') {
+        setHostname(updated || defaultHostname())
+      } else {
+        setHostname(loadHostname())
+      }
+    }
+    window.addEventListener(HOSTNAME_CHANGED_EVENT, onHostnameChanged)
+    return () => window.removeEventListener(HOSTNAME_CHANGED_EVENT, onHostnameChanged)
   }, [])
 
   const localWsDown = localWsStatus === 'closed' || localWsStatus === 'failed'
@@ -1991,6 +2012,8 @@ export default function AgentSidebar({
                 const next = saveHostname(hostname)
                 setHostname(next)
                 const override = next === defaultHostname() ? '' : next
+                saveHostnameOverride(override)
+                dispatchHostnameChanged(override)
                 void saveUserPrefs({ hostname_override: override })
               }}
               onKeyDown={(event) => {

--- a/webui/frontend/src/components/SettingsSheet.tsx
+++ b/webui/frontend/src/components/SettingsSheet.tsx
@@ -45,6 +45,7 @@ import {
   loadHostnameOverride,
   saveBumpCompleted,
 } from '../lib/settingsPrefs'
+import { HOSTNAME_CHANGED_EVENT, dispatchHostnameChanged } from '../lib/hostname'
 import { agentLabel, catalogLabel } from '../lib/supportAgent'
 import { applyHostnameOverride, fetchUserPrefs, saveUserPrefs } from '../lib/userPrefs'
 import {
@@ -146,10 +147,25 @@ export default function SettingsSheet({
     }
   }, [isOpen, blueprintId, initialSection])
 
+  useEffect(() => {
+    const onHostnameChanged = (event: Event) => {
+      const custom = event as CustomEvent<{ hostname?: string }>
+      const updated = custom.detail?.hostname
+      if (typeof updated === 'string') {
+        setHostname(updated)
+      } else {
+        setHostname(loadHostnameOverride())
+      }
+    }
+    window.addEventListener(HOSTNAME_CHANGED_EVENT, onHostnameChanged)
+    return () => window.removeEventListener(HOSTNAME_CHANGED_EVENT, onHostnameChanged)
+  }, [])
+
   const handleSaveHostname = (event: FormEvent) => {
     event.preventDefault()
     const next = applyHostnameOverride(hostname)
     setHostname(next)
+    dispatchHostnameChanged(next)
     void saveUserPrefs({ hostname_override: next })
     success('Hostname saved', 'Override stored for this account.')
   }

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -5,12 +5,12 @@ import { MemoryRouter, useSearchParams } from 'react-router-dom'
 import AgentSidebar from '../AgentSidebar'
 import { HIDDEN_AGENTS_STORAGE_KEY } from '../../lib/hiddenAgents'
 import { PINNED_AGENTS_STORAGE_KEY } from '../../lib/pinnedAgents'
-import { HOSTNAME_STORAGE_KEY } from '../../lib/hostname'
+import { HOSTNAME_STORAGE_KEY, dispatchHostnameChanged } from '../../lib/hostname'
 import {
   GENERATION_COMPLETE_EVENT,
   RAIL_ORDER_STORAGE_KEY,
 } from '../../lib/railOrder'
-import { BUMP_COMPLETED_KEY } from '../../lib/settingsPrefs'
+import { BUMP_COMPLETED_KEY, HOSTNAME_OVERRIDE_KEY } from '../../lib/settingsPrefs'
 import { saveAgentSessions, type AgentSession } from '../../lib/scaleOutSessions'
 import { publishChatConnection, resetChatConnection } from '../../lib/chatConnection'
 
@@ -381,6 +381,19 @@ describe('AgentSidebar Grok rail', () => {
     fireEvent.change(hostname, { target: { value: 'lab-box' } })
     fireEvent.blur(hostname)
     expect(localStorage.getItem(HOSTNAME_STORAGE_KEY)).toBe('lab-box')
+    expect(localStorage.getItem(HOSTNAME_OVERRIDE_KEY)).toBe('lab-box')
+  })
+
+  it('syncs hostname live without reload when HOSTNAME_CHANGED_EVENT is dispatched (REQ-188B-2)', async () => {
+    renderSidebar()
+    await screen.findByRole('navigation', { name: 'Agent list' })
+    const input = screen.getByLabelText('Hostname') as HTMLInputElement
+    expect(input.value).toBe('localhost')
+
+    act(() => {
+      dispatchHostnameChanged('remote.box.net')
+    })
+    expect(input.value).toBe('remote.box.net')
   })
 
   it('renders a server icon left of hostname and clicking it opens remote sessions popup (REQ-118)', async () => {

--- a/webui/frontend/src/components/__tests__/SettingsSheet.test.tsx
+++ b/webui/frontend/src/components/__tests__/SettingsSheet.test.tsx
@@ -8,6 +8,7 @@ import {
   HOSTNAME_OVERRIDE_KEY,
   RETENTION_MODE_KEY,
 } from '../../lib/settingsPrefs'
+import { HOSTNAME_CHANGED_EVENT } from '../../lib/hostname'
 
 function renderSheet({
   isOpen = true,
@@ -323,7 +324,13 @@ describe('SettingsSheet', () => {
     expect(link).toHaveAttribute('href', '/settings/#chat-retention-title')
   })
 
-  it('persists a hostname override and toasts on save', async () => {
+  it('persists a hostname override, toasts on save, and dispatches HOSTNAME_CHANGED_EVENT (REQ-188B-2)', async () => {
+    let dispatchedHost = ''
+    const onHostChanged = (event: Event) => {
+      dispatchedHost = (event as CustomEvent<{ hostname: string }>).detail?.hostname ?? ''
+    }
+    window.addEventListener(HOSTNAME_CHANGED_EVENT, onHostChanged)
+
     renderSheet()
     fireEvent.click(screen.getByRole('button', { name: 'Hostname' }))
     fireEvent.change(screen.getByRole('textbox', { name: 'Hostname override' }), {
@@ -332,6 +339,9 @@ describe('SettingsSheet', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save hostname' }))
     expect(localStorage.getItem(HOSTNAME_OVERRIDE_KEY)).toBe('swarm.example.com')
     expect(await screen.findByText('Hostname saved')).toBeInTheDocument()
+    expect(dispatchedHost).toBe('swarm.example.com')
+
+    window.removeEventListener(HOSTNAME_CHANGED_EVENT, onHostChanged)
   })
 
   it('lists configured profiles and persists the Default picker', async () => {

--- a/webui/frontend/src/lib/__tests__/hostname.test.ts
+++ b/webui/frontend/src/lib/__tests__/hostname.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { HOSTNAME_STORAGE_KEY, defaultHostname, loadHostname, saveHostname } from '../hostname'
+import {
+  HOSTNAME_STORAGE_KEY,
+  defaultHostname,
+  loadHostname,
+  saveHostname,
+  HOSTNAME_CHANGED_EVENT,
+  dispatchHostnameChanged,
+} from '../hostname'
 import {
   HOSTNAME_OVERRIDE_KEY,
   loadHostnameOverride,
@@ -33,5 +40,16 @@ describe('hostname override', () => {
 
     saveHostname('   ')
     expect(loadHostnameOverride()).toBe('settings.example.com')
+  })
+
+  it('dispatches and notifies listeners on HOSTNAME_CHANGED_EVENT (REQ-188B-2)', () => {
+    let notified = ''
+    const listener = (event: Event) => {
+      notified = (event as CustomEvent<{ hostname: string }>).detail?.hostname ?? ''
+    }
+    window.addEventListener(HOSTNAME_CHANGED_EVENT, listener)
+    dispatchHostnameChanged('new-host.example.com')
+    expect(notified).toBe('new-host.example.com')
+    window.removeEventListener(HOSTNAME_CHANGED_EVENT, listener)
   })
 })

--- a/webui/frontend/src/lib/hostname.ts
+++ b/webui/frontend/src/lib/hostname.ts
@@ -36,3 +36,17 @@ export function saveHostname(value: string): string {
   }
   return next
 }
+
+export const HOSTNAME_CHANGED_EVENT = 'swarm:hostname-changed'
+
+export function dispatchHostnameChanged(hostname: string): void {
+  try {
+    window.dispatchEvent(
+      new CustomEvent<{ hostname: string }>(HOSTNAME_CHANGED_EVENT, {
+        detail: { hostname },
+      }),
+    )
+  } catch {
+    /* ignore in environments without window */
+  }
+}


### PR DESCRIPTION
Fixes #664
Refs #644, #592

## Intent
One hostname string for the human: Settings field and rail input stay in sync, and (via #592) survive a second browser.

## Success
1. Sheet Save updates mounted rail live without page reload via HOSTNAME_CHANGED_EVENT.
2. Rail input onBlur updates both hostname keys and dispatches HOSTNAME_CHANGED_EVENT so Settings field updates live if reopened or mounted.
3. Tests updated and verified for live bridge in hostname.test.ts, SettingsSheet.test.tsx, and AgentSidebar.test.tsx.

## Constraints
UI-only bridge using existing prefs storage and custom window event. No third prefs API. No secrets. No Neon.