### PR TITLE
feat(webui): unify avatar theme store for Settings Rail and /agents (REQ-188C-3, Fixes #662)

### DIFF
--- a/docs/qa/REQ-188-surface-c-rail-system-chrome.md
+++ b/docs/qa/REQ-188-surface-c-rail-system-chrome.md
@@ -137,16 +137,14 @@ Three child Issues for CoS (drafts at the bottom). Suggested first wave (2–3):
 | **Test** | **Weak.** Happy-path Vitest + e2e. Error path asserts empty paint. No test that 500/401 shows a warning and keeps retry. |
 | **Coordinate** | Closed #377 — do **not** reopen “say Django” or add connection strings. Keep missing-store empty. Split **error** from **not created**. |
 
-### C-H3 — Settings → Rail avatar theme is a second, weaker store
+### C-H3 — Settings → Rail avatar theme unified with /agents (RESOLVED)
 
 | Field | Value |
 |-------|--------|
-| **Severity** | HIGH |
-| **File / area** | `AvatarThemePicker.tsx`; `lib/avatarTheme.ts` (`swarm_avatar_theme`, blobs/bland/default); `components/AgentAvatar.tsx`; `types/agent.ts` `AVATAR_THEMES` (ten packs); `lib/agent-store.ts` (`agent_avatar_theme`); `components/AgentSidebar/SidebarHeader.tsx`; `pages/AgentRouterPage.tsx` |
-| **Evidence** | Settings Rail offers two options and writes `swarm_avatar_theme`. Grok chat rail / header / favourite tiles (`components/AgentAvatar`) honour that. `/agents` (and the unused nested `AgentSidebar/SidebarHeader`) honour `useAgentStore.avatarTheme` — chassis/pixel/glyph/… + eyes — persisted as `agent_avatar_theme`. Same noun (“avatar theme” / “avatar pack”), two keys, two UIs. Opening Settings from Search while on `/agents` and picking Bland does not change Agent Router faces. Settings never exposes the ten packs. RailPane copy does not say “chat rail only”. |
-| **Suggested fix Issue title** | One avatar-theme store for Settings → Rail and /agents (REQ-188 / #644) |
-| **Test** | **Missing** as a product contract. Each store has its own unit tests. No test that Settings → Rail changes `/agents` faces (or that the picker copy says chat-only). |
-| **Coordinate** | #563 / #619 Blobs default stays. Do not delete Bland. Do not fight #579 prefs persist — pick one key before persisting both. |
+| **Severity** | HIGH (Resolved in #662) |
+| **File / area** | `AvatarThemePicker.tsx`; `lib/avatarTheme.ts` (`swarm_avatar_theme`, blobs/bland/default); `components/AgentAvatar.tsx`; `types/agent.ts`; `lib/agent-store.ts` (`swarm_avatar_theme`); `components/AgentSidebar/AgentAvatar.tsx`; `pages/AgentRouterPage.tsx` |
+| **Resolution** | Unified on `swarm_avatar_theme` as the single store of truth. `agent_avatar_theme` eliminated. Settings Rail theme changes synchronize live with Agent Router and rail faces via `AVATAR_THEME_SET_EVENT`. When Bland is chosen, both chat and `/agents` faces fall back to bland static circles. Custom uploaded faces always win. |
+| **Test** | `agent-store.test.ts`, `avatarTheme.test.ts`, `components/AgentSidebar/__tests__/AgentSidebar.test.tsx`. |
 
 ---
 

--- a/webui/frontend/src/components/AgentSidebar/AgentAvatar.tsx
+++ b/webui/frontend/src/components/AgentSidebar/AgentAvatar.tsx
@@ -11,6 +11,7 @@ import {
 import type { Agent, AgentStatus, AvatarState, AvatarMotion, AvatarTheme, AvatarEyes } from '../../types/agent'
 import { getInitials, getReadableTextColor } from '../../lib/agent-utils'
 import { useAgentStore } from '../../lib/agent-store'
+import { useAvatarTheme } from '../../lib/useAvatarTheme'
 import { RobotAvatar } from './RobotAvatar'
 
 export interface AgentAvatarProps {
@@ -54,10 +55,10 @@ export const AgentAvatar = memo(function AgentAvatar({
   const resolvedTheme = theme || storeTheme
   const resolvedEyes = eyes || storeEyes
 
-  const IconComponent = agent.icon ? EMOJI_ICON_MAP[agent.icon] : null
-  const hasEmojiIcon = agent.icon && agent.icon.length <= 2 && !IconComponent
-  // Use RobotAvatar if animated; fall back to plain circle for very small sizes
-  const useRobot = isAnimated && size >= 32
+  const globalAvatarTheme = useAvatarTheme()
+  const isBland = globalAvatarTheme === 'bland' || resolvedTheme === 'bland'
+  // Use RobotAvatar if animated and not bland; fall back to plain circle for bland or very small sizes
+  const useRobot = isAnimated && size >= 32 && !isBland
 
   if (useRobot) {
     return (
@@ -76,6 +77,8 @@ export const AgentAvatar = memo(function AgentAvatar({
   }
 
   // Fallback: plain color circle with icon/initials
+  const IconComponent = agent.icon ? EMOJI_ICON_MAP[agent.icon] : null
+  const hasEmojiIcon = agent.icon && agent.icon.length <= 2 && !IconComponent
   const bgColor = agent.color || '#6366f1'
   const textColor = getReadableTextColor(bgColor)
   const sizeClass =
@@ -95,6 +98,7 @@ export const AgentAvatar = memo(function AgentAvatar({
         className={`${sizeClass} rounded-full flex items-center justify-center font-bold shadow-sm overflow-hidden select-none`}
         style={{ backgroundColor: bgColor, color: textColor }}
         title={`${agent.customName || agent.name}`}
+        data-avatar-theme={isBland ? 'bland' : undefined}
       >
         {IconComponent ? (
           <IconComponent className={iconSizeClass} />

--- a/webui/frontend/src/components/AgentSidebar/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/AgentSidebar/__tests__/AgentSidebar.test.tsx
@@ -9,6 +9,7 @@ import { SidebarHeader } from '../SidebarHeader'
 import type { Agent } from '../../../types/agent'
 import { AVATAR_THEMES } from '../../../types/agent'
 import { useAgentStore } from '../../../lib/agent-store'
+import { AVATAR_THEME_STORAGE_KEY } from '../../../lib/avatarTheme'
 
 const mockAgent: Agent = {
   agent_id: 'coder',
@@ -129,6 +130,16 @@ describe('AgentAvatar', () => {
     // With animated=false, uses the plain circle fallback — no SVG avatar
     const noSvg = screen.queryByRole('img', { name: /Coder/i })
     expect(noSvg).toBeNull()
+  })
+
+  it('falls back to plain circle when avatar theme is bland (REQ-188C-3)', () => {
+    localStorage.setItem(AVATAR_THEME_STORAGE_KEY, 'bland')
+    render(<AgentAvatar agent={mockAgent} size={40} />)
+    const noSvg = screen.queryByRole('img', { name: /Coder/i })
+    expect(noSvg).toBeNull()
+    const fallback = screen.getByTitle('Coder')
+    expect(fallback).toHaveAttribute('data-avatar-theme', 'bland')
+    localStorage.removeItem(AVATAR_THEME_STORAGE_KEY)
   })
 })
 

--- a/webui/frontend/src/lib/__tests__/agent-store.test.ts
+++ b/webui/frontend/src/lib/__tests__/agent-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { useAgentStore } from '../agent-store'
 import { STARTER_API_ID, STARTER_CLI_ID, STARTER_REMOTE_ID, STARTER_SUPPORT_ID } from '../starter-agents'
+import { AVATAR_THEME_STORAGE_KEY, dispatchAvatarTheme } from '../avatarTheme'
 import type { Agent } from '../../types/agent'
 
 const mockAgents: Agent[] = [
@@ -42,10 +43,15 @@ describe('useAgentStore avatar themes', () => {
     })
   })
 
-  it('persists the Swarm-wide avatar pack', () => {
+  it('persists the Swarm-wide avatar pack to swarm_avatar_theme (REQ-188C-3)', () => {
     useAgentStore.getState().setAvatarTheme('pixel')
     expect(useAgentStore.getState().avatarTheme).toBe('pixel')
-    expect(JSON.parse(localStorage.getItem('agent_avatar_theme') || '""')).toBe('pixel')
+    expect(localStorage.getItem(AVATAR_THEME_STORAGE_KEY)).toBe('pixel')
+  })
+
+  it('synchronizes Swarm-wide avatar pack when dispatchAvatarTheme is called (REQ-188C-3)', () => {
+    dispatchAvatarTheme('bland')
+    expect(useAgentStore.getState().avatarTheme).toBe('bland')
   })
 
   it('stores a per-agent override and can clear it', () => {

--- a/webui/frontend/src/lib/agent-store.ts
+++ b/webui/frontend/src/lib/agent-store.ts
@@ -34,6 +34,11 @@ import {
   mergeStarters,
 } from './starter-agents'
 import { cycleSessionMode as nextSessionMode, normalizeSessionMode, type SessionMode } from './session-modes'
+import {
+  AVATAR_THEME_STORAGE_KEY,
+  AVATAR_THEME_SET_EVENT,
+  dispatchAvatarTheme,
+} from './avatarTheme'
 
 interface AgentStoreState {
   // Bots/Agents
@@ -161,6 +166,30 @@ function saveStored<T>(key: string, value: T): void {
   }
 }
 
+function loadAvatarThemeStored(fallback: AvatarTheme): AvatarTheme {
+  try {
+    const raw = localStorage.getItem(AVATAR_THEME_STORAGE_KEY)
+    if (!raw) return fallback
+    let parsed: any = raw
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      /* plain string */
+    }
+    return (parsed as AvatarTheme) || fallback
+  } catch {
+    return fallback
+  }
+}
+
+function saveAvatarThemeStored(theme: AvatarTheme): void {
+  try {
+    localStorage.setItem(AVATAR_THEME_STORAGE_KEY, theme)
+  } catch {
+    // best-effort persistence
+  }
+}
+
 function persistOverlayKeys(state: {
   renames: Record<string, string>
   purposes: Record<string, string>
@@ -279,7 +308,7 @@ export const useAgentStore = create<AgentStoreState>((set) => ({
   sidebarOpen: loadStored<boolean>('agent_sidebar_open', true),
   sidebarDensity: loadStored<SidebarDensity>('agent_sidebar_density', 'compact'),
   collapsedSections: loadStored<string[]>('agent_collapsed_sections', []),
-  avatarTheme: loadStored<AvatarTheme>('agent_avatar_theme', 'chassis'),
+  avatarTheme: loadAvatarThemeStored('chassis'),
   avatarThemeByAgent: loadStored<Record<string, AvatarTheme>>('agent_avatar_theme_by_agent', {}),
   avatarEyes: loadStored<AvatarEyes>('agent_avatar_eyes', 'lens'),
   avatarEyesByAgent: loadStored<Record<string, AvatarEyes>>('agent_avatar_eyes_by_agent', {}),
@@ -412,7 +441,8 @@ export const useAgentStore = create<AgentStoreState>((set) => ({
   },
 
   setAvatarTheme: (theme) => {
-    saveStored('agent_avatar_theme', theme)
+    saveAvatarThemeStored(theme)
+    dispatchAvatarTheme(theme as any)
     set({ avatarTheme: theme })
   },
 
@@ -810,3 +840,25 @@ useAgentStore.subscribe((state, prev) => {
     persistingTeam = false
   }
 })
+
+if (typeof window !== 'undefined') {
+  const onAvatarThemeSet = (event: Event) => {
+    const detail = (event as CustomEvent<AvatarTheme>).detail
+    if (detail && detail !== useAgentStore.getState().avatarTheme) {
+      useAgentStore.setState({ avatarTheme: detail })
+    }
+  }
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === AVATAR_THEME_STORAGE_KEY && event.newValue) {
+      try {
+        const val = JSON.parse(event.newValue)
+        if (val) useAgentStore.setState({ avatarTheme: val })
+      } catch {
+        useAgentStore.setState({ avatarTheme: event.newValue as AvatarTheme })
+      }
+    }
+  }
+  window.addEventListener(AVATAR_THEME_SET_EVENT, onAvatarThemeSet)
+  window.addEventListener('storage', onStorage)
+}
+

--- a/webui/frontend/src/types/agent.ts
+++ b/webui/frontend/src/types/agent.ts
@@ -21,6 +21,9 @@ export type AvatarTheme =
   | 'beetle'
   | 'ghost'
   | 'crystal'
+  | 'blobs'
+  | 'bland'
+  | 'default'
 
 export type AvatarEyes = 'lens' | 'googly' | 'mismatched' | 'crazy' | 'sleepy' | 'spiral'
 


### PR DESCRIPTION
Fixes #662

## Intent
Settings → Rail → Avatar theme is the avatar theme the user sees on every rail Settings can reach. One persist key. One picker.

## Success
1. Single store (one key / one API) for Settings Rail and `/agents` faces.
2. Changing theme in Settings updates Agent Router / rail faces (and vice versa if both exist).
3. Docs/tests name one key; #579 must not persist two avatar keys.
4. Custom uploaded faces still win over theme packs.

## Constraints
Do not persist two keys in #579. No Neon. No secrets.

## Changes
- Unify avatar theme key to `AVATAR_THEME_STORAGE_KEY` (`swarm_avatar_theme`) across `webui/frontend/src/lib/agent-store.ts`, Settings sheet, and Agent Router sidebar.
- Added `'blobs' | 'bland' | 'default'` support to `AvatarTheme` type in `webui/frontend/src/types/agent.ts`.
- Subscribed `agent-store` to `AVATAR_THEME_SET_EVENT` and `window.addEventListener('storage')` for instant cross-component live sync.
- Made `AgentAvatar.tsx` respect active avatar theme with `'bland'` fallback.
- Updated QA documentation (`docs/qa/REQ-188-surface-c-rail-system-chrome.md`) marking C-H3 resolved.
- Added tests in `agent-store.test.ts`, verified frontend suite and python backend tests.