### PR TITLE
style(webui): align sidepane avatar role badges to bottom and center pinned role badge (Fixes #757)

### DIFF
--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -1075,8 +1075,9 @@ export default function AgentSidebar({
         aria-label={`Open ${role} settings`}
         style={{
           position: 'absolute',
-          bottom: '-0.2rem',
-          right: '-0.25rem',
+          bottom: '0',
+          left: '50%',
+          transform: 'translateX(-50%)',
           zIndex: 10,
           fontSize: '0.55rem',
           padding: '0 0.25rem',
@@ -1317,8 +1318,9 @@ export default function AgentSidebar({
             data-definition-id={team.id}
             style={{
               position: 'absolute',
-              bottom: '-0.25rem',
-              right: '-0.25rem',
+              bottom: '0',
+              left: '50%',
+              transform: 'translateX(-50%)',
               zIndex: 10,
               fontSize: '0.55rem',
               padding: '0 0.25rem',
@@ -1473,8 +1475,9 @@ export default function AgentSidebar({
             data-avatar-overlay="true"
             style={{
               position: 'absolute',
-              bottom: '-0.25rem',
-              right: '-0.25rem',
+              bottom: '0',
+              left: '50%',
+              transform: 'translateX(-50%)',
               zIndex: 10,
               fontSize: '0.55rem',
               padding: '0 0.25rem',
@@ -1556,8 +1559,9 @@ export default function AgentSidebar({
                         aria-label={`Open ${m.team_id || m.id} team settings`}
                         style={{
                           position: 'absolute',
-                          bottom: '-0.25rem',
-                          right: '-0.25rem',
+                          bottom: '0',
+                          left: '50%',
+                          transform: 'translateX(-50%)',
                           zIndex: 10,
                           fontSize: '0.55rem',
                           padding: '0 0.25rem',

--- a/webui/frontend/src/components/__tests__/AgentRolePillOverlay.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentRolePillOverlay.test.tsx
@@ -132,13 +132,40 @@ describe('AgentSidebar Role Badges Overlay Avatar (REQ-175)', () => {
     expect(teamBadge).toHaveAttribute('data-kind', 'team')
     expect(teamBadge).toHaveTextContent('Team')
 
-    // Badge is inside avatar container
+    // Badge is inside avatar container and aligned to bottom
     const avatarContainer = teamBadge?.parentElement
     expect(avatarContainer).toHaveClass('relative')
+    expect(teamBadge).toHaveStyle({ bottom: '0' })
 
     // Second row contains team snippet without badge
     const textColumn = teamRow.querySelector('.min-w-0.flex-1')
     expect(textColumn?.querySelector('.os-agent-role-badge')).toBeNull()
     expect(textColumn?.querySelector('.block.truncate')).not.toBeNull()
+  })
+
+  it('aligns role badge to bottom of sidepane avatar card and renders pinned role badge in dead centre', async () => {
+    localStorage.setItem(
+      PINNED_AGENTS_STORAGE_KEY,
+      JSON.stringify([{ id: 'support', name: 'Support' }]),
+    )
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/chat']}>
+          <AgentSidebar open />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    // Pinned section tile badge is present with .os-fav-tile__badge
+    const grid = screen.getByTestId('agent-fav-grid')
+    const pinnedSupport = await within(grid).findByRole('link', { name: /Support/i })
+    const pinnedBadge = pinnedSupport.querySelector('.os-fav-tile__badge')
+    expect(pinnedBadge).not.toBeNull()
+    expect(pinnedBadge).toHaveClass('os-agent-role-badge')
+    expect(pinnedBadge).toHaveAttribute('data-role', 'support')
   })
 })

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -538,9 +538,10 @@ html:not([data-theme="light"]) .os-chat-md a,
 }
 .os-fav-tile__badge {
   position: absolute;
-  top: 0.2rem;
-  right: 0.2rem;
-  z-index: 1;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10;
   max-width: calc(100% - 0.3rem);
 }
 .os-fav-tile__name {
@@ -597,6 +598,19 @@ html:not([data-theme="light"]) .os-chat-md a,
   position: relative;
   align-self: flex-start;
   margin-top: 0.125rem;
+}
+.os-agent-row__avatar-slot .os-agent-role-badge {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  font-size: 0.55rem;
+  padding: 0 0.25rem;
+  line-height: 1.2;
+  height: 0.9rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  white-space: nowrap;
 }
 .os-agent-row__label-col {
   min-width: 0;


### PR DESCRIPTION
Fixes #757

## Intent
Align sidepane agent role badges to the bottom of the avatar card/slot, and center the role badge in the pinned section into the dead centre.

## Success
1. In unpinned sidepane rows (agents, teams, remotes), role badges are aligned to the bottom of the avatar card/slot (`bottom: 0`, centered horizontally).
2. In the pinned section, the role badge sits in the dead centre of the tile card (`top: 50%`, `left: 50%`, `transform: translate(-50%, -50%)`).
3. Existing accessibility attributes and keyboard/click handlers are preserved.
4. Unit tests pass with new assertions verifying placement.

## Constraints
DaisyUI 5 / React 18 SPA chrome only. No backend changes.