### PR TITLE
REQ-71: PR-opened card — View PR, jump to opener unless already in that chat

### DIFF
--- a/src/swarm/consumers.py
+++ b/src/swarm/consumers.py
@@ -513,8 +513,27 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
         await self.send(text_data=final_message_html)
 
     async def emit_tool_event(self, payload: dict) -> None:
-        """JSON tool-status / approval frames for the SPA (not HTMx HTML)."""
+        """JSON tool-status / approval / PR-opened frames for the SPA."""
         try:
+            from swarm.core.pr_opened import persist_pr_opened_message
+
+            if isinstance(payload, dict) and payload.get("type") == "pr_opened":
+                opener = payload.get("opener")
+                if not isinstance(opener, dict):
+                    opener = {}
+                    payload["opener"] = opener
+                agent_id = (
+                    opener.get("agent_id")
+                    or getattr(self, "active_agent", None)
+                    or getattr(self, "default_blueprint", None)
+                    or ""
+                )
+                if agent_id and not opener.get("agent_id"):
+                    opener["agent_id"] = str(agent_id)
+                conversation_id = getattr(self, "conversation_id", None) or ""
+                if conversation_id and not opener.get("conversation_id"):
+                    opener["conversation_id"] = str(conversation_id)
+                persist_pr_opened_message(self.messages, payload)
             await self.send(text_data=json.dumps(payload))
         except Exception:
             logger.debug("tool event send failed", exc_info=True)

--- a/src/swarm/core/pr_opened.py
+++ b/src/swarm/core/pr_opened.py
@@ -1,0 +1,197 @@
+"""REQ-71: structured GitHub PR-opened tool events (no markdown scrape).
+
+A tool result becomes a ``pr_opened`` chrome event only when it already
+carries a GitHub pull URL and/or explicit ``type: pr_opened``. Optional
+branch / ``+N/-M`` / file counts are copied when present and never invented.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+PR_OPENED_TYPE = "pr_opened"
+
+# https://github.com/{owner}/{repo}/pull/{n} — no LAN, no :8001, no other hosts.
+_GITHUB_PR_URL = re.compile(
+    r"^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+(?:/[A-Za-z0-9._~-]*)?(?:\?[^#]*)?(?:#.*)?$",
+    re.IGNORECASE,
+)
+
+_URL_KEYS = ("url", "html_url", "pr_url", "pull_request_url")
+_TITLE_KEYS = ("title", "name")
+_NUMBER_KEYS = ("number", "pr_number", "pull_number")
+_BRANCH_KEYS = ("branch", "head_ref", "head")
+_ADDITIONS_KEYS = ("additions", "additions_count", "plus")
+_DELETIONS_KEYS = ("deletions", "deletions_count", "minus")
+_FILES_KEYS = ("files_changed", "changed_files", "files")
+_STATUS_KEYS = ("status", "state")
+
+
+def is_github_pr_url(value: object) -> bool:
+    """True only for a public ``https://github.com/…/pull/N`` URL."""
+    if not isinstance(value, str):
+        return False
+    text = value.strip()
+    if not text or "://" not in text:
+        return False
+    lowered = text.lower()
+    if lowered.startswith(("http://", "ws://", "wss://")):
+        return False
+    if "localhost" in lowered or "127.0.0.1" in lowered:
+        return False
+    if ":8001" in lowered:
+        return False
+    return bool(_GITHUB_PR_URL.match(text))
+
+
+def _as_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str) and value.strip().lstrip("+-").isdigit():
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _first_str(obj: dict[str, Any], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        raw = obj.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+    return None
+
+
+def _first_int(obj: dict[str, Any], keys: tuple[str, ...]) -> int | None:
+    for key in keys:
+        parsed = _as_int(obj.get(key))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _github_pr_url_from(obj: dict[str, Any]) -> str | None:
+    for key in _URL_KEYS:
+        raw = obj.get(key)
+        if is_github_pr_url(raw):
+            return str(raw).strip()
+    return None
+
+
+def _opener_from(obj: dict[str, Any], *, agent_id: str = "", conversation_id: str = "") -> dict[str, str]:
+    raw = obj.get("opener")
+    opener: dict[str, str] = {}
+    if isinstance(raw, dict):
+        oid = raw.get("agent_id") or raw.get("agentId") or raw.get("id")
+        name = raw.get("name")
+        cid = raw.get("conversation_id") or raw.get("conversationId")
+        if isinstance(oid, str) and oid.strip():
+            opener["agent_id"] = oid.strip()
+        if isinstance(name, str) and name.strip():
+            opener["name"] = name.strip()
+        if isinstance(cid, str) and cid.strip():
+            opener["conversation_id"] = cid.strip()
+    if agent_id and "agent_id" not in opener:
+        opener["agent_id"] = agent_id
+    if conversation_id and "conversation_id" not in opener:
+        opener["conversation_id"] = conversation_id
+    return opener
+
+
+def _unwrap_candidate(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        for nested_key in ("pull_request", "pr", "result", "data"):
+            nested = value.get(nested_key)
+            if isinstance(nested, dict) and (
+                _github_pr_url_from(nested) or nested.get("type") == PR_OPENED_TYPE
+            ):
+                return nested
+        return value
+    return None
+
+
+def parse_pr_opened(
+    value: Any,
+    *,
+    agent_id: str = "",
+    conversation_id: str = "",
+) -> dict[str, Any] | None:
+    """Return a chrome payload, or None when this is not a PR-opened result."""
+    if isinstance(value, str):
+        text = value.strip()
+        if not text.startswith("{"):
+            return None
+        try:
+            value = json.loads(text)
+        except json.JSONDecodeError:
+            return None
+    obj = _unwrap_candidate(value)
+    if obj is None:
+        return None
+
+    explicit = str(obj.get("type") or "").strip() == PR_OPENED_TYPE
+    url = _github_pr_url_from(obj)
+    number = _first_int(obj, _NUMBER_KEYS)
+    title = _first_str(obj, _TITLE_KEYS)
+    if not explicit and not url:
+        return None
+    if not explicit and url and number is None and title is None:
+        # A lone GitHub link is not enough — require number or title.
+        return None
+
+    payload: dict[str, Any] = {"type": PR_OPENED_TYPE}
+    if url:
+        payload["url"] = url
+    if number is not None:
+        payload["number"] = number
+    if title:
+        payload["title"] = title
+
+    branch = obj.get("branch")
+    if not isinstance(branch, str) or not branch.strip():
+        head = obj.get("head")
+        if isinstance(head, dict):
+            ref = head.get("ref")
+            if isinstance(ref, str) and ref.strip():
+                branch = ref
+        elif isinstance(head, str) and head.strip() and "/" not in head.strip():
+            branch = head
+        else:
+            branch = _first_str(obj, ("head_ref",))
+    if isinstance(branch, str) and branch.strip():
+        payload["branch"] = branch.strip()
+
+    additions = _first_int(obj, _ADDITIONS_KEYS)
+    if additions is not None:
+        payload["additions"] = additions
+    deletions = _first_int(obj, _DELETIONS_KEYS)
+    if deletions is not None:
+        payload["deletions"] = deletions
+    files_changed = _first_int(obj, _FILES_KEYS)
+    if files_changed is not None:
+        payload["files_changed"] = files_changed
+
+    status = _first_str(obj, _STATUS_KEYS)
+    if status and status.lower() not in {PR_OPENED_TYPE, "tool_status", "tool_approval"}:
+        payload["status"] = status
+
+    opener = _opener_from(obj, agent_id=agent_id, conversation_id=conversation_id)
+    if opener:
+        payload["opener"] = opener
+    return payload
+
+
+def persist_pr_opened_message(messages: list[dict[str, Any]], payload: dict[str, Any]) -> None:
+    """Append a status row so reload can rehydrate the card (not model context)."""
+    content = json.dumps(payload, separators=(",", ":"))
+    for row in messages:
+        if row.get("role") == "status" and row.get("content") == content:
+            return
+    messages.append({"role": "status", "content": content})

--- a/src/swarm/tool_executor.py
+++ b/src/swarm/tool_executor.py
@@ -257,6 +257,7 @@ async def handle_tool_calls(
                 "content": result_content_json
             })
             await _emit_tool_status(tool_call_id, tool_name, "done")
+            await _emit_pr_opened_if_any(result_content_json)
 
             # Update context variables from the result
             if processed_result.context_variables:
@@ -329,6 +330,25 @@ async def _maybe_deny_tool(tool_name: str, tool_call_id: str, args: dict) -> dic
         "name": tool_name,
         "content": json.dumps({"error": f"DENIED: tool call {tool_name!r} was not approved"}),
     }
