### PR TITLE
feat(webui): composer send is an up-arrow, only while the field has text (REQ-76)

### DIFF
--- a/webui/frontend/e2e/chat-send.spec.ts
+++ b/webui/frontend/e2e/chat-send.spec.ts
@@ -36,7 +36,7 @@ async function awaitComposerReady(page: import('@playwright/test').Page) {
 async function sendChatMessage(page: import('@playwright/test').Page, text: string) {
   const { composer } = await awaitComposerReady(page)
   await composer.fill(text)
-  // Compact composer: Send is sr-only; Enter submits the form.
+  // REQ-76: circular up-arrow Send appears once the field has text.
   await expect(page.getByRole('button', { name: /^Send$/i })).toBeEnabled()
   await composer.press('Enter')
 }

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -1197,6 +1197,26 @@ html[data-theme="light"] .os-code--collapsible.os-code--collapsed::after {
 .os-composer__icon:hover {
   background: color-mix(in srgb, var(--color-base-content) 8%, transparent);
 }
+.os-composer__send {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  border: 0;
+  flex-shrink: 0;
+  background: var(--color-base-content);
+  color: var(--color-base-100);
+}
+.os-composer__send:hover {
+  opacity: 0.92;
+}
+html:not([data-theme="light"]) .os-composer__send,
+[data-theme="dark"] .os-composer__send {
+  background: #fff;
+  color: #111;
+}
 .os-composer__hint {
   font-size: 0.65rem;
   padding: 0.1rem 0.35rem;

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Layers, Mic, PanelLeft, Pencil, Plus, Reply, Settings } from 'lucide-react'
+import { ArrowUp, Layers, Mic, PanelLeft, Pencil, Plus, Reply, Settings } from 'lucide-react'
 import AgentAvatar from '../components/AgentAvatar'
 import { TOAST_KIND_WS_DISCONNECT, useToast } from '../components/DaisyUI'
 import ThemeToggle from '../components/ThemeToggle'
@@ -1045,7 +1045,8 @@ const ChatPage = () => {
     })
   }, [status, authRejected, signInHref, addToast, dismissByKind, reconnect])
 
