### PR TITLE
fix(webui): CLI session-start status line before the assistant reply

### DIFF
--- a/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
+++ b/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
@@ -277,6 +277,9 @@ class CliAgentBlueprint(BlueprintBase):
                 yield support.progress_chunk(f"_Streaming CLI agent `{target}`…_")
                 stored = self._stored_session(params, adapter.name)
                 can_resume = bool(stored and adapter.can_resume())
+                # REQ-92: new-session status is context for the reply — emit first.
+                if not can_resume:
+                    yield support.session_notice_chunk(adapter.name, resumed=False)
                 turn_prompt = self._turn_prompt(
                     messages, prompt, params, workdir, resume=can_resume
                 )
@@ -293,6 +296,7 @@ class CliAgentBlueprint(BlueprintBase):
                 resumed = can_resume and result is not None and result.ok
                 if result is not None and can_resume and not result.ok and is_resume_failure(result):
                     self._forget_session(params, adapter.name)
+                    yield support.session_notice_chunk(adapter.name, resumed=False)
                     turn_prompt = self._turn_prompt(
                         messages, prompt, params, workdir, resume=False
                     )
@@ -303,11 +307,12 @@ class CliAgentBlueprint(BlueprintBase):
                         elif chunk.delta:
                             yield support.message_chunk(chunk.delta)
                     resumed = False
+                elif can_resume:
+                    yield support.session_notice_chunk(adapter.name, resumed=resumed)
                 if result is not None and result.session_id:
                     self._remember_session(params, adapter.name, result.session_id)
                 elif resumed and stored:
                     self._remember_session(params, adapter.name, stored)
-                yield support.session_notice_chunk(adapter.name, resumed=resumed)
                 if result is None or not result.ok:
                     err = (result.error if result else None) or "unknown error"
                     yield support.message_chunk(support.format_cli_error(adapter, err), final=True)
@@ -325,10 +330,17 @@ class CliAgentBlueprint(BlueprintBase):
                 yield support.progress_chunk(f"_Skipping `{name}` (not installed); failing over…_")
                 continue
             yield support.progress_chunk(f"_Running CLI agent `{name}`…_")
+            announce_new = not bool(
+                self._stored_session(params, adapter.name) and adapter.can_resume()
+            )
+            # REQ-92: new-session line before the CLI runs so it precedes the reply.
+            if announce_new:
+                yield support.session_notice_chunk(adapter.name, resumed=False)
             result, resumed = await self._invoke_cli(
                 adapter, messages, prompt, params, workdir
             )
-            yield support.session_notice_chunk(adapter.name, resumed=resumed)
+            if not announce_new:
+                yield support.session_notice_chunk(adapter.name, resumed=resumed)
             if result.ok:
                 if result.parse_error:
                     logger.warning("CLI %s parse issue: %s", name, result.parse_error)

--- a/src/swarm/consumers.py
+++ b/src/swarm/consumers.py
@@ -295,6 +295,9 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
         )
         await self.send(text_data=user_message_html)
 