+
+
+async def _emit_pr_opened_if_any(result_content: str) -> None:
+    """REQ-71: structured PR-opened chrome when a tool result is a GitHub PR."""
+    try:
+        from swarm.core.pr_opened import parse_pr_opened
+        from swarm.core.safety import current_safety_session, maybe_await
+    except Exception:
+        return
+    session = current_safety_session()
+    if session is None or session.emit_fn is None:
+        return
+    payload = parse_pr_opened(
+        result_content,
+        agent_id=getattr(session, "agent_id", "") or "",
+    )
+    if payload is None:
+        return
+    await maybe_await(session.emit_fn(payload))
 
 
 async def _emit_tool_status(tool_call_id: str, tool_name: str, status: str) -> None:

--- a/tests/core/test_pr_opened.py
+++ b/tests/core/test_pr_opened.py
@@ -1,0 +1,70 @@
+"""REQ-71: structured PR-opened payloads — no markdown scrape, no invented stats."""
+
+from swarm.core.pr_opened import is_github_pr_url, parse_pr_opened, persist_pr_opened_message
+
+GH = "https://github.com/matthewhand/open-swarm/pull/416"
+
+
+def test_github_pr_url_is_public_https_only():
+    assert is_github_pr_url(GH)
+    assert is_github_pr_url(f"{GH}/files")
+    assert not is_github_pr_url("http://github.com/matthewhand/open-swarm/pull/416")
+    assert not is_github_pr_url("https://gitlab.com/acme/repo/pull/1")
+    assert not is_github_pr_url("http://127.0.0.1:8001/pull/1")
+    assert not is_github_pr_url("Opened a PR")
+
+
+def test_parse_explicit_pr_opened_keeps_supplied_fields_only():
+    payload = parse_pr_opened(
+        {
+            "type": "pr_opened",
+            "url": GH,
+            "number": 416,
+            "title": "REQ-71 card",
+            "branch": "cursor/req-71",
+            "additions": 4,
+            "deletions": 1,
+            "opener": {"agent_id": "codey", "name": "Codey"},
+        },
+        agent_id="codey",
+        conversation_id="conv-1",
+    )
+    assert payload["type"] == "pr_opened"
+    assert payload["url"] == GH
+    assert payload["number"] == 416
+    assert payload["additions"] == 4
+    assert payload["deletions"] == 1
+    assert "files_changed" not in payload
+    assert payload["opener"]["agent_id"] == "codey"
+    assert payload["opener"]["conversation_id"] == "conv-1"
+
+
+def test_parse_github_api_shape_does_not_invent_stats():
+    payload = parse_pr_opened(
+        {
+            "html_url": GH,
+            "number": 416,
+            "title": "REQ-71 card",
+            "head": {"ref": "feat/card"},
+        }
+    )
+    assert payload is not None
+    assert payload["branch"] == "feat/card"
+    assert "additions" not in payload
+    assert "deletions" not in payload
+
+
+def test_parse_rejects_markdown_and_lone_links():
+    assert parse_pr_opened(f"Opened {GH}") is None
+    assert parse_pr_opened({"html_url": GH}) is None
+    assert parse_pr_opened({"url": "https://example.com/pull/1", "type": "pr_opened"}).get("url") is None
+
+
+def test_persist_status_row_is_idempotent():
+    messages: list[dict] = []
+    payload = {"type": "pr_opened", "url": GH, "number": 416}
+    persist_pr_opened_message(messages, payload)
+    persist_pr_opened_message(messages, payload)
+    assert len(messages) == 1
+    assert messages[0]["role"] == "status"
+    assert '"type":"pr_opened"' in messages[0]["content"]

