### PR TITLE
feat(chat): status/info lines are UI-only — not in LLM context (REQ-70)

### DIFF
--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -30,6 +30,7 @@ Oracle from anything in this tree.
 | [REQ-66](./REQ-66.md) | [Scale-out rail — stacked avatars + session picker popup](https://github.com/matthewhand/open-swarm/issues/394) |
 | [REQ-67](./REQ-67.md) | [Role chrome is the badge only — no row fill/border](https://github.com/matthewhand/open-swarm/issues/396) |
 | [REQ-68](./REQ-68.md) | [Stacked avatars for teams and remotes (3 most recent, animate while working)](https://github.com/matthewhand/open-swarm/issues/398) |
+| [REQ-70](./REQ-70.md) | [Info/status lines are UI-only — not in LLM context](https://github.com/matthewhand/open-swarm/issues/407) |
 | [REQ-106](./REQ-106.md) | [Bee brand mark — SVG favicon + multi-size app icons (colour + mono)](https://github.com/matthewhand/open-swarm/issues/470); surface split [minimal / geometric / cyber-swarm](https://github.com/matthewhand/open-swarm/issues/768) |
 | [REQ-189](./REQ-189.md) | [Look-only — OMB+Rakazo local computer control → open-swarm adaptation](https://github.com/matthewhand/open-swarm/issues/645) |
 | [REQ-156](./REQ-156.md) | [README — why openai-agents + 3 harness types + workflow diagrams](https://github.com/matthewhand/open-swarm/issues/564) |

--- a/docs/requirements/REQ-70.md
+++ b/docs/requirements/REQ-70.md
@@ -1,0 +1,3 @@
+# REQ-70 — Info/status lines are UI-only (not in LLM context)
+
+https://github.com/matthewhand/open-swarm/issues/407

--- a/docs/websocket_chat.md
+++ b/docs/websocket_chat.md
@@ -73,11 +73,12 @@ mirrors the transcript there on save; `GET /chat/thread/?agent=` hydrates the
 SPA after reload or agent switch. Retention (counts, disk, trash,
 `SWARM_CHAT_MAX_AGE_DAYS`) is on **Settings only** — not in the Chat chrome.
 
-Dropdown changes (REQ-46) append a `role=status` row. The SPA POSTs
-`/chat/thread/` and, when the socket is open, also sends
+Dropdown changes (REQ-46) append a `role=status` row with a timestamp. The SPA
+POSTs `/chat/thread/` and, when the socket is open, also sends
 `{"type":"status","text":"CLI: antigravity → grok"}`. The consumer persists
-that line and does **not** invoke a blueprint or LLM. Status rows are omitted
-from the model context.
+that line and does **not** invoke a blueprint or LLM. Status/info rows are
+omitted from the model context (REQ-70), including compact-fallback and CLI
+`render_prompt` paths.
 
 Tests: `tests/test_asgi_routing.py` (full-stack routing/auth/round-trip) and
 `tests/test_consumers.py` (consumer unit tests).

--- a/src/swarm/blueprints/common/cli_fusion_support.py
+++ b/src/swarm/blueprints/common/cli_fusion_support.py
@@ -75,16 +75,18 @@ def render_prompt(messages: list[dict[str, Any]]) -> str:
 
     A lone user message is passed through verbatim. A multi-turn conversation
     is rendered as a simple ``ROLE: content`` transcript so a one-shot CLI sees
-    the full context.
+    the full context. UI-only status/info rows are dropped (REQ-70). CLI
+    adapters strip a structured ``name`` field, so speaker identity uses the
+    tested delimiter wrap.
     """
-    msgs = [
-        m
-        for m in (messages or [])
-        if isinstance(m, dict)
-        and m.get("content")
-        and m.get("kind") != "prior_history"
-        and (m.get("role") or "") != "status"
-    ]
+    from swarm.core.speaker_identity import apply_speaker_identity
+    from swarm.core.transcript_roles import messages_for_model
+
+    labeled = apply_speaker_identity(
+        messages_for_model(messages),
+        adapter_id="cli",
+    )
+    msgs = [m for m in labeled if isinstance(m, dict) and m.get("content")]
     if not msgs:
         return ""
     if len(msgs) == 1:

--- a/src/swarm/consumers.py
+++ b/src/swarm/consumers.py
@@ -101,8 +101,7 @@ async def _compacted_context(conversation_id, messages):
     """Model context: summary tree replaces covered raw turns (REQ-37).
 
     Raw ``messages`` stay on the consumer and on disk. Failures fall back
-    to the raw list so tests without a DB and live sessions without
-    summaries keep working.
+    to the filtered list (status/info never reach the model — REQ-70).
     """
     try:
         from swarm.core.chat_compact import context_for_conversation
@@ -111,8 +110,11 @@ async def _compacted_context(conversation_id, messages):
             conversation_id, messages
         )
     except Exception:
-        logger.debug("compact context unavailable; using raw transcript", exc_info=True)
-        return list(messages or [])
+        logger.debug("compact context unavailable; using filtered transcript", exc_info=True)
+        from swarm.core.speaker_identity import apply_speaker_identity
+        from swarm.core.transcript_roles import messages_for_model
+
+        return apply_speaker_identity(messages_for_model(messages), adapter_id="openai_compat")
 
 
 def _status_line_html(text: str) -> str:
@@ -267,7 +269,9 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
             agent = text_data_json.get("agent")
             if isinstance(agent, str) and agent.strip():
                 self.active_agent = agent.strip()
-            self.messages.append({"role": "status", "content": status_text})
+            self.messages.append(
+                {"role": "status", "content": status_text, "ts": _message_ts()}
+            )
             conversation_id = getattr(self, "conversation_id", None)
             if conversation_id:
                 await self.save_conversation(conversation_id, self.messages)
@@ -552,7 +556,7 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
                             await self.send(text_data=_status_line_html(notice))
                             self.messages = insert_status_before_turn_assistant(
                                 self.messages,
-                                {"role": "status", "content": notice},
+                                {"role": "status", "content": notice, "ts": _message_ts()},
                             )
                     continue
                 message = _extract_message_from_chunk(chunk)

--- a/src/swarm/core/chat_compact.py
+++ b/src/swarm/core/chat_compact.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
+from swarm.core.speaker_identity import apply_speaker_identity
+from swarm.core.transcript_roles import is_ui_only_role, messages_for_model
 from swarm.models import ChatConversation, ChatMessage, ConversationSummary
 
 
@@ -79,18 +81,39 @@ def _clip(text: str, limit: int = 240) -> str:
 
 
 def summarize_items(items: list[dict[str, Any]]) -> str:
-    """Deterministic extractive compact. No LLM, no secrets, no network."""
+    """Deterministic extractive compact. No LLM, no secrets, no network.
+
+    UI-only status/info rows are skipped so summaries never re-inject chrome.
+    """
     lines: list[str] = []
+    real: list[dict[str, Any]] = []
     for item in items:
         if item.get("kind") == "summary":
+            real.append(item)
             lines.append(f"- [summary] {_clip(str(item.get('body') or ''))}")
             continue
         role = item.get("role") or "user"
+        if is_ui_only_role(role):
+            continue
+        real.append(item)
         content = item.get("content") or item.get("text") or ""
         lines.append(f"- {role}: {_clip(str(content))}")
-    count = len(items)
+    count = len(real)
     noun = "item" if count == 1 else "items"
     return f"Summary of {count} {noun}:\n" + "\n".join(lines)
+
+
+def _message_item(message: dict[str, Any], offset: int) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "kind": "message",
+        "role": (message.get("role") or message.get("sender") or "user"),
+        "content": message.get("content") or message.get("text") or "",
+        "offset": offset,
+    }
+    name = message.get("name") or message.get("speaker") or message.get("agent")
+    if isinstance(name, str) and name.strip():
+        item["name"] = name.strip()
+    return item
 
 
 def build_context_items(
@@ -102,12 +125,7 @@ def build_context_items(
     rows = _as_summary_rows(summaries)
     if not rows:
         return [
-            {
-                "kind": "message",
-                "role": (m.get("role") or m.get("sender") or "user"),
-                "content": m.get("content") or m.get("text") or "",
-                "offset": idx,
-            }
+            _message_item(m, idx)
             for idx, m in enumerate(raw)
         ]
 
@@ -141,14 +159,7 @@ def build_context_items(
             idx = min(len(raw) - 1, _span_bounds(row)[1]) + 1
             continue
         message = raw[idx]
-        items.append(
-            {
-                "kind": "message",
-                "role": (message.get("role") or message.get("sender") or "user"),
-                "content": message.get("content") or message.get("text") or "",
-                "offset": idx,
-            }
-        )
+        items.append(_message_item(message, idx))
         idx += 1
     return items
 
@@ -178,14 +189,18 @@ def build_model_context(
             tree = _format_summary_tree(row, by_id) if row is not None else (item.get("body") or "")
             out.append({"role": "system", "content": f"[Conversation summary]\n{tree}"})
             continue
+        if is_ui_only_role(item.get("role")):
+            continue
         role = item.get("role") or "user"
-        if str(role) == "status":
-            continue  # bubble-less session/status lines are not model context
-        role_s = "assistant" if str(role) == "assistant" else "user"
-        if str(role) == "system":
-            role_s = "system"
-        out.append({"role": role_s, "content": str(item.get("content") or "")})
-    return out
+        role_s = str(role)
+        if role_s not in ("system", "assistant", "tool", "developer"):
+            role_s = "user"
+        row: dict[str, str] = {"role": role_s, "content": str(item.get("content") or "")}
+        name = item.get("name") or item.get("speaker") or item.get("agent")
+        if isinstance(name, str) and name.strip():
+            row["name"] = name.strip()
+        out.append(row)
+    return apply_speaker_identity(out, adapter_id="openai_compat")
 
 
 def context_for_conversation(
@@ -194,21 +209,13 @@ def context_for_conversation(
 ) -> list[dict[str, str]]:
     """Load sqlite summaries for ``conversation_id`` and build model context."""
     if not conversation_id:
-        return [
-            {"role": (m.get("role") or "user"), "content": m.get("content") or ""}
-            for m in (messages or [])
-            if (m.get("role") or "user") != "status"
-        ]
+        return apply_speaker_identity(messages_for_model(messages), adapter_id="openai_compat")
     try:
         rows = list(
             ConversationSummary.objects.filter(conversation_id=conversation_id).order_by("id")
         )
     except Exception:
-        return [
-            {"role": (m.get("role") or "user"), "content": m.get("content") or ""}
-            for m in (messages or [])
-            if (m.get("role") or "user") != "status"
-        ]
+        return apply_speaker_identity(messages_for_model(messages), adapter_id="openai_compat")
     return build_model_context(messages, rows)
 
 
@@ -248,8 +255,21 @@ def _normalize_client_messages(raw: Any) -> list[dict[str, str]]:
             content = item.get("text") or ""
         if not isinstance(content, str):
             content = str(content)
-        role_s = "assistant" if str(role) == "assistant" else "user"
-        out.append({"role": role_s, "content": content})
+        role_raw = str(role)
+        if role_raw == "assistant":
+            role_s = "assistant"
+        elif role_raw in ("status", "info", "system", "tool"):
+            role_s = role_raw
+        else:
+            role_s = "user"
+        row = {"role": role_s, "content": content}
+        ts = item.get("ts") or item.get("timestamp") or item.get("created_at")
+        if isinstance(ts, str) and ts:
+            row["ts"] = ts
+        name = item.get("name")
+        if isinstance(name, str) and name.strip():
+            row["name"] = name.strip()
+        out.append(row)
     return out
 
 
@@ -275,10 +295,7 @@ def ensure_transcript(
     record = chat_store.load(user_key, agent_id)
     stored: list[dict[str, str]] = []
     if record:
-        stored = [
-            {"role": m.get("role", "user"), "content": m.get("content", "")}
-            for m in (record.get("messages") or [])
-        ]
+        stored = _normalize_client_messages(record.get("messages") or [])
 
     chat, _created = ChatConversation.objects.get_or_create(
         conversation_id=conversation_id,
@@ -353,6 +370,8 @@ def compact_backlog(
             if span["end"] < start or span["start"] > end:
                 continue
             mix.append(item)
+            continue
+        if is_ui_only_role(item.get("role")):
             continue
         offset = item.get("offset")
         if isinstance(offset, int) and start <= offset <= end:

--- a/src/swarm/core/chat_store.py
+++ b/src/swarm/core/chat_store.py
@@ -218,16 +218,19 @@ def _normalize_messages(raw: Any) -> list[dict[str, Any]]:
         role_raw = str(role)
         if role_raw == "assistant":
             role_s = "assistant"
-        elif role_raw == "status":
-            role_s = "status"
-        elif role_raw == "system":
-            role_s = "system"
+        elif role_raw in ("status", "info"):
+            role_s = role_raw
+        elif role_raw in ("system", "tool"):
+            role_s = role_raw
         else:
             role_s = "user"
         msg: dict[str, Any] = {"role": role_s, "content": content}
-        ts = item.get("ts") or item.get("timestamp")
+        ts = item.get("ts") or item.get("timestamp") or item.get("created_at")
         if isinstance(ts, str) and ts:
             msg["ts"] = ts
+        name = item.get("name")
+        if isinstance(name, str) and name.strip():
+            msg["name"] = name.strip()
         if item.get("edited") is True or item.get("edited") == "true":
             msg["edited"] = True
         kind = item.get("kind")

--- a/src/swarm/core/speaker_identity.py
+++ b/src/swarm/core/speaker_identity.py
@@ -1,0 +1,183 @@
+"""Provider-correct speaker identity for the model (REQ-70 / #407).
+
+Named assistant (OpenAI ``name``) when the adapter accepts it. Otherwise a
+tested delimiter wrap around the body. No second inference stack — this only
+labels messages the existing adapters already send.
+
+Empirical ``name``-field behaviour is documented in :data:`ADAPTER_NAME_FIELD`
+and proven by stubs in ``tests/core/test_speaker_identity.py``. Failures stay
+in that table; they are never a silent fallback that puts info lines into
+context.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from swarm.core.transcript_roles import messages_for_model
+
+SpeakerPath = Literal["named", "delimiter"]
+NameField = Literal["accepted", "stripped", "error"]
+
+# Proven wrap. Tests lock this exact scheme — do not change without updating them.
+SPEAKER_OPEN = "<<<speaker:"
+SPEAKER_CLOSE = ">>>"
+SPEAKER_END = "<<<end>>>"
+
+# Shipped adapters. CLI/remote stubs flatten to a prompt string, so a structured
+# ``name`` field is never forwarded (stripped). API OpenAI-compat keeps ``name``.
+ADAPTER_NAME_FIELD: dict[str, dict[str, str]] = {
+    "openai_compat": {
+        "name_field": "accepted",
+        "path": "named",
+        "notes": "Chat Completions Message.name; serializer already allows it.",
+    },
+    "cli": {
+        "name_field": "stripped",
+        "path": "delimiter",
+        "notes": "Generic CLI flatten (render_prompt); no message objects.",
+    },
+    "cli:grok": {
+        "name_field": "stripped",
+        "path": "delimiter",
+        "notes": "One-shot argv/stdin prompt; no message objects.",
+    },
+    "cli:agy": {
+        "name_field": "stripped",
+        "path": "delimiter",
+        "notes": "One-shot argv/stdin prompt; no message objects.",
+    },
+    "cli:claude": {
+        "name_field": "stripped",
+        "path": "delimiter",
+        "notes": "One-shot argv/stdin prompt; no message objects.",
+    },
+    "cli:gemini": {
+        "name_field": "stripped",
+        "path": "delimiter",
+        "notes": "One-shot argv/stdin prompt; no message objects.",
+    },
+    "cli:codex": {
+        "name_field": "stripped",
+        "path": "delimiter",
+        "notes": "One-shot argv/stdin prompt; no message objects.",
+    },
+    "cli:opencode": {
+        "name_field": "stripped",
+        "path": "delimiter",
+        "notes": "One-shot argv/stdin prompt; no message objects.",
+    },
+    "cli:pi": {
+        "name_field": "stripped",
+        "path": "delimiter",
+        "notes": "One-shot argv/stdin prompt; no message objects.",
+    },
+    "remote:hermes": {
+        "name_field": "stripped",
+        "path": "delimiter",
+        "notes": "Harness send is a prompt string, not Chat Completions messages.",
+    },
+    "remote:omb": {
+        "name_field": "stripped",
+        "path": "delimiter",
+        "notes": "Harness send is a prompt string, not Chat Completions messages.",
+    },
+    "remote:rakazo": {
+        "name_field": "stripped",
+        "path": "delimiter",
+        "notes": "Harness send is a prompt string, not Chat Completions messages.",
+    },
+    "remote:herdr": {
+        "name_field": "stripped",
+        "path": "delimiter",
+        "notes": "Harness send is a prompt string, not Chat Completions messages.",
+    },
+    "remote:swarm": {
+        "name_field": "stripped",
+        "path": "delimiter",
+        "notes": "Nested send wraps the prompt as a single user message.",
+    },
+}
+
+
+def speaker_path_for(adapter_id: str) -> SpeakerPath:
+    key = (adapter_id or "").strip() or "openai_compat"
+    row = ADAPTER_NAME_FIELD.get(key)
+    if row is None and key.startswith("cli:"):
+        row = ADAPTER_NAME_FIELD.get("cli")
+    if row is None and key.startswith("remote:"):
+        row = ADAPTER_NAME_FIELD.get("remote:hermes")
+    if row is None:
+        row = ADAPTER_NAME_FIELD["openai_compat"]
+    path = row.get("path") or "named"
+    return "delimiter" if path == "delimiter" else "named"
+
+
+def speaker_name(item: dict[str, Any]) -> str:
+    for key in ("name", "speaker", "agent"):
+        raw = item.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+    return ""
+
+
+def wrap_speaker(name: str, content: str) -> str:
+    """Delimiter wrap used when the adapter strips ``name``. Test-locked."""
+    body = content if isinstance(content, str) else str(content or "")
+    label = (name or "").strip()
+    if not label:
+        return body
+    if body.startswith(f"{SPEAKER_OPEN}{label}{SPEAKER_CLOSE}"):
+        return body
+    return f"{SPEAKER_OPEN}{label}{SPEAKER_CLOSE}\n{body}\n{SPEAKER_END}"
+
+
+def unwrap_speaker(text: str) -> tuple[str, str]:
+    """Return ``(name, body)`` when ``text`` is a delimiter wrap, else ``('', text)``."""
+    raw = text if isinstance(text, str) else str(text or "")
+    if not raw.startswith(SPEAKER_OPEN):
+        return "", raw
+    rest = raw[len(SPEAKER_OPEN) :]
+    close = rest.find(SPEAKER_CLOSE)
+    if close <= 0:
+        return "", raw
+    name = rest[:close].strip()
+    body = rest[close + len(SPEAKER_CLOSE) :]
+    if body.startswith("\n"):
+        body = body[1:]
+    end = f"\n{SPEAKER_END}"
+    if body.endswith(end):
+        body = body[: -len(end)]
+    elif body.endswith(SPEAKER_END):
+        body = body[: -len(SPEAKER_END)]
+    return name, body
+
+
+def apply_speaker_identity(
+    messages: list[dict[str, Any]] | None,
+    *,
+    adapter_id: str = "openai_compat",
+) -> list[dict[str, Any]]:
+    """Label real turns for ``adapter_id``. UI-only roles are already gone.
+
+    * **named** — set OpenAI ``name``; body unchanged.
+    * **delimiter** — wrap body; do not rely on a structured ``name`` field
+      (CLI/remote stubs strip it).
+    """
+    path = speaker_path_for(adapter_id)
+    out: list[dict[str, Any]] = []
+    for item in messages_for_model(messages):
+        row = dict(item)
+        name = speaker_name(row)
+        if not name or row.get("role") not in ("assistant", "user"):
+            out.append(row)
+            continue
+        if path == "named":
+            row["name"] = name
+            out.append(row)
+            continue
+        content = row.get("content")
+        row["content"] = wrap_speaker(name, str(content if content is not None else ""))
+        row.pop("name", None)
+        out.append(row)
+    return out

--- a/src/swarm/core/transcript_roles.py
+++ b/src/swarm/core/transcript_roles.py
@@ -1,0 +1,85 @@
+"""Transcript roles that are UI chrome vs model context (REQ-70 / #407).
+
+Info/status lines persist for the human (with timestamps) and must never
+enter the LLM payload. Compact summaries and speaker labelling operate on
+the filtered list only.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+# Bubble-less chrome. ``system`` is kept: compact summaries and real prompts
+# use it. Frontend maps leftover ``system`` rows to status *display* only.
+UI_ONLY_ROLES = frozenset({"status", "info"})
+MODEL_ROLES = frozenset({"system", "user", "assistant", "tool", "developer"})
+
+
+def _role_of(item: dict[str, Any]) -> str:
+    return str(item.get("role") or item.get("sender") or "user").strip().lower()
+
+
+def is_ui_only_role(role: Any) -> bool:
+    return str(role or "").strip().lower() in UI_ONLY_ROLES
+
+
+def message_timestamp(item: dict[str, Any] | None) -> str:
+    """ISO timestamp already on the row, or empty."""
+    if not isinstance(item, dict):
+        return ""
+    ts = item.get("ts") or item.get("timestamp") or item.get("created_at")
+    return ts.strip() if isinstance(ts, str) and ts.strip() else ""
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def stamp_ui_event(item: dict[str, Any]) -> dict[str, Any]:
+    """Ensure a UI-only row has ``ts`` so reload can show when it occurred."""
+    row = dict(item)
+    if not message_timestamp(row):
+        row["ts"] = utc_now_iso()
+    return row
+
+
+def messages_for_model(messages: Iterable[Any] | None) -> list[dict[str, Any]]:
+    """Transcript → LLM payload: drop status/info; keep real turns + tool rows.
+
+    Preserves ``name`` / ``tool_call_id`` / ``tool_calls`` so speaker identity
+    and tool pairing survive. Does not invent content or wrap speakers.
+    """
+    out: list[dict[str, Any]] = []
+    for raw in messages or []:
+        if not isinstance(raw, dict):
+            continue
+        role = _role_of(raw)
+        if is_ui_only_role(role):
+            continue
+        if role not in MODEL_ROLES:
+            # Unknown chrome (e.g. leftover ``suggestions``) stays out of context.
+            continue
+        content = raw.get("content")
+        if content is None:
+            content = raw.get("text") or ""
+        row: dict[str, Any] = {"role": role, "content": content}
+        name = raw.get("name")
+        if isinstance(name, str) and name.strip():
+            row["name"] = name.strip()
+        if raw.get("tool_call_id"):
+            row["tool_call_id"] = raw["tool_call_id"]
+        if raw.get("tool_calls"):
+            row["tool_calls"] = raw["tool_calls"]
+        out.append(row)
+    return out
+
+
+def context_blob(messages: Iterable[dict[str, Any]] | None) -> str:
+    """Concatenated payload text for leak assertions."""
+    parts: list[str] = []
+    for item in messages or []:
+        parts.append(str(item.get("role") or ""))
+        parts.append(str(item.get("content") or ""))
+        parts.append(str(item.get("name") or ""))
+    return "\n".join(parts)

--- a/src/swarm/core/transcript_roles.py
+++ b/src/swarm/core/transcript_roles.py
@@ -64,7 +64,7 @@ def messages_for_model(messages: Iterable[Any] | None) -> list[dict[str, Any]]:
         if content is None:
             content = raw.get("text") or ""
         row: dict[str, Any] = {"role": role, "content": content}
-        name = raw.get("name")
+        name = raw.get("name") or raw.get("speaker") or raw.get("agent")
         if isinstance(name, str) and name.strip():
             row["name"] = name.strip()
         if raw.get("tool_call_id"):

--- a/src/swarm/views/chat_persist_views.py
+++ b/src/swarm/views/chat_persist_views.py
@@ -44,10 +44,14 @@ def _messages_from_db(user, conversation_id: str) -> list[dict[str, str]]:
         )
     except ChatConversation.DoesNotExist:
         return []
-    return [
-        {"role": row.sender, "content": row.content}
-        for row in chat.chat_messages.all()
-    ]
+    out: list[dict[str, str]] = []
+    for row in chat.chat_messages.all():
+        item = {"role": row.sender, "content": row.content}
+        ts = row.timestamp.isoformat() if getattr(row, "timestamp", None) else ""
+        if ts:
+            item["ts"] = ts
+        out.append(item)
+    return out
 
 
 def _json_body(request) -> dict:
@@ -131,6 +135,9 @@ def _sync_django_and_memory(user, messages, conversation_ids: list[str]) -> None
                 "role": item.get("role", "user"),
                 "content": item.get("content", ""),
             }
+            ts = item.get("ts") or item.get("timestamp")
+            if isinstance(ts, str) and ts:
+                row["ts"] = ts
             if item.get("edited"):
                 row["edited"] = True
             mem_rows.append(row)
@@ -214,11 +221,18 @@ def chat_thread(request):
         body = _json_body(request)
         msg = body.get("message")
         if isinstance(msg, dict) and msg.get("content"):
+            from swarm.core.transcript_roles import stamp_ui_event
+
             current_messages = list(messages or [])
             new_row = {
                 "role": str(msg.get("role") or "status"),
                 "content": str(msg.get("content") or ""),
             }
+            ts = msg.get("ts") or msg.get("timestamp") or msg.get("created_at")
+            if isinstance(ts, str) and ts.strip():
+                new_row["ts"] = ts.strip()
+            if new_row["role"] in ("status", "info") or not new_row.get("ts"):
+                new_row = stamp_ui_event(new_row)
             current_messages.append(new_row)
             try:
                 chat_store.save(

--- a/tests/core/test_chat_store.py
+++ b/tests/core/test_chat_store.py
@@ -105,8 +105,31 @@ def test_normalize_keeps_status_role(tmp_path):
         base_dir=tmp_path,
     )
     loaded = chat_store.load("u1", "cli_agent", base_dir=tmp_path)
-    assert loaded["messages"][0] == {"role": "status", "content": "CLI: antigravity → grok"}
+    assert loaded["messages"][0]["role"] == "status"
+    assert loaded["messages"][0]["content"] == "CLI: antigravity → grok"
     assert loaded["messages"][1]["role"] == "user"
+
+
+def test_save_preserves_info_role_and_status_timestamp(tmp_path):
+    chat_store.save(
+        "u1",
+        "cli_agent",
+        [
+            {
+                "role": "info",
+                "content": "Rate limited — retrying with grok",
+                "ts": "2026-09-05T12:00:00Z",
+            },
+            {"role": "status", "content": "CLI: antigravity → grok", "created_at": "2026-09-05T12:01:00Z"},
+            {"role": "user", "content": "hi"},
+        ],
+        base_dir=tmp_path,
+    )
+    loaded = chat_store.load("u1", "cli_agent", base_dir=tmp_path)
+    assert loaded["messages"][0]["role"] == "info"
+    assert loaded["messages"][0]["ts"] == "2026-09-05T12:00:00Z"
+    assert loaded["messages"][1]["role"] == "status"
+    assert loaded["messages"][1]["ts"] == "2026-09-05T12:01:00Z"
     assert chat_store.normalize_agent_id("../etc/passwd") == "etc-passwd"
 
 

--- a/tests/core/test_req70_ui_only_context.py
+++ b/tests/core/test_req70_ui_only_context.py
@@ -1,0 +1,223 @@
+"""REQ-70 / #407: status/info are UI-only — never in the LLM payload."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from swarm.core.chat_compact import (
+    build_model_context,
+    compact_backlog,
+    context_for_conversation,
+    summarize_items,
+)
+from swarm.core.speaker_identity import apply_speaker_identity
+from swarm.core.transcript_roles import context_blob, messages_for_model
+from swarm.blueprints.common import cli_fusion_support as support
+
+
+STATUS_CLI = "CLI: antigravity → grok"
+STATUS_MESSAGED = "Messaged 3 Bots"
+STATUS_FROM = "Message from Codey"
+STATUS_FALLBACK = "Rate limited — retrying with grok"
+INFO_CONNECTING = "Connecting…"
+
+
+def _thread():
+    return [
+        {"role": "status", "content": STATUS_CLI, "ts": "2026-09-05T12:00:00+00:00"},
+        {"role": "info", "content": INFO_CONNECTING, "ts": "2026-09-05T12:00:01+00:00"},
+        {"role": "status", "content": STATUS_MESSAGED},
+        {"role": "status", "content": STATUS_FROM},
+        {"role": "info", "content": STATUS_FALLBACK},
+        {"role": "user", "content": "hello there"},
+        {"role": "assistant", "content": "hi back", "name": "jeeves"},
+        {"role": "tool", "content": "ok", "name": "lookup", "tool_call_id": "c1"},
+    ]
+
+
+def _assert_no_chrome(payload: list[dict]):
+    blob = context_blob(payload)
+    for chrome in (STATUS_CLI, STATUS_MESSAGED, STATUS_FROM, STATUS_FALLBACK, INFO_CONNECTING):
+        assert chrome not in blob
+    roles = [m.get("role") for m in payload]
+    assert "status" not in roles
+    assert "info" not in roles
+
+
+def test_messages_for_model_keeps_pair_and_tool_drops_chrome():
+    payload = messages_for_model(_thread())
+    assert [(m["role"], m["content"]) for m in payload] == [
+        ("user", "hello there"),
+        ("assistant", "hi back"),
+        ("tool", "ok"),
+    ]
+    assert payload[1]["name"] == "jeeves"
+    assert payload[2]["tool_call_id"] == "c1"
+    _assert_no_chrome(payload)
+
+
+def test_build_model_context_excludes_status_info():
+    payload = build_model_context(_thread(), [])
+    assert [(m["role"], m["content"]) for m in payload] == [
+        ("user", "hello there"),
+        ("assistant", "hi back"),
+        ("tool", "ok"),
+    ]
+    assert payload[1].get("name") == "jeeves"
+    _assert_no_chrome(payload)
+
+
+def test_context_for_conversation_no_cid_filters_chrome():
+    payload = context_for_conversation("", _thread())
+    _assert_no_chrome(payload)
+    assert any(m["role"] == "user" and m["content"] == "hello there" for m in payload)
+    assert any(m["role"] == "assistant" and m["content"] == "hi back" for m in payload)
+
+
+def test_summarize_items_skips_status_info():
+    body = summarize_items(
+        [
+            {"kind": "message", "role": "status", "content": STATUS_CLI},
+            {"kind": "message", "role": "info", "content": INFO_CONNECTING},
+            {"kind": "message", "role": "user", "content": "alpha question"},
+            {"kind": "message", "role": "assistant", "content": "alpha answer"},
+        ]
+    )
+    assert "alpha question" in body
+    assert "alpha answer" in body
+    assert STATUS_CLI not in body
+    assert INFO_CONNECTING not in body
+    assert "status" not in body
+    assert "Summary of 2 items" in body
+
+
+@pytest.mark.django_db
+def test_compact_backlog_summarises_real_messages_only():
+    from django.contrib.auth import get_user_model
+    from swarm.core import chat_store
+
+    user = get_user_model().objects.create_user(username="req70-compact", password="pw")
+    cid = "conv-req70-compact"
+    messages = [
+        {"role": "status", "content": STATUS_CLI, "ts": "2026-09-05T01:00:00Z"},
+        {"role": "user", "content": "remember this"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "info", "content": STATUS_FALLBACK},
+    ]
+    chat_store.save(chat_store.user_key_for(user), "jeeves", messages, conversation_id=cid)
+    row, raw = compact_backlog(
+        user=user,
+        conversation_id=cid,
+        agent_id="jeeves",
+        messages=messages,
+    )
+    assert raw[0]["role"] == "status"
+    assert STATUS_CLI not in row.body
+    assert STATUS_FALLBACK not in row.body
+    assert "remember this" in row.body
+    context = build_model_context(raw, [row])
+    blob = context_blob(context)
+    assert STATUS_CLI not in blob
+    assert STATUS_FALLBACK not in blob
+    assert any(m["role"] == "system" and "[Conversation summary]" in m["content"] for m in context)
+
+
+@pytest.mark.django_db
+def test_thread_post_stamps_status_timestamp():
+    import json
+
+    from django.contrib.auth import get_user_model
+    from django.test import Client
+
+    get_user_model().objects.create_user(username="req70-ts", password="pw")
+    client = Client()
+    client.login(username="req70-ts", password="pw")
+    resp = client.post(
+        "/chat/thread/?agent=jeeves",
+        data=json.dumps(
+            {
+                "message": {
+                    "role": "info",
+                    "content": STATUS_FALLBACK,
+                }
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    rows = resp.json()["messages"]
+    assert rows[-1]["role"] == "info"
+    assert rows[-1]["content"] == STATUS_FALLBACK
+    assert rows[-1]["ts"]
+
+    again = client.get("/chat/thread/?agent=jeeves")
+    assert again.status_code == 200
+    restored = again.json()["messages"][-1]
+    assert restored["role"] == "info"
+    assert restored["ts"] == rows[-1]["ts"]
+
+
+def test_render_prompt_excludes_status_and_keeps_turns():
+    prompt = support.render_prompt(
+        [
+            {"role": "status", "content": STATUS_CLI},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "ok", "name": "echo"},
+            {"role": "user", "content": "again"},
+        ]
+    )
+    assert STATUS_CLI not in prompt
+    assert "hello" in prompt
+    assert "again" in prompt
+    assert "ok" in prompt
+
+
+@pytest.mark.asyncio
+async def test_compacted_context_exception_still_strips_chrome():
+    from swarm.consumers import _compacted_context
+
+    thread = _thread()
+    with patch(
+        "swarm.core.chat_compact.context_for_conversation",
+        side_effect=RuntimeError("db down"),
+    ):
+        payload = await _compacted_context("conv-x", thread)
+    _assert_no_chrome(payload)
+    assert any(m["role"] == "user" and m["content"] == "hello there" for m in payload)
+
+
+@pytest.mark.asyncio
+async def test_blueprint_run_payload_has_zero_status_strings(monkeypatch):
+    from swarm.consumers import DjangoChatConsumer
+
+    monkeypatch.delenv("SWARM_TEST_MODE", raising=False)
+    consumer = DjangoChatConsumer()
+    consumer.conversation_id = "conv-req70"
+    consumer.messages = _thread()
+    consumer.user = type("U", (), {"is_authenticated": False, "pk": None})()
+    seen = {}
+
+    async def fake_run(messages, **kwargs):
+        seen["messages"] = messages
+        yield {"messages": [{"role": "assistant", "content": "ok"}]}
+
+    instance = MagicMock()
+    instance.run = fake_run
+    instance.metadata = {}
+    instance.agents = None
+
+    async def fake_context(conversation_id, messages):
+        return build_model_context(messages, [])
+
+    with patch("swarm.consumers._compacted_context", side_effect=fake_context):
+        with patch("swarm.views.utils.get_blueprint_instance", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = instance
+            with patch.object(consumer, "send", new_callable=AsyncMock):
+                await consumer.respond_with_blueprint("jeeves", "message-response-req70")
+
+    payload = seen["messages"]
+    _assert_no_chrome(payload)
+    assert any(m["content"] == "hello there" for m in payload)
+    assert any(m["content"] == "hi back" for m in payload)

--- a/tests/core/test_speaker_identity.py
+++ b/tests/core/test_speaker_identity.py
@@ -1,0 +1,144 @@
+"""REQ-70 speaker identity: named assistant vs tested delimiter wrap.
+
+No live paid calls. Stubs document ``name`` field behaviour per shipped adapter.
+"""
+
+from __future__ import annotations
+
+from swarm.blueprints.common import cli_fusion_support as support
+from swarm.core.cli_catalog import catalog_names
+from swarm.core.remotes import REMOTE_IDS
+from swarm.core.speaker_identity import (
+    ADAPTER_NAME_FIELD,
+    SPEAKER_END,
+    SPEAKER_OPEN,
+    apply_speaker_identity,
+    speaker_path_for,
+    unwrap_speaker,
+    wrap_speaker,
+)
+from swarm.core.transcript_roles import messages_for_model
+from swarm.serializers import MessageSerializer
+
+
+def _openai_compat_stub(messages: list[dict]) -> list[dict]:
+    """API OpenAI-compat: ``name`` is accepted and forwarded (serializer + dict)."""
+    out = []
+    for item in messages:
+        ser = MessageSerializer(
+            data={
+                "role": item.get("role") or "user",
+                "content": item.get("content") or "",
+                **({"name": item["name"]} if item.get("name") else {}),
+            }
+        )
+        assert ser.is_valid(), ser.errors
+        out.append(dict(ser.validated_data))
+    return out
+
+
+def _cli_or_remote_stub(prompt: str) -> dict:
+    """CLI/remote flatten: only a prompt string exists. ``name`` is stripped."""
+    return {"prompt": prompt, "name_field": None}
+
+
+def test_delimiter_wrap_roundtrip():
+    wrapped = wrap_speaker("Codey", "hello from the coder")
+    assert wrapped.startswith(f"{SPEAKER_OPEN}Codey>>>")
+    assert wrapped.endswith(SPEAKER_END)
+    assert "hello from the coder" in wrapped
+    name, body = unwrap_speaker(wrapped)
+    assert name == "Codey"
+    assert body == "hello from the coder"
+
+
+def test_named_path_sets_name_does_not_wrap_body():
+    labeled = apply_speaker_identity(
+        [
+            {"role": "user", "content": "hi", "name": "matt"},
+            {"role": "assistant", "content": "hello", "name": "jeeves"},
+            {"role": "status", "content": "CLI: antigravity → grok"},
+        ],
+        adapter_id="openai_compat",
+    )
+    assert [m["role"] for m in labeled] == ["user", "assistant"]
+    assert labeled[0]["name"] == "matt"
+    assert labeled[0]["content"] == "hi"
+    assert labeled[1]["name"] == "jeeves"
+    assert labeled[1]["content"] == "hello"
+    assert SPEAKER_OPEN not in labeled[1]["content"]
+    forwarded = _openai_compat_stub(labeled)
+    assert forwarded[1]["name"] == "jeeves"
+    assert forwarded[1]["content"] == "hello"
+
+
+def test_delimiter_path_wraps_body_and_strips_name_field():
+    labeled = apply_speaker_identity(
+        [
+            {"role": "assistant", "content": "hello", "name": "Codey"},
+            {"role": "status", "content": "Messaged 2 Bots"},
+        ],
+        adapter_id="cli:grok",
+    )
+    assert len(labeled) == 1
+    assert "name" not in labeled[0]
+    name, body = unwrap_speaker(str(labeled[0]["content"]))
+    assert name == "Codey"
+    assert body == "hello"
+    stub = _cli_or_remote_stub(str(labeled[0]["content"]))
+    assert stub["name_field"] is None
+    assert "Messaged" not in stub["prompt"]
+
+
+def test_render_prompt_uses_delimiter_for_named_assistant():
+    prompt = support.render_prompt(
+        [
+            {"role": "system", "content": "be terse"},
+            {"role": "assistant", "content": "prior", "name": "echo"},
+            {"role": "user", "content": "hello"},
+        ]
+    )
+    assert f"{SPEAKER_OPEN}echo{SPEAKER_CLOSE}" in prompt
+    assert "prior" in prompt
+    assert "hello" in prompt
+    assert "be terse" in prompt
+
+
+def test_adapter_table_covers_shipped_cli_and_remotes():
+    assert ADAPTER_NAME_FIELD["openai_compat"]["name_field"] == "accepted"
+    assert ADAPTER_NAME_FIELD["openai_compat"]["path"] == "named"
+    for cli in catalog_names():
+        key = f"cli:{cli}"
+        assert key in ADAPTER_NAME_FIELD, f"missing CLI adapter row: {key}"
+        assert ADAPTER_NAME_FIELD[key]["name_field"] == "stripped"
+        assert ADAPTER_NAME_FIELD[key]["path"] == "delimiter"
+        assert speaker_path_for(key) == "delimiter"
+    for remote in REMOTE_IDS:
+        key = f"remote:{remote}"
+        assert key in ADAPTER_NAME_FIELD, f"missing remote adapter row: {key}"
+        assert ADAPTER_NAME_FIELD[key]["name_field"] == "stripped"
+        assert ADAPTER_NAME_FIELD[key]["path"] == "delimiter"
+        assert speaker_path_for(key) == "delimiter"
+
+
+def test_remote_stub_uses_delimiter_not_name_field():
+    labeled = apply_speaker_identity(
+        [{"role": "assistant", "content": "pong", "agent": "hermes"}],
+        adapter_id="remote:hermes",
+    )
+    stub = _cli_or_remote_stub(str(labeled[0]["content"]))
+    assert stub["name_field"] is None
+    assert unwrap_speaker(stub["prompt"]) == ("hermes", "pong")
+
+
+def test_ui_only_never_reenters_via_speaker_label():
+    labeled = apply_speaker_identity(
+        [
+            {"role": "info", "content": "Rate limited — retrying", "name": "grok"},
+            {"role": "user", "content": "go"},
+        ],
+        adapter_id="openai_compat",
+    )
+    blob = " ".join(f"{m.get('name','')} {m.get('content','')}" for m in labeled)
+    assert "Rate limited" not in blob
+    assert messages_for_model([{"role": "info", "content": "x"}]) == []

--- a/tests/core/test_speaker_identity.py
+++ b/tests/core/test_speaker_identity.py
@@ -10,6 +10,7 @@ from swarm.core.cli_catalog import catalog_names
 from swarm.core.remotes import REMOTE_IDS
 from swarm.core.speaker_identity import (
     ADAPTER_NAME_FIELD,
+    SPEAKER_CLOSE,
     SPEAKER_END,
     SPEAKER_OPEN,
     apply_speaker_identity,

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -663,9 +663,9 @@ class TestBlueprintSelection:
                 with patch.object(consumer, "respond_with_default_model", new_callable=AsyncMock) as mock_default:
                     await consumer.receive(text_data)
 
-        assert consumer.messages == [
-            {"role": "status", "content": "CLI: antigravity → grok"}
-        ]
+        assert consumer.messages[0]["role"] == "status"
+        assert consumer.messages[0]["content"] == "CLI: antigravity → grok"
+        assert consumer.messages[0]["ts"]
         assert consumer.active_agent == "cli_agent"
         mock_save.assert_awaited_once()
         mock_bp.assert_not_awaited()
@@ -789,7 +789,10 @@ class TestBlueprintSelection:
                 assert any("chat-status-line" in frame for frame in frames)
                 assert any("Started a new echo session." in frame for frame in frames)
                 assert "Restored" not in "".join(frames)
-                assert {"role": "status", "content": "Started a new echo session."} in consumer.messages
+                status_rows = [m for m in consumer.messages if m.get("role") == "status"]
+                assert status_rows
+                assert status_rows[0]["content"] == "Started a new echo session."
+                assert status_rows[0].get("ts")
                 roles = [m["role"] for m in consumer.messages]
                 assert roles.index("status") < roles.index("assistant")
                 status_i = next(i for i, frame in enumerate(frames) if "Started a new echo session." in frame)

--- a/tests/unit/test_req133_cli_api_dropdowns_models.py
+++ b/tests/unit/test_req133_cli_api_dropdowns_models.py
@@ -66,8 +66,11 @@ def test_chat_thread_post_appends_status_line():
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert any(m["role"] == "status" and m["content"] == "CLI: antigravity → grok" for m in data["messages"])
+    status = next(m for m in data["messages"] if m["role"] == "status")
+    assert status["content"] == "CLI: antigravity → grok"
+    assert status.get("ts")
 
     loaded = chat_store.load(chat_store.user_key_for(user), "codey")
     assert loaded is not None
     assert loaded["messages"][-1]["content"] == "CLI: antigravity → grok"
+    assert loaded["messages"][-1].get("ts")

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -1408,6 +1408,12 @@ html:not([data-theme="light"]) .os-composer__send,
   max-width: 28rem;
   text-align: center;
 }
+.os-chat-status > time {
+  flex: 0 0 auto;
+  font-size: 0.7rem;
+  opacity: 0.85;
+  white-space: nowrap;
+}
 
 /* REQ-71: structured PR-opened tool result is thread chrome, not a chat bubble. */
 .os-pr-opened-wrap {

--- a/webui/frontend/src/lib/__tests__/agentChat.test.ts
+++ b/webui/frontend/src/lib/__tests__/agentChat.test.ts
@@ -70,7 +70,11 @@ describe('fetchAgentThread', () => {
           conversation_id: 'agt-1-jeeves',
           messages: [
             { role: 'user', content: 'hi' },
-            { role: 'status', content: 'Started a new grok session.' },
+            {
+              role: 'status',
+              content: 'Started a new grok session.',
+              ts: '2026-09-05T12:00:00Z',
+            },
             { role: 'assistant', content: 'hello' },
           ],
         }),
@@ -79,7 +83,11 @@ describe('fetchAgentThread', () => {
     const thread = await fetchAgentThread('jeeves')
     expect(thread.messages).toEqual([
       { role: 'user', content: 'hi' },
-      { role: 'status', content: 'Started a new grok session.' },
+      {
+        role: 'status',
+        content: 'Started a new grok session.',
+        ts: '2026-09-05T12:00:00Z',
+      },
       { role: 'assistant', content: 'hello' },
     ])
     expect(thread.conversation_id).toBe('agt-1-jeeves')
@@ -106,6 +114,35 @@ describe('fetchAgentThread', () => {
     expect(thread.messages).toEqual([
       { role: 'system', content: '**User:** old', kind: 'prior_history' },
       { role: 'status', content: 'Switched to grok session sid-1.' },
+    ])
+  })
+
+  it('keeps created_at as ts so status chrome can show when it occurred', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          agent_id: 'jeeves',
+          conversation_id: 'agt-1-jeeves',
+          messages: [
+            {
+              role: 'info',
+              content: 'Rate limited — retrying with grok',
+              created_at: '2026-09-05T12:00:00Z',
+            },
+          ],
+        }),
+      } as Response),
+    )
+    const thread = await fetchAgentThread('jeeves')
+    expect(thread.messages).toEqual([
+      {
+        role: 'status',
+        content: 'Rate limited — retrying with grok',
+        ts: '2026-09-05T12:00:00Z',
+      },
     ])
   })
 

--- a/webui/frontend/src/lib/__tests__/chatCompact.test.ts
+++ b/webui/frontend/src/lib/__tests__/chatCompact.test.ts
@@ -66,4 +66,13 @@ describe('contextTextsForMeter', () => {
     const texts = contextTextsForMeter(messages, [summary(1, 0, 1, 'short')])
     expect(texts).toEqual(['short'])
   })
+
+  it('excludes status/info chrome from the meter (REQ-70)', () => {
+    const messages: ChatBubble[] = [
+      { key: 's', role: 'status', text: 'CLI: antigravity → grok', streaming: false },
+      bubble('1', 'user', 'hello'),
+      bubble('2', 'assistant', 'hi'),
+    ]
+    expect(contextTextsForMeter(messages, [])).toEqual(['hello', 'hi'])
+  })
 })

--- a/webui/frontend/src/lib/agentChat.ts
+++ b/webui/frontend/src/lib/agentChat.ts
@@ -110,6 +110,8 @@ export interface AgentThreadMessage {
   content: string
   edited?: boolean
   kind?: 'prior_history'
+  /** ISO timestamp so status/info chrome can show when it occurred after reload. */
+  ts?: string
 }
 
 export interface AgentThread {
@@ -129,7 +131,15 @@ export interface CompactResult {
 
 function parseThreadMessage(value: unknown): AgentThreadMessage | null {
   if (!value || typeof value !== 'object') return null
-  const row = value as { role?: unknown; content?: unknown; edited?: unknown; kind?: unknown }
+  const row = value as {
+    role?: unknown
+    content?: unknown
+    edited?: unknown
+    kind?: unknown
+    ts?: unknown
+    timestamp?: unknown
+    created_at?: unknown
+  }
   if (typeof row.role !== 'string' || typeof row.content !== 'string') return null
   if (row.edited !== undefined && row.edited !== true) return null
   if (row.kind === 'prior_history') {
@@ -149,6 +159,8 @@ function parseThreadMessage(value: unknown): AgentThreadMessage | null {
     content: row.content,
   }
   if (row.edited === true) parsed.edited = true
+  const ts = row.ts || row.timestamp || row.created_at
+  if (typeof ts === 'string' && ts.trim()) parsed.ts = ts.trim()
   return parsed
 }
 

--- a/webui/frontend/src/lib/chatCompact.ts
+++ b/webui/frontend/src/lib/chatCompact.ts
@@ -17,6 +17,7 @@ export interface ChatBubble {
   streaming: boolean
   /** REQ-104 — expandable archive of the previous swarm thread. */
   kind?: 'prior_history'
+  ts?: string
 }
 
 export type DisplayItem =
@@ -94,9 +95,9 @@ export function contextTextsForMeter(
   messages: ChatBubble[],
   summaries: ConversationSummary[],
 ): string[] {
-  return buildDisplayItems(messages, summaries).map((item) =>
-    item.kind === 'summary' ? item.summary.body : item.message.text,
-  )
+  return buildDisplayItems(messages, summaries)
+    .filter((item) => item.kind === 'summary' || item.message.role !== 'status')
+    .map((item) => (item.kind === 'summary' ? item.summary.body : item.message.text))
 }
 
 export function isConversationSummary(value: unknown): value is ConversationSummary {

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -122,6 +122,7 @@ import {
   estimateTokensInContext,
   formatTokenCount,
 } from '../lib/chatMeter'
+import { formatGapLabel, parseCreatedAtMs } from '../lib/chatTime'
 import { workingLabel } from '../lib/chatBubble'
 import { isExperimentalEnabled } from '../experimental/flags'
 import { ChatMessageActions } from '../experimental/ChatMessageActions'
@@ -171,10 +172,12 @@ interface ChatMessage {
   prOpened?: PrOpenedEvent
   /** REQ-104 — expandable archive of the previous swarm thread. */
   kind?: 'prior_history'
+  /** Persist/reload timestamp (ISO). Status/info chrome shows this. */
+  ts?: string
 }
 
 function chatMessageFromThreadRow(
-  message: { role: string; content: string; edited?: boolean; kind?: string },
+  message: { role: string; content: string; edited?: boolean; kind?: string; ts?: string },
   index: number,
 ): ChatMessage {
   const prOpened = parsePrOpened(message.content) ?? undefined
@@ -187,6 +190,7 @@ function chatMessageFromThreadRow(
     edited: message.edited === true,
     prOpened,
     kind: prior ? 'prior_history' : undefined,
+    ts: message.ts,
   }
 }
 
@@ -561,6 +565,7 @@ const ChatPage = () => {
         role: 'status',
         text: statusText,
         streaming: false,
+        ts: new Date().toISOString(),
       }
       setThreads((prev) => ({
         ...prev,
@@ -1909,14 +1914,21 @@ const ChatPage = () => {
               )
             }
             if (isStatusRole(message.role)) {
+              const statusMs = parseCreatedAtMs(message.ts)
               return (
                 <p
                   key={message.key}
                   className="os-chat-status"
                   data-role="status"
                   data-testid="chat-status"
+                  data-ts={message.ts || undefined}
                 >
                   <span>{message.text}</span>
+                  {statusMs != null ? (
+                    <time dateTime={message.ts} data-testid="chat-status-time">
+                      {formatGapLabel(statusMs)}
+                    </time>
+                  ) : null}
                 </p>
               )
             }

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -988,7 +988,11 @@ describe('ChatPage per-agent persistence (no retention chrome)', () => {
               conversation_id: 'agt-1-cli',
               messages: [
                 { role: 'user', content: 'hello' },
-                { role: 'status', content: 'Started a new grok session.' },
+                {
+                  role: 'status',
+                  content: 'Started a new grok session.',
+                  ts: '2026-09-05T12:00:00Z',
+                },
                 { role: 'assistant', content: 'hi' },
               ],
             }),
@@ -1018,6 +1022,8 @@ describe('ChatPage per-agent persistence (no retention chrome)', () => {
     expect(started!.className).not.toMatch(/chat-start|chat-end/)
     expect(started!.querySelector('.chat-bubble')).toBeNull()
     expect(started!.querySelector('span')).toHaveTextContent('Started a new grok session.')
+    expect(started!.querySelector('[data-testid="chat-status-time"]')).toBeTruthy()
+    expect(started).toHaveAttribute('data-ts', '2026-09-05T12:00:00Z')
     expect(screen.getByText('hello').closest('.chat-end')).toBeTruthy()
     expect(screen.getByText('hi').closest('.chat-start')).toBeTruthy()
     const startedPos = started!.compareDocumentPosition(screen.getByText('hi'))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #407

**Feasibility:** Shipped — filter is one shared helper on every context path; speaker identity is named-assistant vs a tested delimiter wrap, no second inference stack.

## Intent
Chat can show info/status lines (dropdown changes, “Messaged” / “Message from”, inference fallback, etc.) with timestamps for the human. Those lines must **not** be fed to the agent/LLM. The model only sees actual sent messages. How we label speakers (named assistant vs delimiter wrap) is provider-dependent and must be proven, not assumed.

## Success
1. Info/status events persist with `created_at` (or equivalent) so the UI can show when they occurred. They remain in the thread on reload.
2. Prompt/context builder **excludes** `role=status` / info events (and any “Messaged” / “Message from” chrome). Tests: a thread with a status line + a real user/assistant pair → LLM payload has the pair, **zero** status/info strings.
3. Actual user and assistant (and tool) messages **are** included. Compact summaries (#350) still summarise real messages only.
4. Speaker identity for the model: prefer provider **named assistant** (or equivalent) when the catalog/provider supports it. If not, wrap the body in a delimiter / prefix that names the speaker. v1 must not invent a second inference stack.
5. **Empirical:** PR includes a short table of shipped adapters (API OpenAI-compat, plus each CLI/remote stub) — `name` field accepted vs stripped vs error — and which path (named vs delimiter) that adapter uses. Failures go in the table, not as silent fallbacks that put info lines into context.
6. Rate-limit vs config-fail info lines from #405, if present, follow the same exclude-from-context rule.

## Constraints
- Builds on #362 (status lines), #350 (compact), #405 (fallback info). Distinct from #366 (edit API bubbles).
- GitHub-only. No `:8001`. No Neon. No secrets.
- Do not fold into 344 / 376 / 379.
- **Do not launch a Cursor cloud while freeze is on.** One cloud later, small wave, `Fixes` this issue, from stable main.
- Tests use fixtures/stubs; no live paid calls required for v1 table if the adapter client already documents the `name` field behaviour — but do not claim a provider works without a stub or documented probe.

## Owner
open-swarm engineer + Cursor cloud (after CoS unblocks). CoS: Open Swarm. Skeptic after the PR (text-only PASS/FAIL).

## Where exclusion is enforced
- `swarm.core.transcript_roles.messages_for_model` — single filter (`status` / `info`)
- `build_model_context` / `context_for_conversation` / `summarize_items` / compact mix (`chat_compact.py`)
- `_compacted_context` exception fallback (`consumers.py`) — no longer returns the raw transcript
- `render_prompt` (`cli_fusion_support.py`) — CLI/remote flatten
- Persist stamps `ts` on WS status, CLI session notice, and `POST /chat/thread/`

## Speaker identity (empirical, stubs — no live paid calls)

| Adapter | `name` field | Path |
|---------|--------------|------|
| API OpenAI-compat | **accepted** (MessageSerializer) | named (`name=`) |
| cli:grok | stripped (prompt string only) | delimiter `<<<speaker:Name>>>` |
| cli:agy | stripped | delimiter |
| cli:claude | stripped | delimiter |
| cli:gemini | stripped | delimiter |
| cli:codex | stripped | delimiter |
| cli:opencode | stripped | delimiter |
| cli:pi | stripped | delimiter |
| remote:hermes | stripped (prompt/job string) | delimiter |
| remote:omb | stripped | delimiter |
| remote:rakazo | stripped | delimiter |
| remote:herdr | stripped | delimiter |
| remote:swarm | stripped (single user message) | delimiter |

Delimiter scheme is test-locked in `tests/core/test_speaker_identity.py`. Failures stay in this table; they do not fall back to stuffing info lines into context.

## Tests
- `tests/core/test_req70_ui_only_context.py` — pair kept, zero chrome strings; compact; persist `ts`; fallback filter
- `tests/core/test_speaker_identity.py` — named vs delimiter + adapter table
- `tests/core/test_chat_store.py` — `info` + `ts` persist
- frontend: thread `ts` parse, meter excludes status, status `<time>` on reload

Local own-diff: 18 focused pytest + 21 vitest passed. Pre-existing main red ignored: `test_chat_page_renders_cli_and_api_dropdowns_with_models` still looks for `data-testid="api-select"` (absent on main ChatPage).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c999b9a-78a8-42b9-985b-5bd19a9e39c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c999b9a-78a8-42b9-985b-5bd19a9e39c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