+        # REQ-92: new-session status must precede the assistant bubble on the wire.
+        await self._emit_new_cli_session_notice(blueprint_id, params)
+
         message_id = uuid.uuid4().hex
         contents_div_id = f"message-response-{message_id}"
         system_message_html = render_to_string(
@@ -309,6 +312,44 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
             await self.respond_with_blueprint(blueprint_id, contents_div_id, params=params)
         else:
             await self.respond_with_default_model(contents_div_id)
+
+    async def _emit_new_cli_session_notice(self, blueprint_id, params):
+        """REQ-92: send ``Started a new {cli} session.`` before assistant_start.
+
+        Resume / same-session turns stay quiet here. The blueprint still yields
+        the honest resumed/fallback line after it knows the outcome.
+        """
+        try:
+            from swarm.core import chat_store
+            from swarm.core.chat_transcript import (
+                insert_status_before_turn_assistant,
+                new_cli_session_notice_if_needed,
+                transcript_already_has_notice,
+            )
+
+            user_key = None
+            if getattr(self.user, "is_authenticated", False):
+                user_key = chat_store.user_key_for(self.user)
+            thread_params = dict(params or {})
+            thread_params.setdefault("agent", blueprint_id)
+            thread_params.setdefault("agent_id", blueprint_id)
+            thread_params.setdefault(
+                "conversation_id", getattr(self, "conversation_id", "") or ""
+            )
+            notice = new_cli_session_notice_if_needed(
+                blueprint_id=blueprint_id,
+                params=thread_params,
+                user_key=user_key,
+            )
+            if not notice or transcript_already_has_notice(self.messages, notice):
+                return
+            await self.send(text_data=_status_line_html(notice))
+            self.messages = insert_status_before_turn_assistant(
+                self.messages,
+                {"role": "status", "content": notice},
+            )
+        except Exception:
+            logger.debug("CLI new-session notice pre-emit skipped", exc_info=True)
 
     async def respond_with_team_stub(self, params, message_text, contents_div_id):
         """Stub team send-to-all / member-target runtime (REQ-23).
@@ -453,8 +494,17 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
                 if isinstance(chunk, dict) and chunk.get("type") == "cli_session_notice":
                     notice = str(chunk.get("content") or "").strip()
                     if notice:
-                        await self.send(text_data=_status_line_html(notice))
-                        self.messages.append({"role": "status", "content": notice})
+                        from swarm.core.chat_transcript import (
+                            insert_status_before_turn_assistant,
+                            transcript_already_has_notice,
+                        )
+
+                        if not transcript_already_has_notice(self.messages, notice):
+                            await self.send(text_data=_status_line_html(notice))
+                            self.messages = insert_status_before_turn_assistant(
+                                self.messages,
+                                {"role": "status", "content": notice},
+                            )
                     continue
                 message = _extract_message_from_chunk(chunk)
                 if message is None:

--- a/src/swarm/core/chat_transcript.py
+++ b/src/swarm/core/chat_transcript.py
@@ -1,0 +1,120 @@
+"""Shared CLI transcript ordering — session notices sit before the reply.
+
+REQ-92: a new-session status line is context for the assistant turn that
+follows. Live stream and persist/hydrate must keep that order. Resume must
+not invent a spurious ``Started a new …`` line.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_NEW_SESSION_RE = re.compile(r"^Started a new \S+ session\.?$", re.IGNORECASE)
+_RESUME_SESSION_RE = re.compile(r"^Resumed \S+ session\.?$", re.IGNORECASE)
+
+
+def is_cli_session_notice(text: str | None) -> bool:
+    """True for the honest CLI session lines (new or resumed)."""
+    blob = (text or "").strip()
+    return bool(_NEW_SESSION_RE.match(blob) or _RESUME_SESSION_RE.match(blob))
+
+
+def is_new_cli_session_notice(text: str | None) -> bool:
+    return bool(_NEW_SESSION_RE.match((text or "").strip()))
+
+
+def _status_text(row: dict[str, Any]) -> str:
+    return str(row.get("content") or row.get("text") or "").strip()
+
+
+def _last_user_index(messages: list[dict[str, Any]]) -> int:
+    last = -1
+    for index, row in enumerate(messages):
+        if (row.get("role") or "") == "user":
+            last = index
+    return last
+
+
+def transcript_already_has_notice(messages: list[dict[str, Any]], text: str) -> bool:
+    """True when this turn already recorded the same status line."""
+    needle = (text or "").strip()
+    if not needle:
+        return False
+    last_user = _last_user_index(messages)
+    for row in messages[last_user + 1 :]:
+        if (row.get("role") or "") == "status" and _status_text(row) == needle:
+            return True
+    return False
+
+
+def insert_status_before_turn_assistant(
+    messages: list[dict[str, Any]],
+    status_row: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Insert ``status_row`` immediately before this turn's assistant content.
+
+    Dropdown / other status lines still append. Duplicate CLI session notices
+    for the same turn are ignored so a pre-emitted new-session line is not
+    repeated when the blueprint yields the same chunk.
+    """
+    text = _status_text(status_row)
+    if not is_cli_session_notice(text):
+        return [*messages, status_row]
+    if transcript_already_has_notice(messages, text):
+        return list(messages)
+    last_user = _last_user_index(messages)
+    assistant_idx = next(
+        (
+            index
+            for index, row in enumerate(messages)
+            if index > last_user and (row.get("role") or "") == "assistant"
+        ),
+        None,
+    )
+    if assistant_idx is None:
+        return [*messages, status_row]
+    return [*messages[:assistant_idx], status_row, *messages[assistant_idx:]]
+
+
+def new_cli_session_notice_if_needed(
+    *,
+    blueprint_id: str | None,
+    params: dict[str, Any] | None = None,
+    user_key: str | None = None,
+) -> str | None:
+    """Return ``Started a new {cli} session.`` only when this turn cannot resume.
+
+    Returns None when the agent is not a CLI, or when a stored CLI session id
+    exists (resume / same-session — do not print a spurious new-session line).
+    """
+    from swarm.core import chat_store
+    from swarm.core.agent_settings import is_new_chat_per_task
+    from swarm.core.cli_catalog import cli_from_rail_id
+    from swarm.core.cli_sessions import get_cli_session, session_notice_text
+
+    params = params or {}
+    cli_name = None
+    raw_cli = params.get("cli")
+    if isinstance(raw_cli, str) and raw_cli.strip():
+        cli_name = raw_cli.strip()
+    if not cli_name:
+        cli_name = cli_from_rail_id(blueprint_id)
+    if not cli_name:
+        return None
+
+    agent = str(
+        params.get("agent") or params.get("agent_id") or blueprint_id or ""
+    ).strip()
+    agent_id = chat_store.normalize_agent_id(agent) if agent else ""
+    if agent_id and is_new_chat_per_task(agent_id):
+        return session_notice_text(cli_name, resumed=False)
+    if is_new_chat_per_task(cli_name):
+        return session_notice_text(cli_name, resumed=False)
+    if not user_key or not agent_id:
+        # Without a thread we cannot prove resume; stay quiet (no spurious line).
+        return None
+    stored = get_cli_session(user_key, agent_id, cli_name)
+    if stored:
+        return None
+    return session_notice_text(cli_name, resumed=False)

--- a/tests/blueprints/test_cli_agent.py
+++ b/tests/blueprints/test_cli_agent.py
@@ -273,6 +273,24 @@ def _session_notices(chunks):
     ]
 
 
+def _assert_notice_before_assistant(chunks, notice: str):
+    notice_idx = next(
+        i
+        for i, c in enumerate(chunks)
+        if isinstance(c, dict)
+        and c.get("type") == "cli_session_notice"
+        and c.get("content") == notice
+    )
+    assistant_idx = next(
+        i
+        for i, c in enumerate(chunks)
+        if isinstance(c, dict)
+        and c.get("messages")
+        and c["messages"][0].get("content") is not None
+    )
+    assert notice_idx < assistant_idx
+
+
 async def test_second_turn_passes_stored_resume_id(tmp_path, monkeypatch):
     """Fixture CLI echoes --resume ID; turn two must pass the stored id."""
     monkeypatch.setenv("SWARM_CHAT_DIR", str(tmp_path))
@@ -307,6 +325,7 @@ async def test_second_turn_passes_stored_resume_id(tmp_path, monkeypatch):
     first = await _collect(bp.run([{"role": "user", "content": "hello"}]))
     assert _final_content(first) == "resume=None prompt=hello"
     assert _session_notices(first) == ["Started a new echo session."]
+    _assert_notice_before_assistant(first, "Started a new echo session.")
     assert "restored" not in " ".join(_session_notices(first)).lower()
 
     from swarm.core.cli_sessions import get_cli_session
@@ -325,6 +344,7 @@ async def test_second_turn_passes_stored_resume_id(tmp_path, monkeypatch):
     )
     assert _final_content(second) == "resume=sid-1 prompt=again"
     assert _session_notices(second) == ["Resumed echo session."]
+    assert all("Started a new" not in n for n in _session_notices(second))
 
 
 async def test_missing_session_starts_new_and_is_honest(tmp_path, monkeypatch):
@@ -372,6 +392,7 @@ async def test_cli_without_resume_never_claims_restore(tmp_path, monkeypatch):
     chunks = await _collect(bp.run([{"role": "user", "content": "ping"}]))
     assert _final_content(chunks) == "ECHO: ping"
     assert _session_notices(chunks) == ["Started a new echo session."]
+    _assert_notice_before_assistant(chunks, "Started a new echo session.")
     assert all("Resumed" not in n and "restored" not in n.lower() for n in _session_notices(chunks))
 
 
@@ -400,6 +421,14 @@ async def test_blueprint_streams_deltas_without_duplication():
     chunks = await _collect(bp.run([{"role": "user", "content": "go"}], stream=True))
     # The concatenated deltas reproduce the output exactly — no final full resend.
     assert "".join(_message_contents(chunks)) == "line1\nline2\n"
+
+
+async def test_streaming_new_session_notice_precedes_deltas():
+    """REQ-92: live stream yields the new-session line before assistant deltas."""
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=_stream_config())
+    chunks = await _collect(bp.run([{"role": "user", "content": "go"}], stream=True))
+    _assert_notice_before_assistant(chunks, "Started a new s session.")
+    assert _session_notices(chunks) == ["Started a new s session."]
 
 
 async def test_blueprint_non_streaming_still_single_full_message():

--- a/tests/core/test_chat_transcript.py
+++ b/tests/core/test_chat_transcript.py
@@ -1,0 +1,91 @@
+"""REQ-92 — CLI session notice sits immediately before the assistant turn."""
+
+from __future__ import annotations
+
+from swarm.core.chat_transcript import (
+    insert_status_before_turn_assistant,
+    is_cli_session_notice,
+    is_new_cli_session_notice,
+    new_cli_session_notice_if_needed,
+    transcript_already_has_notice,
+)
+
+
+def test_notice_helpers_match_honest_copy():
+    assert is_new_cli_session_notice("Started a new grok session.")
+    assert is_cli_session_notice("Resumed opencode session.")
+    assert not is_new_cli_session_notice("Resumed grok session.")
+    assert not is_cli_session_notice("CLI: antigravity → grok")
+
+
+def test_insert_puts_new_session_before_assistant():
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    out = insert_status_before_turn_assistant(
+        messages,
+        {"role": "status", "content": "Started a new grok session."},
+    )
+    assert [m["role"] for m in out] == ["user", "status", "assistant"]
+    assert out[1]["content"] == "Started a new grok session."
+
+
+def test_insert_skips_duplicate_new_session_line():
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "status", "content": "Started a new grok session."},
+    ]
+    out = insert_status_before_turn_assistant(
+        messages,
+        {"role": "status", "content": "Started a new grok session."},
+    )
+    assert out == messages
+    assert transcript_already_has_notice(messages, "Started a new grok session.")
+
+
+def test_dropdown_status_still_appends():
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    out = insert_status_before_turn_assistant(
+        messages,
+        {"role": "status", "content": "CLI: antigravity → grok"},
+    )
+    assert [m["role"] for m in out] == ["user", "assistant", "status"]
+
+
+def test_new_session_notice_if_needed_skips_resume(tmp_path, monkeypatch):
+    monkeypatch.setenv("SWARM_CHAT_DIR", str(tmp_path))
+    from swarm.core.cli_sessions import put_cli_session
+
+    put_cli_session("u1", "cli_agent", "grok", "sid-1")
+    assert (
+        new_cli_session_notice_if_needed(
+            blueprint_id="cli_agent",
+            params={"cli": "grok", "agent": "cli_agent"},
+            user_key="u1",
+        )
+        is None
+    )
+
+
+def test_new_session_notice_if_needed_announces_first_turn(tmp_path, monkeypatch):
+    monkeypatch.setenv("SWARM_CHAT_DIR", str(tmp_path))
+    assert (
+        new_cli_session_notice_if_needed(
+            blueprint_id="cli_agent",
+            params={"cli": "grok", "agent": "cli_agent"},
+            user_key="u1",
+        )
+        == "Started a new grok session."
+    )
+    assert (
+        new_cli_session_notice_if_needed(
+            blueprint_id="jeeves",
+            params={},
+            user_key="u1",
+        )
+        is None
+    )

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -751,9 +751,91 @@ class TestBlueprintSelection:
                 assert any("Started a new echo session." in frame for frame in frames)
                 assert "Restored" not in "".join(frames)
                 assert {"role": "status", "content": "Started a new echo session."} in consumer.messages
+                roles = [m["role"] for m in consumer.messages]
+                assert roles.index("status") < roles.index("assistant")
+                status_i = next(i for i, frame in enumerate(frames) if "Started a new echo session." in frame)
+                assistant_i = next(i for i, frame in enumerate(frames) if "ok" in frame)
+                assert status_i < assistant_i
                 instance.set_params.assert_called()
                 passed = instance.set_params.call_args[0][0]
                 assert passed.get("agent") == "cli_agent"
+
+    @pytest.mark.asyncio
+    async def test_receive_new_cli_session_notice_before_assistant_start(
+        self, consumer, tmp_path, monkeypatch
+    ):
+        """REQ-92: first CLI turn sends the status line before assistant_start."""
+        monkeypatch.setenv("SWARM_CHAT_DIR", str(tmp_path))
+        consumer.messages = []
+        consumer.conversation_id = "conv-cli-new"
+
+        def fake_render(template, context=None):
+            if "user_message" in template:
+                return "<div class='user-message'>hi</div>"
+            if "system_message" in template:
+                div_id = (context or {}).get("contents_div_id", "message-response-x")
+                return (
+                    '<div id="message-list" hx-swap-oob="beforeend">'
+                    f'<div id="{div_id}" class="assistant-message"></div></div>'
+                )
+            return "<div></div>"
+
+        frames = []
+
+        async def capture_send(**kwargs):
+            frames.append(kwargs.get("text_data") or "")
+
+        with patch("swarm.consumers.render_to_string", side_effect=fake_render):
+            with patch.object(consumer, "respond_with_blueprint", new_callable=AsyncMock):
+                with patch.object(consumer, "send", new_callable=AsyncMock, side_effect=capture_send):
+                    await consumer.receive(
+                        json.dumps(
+                            {
+                                "message": "hello",
+                                "blueprint": "cli_agent",
+                                "params": {"cli": "grok"},
+                            }
+                        )
+                    )
+
+        assert any("Started a new grok session." in frame for frame in frames)
+        status_i = next(i for i, frame in enumerate(frames) if "Started a new grok session." in frame)
+        start_i = next(i for i, frame in enumerate(frames) if "assistant-message" in frame)
+        assert status_i < start_i
+        assert [m["role"] for m in consumer.messages[:2]] == ["user", "status"]
+        assert consumer.messages[1]["content"] == "Started a new grok session."
+
+    @pytest.mark.asyncio
+    async def test_receive_resume_does_not_emit_spurious_new_session(
+        self, consumer, tmp_path, monkeypatch
+    ):
+        """REQ-92 / REQ-52: same-session turns do not print Started a new …"""
+        monkeypatch.setenv("SWARM_CHAT_DIR", str(tmp_path))
+        from swarm.core.cli_sessions import put_cli_session
+
+        put_cli_session("u1", "cli_agent", "grok", "sid-1")
+        consumer.messages = []
+        consumer.conversation_id = "conv-cli-resume"
+
+        with patch("swarm.consumers.render_to_string", return_value="<div></div>"):
+            with patch.object(consumer, "respond_with_blueprint", new_callable=AsyncMock):
+                with patch.object(consumer, "send", new_callable=AsyncMock) as mock_send:
+                    await consumer.receive(
+                        json.dumps(
+                            {
+                                "message": "again",
+                                "blueprint": "cli_agent",
+                                "params": {"cli": "grok"},
+                            }
+                        )
+                    )
+                    frames = [
+                        call.kwargs.get("text_data") or call.args[0]
+                        for call in mock_send.await_args_list
+                    ]
+
+        assert all("Started a new" not in str(frame) for frame in frames)
+        assert all(m.get("content") != "Started a new grok session." for m in consumer.messages)
 
     @pytest.mark.asyncio
     async def test_blueprint_run_uses_compacted_context(self, consumer, monkeypatch):

--- a/webui/frontend/src/lib/__tests__/chatTranscript.test.ts
+++ b/webui/frontend/src/lib/__tests__/chatTranscript.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import {
+  insertCliSessionNotice,
+  isCliSessionNoticeText,
+  isNewCliSessionNoticeText,
+  transcriptAlreadyHasNotice,
+} from '../chatTranscript'
+
+describe('CLI session notice transcript order (REQ-92)', () => {
+  it('recognises new-session and resume copy only', () => {
+    expect(isNewCliSessionNoticeText('Started a new grok session.')).toBe(true)
+    expect(isCliSessionNoticeText('Resumed opencode session.')).toBe(true)
+    expect(isNewCliSessionNoticeText('Resumed grok session.')).toBe(false)
+    expect(isCliSessionNoticeText('CLI: antigravity → grok')).toBe(false)
+  })
+
+  it('inserts a new-session line immediately before this turn assistant', () => {
+    const next = insertCliSessionNotice(
+      [
+        { role: 'user', text: 'hello' },
+        { role: 'assistant', text: 'hi' },
+      ],
+      { role: 'status', text: 'Started a new grok session.' },
+    )
+    expect(next.map((row) => row.role)).toEqual(['user', 'status', 'assistant'])
+    expect(next[1]?.text).toBe('Started a new grok session.')
+  })
+
+  it('does not invent a second new-session line on resume / same turn', () => {
+    const current = [
+      { role: 'user', text: 'hello' },
+      { role: 'status', text: 'Started a new grok session.' },
+      { role: 'assistant', text: 'hi' },
+      { role: 'user', text: 'again' },
+      { role: 'assistant', text: '' },
+    ]
+    expect(transcriptAlreadyHasNotice(current, 'Started a new grok session.')).toBe(false)
+    const resumed = insertCliSessionNotice(current, {
+      role: 'status',
+      text: 'Resumed grok session.',
+    })
+    expect(resumed.map((row) => `${row.role}:${row.text}`)).toEqual([
+      'user:hello',
+      'status:Started a new grok session.',
+      'assistant:hi',
+      'user:again',
+      'status:Resumed grok session.',
+      'assistant:',
+    ])
+    const dup = insertCliSessionNotice(resumed, {
+      role: 'status',
+      text: 'Resumed grok session.',
+    })
+    expect(dup).toEqual(resumed)
+    expect(resumed.some((row) => row.text === 'Started a new grok session.')).toBe(true)
+    expect(resumed.filter((row) => row.text?.startsWith('Started a new')).length).toBe(1)
+  })
+
+  it('appends dropdown status after the assistant (REQ-46)', () => {
+    const next = insertCliSessionNotice(
+      [
+        { role: 'user', text: 'hello' },
+        { role: 'assistant', text: 'hi' },
+      ],
+      { role: 'status', text: 'CLI: antigravity → grok' },
+    )
+    expect(next.map((row) => row.role)).toEqual(['user', 'assistant', 'status'])
+  })
+})

--- a/webui/frontend/src/lib/chatTranscript.ts
+++ b/webui/frontend/src/lib/chatTranscript.ts
@@ -1,0 +1,69 @@
+/**
+ * REQ-92 — CLI session-start status sits immediately before that turn's reply.
+ *
+ * Shared by the live WS reducer and hydrate so stream + reload keep one order.
+ * Resume / same-session turns must not invent a "Started a new …" line.
+ */
+
+export const CLI_SESSION_NOTICE_RE =
+  /^(Started a new|Resumed) \S+ session\.?$/i
+
+export function isCliSessionNoticeText(text: string | null | undefined): boolean {
+  return CLI_SESSION_NOTICE_RE.test(String(text || '').trim())
+}
+
+export function isNewCliSessionNoticeText(text: string | null | undefined): boolean {
+  return /^Started a new \S+ session\.?$/i.test(String(text || '').trim())
+}
+
+type TranscriptRow = {
+  role: string
+  text?: string
+  content?: string
+}
+
+function rowText(row: TranscriptRow): string {
+  return String(row.text ?? row.content ?? '').trim()
+}
+
+function lastUserIndex(messages: TranscriptRow[]): number {
+  let last = -1
+  for (let i = 0; i < messages.length; i += 1) {
+    if (messages[i]?.role === 'user') last = i
+  }
+  return last
+}
+
+export function transcriptAlreadyHasNotice<T extends TranscriptRow>(
+  messages: T[],
+  text: string,
+): boolean {
+  const needle = text.trim()
+  if (!needle) return false
+  const lastUser = lastUserIndex(messages)
+  return messages
+    .slice(lastUser + 1)
+    .some((row) => row.role === 'status' && rowText(row) === needle)
+}
+
+/** Insert a CLI session notice immediately before this turn's assistant row. */
+export function insertCliSessionNotice<T extends TranscriptRow>(
+  messages: T[],
+  notice: T,
+): T[] {
+  const text = rowText(notice)
+  if (!isCliSessionNoticeText(text)) {
+    return [...messages, notice]
+  }
+  if (transcriptAlreadyHasNotice(messages, text)) {
+    return messages
+  }
+  const lastUser = lastUserIndex(messages)
+  const assistantIdx = messages.findIndex(
+    (row, index) => index > lastUser && row.role === 'assistant',
+  )
+  if (assistantIdx === -1) {
+    return [...messages, notice]
+  }
+  return [...messages.slice(0, assistantIdx), notice, ...messages.slice(assistantIdx)]
+}

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -129,6 +129,7 @@ import {
   shouldRecordDropdownChange,
   type DropdownKind,
 } from '../lib/chatStatus'
+import { insertCliSessionNotice } from '../lib/chatTranscript'
 import { restoreKindForAgent, restoredSessionNotice } from '../lib/sessionRestore'
 import {
   discoverChatClis,
@@ -858,15 +859,12 @@ const ChatPage = () => {
             )
             break
           case 'status':
-            next = [
-              ...current,
-              {
-                key: `status-${current.length}-${Date.now()}`,
-                role: 'status',
-                text: event.text,
-                streaming: false,
-              },
-            ]
+            next = insertCliSessionNotice(current, {
+              key: `status-${current.length}-${Date.now()}`,
+              role: 'status',
+              text: event.text,
+              streaming: false,
+            })
             break
         }
         return { ...prev, [threadKey]: next }

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -1014,6 +1014,131 @@ describe('ChatPage per-agent persistence (no retention chrome)', () => {
     expect(started!.querySelector('span')).toHaveTextContent('Started a new grok session.')
     expect(screen.getByText('hello').closest('.chat-end')).toBeTruthy()
     expect(screen.getByText('hi').closest('.chat-start')).toBeTruthy()
+    const startedPos = started!.compareDocumentPosition(screen.getByText('hi'))
+    expect(startedPos & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('REQ-92: live new-session status lands immediately before the assistant reply', async () => {
+    MockWebSocket.instances = []
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [{ id: 'cli_agent', name: 'CLI Agent', description: 'CLI' }],
+        }),
+      } as Response),
+    )
+
+    renderChat('/chat?blueprint=cli_agent')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+
+    const composer = await screen.findByRole('textbox', { name: 'Chat message' })
+    fireEvent.change(composer, { target: { value: 'hello grok' } })
+    fireEvent.click(screen.getByRole('button', { name: /^Send$/i }))
+
+    const ws = MockWebSocket.instances[0]!
+    await act(async () => {
+      ws.onmessage?.(
+        new MessageEvent('message', {
+          data: '<div id="message-list" hx-swap-oob="beforeend"><div class="user-message">hello grok</div></div>',
+        }),
+      )
+      ws.onmessage?.(
+        new MessageEvent('message', {
+          data: '<div id="message-list" hx-swap-oob="beforeend"><div id="message-response-cli1" class="assistant-message"></div></div>',
+        }),
+      )
+      ws.onmessage?.(
+        new MessageEvent('message', {
+          data: '<div id="message-list" hx-swap-oob="beforeend"><div class="chat-status-line os-chat-status">Started a new grok session.</div></div>',
+        }),
+      )
+      ws.onmessage?.(
+        new MessageEvent('message', {
+          data: '<div id="message-response-cli1" class="assistant-message" hx-swap-oob="true">reply after start</div>',
+        }),
+      )
+    })
+
+    const started = screen.getByText('Started a new grok session.')
+    const reply = screen.getByText('reply after start')
+    expect(started.compareDocumentPosition(reply) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(started.closest('.chat-start')).toBeNull()
+  })
+
+  it('REQ-92: a resume turn does not print a second Started a new line', async () => {
+    MockWebSocket.instances = []
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/chat/thread/')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              agent_id: 'cli_agent',
+              conversation_id: 'agt-1-cli',
+              messages: [
+                { role: 'user', content: 'hello' },
+                { role: 'status', content: 'Started a new grok session.' },
+                { role: 'assistant', content: 'hi' },
+              ],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: [{ id: 'cli_agent', name: 'CLI Agent', description: 'CLI' }],
+          }),
+        } as Response
+      }),
+    )
+
+    renderChat('/chat?blueprint=cli_agent')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+
+    expect(await screen.findByText('Started a new grok session.')).toBeInTheDocument()
+
+    const ws = MockWebSocket.instances[0]!
+    await act(async () => {
+      ws.onmessage?.(
+        new MessageEvent('message', {
+          data: '<div id="message-list" hx-swap-oob="beforeend"><div class="user-message">again</div></div>',
+        }),
+      )
+      ws.onmessage?.(
+        new MessageEvent('message', {
+          data: '<div id="message-list" hx-swap-oob="beforeend"><div id="message-response-cli2" class="assistant-message"></div></div>',
+        }),
+      )
+      ws.onmessage?.(
+        new MessageEvent('message', {
+          data: '<div id="message-list" hx-swap-oob="beforeend"><div class="chat-status-line os-chat-status">Resumed grok session.</div></div>',
+        }),
+      )
+      ws.onmessage?.(
+        new MessageEvent('message', {
+          data: '<div id="message-response-cli2" class="assistant-message" hx-swap-oob="true">second reply</div>',
+        }),
+      )
+    })
+
+    expect(screen.getAllByText('Started a new grok session.')).toHaveLength(1)
+    const resumed = screen.getByText('Resumed grok session.')
+    expect(resumed.compareDocumentPosition(screen.getByText('second reply')) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
   it('renders info and system thread rows as centred status chrome', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #449

**Feasibility:** Yes — the notice was yielded after the CLI finished and the SPA appended it after an already-created assistant bubble; emit/insert it immediately before that turn’s assistant content.

## Intent
Session-start is context for the reply that follows. Trailing it makes the UI look like the session started after the work finished.

## Success
1. When a CLI chat (opencode, grok, agy, etc.) starts a **new** session for a turn, the bubble-less / info status line (“Started a new {cli} session.” or existing copy) is inserted **immediately before** that turn’s assistant content in the transcript order.
2. Resume / same-session turns do not print a spurious “Started a new …” line (existing resume behaviour from #369 / REQ-52 stays).
3. Ordering is stable on live stream and on reload/persist (status line stays above the reply it belongs to).
4. Distinct from #362 (dropdown change line), #407 (info not in LLM context — this line stays UI-only), #447 (queued sends).
5. API-owned SPA + any shared transcript builder for CLI. Tests: new-session stub emits status then reply in that order; reload preserves order. DaisyUI 5 / React 18. No live host.

## Constraints
- GitHub-only. No Neon. No secrets. Do not fold into fat chrome 344.
- **Do not launch a Cursor cloud while the merge smash is in flight.** One cloud later; `Fixes` this issue.

## Owner
open-swarm engineer + Cursor cloud (after CoS unblocks). CoS: Open Swarm. Skeptic text-only PASS/FAIL.

## Root cause
Two ordering bugs stacked:

1. `CliAgentBlueprint` yielded `cli_session_notice` **after** the CLI run (and after streamed deltas), so chunk order was reply-then-status.
2. `DjangoChatConsumer.receive()` sent `assistant_start` **before** running the blueprint, and the SPA WS reducer always appended `status` events at the end of the thread. Live transcript order became `[user, assistant, status]` even when persist later stored `[user, status, assistant]`.

## Fix
- Blueprint emits “Started a new …” **before** invoke/stream when the turn cannot resume; resume/fallback still uses the honest post-run line.
- Consumer pre-emits the new-session line before `assistant_start` when no stored CLI session exists, and dedupes the blueprint chunk so resume stays quiet.
- Shared transcript helper (`chat_transcript` / `chatTranscript`) inserts a CLI session notice immediately before the current turn’s assistant row for live stream and persist.

## Tests
- New-session notice precedes assistant chunks (oneshot + stream).
- Resume / same-session does not print a spurious new-session line.
- Consumer wire + persist order is status then assistant.
- SPA live WS and hydrate keep the status line above the reply.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d90d5e9c-1169-4e4e-b96e-d8522a614841?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d90d5e9c-1169-4e4e-b96e-d8522a614841&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