--- a/webui/frontend/src/components/PrOpenedCard.tsx
+++ b/webui/frontend/src/components/PrOpenedCard.tsx
@@ -1,0 +1,117 @@
+import AgentAvatar from './AgentAvatar'
+import { Badge, Button, Card } from './DaisyUI'
+import {
+  formatPrFileStats,
+  isGithubPrUrl,
+  isSameOpenerChat,
+  type PrOpenedEvent,
+  type PrOpenedOpener,
+} from '../lib/prOpened'
+
+export interface PrOpenedCardProps {
+  event: PrOpenedEvent
+  currentAgentId?: string
+  currentConversationId?: string
+  openerName?: string
+  openerAvatarSrc?: string | null
+  onJumpToOpener?: (opener: PrOpenedOpener) => void
+}
+
+/**
+ * Thread chrome for a structured PR-opened tool result (REQ-71).
+ * Always View PR when the URL is a real GitHub pull. Jump to the opener
+ * only when that agent/thread is not the one already on screen.
+ */
+export function PrOpenedCard({
+  event,
+  currentAgentId,
+  currentConversationId,
+  openerName,
+  openerAvatarSrc,
+  onJumpToOpener,
+}: PrOpenedCardProps) {
+  const viewUrl = isGithubPrUrl(event.url) ? event.url : undefined
+  const stats = formatPrFileStats(event)
+  const showJump =
+    !isSameOpenerChat(event.opener, {
+      agentId: currentAgentId,
+      conversationId: currentConversationId,
+    }) && Boolean(event.opener?.agentId)
+  const jumpLabel = (openerName || event.opener?.name || event.opener?.agentId || '').trim()
+
+  return (
+    <Card
+      bordered
+      compact
+      className="os-pr-opened-card bg-base-100 w-full max-w-xl"
+      data-testid="pr-opened-card"
+      role="region"
+      aria-label={event.title ? `Pull request ${event.title}` : 'Pull request opened'}
+    >
+      <div className="os-pr-opened-card__header flex flex-wrap items-center gap-2">
+        {event.status ? (
+          <Badge type="success" size="sm" className="os-pr-opened-card__status">
+            {event.status}
+          </Badge>
+        ) : null}
+        {typeof event.number === 'number' ? (
+          <span className="os-pr-opened-card__number text-xs opacity-70" data-testid="pr-opened-number">
+            PR #{event.number}
+          </span>
+        ) : null}
+        {event.branch ? (
+          <span className="os-pr-opened-card__branch font-mono text-xs opacity-70" data-testid="pr-opened-branch">
+            {event.branch}
+          </span>
+        ) : null}
+        {stats ? (
+          <span className="os-pr-opened-card__stats font-mono text-xs" data-testid="pr-opened-stats">
+            <span className="text-success">{stats.split(' ')[0]}</span>
+            {stats.includes(' ') ? (
+              <span className="text-error">{` ${stats.split(' ').slice(1).join(' ')}`}</span>
+            ) : null}
+          </span>
+        ) : null}
+      </div>
+      {event.title ? (
+        <p className="os-pr-opened-card__title font-medium" data-testid="pr-opened-title">
+          {event.title}
+        </p>
+      ) : null}
+      <div className="os-pr-opened-card__actions card-actions justify-end mt-2 flex flex-wrap gap-2">
+        {viewUrl ? (
+          <a
+            className="btn btn-primary btn-sm"
+            href={viewUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="pr-opened-view"
+          >
+            View PR
+          </a>
+        ) : null}
+        {showJump && event.opener ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="os-pr-opened-card__jump gap-2"
+            data-testid="pr-opened-jump"
+            aria-label={jumpLabel}
+            onClick={() => onJumpToOpener?.(event.opener!)}
+          >
+            <AgentAvatar
+              agentId={event.opener.agentId}
+              src={openerAvatarSrc}
+              alt=""
+              size="xs"
+            />
+            <span>{jumpLabel}</span>
+          </Button>
+        ) : null}
+      </div>
+    </Card>
+  )
+}
+
+export default PrOpenedCard

--- a/webui/frontend/src/components/PrOpenedCard.tsx
+++ b/webui/frontend/src/components/PrOpenedCard.tsx
@@ -4,6 +4,7 @@ import {
   formatPrFileStats,
   isGithubPrUrl,
   isSameOpenerChat,
+  prOpenedRegionLabel,
   type PrOpenedEvent,
   type PrOpenedOpener,
 } from '../lib/prOpened'
