### PR TITLE
test: align stale chrome unit contracts after #751/#749 (Fixes #764)

### DIFF
--- a/tests/unit/test_req132_remotes_dropdown_scope.py
+++ b/tests/unit/test_req132_remotes_dropdown_scope.py
@@ -12,9 +12,13 @@ def test_chat_page_guards_remotes_dropdown():
     assert "isRemoteBackedTeam" in tsx
     assert "isRemoteAgent" in tsx
     assert "showRemotesControl" in tsx
+    # Post-#749: remotes chrome is remote-only (agent or remote-backed team).
+    assert "showRemotesControl = isRemoteAgent || isRemoteBackedTeam" in tsx
 
-    # Must be conditionally rendered, omitted entirely when false (no empty stub)
-    assert "{showRemotesControl ? (" in tsx
+    # Empty catalog shows Add remote; otherwise RemoteSelect; omitted when not remote.
+    assert "showEmptyRemoteChrome" in tsx
+    assert "{showEmptyRemoteChrome ? (" in tsx
+    assert "showRemotesControl ? (" in tsx
     assert "<RemoteSelect" in tsx
     assert ") : null}" in tsx
 

--- a/tests/unit/test_req133_cli_api_dropdowns_models.py
+++ b/tests/unit/test_req133_cli_api_dropdowns_models.py
@@ -1,4 +1,8 @@
-"""REQ-133: CLI and API chat dropdowns with model selectors (Fixes #523)."""
+"""REQ-133: CLI chat dropdowns with model selectors (Fixes #523).
+
+API You/Default chrome (`api-select`) was removed in #751 / REQ-186.
+This contract keeps the CLI + model picker that still exist on ChatPage.
+"""
 
 from pathlib import Path
 import pytest
@@ -14,24 +18,24 @@ CLI_CONTEXT_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "cliAgentCon
 CHAT_STATUS_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "chatStatus.ts"
 
 
-def test_chat_page_renders_cli_and_api_dropdowns_with_models():
+def test_chat_page_renders_cli_dropdowns_with_models():
     tsx = CHAT_PAGE_TSX.read_text(encoding="utf-8")
     assert "isCliAgent" in tsx
     assert "isApiAgent" in tsx
     assert "showRemotesControl" in tsx
 
-    # CLI controls
+    # CLI + model picker still on ChatPage
     assert 'data-testid="cli-select"' in tsx
     assert 'aria-label="CLI"' in tsx
     assert 'data-testid="cli-model-select"' in tsx
 
-    # API controls
-    assert 'data-testid="api-select"' in tsx
-    assert 'aria-label="API"' in tsx
+    # #751 removed You/Default API chrome — do not require it here (REQ-186 forbids it)
+    assert 'data-testid="api-select"' not in tsx
+    assert 'aria-label="API"' not in tsx
+    assert "recordDropdownChange('api'" not in tsx
 
-    # Status tracking on change
+    # Status tracking on remaining dropdowns
     assert "recordDropdownChange('cli'" in tsx
-    assert "recordDropdownChange('api'" in tsx
     assert "recordDropdownChange('model'" in tsx
 
 

--- a/tests/unit/test_req175_role_pill_avatar_overlay.py
+++ b/tests/unit/test_req175_role_pill_avatar_overlay.py
@@ -20,11 +20,12 @@ def test_sidebar_role_badge_overlays_avatar():
         content,
     )
 
-    # Avatar container has relative inline-flex wrapping mark and role badge
+    # Avatar slot (relative) wraps mark + role badge so the pill overlays the avatar
     assert re.search(
-        r'<span className="relative inline-flex shrink-0 mt-1\.5">\s*\{mark\}\s*\{roleBadgeNode\}\s*</span>',
+        r'<span className="os-agent-row__avatar-slot relative inline-flex shrink-0 items-center justify-center">\s*\{mark\}\s*\{roleBadgeNode\}\s*</span>',
         content,
     )
+    assert "position: 'absolute'" in content
 
 
 def test_second_row_does_not_contain_role_badge_chip():

--- a/tests/unit/test_screenshot_registry.py
+++ b/tests/unit/test_screenshot_registry.py
@@ -441,7 +441,6 @@ def test_spa_app_mobile_dock_omits_settings_tab():
     # REQ-59: Remotes is an opt-in catalog, not a menu-dropdown of unused kinds.
     assert "Add remote" in sheet
     assert "menu-dropdown" not in sheet
-    assert "join-item" in sheet
 
 
 def test_feature_status_mobile_dock_omits_settings():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #764

Update four stale Python source-lock tests so they match current ChatPage / rail / mobile-dock chrome after #751 (You/Default API chrome removed) and #749 (remote bind). Tests-only — no product UI changes.

## Assertion changes

### `tests/unit/test_req133_cli_api_dropdowns_models.py`
- Stop requiring `data-testid="api-select"`, `aria-label="API"`, and `recordDropdownChange('api'`.
- Lock the opposite: those You/Default API hooks must stay gone (aligned with REQ-186 / #751).
- Keep CLI + model picker locks (`cli-select`, `cli-model-select`, `recordDropdownChange('cli'|'model'`).
- Rename the chrome lock to `test_chat_page_renders_cli_dropdowns_with_models`.

### `tests/unit/test_req132_remotes_dropdown_scope.py`
- Drop the stale `{showRemotesControl ? (` outer-ternary lock (post-#749 the outer branch is empty-remote chrome).
- Keep `showRemotesControl` — it is still the live remote-only guard (`isRemoteAgent || isRemoteBackedTeam`).
- Lock `showEmptyRemoteChrome ? (` → `showRemotesControl ? (` → `<RemoteSelect` → `) : null}` so remotes chrome stays remote-only.

### `tests/unit/test_req175_role_pill_avatar_overlay.py`
- Replace the old `relative inline-flex shrink-0 mt-1.5` wrapper regex with current `os-agent-row__avatar-slot relative inline-flex shrink-0 items-center justify-center` wrapping `{mark}` + `{roleBadgeNode}`.
- Keep overlay coverage: `data-avatar-overlay="true"`, `roleBadgeNode`, `os-agent-role-badge` class template, `position: 'absolute'`, and second-row snippet-only regexes.

### `tests/unit/test_screenshot_registry.py::test_spa_app_mobile_dock_omits_settings_tab`
- Drop stale `assert "join-item" in sheet` (`join-item` is gone from SettingsSheet).
- Keep Settings-as-sheet locks (`Open settings`, `placement="end"` / `modal-end`, no `MobileTab` / `/settings/` dock tab).

## Out of scope
- No product UI changes.
- Does not resurrect `api-select` / You/Default navbar.
- Does not weaken remotes-only-on-remote-agents or role-pill overlay behaviour.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66726095-9ed7-4c1a-9aa6-70047fff5ce6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66726095-9ed7-4c1a-9aa6-70047fff5ce6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