-  const canSend = status === 'open' && input.trim().length > 0
+  const hasSendableDraft = input.trim().length > 0
+  const canSend = status === 'open' && hasSendableDraft
 
   const sendText = useCallback(
     (text: string) => {
@@ -1998,12 +1999,18 @@ const ChatPage = () => {
                   >
                     <Mic className="h-4 w-4" aria-hidden="true" />
                   </button>
+                  {hasSendableDraft ? (
+                    <button
+                      type="submit"
+                      className="os-composer__send"
+                      aria-label="Send"
+                    >
+                      <ArrowUp className="h-4 w-4" strokeWidth={2.5} aria-hidden="true" />
+                    </button>
+                  ) : null}
                 </div>
               </div>
             </div>
-            <button type="submit" className="sr-only" disabled={!canSend}>
-              Send
-            </button>
           </form>
         </div>
       </div>

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -171,7 +171,8 @@ describe('ChatPage Unavailable / Sign-in CTA + connection status', () => {
     const composer = screen.getByRole('textbox', { name: 'Chat message' })
     expect(composer).toBeDisabled()
     expect(composer).toHaveAttribute('placeholder', 'Message …')
-    expect(screen.getByRole('button', { name: /Send/i })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: /^Send$/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Voice input' })).toBeInTheDocument()
     expect(screen.queryByText(/^Connected$/)).not.toBeInTheDocument()
 
     await act(async () => {
@@ -577,8 +578,13 @@ describe('ChatPage Send button honesty while streaming', () => {
       )
     })
 
+    fireEvent.change(screen.getByRole('textbox', { name: 'Chat message' }), {
+      target: { value: 'follow-up while streaming' },
+    })
     const send = screen.getByRole('button', { name: /^Send$/i })
     expect(send).not.toHaveAttribute('aria-busy', 'true')
+    expect(send).not.toHaveClass('loading')
+    expect(send.querySelector('.loading')).toBeNull()
 
     const loaders = screen.getAllByRole('status', { name: 'Loading' })
     expect(loaders.length).toBeGreaterThan(0)
@@ -1200,6 +1206,41 @@ describe('ChatPage Grok composer and per-agent threads', () => {
     expect(screen.getByRole('button', { name: 'Voice input' })).toBeInTheDocument()
     expect(screen.getByLabelText('Tokens in context')).toBeInTheDocument()
     expect(document.querySelector('.os-chat-header [data-avatar-theme="blobs"]')).toBeInTheDocument()
+  })
+
+  it('REQ-76: circular up-arrow send appears only while the field has text', async () => {
+    renderChat()
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+
+    const composer = screen.getByRole('textbox', { name: 'Chat message' })
+    expect(screen.queryByRole('button', { name: /^Send$/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Voice input' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument()
+
+    fireEvent.change(composer, { target: { value: 'hi' } })
+    const send = screen.getByRole('button', { name: /^Send$/i })
+    expect(send).toBeEnabled()
+    expect(send).toHaveClass('os-composer__send')
+    expect(send.querySelector('svg')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Voice input' })).toBeInTheDocument()
+
+    fireEvent.change(composer, { target: { value: '   ' } })
+    expect(screen.queryByRole('button', { name: /^Send$/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Voice input' })).toBeInTheDocument()
+
+    fireEvent.change(composer, { target: { value: 'hi' } })
+    expect(screen.getByRole('button', { name: /^Send$/i })).toBeInTheDocument()
+    fireEvent.change(composer, { target: { value: '' } })
+    expect(screen.queryByRole('button', { name: /^Send$/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Voice input' })).toBeInTheDocument()
+
+    fireEvent.change(composer, { target: { value: 'hi' } })
+    fireEvent.click(screen.getByRole('button', { name: /^Send$/i }))
+    expect(composer).toHaveValue('')
+    expect(screen.queryByRole('button', { name: /^Send$/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Voice input' })).toBeInTheDocument()
   })
 
   it('ghosts composer shortcut chips until hover or focus, swapping Enter/Esc by draft', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #421

**Feasibility:** Small ChatPage composer change — mount a circular Lucide `ArrowUp` submit only when `input.trim()` is non-empty; no attachment send-rule exists yet, so text is the only sendable signal.

## Issue quotes

**Intent:** Match the Grok-style composer: send is a circular **up-arrow** that **only appears when the input has text**. If the field is empty, the trailing control is **only the microphone**. Do not show a disabled send next to the mic.

**Success:**
1. Empty composer (no text, no pending attach that counts as sendable): trailing control is microphone only. No send/up-arrow.
2. When the user types any non-whitespace text (or the existing sendable-attachment rule if one already exists): a circular up-arrow send button appears (white/contrast circle, dark arrow), same row, trailing. Click or Enter still sends.
3. Clearing the field (or sending) hides the arrow again; mic remains.
4. `+` attach stays leading (existing #351). Do not replace mic with send; they are not two always-visible buttons.
5. Tests: empty → no send button, mic present; type “hi” → send button present; clear → send gone.
6. Distinct from #354 (jump-to-bottom arrow in the transcript).

**Constraints:**
- DaisyUI 5 / React 18. Chat stays mounted. Native controls, no extra icon library required if Lucide/Heroicons already in tree.
- Do not fold into 344. GitHub-only. No `:8001`. No Neon. No secrets.
- **Do not launch a Cursor cloud while feature freeze is on.** One cloud later, small wave, `Fixes` this issue, from stable main.

**Owner:** open-swarm engineer + Cursor cloud (after CoS unblocks). CoS: Open Swarm. Skeptic after the PR (text-only PASS/FAIL).

## What changed

- Removed the always-present `sr-only` Send control.
- Trailing row is `+` (leading) · input · hint · mic · **Send only when there is a non-whitespace draft**.
- Send is a contrast-circle `ArrowUp` (`os-composer__send`); dark theme is white circle / dark arrow.
- Click and Enter still submit. Clear or send unmounts the arrow; mic stays.
- No sendable-attachment rule is wired in ChatPage yet (`ComposerAttachChips` is unused), so sendability is `input.trim().length > 0`.

## Tests

- `REQ-76: circular up-arrow send appears only while the field has text` — empty → no send, mic present; type `hi` → send present; whitespace/clear/send → send gone.
- Connecting empty composer no longer expects a disabled Send.
- Streaming honesty still asserts a real Send (no spinner) when a draft exists.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c044852b-e98c-441c-9154-bc6a4749897f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c044852b-e98c-441c-9154-bc6a4749897f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