@@ -46,7 +47,7 @@ export function PrOpenedCard({
       className="os-pr-opened-card bg-base-100 w-full max-w-xl"
       data-testid="pr-opened-card"
       role="region"
-      aria-label={event.title ? `Pull request ${event.title}` : 'Pull request opened'}
+      aria-label={prOpenedRegionLabel(event)}
     >
       <div className="os-pr-opened-card__header flex flex-wrap items-center gap-2">
         {event.status ? (

--- a/webui/frontend/src/components/__tests__/PrOpenedCard.test.tsx
+++ b/webui/frontend/src/components/__tests__/PrOpenedCard.test.tsx
@@ -83,6 +83,16 @@ describe('PrOpenedCard', () => {
     })
   })
 
+  it('does not put a quoted title into aria-label (title stays React text)', () => {
+    const nasty = '"><img src=x onerror=alert(1)>'
+    render(<PrOpenedCard event={event({ title: nasty })} currentAgentId="codey" />)
+    const card = screen.getByTestId('pr-opened-card')
+    expect(card).toHaveAttribute('aria-label', 'Pull request #416')
+    expect(card.getAttribute('aria-label')).not.toContain('<')
+    expect(card.querySelector('img[src="x"]')).toBeNull()
+    expect(screen.getByTestId('pr-opened-title')).toHaveTextContent(nasty)
+  })
+
   it('malformed or missing PR URL: no fake View PR', () => {
     const { rerender } = render(
       <PrOpenedCard event={event({ url: 'https://example.com/pull/1' })} currentAgentId="codey" />,

--- a/webui/frontend/src/components/__tests__/PrOpenedCard.test.tsx
+++ b/webui/frontend/src/components/__tests__/PrOpenedCard.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { PrOpenedCard } from '../PrOpenedCard'
+import type { PrOpenedEvent } from '../../lib/prOpened'
+
+const GH = 'https://github.com/matthewhand/open-swarm/pull/416'
+
+function event(extra: Partial<PrOpenedEvent> = {}): PrOpenedEvent {
+  return {
+    type: 'pr_opened',
+    url: GH,
+    number: 416,
+    title: 'REQ-71: PR-opened card',
+    ...extra,
+  }
+}
+
+describe('PrOpenedCard', () => {
+  it('renders DaisyUI chrome with View PR and omits missing optionals', () => {
+    const { container } = render(
+      <PrOpenedCard event={event()} currentAgentId="codey" currentConversationId="conv-1" />,
+    )
+    const card = screen.getByTestId('pr-opened-card')
+    expect(card).toHaveClass('card')
+    expect(screen.getByTestId('pr-opened-title')).toHaveTextContent('REQ-71: PR-opened card')
+    expect(screen.getByTestId('pr-opened-number')).toHaveTextContent('PR #416')
+    expect(screen.queryByTestId('pr-opened-branch')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('pr-opened-stats')).not.toBeInTheDocument()
+    const view = screen.getByTestId('pr-opened-view')
+    expect(view).toHaveAttribute('href', GH)
+    expect(view).toHaveAttribute('target', '_blank')
+    expect(view).toHaveTextContent('View PR')
+    expect(screen.queryByTestId('pr-opened-jump')).not.toBeInTheDocument()
+    expect(container.textContent).not.toMatch(/Open in Cursor/i)
+    expect(container.textContent).not.toMatch(/Cursor/)
+  })
+
+  it('shows optional branch, status, and +N/-M only when supplied', () => {
+    render(
+      <PrOpenedCard
+        event={event({ branch: 'feat/card', additions: 8, deletions: 2, status: 'Done' })}
+        currentAgentId="codey"
+      />,
+    )
+    expect(screen.getByTestId('pr-opened-branch')).toHaveTextContent('feat/card')
+    expect(screen.getByTestId('pr-opened-stats')).toHaveTextContent('+8')
+    expect(screen.getByTestId('pr-opened-stats')).toHaveTextContent('-2')
+    expect(screen.getByText('Done')).toBeInTheDocument()
+  })
+
+  it('same agent same thread: View PR only — zero jump controls', () => {
+    render(
+      <PrOpenedCard
+        event={event({ opener: { agentId: 'codey', name: 'Codey', conversationId: 'conv-1' } })}
+        currentAgentId="codey"
+        currentConversationId="conv-1"
+      />,
+    )
+    expect(screen.getByTestId('pr-opened-view')).toBeInTheDocument()
+    expect(screen.queryByTestId('pr-opened-jump')).not.toBeInTheDocument()
+  })
+
+  it('different opener: avatar+name jump selects that agent, not Open in Cursor', () => {
+    const onJump = vi.fn()
+    render(
+      <PrOpenedCard
+        event={event({ opener: { agentId: 'codey', name: 'Codey', conversationId: 'conv-codey' } })}
+        currentAgentId="support"
+        currentConversationId="conv-support"
+        openerName="Codey"
+        onJumpToOpener={onJump}
+      />,
+    )
+    const jump = screen.getByTestId('pr-opened-jump')
+    expect(jump).toHaveTextContent('Codey')
+    expect(jump).not.toHaveTextContent('Open in Cursor')
+    expect(jump.querySelector('[data-agent-avatar]')).toBeTruthy()
+    fireEvent.click(jump)
+    expect(onJump).toHaveBeenCalledWith({
+      agentId: 'codey',
+      name: 'Codey',
+      conversationId: 'conv-codey',
+    })
+  })
+
+  it('malformed or missing PR URL: no fake View PR', () => {
+    const { rerender } = render(
+      <PrOpenedCard event={event({ url: 'https://example.com/pull/1' })} currentAgentId="codey" />,
+    )
+    expect(screen.queryByTestId('pr-opened-view')).not.toBeInTheDocument()
+    rerender(<PrOpenedCard event={event({ url: undefined })} currentAgentId="codey" />)
+    expect(screen.queryByTestId('pr-opened-view')).not.toBeInTheDocument()
+    rerender(
+      <PrOpenedCard event={event({ url: 'http://127.0.0.1:8001/pull/9' })} currentAgentId="codey" />,
+    )
+    expect(screen.queryByTestId('pr-opened-view')).not.toBeInTheDocument()
+  })
+})

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -1364,6 +1364,20 @@ html[data-theme="light"] .os-code--collapsible.os-code--collapsed::after {
   text-align: center;
 }
 
+/* REQ-71: structured PR-opened tool result is thread chrome, not a chat bubble. */
+.os-pr-opened-wrap {
+  display: flex;
+  justify-content: flex-start;
+  width: 100%;
+}
+.os-pr-opened-card {
+  text-align: left;
+}
+.os-pr-opened-card .card-body {
+  gap: 0.4rem;
+  padding: 0.85rem 1rem;
+}
+
 .os-search-overlay {
   position: fixed;
   inset: 0;

--- a/webui/frontend/src/lib/__tests__/chatWs.test.ts
+++ b/webui/frontend/src/lib/__tests__/chatWs.test.ts
@@ -157,4 +157,28 @@ describe('parseChatWsMessage', () => {
       ),
     ).toEqual({ kind: 'tool_approval', id: 't2', name: 'wipe', agentId: 'codey' })
   })
+
+  it('parses a structured pr_opened frame (REQ-71)', () => {
+    const url = 'https://github.com/matthewhand/open-swarm/pull/416'
+    expect(
+      parseChatWsMessage(
+        JSON.stringify({
+          type: 'pr_opened',
+          url,
+          number: 416,
+          title: 'REQ-71',
+          opener: { agent_id: 'codey', name: 'Codey' },
+        }),
+      ),
+    ).toEqual({
+      kind: 'pr_opened',
+      event: {
+        type: 'pr_opened',
+        url,
+        number: 416,
+        title: 'REQ-71',
+        opener: { agentId: 'codey', name: 'Codey' },
+      },
+    })
+  })
 })

--- a/webui/frontend/src/lib/__tests__/prOpened.test.ts
+++ b/webui/frontend/src/lib/__tests__/prOpened.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatPrFileStats,
+  isGithubPrUrl,
+  isSameOpenerChat,
+  openerChatSearch,
+  parsePrOpened,
+} from '../prOpened'
+
+const GH = 'https://github.com/matthewhand/open-swarm/pull/416'
+
+describe('isGithubPrUrl', () => {
+  it('accepts public GitHub pull URLs only', () => {
+    expect(isGithubPrUrl(GH)).toBe(true)
+    expect(isGithubPrUrl(`${GH}/files`)).toBe(true)
+    expect(isGithubPrUrl('http://github.com/matthewhand/open-swarm/pull/416')).toBe(false)
+    expect(isGithubPrUrl('https://gitlab.com/acme/repo/pull/1')).toBe(false)
+    expect(isGithubPrUrl('https://github.com/matthewhand/open-swarm/issues/416')).toBe(false)
+    expect(isGithubPrUrl('http://127.0.0.1:8001/pull/1')).toBe(false)
+    expect(isGithubPrUrl('https://localhost/pull/1')).toBe(false)
+    expect(isGithubPrUrl('not-a-url')).toBe(false)
+  })
+})
+
+describe('parsePrOpened', () => {
+  it('parses an explicit pr_opened payload and keeps optional fields', () => {
+    expect(
+      parsePrOpened({
+        type: 'pr_opened',
+        url: GH,
+        number: 416,
+        title: 'REQ-71 card',
+        branch: 'cursor/req-71',
+        additions: 12,
+        deletions: 3,
+        files_changed: 4,
+        status: 'Done',
+        opener: { agent_id: 'codey', name: 'Codey', conversation_id: 'conv-1' },
+      }),
+    ).toEqual({
+      type: 'pr_opened',
+      url: GH,
+      number: 416,
+      title: 'REQ-71 card',
+      branch: 'cursor/req-71',
+      additions: 12,
+      deletions: 3,
+      filesChanged: 4,
+      status: 'Done',
+      opener: { agentId: 'codey', name: 'Codey', conversationId: 'conv-1' },
+    })
+  })
+
+  it('accepts a GitHub API-shaped tool result without inventing stats', () => {
+    expect(
+      parsePrOpened({
+        html_url: GH,
+        number: 416,
+        title: 'REQ-71 card',
+        head: { ref: 'feat/card' },
+      }),
+    ).toEqual({
+      type: 'pr_opened',
+      url: GH,
+      number: 416,
+      title: 'REQ-71 card',
+      branch: 'feat/card',
+    })
+  })
+
+  it('rejects markdown, lone links, and non-GitHub hosts', () => {
+    expect(parsePrOpened(`Opened ${GH}`)).toBeNull()
+    expect(parsePrOpened({ html_url: GH })).toBeNull()
+    expect(
+      parsePrOpened({
+        type: 'pr_opened',
+        url: 'https://example.com/pull/1',
+        number: 1,
+        title: 'nope',
+      })?.url,
+    ).toBeUndefined()
+  })
+
+  it('parses JSON status rows used for thread restore', () => {
+    const row = JSON.stringify({ type: 'pr_opened', url: GH, number: 416, title: 'REQ-71' })
+    expect(parsePrOpened(row)?.number).toBe(416)
+  })
+})
+
+describe('same-opener chat helpers', () => {
+  it('hides jump when already on that agent and thread', () => {
+    const opener = { agentId: 'codey', conversationId: 'conv-1' }
+    expect(isSameOpenerChat(opener, { agentId: 'codey', conversationId: 'conv-1' })).toBe(true)
+    expect(isSameOpenerChat(opener, { agentId: 'support', conversationId: 'conv-1' })).toBe(false)
+    expect(isSameOpenerChat(opener, { agentId: 'codey', conversationId: 'other' })).toBe(false)
+    expect(isSameOpenerChat(undefined, { agentId: 'codey' })).toBe(true)
+  })
+
+  it('builds a blueprint+session jump, not a Cursor remote', () => {
+    const params = openerChatSearch({ agentId: 'codey', conversationId: 'sess-9' })
+    expect(params.get('blueprint')).toBe('codey')
+    expect(params.get('session')).toBe('sess-9')
+    expect(params.toString()).not.toMatch(/cursor/i)
+  })
+
+  it('formats only supplied +N/-M stats', () => {
+    expect(formatPrFileStats({ type: 'pr_opened', additions: 4, deletions: 1 })).toBe('+4 -1')
+    expect(formatPrFileStats({ type: 'pr_opened', additions: 4 })).toBe('+4')
+    expect(formatPrFileStats({ type: 'pr_opened' })).toBeUndefined()
+  })
+})

--- a/webui/frontend/src/lib/__tests__/prOpened.test.ts
+++ b/webui/frontend/src/lib/__tests__/prOpened.test.ts
@@ -5,6 +5,7 @@ import {
   isSameOpenerChat,
   openerChatSearch,
   parsePrOpened,
+  prOpenedRegionLabel,
 } from '../prOpened'
 
 const GH = 'https://github.com/matthewhand/open-swarm/pull/416'
@@ -107,5 +108,12 @@ describe('same-opener chat helpers', () => {
     expect(formatPrFileStats({ type: 'pr_opened', additions: 4, deletions: 1 })).toBe('+4 -1')
     expect(formatPrFileStats({ type: 'pr_opened', additions: 4 })).toBe('+4')
     expect(formatPrFileStats({ type: 'pr_opened' })).toBeUndefined()
+  })
+
+  it('region label uses PR number, not the raw title', () => {
+    expect(prOpenedRegionLabel({ type: 'pr_opened', number: 416, title: '"><img src=x>' })).toBe(
+      'Pull request #416',
+    )
+    expect(prOpenedRegionLabel({ type: 'pr_opened', title: 'only title' })).toBe('Pull request opened')
   })
 })

--- a/webui/frontend/src/lib/chatWs.ts
+++ b/webui/frontend/src/lib/chatWs.ts
@@ -1,3 +1,5 @@
+import { parsePrOpened, type PrOpenedEvent } from './prOpened'
+
 /**
  * Client for the Django Channels chat websocket.
  *
@@ -48,6 +50,7 @@ export type ChatWsEvent =
       agentId?: string
     }
   | { kind: 'status'; text: string }
+  | { kind: 'pr_opened'; event: PrOpenedEvent }
   | {
       kind: 'interbot_hop'
       id: string
@@ -146,6 +149,10 @@ function parseToolJsonFrame(raw: string): ChatWsEvent | null {
         name,
         agentId: payload.agent_id ? String(payload.agent_id) : undefined,
       }
+    }
+    if (type === 'pr_opened') {
+      const event = parsePrOpened(payload)
+      if (event) return { kind: 'pr_opened', event }
     }
   } catch {
     return null

--- a/webui/frontend/src/lib/prOpened.ts
+++ b/webui/frontend/src/lib/prOpened.ts
@@ -168,6 +168,12 @@ export function isSameOpenerChat(
   return true
 }
 
+/** Accessible region name — number only; title stays in visible text (React-escaped). */
+export function prOpenedRegionLabel(event: PrOpenedEvent): string {
+  if (typeof event.number === 'number') return `Pull request #${event.number}`
+  return 'Pull request opened'
+}
+
 export function openerChatSearch(opener: PrOpenedOpener): URLSearchParams {
   const params = new URLSearchParams()
   params.set('blueprint', opener.agentId)

--- a/webui/frontend/src/lib/prOpened.ts
+++ b/webui/frontend/src/lib/prOpened.ts
@@ -1,0 +1,176 @@
+/**
+ * REQ-71: structured GitHub PR-opened tool events (chrome, not markdown).
+ * Missing optional fields stay omitted. Stats are never invented.
+ */
+
+export const PR_OPENED_TYPE = 'pr_opened' as const
+
+export interface PrOpenedOpener {
+  agentId: string
+  name?: string
+  conversationId?: string
+}
+
+export interface PrOpenedEvent {
+  type: typeof PR_OPENED_TYPE
+  url?: string
+  number?: number
+  title?: string
+  branch?: string
+  additions?: number
+  deletions?: number
+  filesChanged?: number
+  status?: string
+  opener?: PrOpenedOpener
+}
+
+const GITHUB_PR_URL =
+  /^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+(?:\/[A-Za-z0-9._~-]*)?(?:\?[^#]*)?(?:#.*)?$/i
+
+export function isGithubPrUrl(value: unknown): value is string {
+  if (typeof value !== 'string') return false
+  const text = value.trim()
+  if (!text) return false
+  const lowered = text.toLowerCase()
+  if (lowered.startsWith('http://') || lowered.startsWith('ws://')) return false
+  if (lowered.includes('localhost') || lowered.includes('127.0.0.1')) return false
+  if (lowered.includes(':8001')) return false
+  return GITHUB_PR_URL.test(text)
+}
+
+function asInt(value: unknown): number | undefined {
+  if (typeof value === 'boolean') return undefined
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value)
+  if (typeof value === 'string' && /^-?\d+$/.test(value.trim())) {
+    return Number.parseInt(value.trim(), 10)
+  }
+  return undefined
+}
+
+function asTrimmed(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const text = value.trim()
+  return text || undefined
+}
+
+function pickUrl(obj: Record<string, unknown>): string | undefined {
+  for (const key of ['url', 'html_url', 'pr_url', 'pull_request_url']) {
+    const raw = obj[key]
+    if (isGithubPrUrl(raw)) return raw.trim()
+  }
+  return undefined
+}
+
+function pickOpener(obj: Record<string, unknown>): PrOpenedOpener | undefined {
+  const raw = obj.opener
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const row = raw as Record<string, unknown>
+  const agentId = asTrimmed(row.agentId ?? row.agent_id ?? row.id)
+  if (!agentId) return undefined
+  const opener: PrOpenedOpener = { agentId }
+  const name = asTrimmed(row.name)
+  if (name) opener.name = name
+  const conversationId = asTrimmed(row.conversationId ?? row.conversation_id)
+  if (conversationId) opener.conversationId = conversationId
+  return opener
+}
+
+function unwrapCandidate(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const obj = value as Record<string, unknown>
+  for (const key of ['pull_request', 'pr', 'result', 'data']) {
+    const nested = obj[key]
+    if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+      const inner = nested as Record<string, unknown>
+      if (inner.type === PR_OPENED_TYPE || pickUrl(inner)) return inner
+    }
+  }
+  return obj
+}
+
+export function parsePrOpened(value: unknown): PrOpenedEvent | null {
+  let raw: unknown = value
+  if (typeof raw === 'string') {
+    const text = raw.trim()
+    if (!text.startsWith('{')) return null
+    try {
+      raw = JSON.parse(text) as unknown
+    } catch {
+      return null
+    }
+  }
+  const obj = unwrapCandidate(raw)
+  if (!obj) return null
+
+  const explicit = String(obj.type || '').trim() === PR_OPENED_TYPE
+  const url = pickUrl(obj)
+  const number = asInt(obj.number ?? obj.pr_number ?? obj.pull_number)
+  const title = asTrimmed(obj.title ?? obj.name)
+  if (!explicit && !url) return null
+  if (!explicit && url && number === undefined && !title) return null
+
+  const event: PrOpenedEvent = { type: PR_OPENED_TYPE }
+  if (url) event.url = url
+  if (number !== undefined) event.number = number
+  if (title) event.title = title
+
+  let branch = asTrimmed(obj.branch)
+  if (!branch) {
+    const head = obj.head
+    if (head && typeof head === 'object' && !Array.isArray(head)) {
+      branch = asTrimmed((head as Record<string, unknown>).ref)
+    } else if (typeof head === 'string' && head.trim() && !head.includes('/')) {
+      branch = head.trim()
+    } else {
+      branch = asTrimmed(obj.head_ref)
+    }
+  }
+  if (branch) event.branch = branch
+
+  const additions = asInt(obj.additions ?? obj.additions_count ?? obj.plus)
+  if (additions !== undefined) event.additions = additions
+  const deletions = asInt(obj.deletions ?? obj.deletions_count ?? obj.minus)
+  if (deletions !== undefined) event.deletions = deletions
+  const filesChanged = asInt(obj.files_changed ?? obj.changed_files ?? obj.files)
+  if (filesChanged !== undefined) event.filesChanged = filesChanged
+
+  const status = asTrimmed(obj.status ?? obj.state)
+  if (status && status !== PR_OPENED_TYPE && status !== 'tool_status') {
+    event.status = status
+  }
+
+  const opener = pickOpener(obj)
+  if (opener) event.opener = opener
+  return event
+}
+
+export function formatPrFileStats(event: PrOpenedEvent): string | undefined {
+  const parts: string[] = []
+  if (typeof event.additions === 'number') parts.push(`+${event.additions}`)
+  if (typeof event.deletions === 'number') parts.push(`-${event.deletions}`)
+  return parts.length ? parts.join(' ') : undefined
+}
+
+function normId(value: string | undefined): string {
+  return (value || '').trim().toLowerCase()
+}
+
+/** True when the card is already on the opener's agent + thread. */
+export function isSameOpenerChat(
+  opener: PrOpenedOpener | undefined,
+  current: { agentId?: string; conversationId?: string },
+): boolean {
+  if (!opener?.agentId) return true
+  if (normId(opener.agentId) !== normId(current.agentId)) return false
+  if (opener.conversationId && normId(opener.conversationId) !== normId(current.conversationId)) {
+    return false
+  }
+  return true
+}
+
+export function openerChatSearch(opener: PrOpenedOpener): URLSearchParams {
+  const params = new URLSearchParams()
+  params.set('blueprint', opener.agentId)
+  if (opener.conversationId) params.set('session', opener.conversationId)
+  return params
+}

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -69,6 +69,13 @@ import {
   type ChatWsEvent,
 } from '../lib/chatWs'
 import { ToolCallPopup } from '../components/ToolCallPopup'
+import { PrOpenedCard } from '../components/PrOpenedCard'
+import {
+  openerChatSearch,
+  parsePrOpened,
+  type PrOpenedEvent,
+  type PrOpenedOpener,
+} from '../lib/prOpened'
 import { TokenDiagnosticsModal } from '../components/TokenDiagnosticsModal'
 import {
   isToolAlwaysAllowed,
@@ -153,6 +160,23 @@ interface ChatMessage {
   streaming: boolean
   tools?: ToolCallState[]
   edited?: boolean
+  /** REQ-71 chrome — structured PR-opened tool result, not markdown. */
+  prOpened?: PrOpenedEvent
+}
+
+function chatMessageFromThreadRow(
+  message: { role: string; content: string; edited?: boolean },
+  index: number,
+): ChatMessage {
+  const prOpened = parsePrOpened(message.content) ?? undefined
+  return {
+    key: `hist-${index}-${message.role}`,
+    role: asTranscriptRole(message.role),
+    text: prOpened ? '' : message.content,
+    streaming: false,
+    edited: message.edited === true,
+    prOpened,
+  }
 }
 
 /** Post-login return path for the Django session gate (rooted, same-origin). */
@@ -630,13 +654,7 @@ const ChatPage = () => {
         setRestoreNotice(restoredSessionNotice(thread.messages, 'team'))
         setThreads((prev) => ({
           ...prev,
-          [key]: thread.messages.map((message, index) => ({
-            key: `hist-${index}-${message.role}`,
-            role: asTranscriptRole(message.role),
-            text: message.content,
-            streaming: false,
-            edited: message.edited === true,
-          })),
+          [key]: thread.messages.map(chatMessageFromThreadRow),
         }))
       })()
       return () => {
@@ -672,13 +690,7 @@ const ChatPage = () => {
         setRestoreNotice(restoredSessionNotice(thread.messages, 'remote'))
         setThreads((prev) => ({
           ...prev,
-          [key]: thread.messages.map((message, index) => ({
-            key: `hist-${index}-${message.role}`,
-            role: asTranscriptRole(message.role),
-            text: message.content,
-            streaming: false,
-            edited: message.edited === true,
-          })),
+          [key]: thread.messages.map(chatMessageFromThreadRow),
         }))
       })()
       return () => {
@@ -735,13 +747,7 @@ const ChatPage = () => {
       setRestoreNotice(restoredSessionNotice(thread.messages, restoreKindForAgent(agent)))
       setThreads((prev) => ({
         ...prev,
-        [threadKey]: thread.messages.map((message, index) => ({
-          key: `hist-${index}-${message.role}`,
-          role: asTranscriptRole(message.role),
-          text: message.content,
-          streaming: false,
-          edited: message.edited === true,
-        })),
+        [threadKey]: thread.messages.map(chatMessageFromThreadRow),
       }))
     })()
     return () => {
@@ -787,6 +793,13 @@ const ChatPage = () => {
     ws.send(buildToolDecisionFrame(id, decision))
   }, [])
 
+  const jumpToPrOpener = useCallback(
+    (opener: PrOpenedOpener) => {
+      setSearchParams(openerChatSearch(opener))
+    },
+    [setSearchParams],
+  )
+
   const handleWsEvent = useCallback(
     (event: ChatWsEvent) => {
       if (event.kind === 'unknown') {
@@ -800,6 +813,25 @@ const ChatPage = () => {
           status: event.status,
           agentId: event.agentId,
           needsApproval: false,
+        })
+        return
+      }
+      if (event.kind === 'pr_opened') {
+        setThreads((prev) => {
+          const current = prev[threadKey] ?? []
+          return {
+            ...prev,
+            [threadKey]: [
+              ...current,
+              {
+                key: `pr-opened-${current.length}-${Date.now()}`,
+                role: 'status' as const,
+                text: '',
+                streaming: false,
+                prOpened: event.event,
+              },
+            ],
+          }
         })
         return
       }
@@ -1772,6 +1804,35 @@ const ChatPage = () => {
               )
             }
             const message = item.message
+            const liveMessage = messages.find((row) => row.key === message.key)
+            const prOpened = liveMessage?.prOpened
+            if (prOpened) {
+              const openerId = prOpened.opener?.agentId
+              const openerAgent = openerId
+                ? blueprints.find((bp) => bp.id === openerId) ||
+                  cliAgents.find((row) => row.id === openerId)
+                : undefined
+              const openerLabel =
+                prOpened.opener?.name ||
+                (openerAgent
+                  ? editedAgentLabel({
+                      id: openerId || '',
+                      name: openerAgent.name || openerId,
+                    })
+                  : openerId)
+              return (
+                <div key={message.key} className="os-pr-opened-wrap my-2">
+                  <PrOpenedCard
+                    event={prOpened}
+                    currentAgentId={activeChatAgentId}
+                    currentConversationId={conversationId}
+                    openerName={openerLabel}
+                    openerAvatarSrc={(openerAgent as { avatar_path?: string } | undefined)?.avatar_path}
+                    onJumpToOpener={jumpToPrOpener}
+                  />
+                </div>
+              )
+            }
             if (isStatusRole(message.role)) {
               return (
                 <p

--- a/webui/frontend/src/pages/__tests__/ChatPage.prOpened.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.prOpened.test.tsx
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Route, Routes, useSearchParams } from 'react-router-dom'
+import ChatPage from '../ChatPage'
+import { ToastProvider } from '../../components/DaisyUI'
+import { resetConversationThreads } from '../../lib/chatMeter'
+
+const GH = 'https://github.com/matthewhand/open-swarm/pull/416'
+
+type WsHandler = ((ev?: Event) => void) | null
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  static instances: MockWebSocket[] = []
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: WsHandler = null
+  onmessage: WsHandler = null
+  onclose: WsHandler = null
+  send = vi.fn()
+  close = vi.fn()
+  url: string
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+}
+
+function SearchProbe() {
+  const [params] = useSearchParams()
+  return <div data-testid="search-probe">{params.toString()}</div>
+}
+
+function renderChat(initialEntry = '/chat?blueprint=codey') {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <MemoryRouter initialEntries={[initialEntry]}>
+          <SearchProbe />
+          <Routes>
+            <Route path="/chat" element={<ChatPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ToastProvider>
+    </QueryClientProvider>,
+  )
+}
+
+function prPayload(opener: Record<string, unknown>) {
+  return {
+    type: 'pr_opened',
+    url: GH,
+    number: 416,
+    title: 'REQ-71: PR-opened card',
+    branch: 'cursor/req-71',
+    additions: 5,
+    deletions: 1,
+    opener,
+  }
+}
+
+describe('ChatPage REQ-71 PR-opened card', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    window.localStorage.clear()
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/chat/thread/')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              agent_id: 'codey',
+              conversation_id: 'conv-codey',
+              messages: [],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: [
+              { id: 'codey', name: 'Codey', description: 'Coder' },
+              { id: 'support', name: 'Support', description: 'Support' },
+            ],
+          }),
+        } as Response
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    window.localStorage.clear()
+    resetConversationThreads()
+  })
+
+  async function openOn(entry: string) {
+    renderChat(entry)
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+    return MockWebSocket.instances[0]!
+  }
+
+  it('same-agent same-thread: card with View PR and zero jump controls', async () => {
+    const ws = await openOn('/chat?blueprint=codey')
+    await act(async () => {
+      ws.onmessage?.(
+        new MessageEvent('message', {
+          data: JSON.stringify(prPayload({ agent_id: 'codey', name: 'Codey' })),
+        }),
+      )
+    })
+    const card = await screen.findByTestId('pr-opened-card')
+    expect(card).toHaveClass('card')
+    expect(screen.getByTestId('pr-opened-view')).toHaveAttribute('href', GH)
+    expect(screen.getByTestId('pr-opened-title')).toHaveTextContent('REQ-71: PR-opened card')
+    expect(screen.queryByTestId('pr-opened-jump')).not.toBeInTheDocument()
+    expect(card.textContent).not.toMatch(/Open in Cursor/i)
+    expect(card.textContent).not.toMatch(/Cursor/)
+  })
+
+  it('cross-agent: View PR plus avatar+name jump selects the opener thread', async () => {
+    const ws = await openOn('/chat?blueprint=support')
+    await act(async () => {
+      ws.onmessage?.(
+        new MessageEvent('message', {
+          data: JSON.stringify(
+            prPayload({ agent_id: 'codey', name: 'Codey', conversation_id: 'conv-codey' }),
+          ),
+        }),
+      )
+    })
+    expect(await screen.findByTestId('pr-opened-view')).toHaveAttribute('href', GH)
+    const jump = screen.getByTestId('pr-opened-jump')
+    expect(jump).toHaveTextContent('Codey')
+    expect(jump).not.toHaveTextContent('Open in Cursor')
+    fireEvent.click(jump)
+    expect(screen.getByTestId('search-probe')).toHaveTextContent('blueprint=codey')
+    expect(screen.getByTestId('search-probe')).toHaveTextContent('session=conv-codey')
+  })
+
+  it('malformed PR URL never invents View PR', async () => {
+    const ws = await openOn('/chat?blueprint=codey')
+    await act(async () => {
+      ws.onmessage?.(
+        new MessageEvent('message', {
+          data: JSON.stringify({
+            type: 'pr_opened',
+            url: 'https://example.com/pull/9',
+            number: 9,
+            title: 'Not GitHub',
+            opener: { agent_id: 'codey', conversation_id: 'conv-codey' },
+          }),
+        }),
+      )
+    })
+    expect(await screen.findByTestId('pr-opened-card')).toBeInTheDocument()
+    expect(screen.queryByTestId('pr-opened-view')).not.toBeInTheDocument()
+  })
+})
+
+describe('ChatPage REQ-71 hydrate from persisted status JSON', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    window.localStorage.clear()
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/chat/thread/')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              agent_id: 'support',
+              conversation_id: 'conv-support',
+              messages: [
+                {
+                  role: 'status',
+                  content: JSON.stringify({
+                    type: 'pr_opened',
+                    url: GH,
+                    number: 416,
+                    title: 'Hydrated card',
+                    opener: { agent_id: 'codey', name: 'Codey', conversation_id: 'conv-codey' },
+                  }),
+                },
+              ],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: [
+              { id: 'codey', name: 'Codey' },
+              { id: 'support', name: 'Support' },
+            ],
+          }),
+        } as Response
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    window.localStorage.clear()
+    resetConversationThreads()
+  })
+
+  it('restores a card with View PR and jump when the opener is another agent', async () => {
+    renderChat('/chat?blueprint=support')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+    expect(await screen.findByTestId('pr-opened-card')).toBeInTheDocument()
+    expect(screen.getByTestId('pr-opened-title')).toHaveTextContent('Hydrated card')
+    expect(screen.getByTestId('pr-opened-view')).toHaveAttribute('href', GH)
+    expect(screen.getByTestId('pr-opened-jump')).toHaveTextContent('Codey')
+    expect(screen.queryByText(/\{"type":"pr_opened"/)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #416.

**Feasibility:** Structured `pr_opened` tool/WS event → DaisyUI thread chrome; View PR always; opener jump only when that agent/thread is not already on screen.

## Intent
When an agent opens a GitHub PR (via a tool), the thread should show a compact card with shortcuts, like a Done/PR summary — not Cursor as a product. Always **View PR**. A second control that jumps to the opener’s agent context (their avatar + name, not “Open in Cursor”) only when that opener is **not** the same agent in the same chat you are already looking at.

## Success
1. A structured tool/result that a PR was opened (URL, number, title, optional branch and `+N/-M` file stats) renders a DaisyUI card in the thread. This is chrome, not an LLM markdown bubble. Missing optional fields are omitted, never invented.
2. **View PR** is always present and opens the GitHub PR URL in a new tab (or the existing in-app link behaviour for GitHub URLs).
3. **Same agent, same chat:** if the opener is the agent/thread currently showing the card, the card has **View PR only**. No “jump to this agent” control (you are already there).
4. **Otherwise:** a second control is the opener’s **avatar + name** (rail-matching face). Click selects that agent and that thread/context. Label is the agent, not “Open in Cursor” and not “Open in \<harness\>”.
5. Optional header bits if the tool supplied them: title, Done/status pill, branch, `PR #N`, files changed. Do not require Cursor.
6. Tests:
   - same-agent same-thread fixture → card with View PR, **zero** jump-to-agent controls.
   - card rendered in a different agent or different thread than the opener → View PR **and** avatar+name jump; click selects that agent/thread.
   - no Cursor branding, no “Open in Cursor” string.
   - malformed/missing PR URL: no fake View PR.

## Constraints
- Not Cursor support. Do not add a Cursor remote, Cursor cloud UI, or Cursor branding.
- Distinct from #394 (session picker), #386 (header avatar), #362 (bubble-less dropdown lines). Prefer a structured PR-opened tool event over scraping markdown links.
- DaisyUI 5 / React 18. Chat stays mounted (#364). Do not fold into 344.
- GitHub-only. No `:8001`. No Neon. No secrets / live tokens / LAN hosts in the Issue, PR, or tests.
- **Do not launch a Cursor cloud while freeze is on.** One cloud later, small wave, `Fixes` this issue, from stable main.

## Owner
open-swarm engineer + Cursor cloud (after CoS unblocks). CoS: Open Swarm. Skeptic after the PR (text-only PASS/FAIL).

## What landed
- Parser (`swarm.core.pr_opened` + `lib/prOpened.ts`) accepts explicit `type: pr_opened` or a GitHub API-shaped tool result. Optional branch / `+N/-M` / files are copied only when present.
- Tool executor emits the structured WS event; consumer persists a status JSON row so reload rehydrates the card (status stays out of model context).
- `PrOpenedCard` is DaisyUI chrome in the thread: View PR (valid `https://github.com/…/pull/N` only) and avatar+name jump unless already in that opener chat.
- Tests: parse, card render, same-chat vs cross-agent jump, no Cursor strings, no fake View PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6fe4ea9-978f-4b94-8158-cf22102ee405?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6fe4ea9-978f-4b94-8158-cf22102ee405&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

