### PR TITLE
feat(webui): REQ-82 rail right-click menu — unpin, unread, edit, duplicate, copy id, hide, delete

### DIFF
--- a/tests/unit/test_req130_req152_team_cos_manage.py
+++ b/tests/unit/test_req130_req152_team_cos_manage.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SIDEBAR = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+RAIL_MENU = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "railContextMenu.ts"
 CHAT_PAGE = REPO_ROOT / "webui" / "frontend" / "src" / "pages" / "ChatPage.tsx"
 SESSION_PICKER_COMPONENT = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "SessionPicker.tsx"
 SESSION_PICKER_LIB = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "sessionPicker.ts"
@@ -38,12 +39,18 @@ def test_req130_sidebar_primary_click_direct_nav_no_picker():
 
 
 def test_req130_sidebar_context_menu_select_agent():
-    """REQ-130: right-click menu has 'Select Agent' action opening group picker."""
-    src = SIDEBAR.read_text(encoding="utf-8")
-    assert "openMenu(event, hideId, name, hidden, 'team', sessions)" in src
-    assert "openMenu(event, hideId, name, hidden, 'remote', sessions)" in src
-    assert "Select Agent" in src
-    assert "openGroupPicker(title, s)" in src or "openGroupPicker" in src
+    """REQ-130: right-click rail menu offers Select Agent and opens the group picker."""
+    sidebar = SIDEBAR.read_text(encoding="utf-8")
+    menu = RAIL_MENU.read_text(encoding="utf-8")
+    assert "rowMenuHandlers(hideId, name, hidden, 'team', sessions, team.id)" in sidebar
+    assert "rowMenuHandlers(hideId, name, hidden, 'remote', sessions, remote.id)" in sidebar
+    assert "onContextMenu" in sidebar
+    assert "id: 'select-agent', label: 'Select Agent'" in menu
+    assert "id === 'select-agent'" in sidebar
+    assert "openGroupPicker(title, sessions)" in sidebar
+    # REQ-82 retired the old openMenu(event, hideId, …) call-shape lock.
+    assert "openMenu(event, hideId, name, hidden, 'team', sessions)" not in sidebar
+    assert "openMenu(event, hideId, name, hidden, 'remote', sessions)" not in sidebar
 
 
 def test_req152_chat_page_team_dropdown_separator_and_manage():

--- a/tests/unit/test_req173_rail_no_pencils.py
+++ b/tests/unit/test_req173_rail_no_pencils.py
@@ -14,6 +14,11 @@ def test_rail_rows_have_no_edit_pencils():
     assert "openBlueprintEditor" not in content, "Undefined openBlueprintEditor call site must be removed (Fixes #606)"
     assert "showsBlueprintEdit" not in content, "showsBlueprintEdit should not be needed in sidebar rows"
 
-    # Context menu edit option must remain accessible
-    assert "Edit agent" in content, "Edit agent context menu must remain available"
-    assert 'role="menuitem"' in content
+    # Context menu lives in RailContextMenu (REQ-82). Edit is no longer inline.
+    menu = (REPO_ROOT / "webui" / "frontend" / "src" / "components" / "RailContextMenu.tsx").read_text(
+        encoding="utf-8"
+    )
+    assert "Edit Profile" in (
+        REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "railContextMenu.ts"
+    ).read_text(encoding="utf-8"), "Edit Profile must remain on the rail context menu"
+    assert 'role="menuitem"' in menu

--- a/tests/unit/test_req72_chrome_contracts.py
+++ b/tests/unit/test_req72_chrome_contracts.py
@@ -13,6 +13,7 @@ REMOTES_LIB = REPO / "webui" / "frontend" / "src" / "lib" / "remotes.ts"
 SEARCH_PALETTE = REPO / "webui" / "frontend" / "src" / "components" / "SearchPalette.tsx"
 CHAT_PAGE = REPO / "webui" / "frontend" / "src" / "pages" / "ChatPage.tsx"
 SIDEBAR = REPO / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+RAIL_MENU = REPO / "webui" / "frontend" / "src" / "lib" / "railContextMenu.ts"
 APP = REPO / "webui" / "frontend" / "src" / "App.tsx"
 HOSTNAME = REPO / "webui" / "frontend" / "src" / "lib" / "hostname.ts"
 SETTINGS_PREFS = REPO / "webui" / "frontend" / "src" / "lib" / "settingsPrefs.ts"
@@ -52,12 +53,21 @@ def test_chat_page_support_default_and_manage_teams():
 
 
 def test_sidebar_team_hide_id_and_plugins_empty_copy():
-    """#342 team hide uses teamHideId; #322 Plugins dialog is empty."""
+    """#342 team hide uses teamHideId; #322 Plugins dialog is empty; REQ-82 menu labels."""
     src = SIDEBAR.read_text(encoding="utf-8")
+    menu = RAIL_MENU.read_text(encoding="utf-8")
     assert "teamHideId(team.id)" in src
     assert "No plugins installed." in src
-    assert "Unpin" in src
     assert 'aria-label="Open agents sidebar"' not in src  # REQ-54: hamburger removed
+    # Unpin / Delete / Edit live in the menu builder, not inline rail JSX.
+    assert "id: 'unpin', label: 'Unpin'" in menu
+    assert "if (opts.pinned)" in menu
+    assert "id: 'delete'" in menu
+    assert "label: 'Delete'" in menu
+    assert "danger: true" in menu
+    assert "label: 'Edit Profile'" in menu
+    assert "opts.kind === 'cli'" in menu
+    assert "id: 'edit'" in menu
 
 
 def test_app_mobile_rail_and_settings_event():

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -5,11 +5,13 @@ import {
   useRef,
   useState,
   type DragEvent as ReactDragEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
+  type TouchEvent as ReactTouchEvent,
 } from 'react'
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
-import { Circle, Eye, EyeOff, Pencil, Pin, PinOff, Plug, Plus, Search, Server, Users, X } from 'lucide-react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { Plug, Plus, Search, Server, Users, X } from 'lucide-react'
 import AddAgentWizard, { type AgentKind } from './AddAgentWizard'
 import {
   UNREAD_CHANGED_EVENT,
@@ -18,6 +20,12 @@ import {
   markAgentUnread,
 } from '../lib/unreadAgents'
 import {
+  createCustomBlueprint,
+  createRemote,
+  createTeamRoster,
+  deleteCustomBlueprint,
+  deleteRemote,
+  deleteTeamRoster,
   fetchBlueprints,
   fetchCliAgents,
   fetchHerdrAgents,
@@ -115,11 +123,33 @@ import {
   openAgentEditor,
 } from '../lib/agentSettings'
 import { activeTaskSessionCount } from '../lib/agentChat'
+import {
+  RAIL_LONG_PRESS_MS,
+  copyableConversationId,
+  duplicateName,
+  isRailMenuKey,
+  railMenuItems,
+  type RailMenuItemId,
+  type RailMenuKind,
+} from '../lib/railContextMenu'
+import { copyTextToClipboard } from '../lib/clipboard'
+import {
+  isRailIdDeleted,
+  loadDeletedRailIds,
+  markRailIdDeleted,
+} from '../lib/deletedRailIds'
 import { openSearchPalette } from './SearchPalette'
 import { isMacPlatform, searchShortcutLabel } from '../lib/keybindingTips'
-import { AGENT_EDITS_CHANGED_EVENT } from '../lib/agentEdits'
+import {
+  AGENT_EDITS_CHANGED_EVENT,
+  assignedBlueprintId,
+  loadAgentEdit,
+  saveAgentEdit,
+} from '../lib/agentEdits'
 import SessionPicker from './SessionPicker'
 import { openSettingsSheet } from './SettingsSheet'
+import { ConfirmModal } from './DaisyUI'
+import RailContextMenu from './RailContextMenu'
 import AvatarStack from './AvatarStack'
 import StackedAvatars from './StackedAvatars'
 import {
@@ -152,7 +182,8 @@ interface ContextMenuState {
   pinned: boolean
   x: number
   y: number
-  kind?: 'agent' | 'team' | 'remote'
+  kind: RailMenuKind
+  entityId: string
   sessions?: MemberSession[]
 }
 
@@ -241,6 +272,7 @@ export default function AgentSidebar({
   const drawerHidden = Boolean(narrow && !open)
   const { pathname } = useLocation()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const [searchParams] = useSearchParams()
   const onChat = pathname.startsWith('/chat') || pathname === '/'
   const selectedTeamId = onChat ? (searchParams.get('team') ?? '') : ''
@@ -253,6 +285,8 @@ export default function AgentSidebar({
   const [hiddenIds, setHiddenIds] = useState<string[] | null>(() =>
     hasHiddenAgentsStorage() ? loadHiddenAgentIds() : null,
   )
+  const [deletedIds, setDeletedIds] = useState<string[]>(() => loadDeletedRailIds())
+  const [deleteConfirm, setDeleteConfirm] = useState<ContextMenuState | null>(null)
   const [pins, setPins] = useState<PinnedAgent[]>(() => loadOrSeedPinnedAgents())
   const [hoveringHidden, setHoveringHidden] = useState(false)
   const [pluginsOpen, setPluginsOpen] = useState(false)
@@ -301,7 +335,11 @@ export default function AgentSidebar({
   const [bumpCompleted, setBumpCompleted] = useState(() => loadBumpCompleted())
   const [sessionTick, setSessionTick] = useState(0)
   const [sessionPicker, setSessionPicker] = useState<SessionPickerState | null>(null)
-  const menuRef = useRef<HTMLDivElement | null>(null)
+  const menuRef = useRef<HTMLUListElement | null>(null)
+  const longPressRef = useRef<{ timer: number | null; opened: boolean }>({
+    timer: null,
+    opened: false,
+  })
   const hideDropDepth = useRef(0)
   const prefsHydrated = useRef(false)
   const skipPrefsSave = useRef(true)
@@ -571,39 +609,71 @@ export default function AgentSidebar({
     () =>
       agents.filter(
         (agent) =>
-          isCliRailAgent(agent) || isApiRailAgent(agent) || !resolvedHiddenIds.includes(agent.id),
+          !isRailIdDeleted(agent.id, deletedIds) &&
+          (isCliRailAgent(agent) || isApiRailAgent(agent) || !resolvedHiddenIds.includes(agent.id)),
       ),
-    [agents, resolvedHiddenIds],
+    [agents, resolvedHiddenIds, deletedIds],
   )
   const hiddenAgents = useMemo(
     () =>
       agents.filter(
         (agent) =>
+          !isRailIdDeleted(agent.id, deletedIds) &&
           !isCliRailAgent(agent) &&
           !isApiRailAgent(agent) &&
           resolvedHiddenIds.includes(agent.id),
       ),
-    [agents, resolvedHiddenIds],
+    [agents, resolvedHiddenIds, deletedIds],
   )
   const visibleTeams = useMemo(
-    () => teams.filter((team) => !resolvedHiddenIds.includes(teamHideId(team.id))),
-    [teams, resolvedHiddenIds],
+    () =>
+      teams.filter(
+        (team) =>
+          !isRailIdDeleted(teamHideId(team.id), deletedIds) &&
+          !isRailIdDeleted(team.id, deletedIds) &&
+          !resolvedHiddenIds.includes(teamHideId(team.id)),
+      ),
+    [teams, resolvedHiddenIds, deletedIds],
   )
   const visibleRootTeams = useMemo(
-    () => rootTeams.filter((team) => !resolvedHiddenIds.includes(teamHideId(team.id))),
-    [rootTeams, resolvedHiddenIds],
+    () =>
+      rootTeams.filter(
+        (team) =>
+          !isRailIdDeleted(teamHideId(team.id), deletedIds) &&
+          !isRailIdDeleted(team.id, deletedIds) &&
+          !resolvedHiddenIds.includes(teamHideId(team.id)),
+      ),
+    [rootTeams, resolvedHiddenIds, deletedIds],
   )
   const hiddenTeams = useMemo(
-    () => teams.filter((team) => resolvedHiddenIds.includes(teamHideId(team.id))),
-    [teams, resolvedHiddenIds],
+    () =>
+      teams.filter(
+        (team) =>
+          !isRailIdDeleted(teamHideId(team.id), deletedIds) &&
+          !isRailIdDeleted(team.id, deletedIds) &&
+          resolvedHiddenIds.includes(teamHideId(team.id)),
+      ),
+    [teams, resolvedHiddenIds, deletedIds],
   )
   const visibleRemotes = useMemo(
-    () => remotes.filter((remote) => !resolvedHiddenIds.includes(remoteHideId(remote.id))),
-    [remotes, resolvedHiddenIds],
+    () =>
+      remotes.filter(
+        (remote) =>
+          !isRailIdDeleted(remoteHideId(remote.id), deletedIds) &&
+          !isRailIdDeleted(remote.id, deletedIds) &&
+          !resolvedHiddenIds.includes(remoteHideId(remote.id)),
+      ),
+    [remotes, resolvedHiddenIds, deletedIds],
   )
   const hiddenRemotes = useMemo(
-    () => remotes.filter((remote) => resolvedHiddenIds.includes(remoteHideId(remote.id))),
-    [remotes, resolvedHiddenIds],
+    () =>
+      remotes.filter(
+        (remote) =>
+          !isRailIdDeleted(remoteHideId(remote.id), deletedIds) &&
+          !isRailIdDeleted(remote.id, deletedIds) &&
+          resolvedHiddenIds.includes(remoteHideId(remote.id)),
+      ),
+    [remotes, resolvedHiddenIds, deletedIds],
   )
   const hiddenCount = hiddenAgents.length + hiddenTeams.length + hiddenRemotes.length
   const visibleCount = visibleAgents.length + visibleTeams.length + visibleRemotes.length
@@ -657,8 +727,11 @@ export default function AgentSidebar({
   )
   const visibleRowIds = useMemo(() => orderedRows.map((row) => row.id), [orderedRows])
   const visiblePins = useMemo(
-    () => pins.filter((pin) => !resolvedHiddenIds.includes(pin.id)),
-    [pins, resolvedHiddenIds],
+    () =>
+      pins.filter(
+        (pin) => !resolvedHiddenIds.includes(pin.id) && !isRailIdDeleted(pin.id, deletedIds),
+      ),
+    [pins, resolvedHiddenIds, deletedIds],
   )
   const hotkeyTargets = useMemo(
     () => computeRailHotkeyTargets({ visiblePins, orderedRows }),
@@ -805,20 +878,32 @@ export default function AgentSidebar({
     return () => window.removeEventListener('keydown', onAltDigit)
   }, [visiblePins, hotkeyTargets, navigate, onClose])
 
-  const openMenu = (
-    event: ReactMouseEvent,
+  const resolveMenuKind = (hideId: string, hinted?: RailMenuKind): RailMenuKind => {
+    if (hinted) return hinted
+    if (hideId.startsWith('team:')) return 'team'
+    if (hideId.startsWith('remote:')) return 'remote'
+    const agent = agents.find((row) => row.id === hideId)
+    if (agent && isCliRailAgent(agent)) return 'cli'
+    if (agent && isHerdrAgent(agent)) return 'remote'
+    return 'api'
+  }
+
+  const openMenuAt = (
+    clientX: number,
+    clientY: number,
     hideId: string,
     label: string,
     hidden: boolean,
-    kind?: 'agent' | 'team' | 'remote',
+    kind?: RailMenuKind,
     sessions?: MemberSession[],
+    entityId?: string,
   ) => {
-    event.preventDefault()
     const pad = 8
-    const width = 200
-    const height = 120
-    const x = Math.min(event.clientX, window.innerWidth - width - pad)
-    const y = Math.min(event.clientY, window.innerHeight - height - pad)
+    const width = 220
+    const height = 280
+    const x = Math.min(clientX, window.innerWidth - width - pad)
+    const y = Math.min(clientY, window.innerHeight - height - pad)
+    const resolvedKind = resolveMenuKind(hideId, kind)
     setMenu({
       agentId: hideId,
       agentName: label,
@@ -826,10 +911,57 @@ export default function AgentSidebar({
       pinned: pins.some((pin) => pin.id === hideId),
       x: Math.max(pad, x),
       y: Math.max(pad, y),
-      kind,
+      kind: resolvedKind,
+      entityId: entityId || hideId,
       sessions,
     })
   }
+
+  const clearLongPress = () => {
+    if (longPressRef.current.timer != null) {
+      window.clearTimeout(longPressRef.current.timer)
+      longPressRef.current.timer = null
+    }
+  }
+
+  const rowMenuHandlers = (
+    hideId: string,
+    label: string,
+    hidden: boolean,
+    kind?: RailMenuKind,
+    sessions?: MemberSession[],
+    entityId?: string,
+  ) => ({
+    onContextMenu: (event: ReactMouseEvent) => {
+      event.preventDefault()
+      openMenuAt(event.clientX, event.clientY, hideId, label, hidden, kind, sessions, entityId)
+    },
+    onKeyDown: (event: ReactKeyboardEvent<HTMLElement>) => {
+      if (!isRailMenuKey(event)) return
+      event.preventDefault()
+      const rect = event.currentTarget.getBoundingClientRect()
+      openMenuAt(rect.left + 12, rect.bottom, hideId, label, hidden, kind, sessions, entityId)
+    },
+    onTouchStart: (event: ReactTouchEvent<HTMLElement>) => {
+      const touch = event.touches[0]
+      if (!touch) return
+      longPressRef.current.opened = false
+      clearLongPress()
+      longPressRef.current.timer = window.setTimeout(() => {
+        longPressRef.current.opened = true
+        openMenuAt(touch.clientX, touch.clientY, hideId, label, hidden, kind, sessions, entityId)
+      }, RAIL_LONG_PRESS_MS)
+    },
+    onTouchEnd: (event: ReactTouchEvent<HTMLElement>) => {
+      clearLongPress()
+      if (longPressRef.current.opened) {
+        event.preventDefault()
+      }
+    },
+    onTouchMove: () => {
+      clearLongPress()
+    },
+  })
 
   const finishDrag = () => {
     endAgentDrag()
@@ -867,11 +999,7 @@ export default function AgentSidebar({
   }
 
   const unhideAgent = (id: string) => {
-    setHiddenIds((current) => {
-      const next = unhideAgentId(id, current ?? resolvedHiddenIds)
-      if (next.length === 0) setHiddenOpen(false)
-      return next
-    })
+    setHiddenIds((current) => unhideAgentId(id, current ?? resolvedHiddenIds))
     closeMenu()
   }
 
@@ -1032,6 +1160,203 @@ export default function AgentSidebar({
     onClose?.()
   }
 
+  const editMenuRow = (row: ContextMenuState) => {
+    if (row.kind === 'cli') return
+    if (row.kind === 'team') {
+      openDefinition('team', row.entityId, { teamId: row.entityId })
+      closeMenu()
+      return
+    }
+    if (row.kind === 'remote') {
+      openSettingsSheet({ section: 'remotes' })
+      closeMenu()
+      onClose?.()
+      return
+    }
+    openAgentSettings({ id: row.entityId, name: row.agentName })
+  }
+
+  const duplicateMenuRow = async (row: ContextMenuState) => {
+    const name = duplicateName(row.agentName)
+    try {
+      if (row.kind === 'cli') return
+      if (row.kind === 'team') {
+        const source = teams.find((team) => team.id === row.entityId)
+        const created = await createTeamRoster({
+          name,
+          members: (source?.members ?? []).map((member) => ({
+            id: member.id,
+            kind: member.kind || 'api',
+            role: member.role || 'default',
+            source: member.kind === 'team' ? `team:${member.team_id || member.id}` : `blueprint:${member.id}`,
+            team_id: member.team_id,
+          })),
+        })
+        await queryClient.invalidateQueries({ queryKey: ['team-rosters'] })
+        const createdHide = teamHideId(created.id)
+        const base = mergeRailOrder(railOrder, visibleRowIds)
+        persistVisibleOrder(bumpRailIdToTop(base, createdHide))
+        closeMenu()
+        return
+      }
+      if (row.kind === 'remote') {
+        const source = configuredRemotesList.find((remote) => remote.id === row.entityId)
+        const created = await createRemote({
+          kind: source?.kind || row.entityId,
+          base_url: source?.base_url,
+          api_key_env: source?.api_key_env,
+          ui_url: source?.ui_url,
+        })
+        await queryClient.invalidateQueries({ queryKey: ['configured-remotes'] })
+        await queryClient.invalidateQueries({ queryKey: ['remotes-list'] })
+        await queryClient.invalidateQueries({ queryKey: ['settings-remotes'] })
+        const createdHide = remoteHideId(created.id)
+        const base = mergeRailOrder(railOrder, visibleRowIds)
+        persistVisibleOrder(bumpRailIdToTop(base, createdHide))
+        closeMenu()
+        return
+      }
+      const sourceEdit = loadAgentEdit(row.entityId)
+      const created = await createCustomBlueprint({
+        name,
+        description: `Copy of ${row.agentName}`,
+        category: 'ai_assistants',
+        tags: ['api'],
+        code: `# Copy of ${assignedBlueprintId(row.entityId)}\n`,
+      })
+      saveAgentEdit(created.id, {
+        name,
+        blueprintId: sourceEdit.blueprintId || assignedBlueprintId(row.entityId),
+        role: sourceEdit.role,
+        llmOverride: sourceEdit.llmOverride,
+      })
+      await queryClient.invalidateQueries({ queryKey: ['blueprints'] })
+      await queryClient.invalidateQueries({ queryKey: ['custom-blueprints'] })
+      const base = mergeRailOrder(railOrder, visibleRowIds)
+      persistVisibleOrder(bumpRailIdToTop(base, created.id))
+    } catch {
+      /* caller / tests mock fetch; failures stay on the current row */
+    }
+    closeMenu()
+  }
+
+  const copyMenuConversationId = async (row: ContextMenuState) => {
+    const id = copyableConversationId(row.kind, row.agentId, row.entityId)
+    if (!id) {
+      closeMenu()
+      return
+    }
+    await copyTextToClipboard(id)
+    closeMenu()
+  }
+
+  const requestDelete = (row: ContextMenuState) => {
+    closeMenu()
+    setDeleteConfirm(row)
+  }
+
+  const confirmDeleteRow = async () => {
+    const row = deleteConfirm
+    if (!row) return
+    const hideId = row.agentId
+    setPins((current) =>
+      current.some((pin) => pin.id === hideId) ? unpinAgent(hideId, current) : current,
+    )
+    if (row.kind === 'remote') {
+      try {
+        await deleteRemote(row.entityId)
+      } catch {
+        /* local remove still applies */
+      }
+      await queryClient.invalidateQueries({ queryKey: ['configured-remotes'] })
+      await queryClient.invalidateQueries({ queryKey: ['remotes-list'] })
+      await queryClient.invalidateQueries({ queryKey: ['settings-remotes'] })
+    } else if (row.kind === 'team') {
+      try {
+        await deleteTeamRoster(row.entityId)
+      } catch {
+        /* local remove still applies */
+      }
+      await queryClient.invalidateQueries({ queryKey: ['team-rosters'] })
+    } else if (row.kind === 'api') {
+      try {
+        await deleteCustomBlueprint(row.entityId)
+      } catch {
+        /* catalog seats are removed locally only */
+      }
+      await queryClient.invalidateQueries({ queryKey: ['blueprints'] })
+      await queryClient.invalidateQueries({ queryKey: ['custom-blueprints'] })
+    }
+    // CLI: hide-or-remove from rail only — do not uninstall the binary.
+    setDeletedIds((current) => {
+      let next = markRailIdDeleted(hideId, current)
+      if (row.entityId !== hideId) next = markRailIdDeleted(row.entityId, next)
+      return next
+    })
+    setDeleteConfirm(null)
+  }
+
+  const handleMenuSelect = (id: RailMenuItemId) => {
+    if (!menu) return
+    if (id === 'select-agent' && menu.sessions && menu.sessions.length > 0) {
+      const title = menu.agentName
+      const sessions = menu.sessions
+      closeMenu()
+      openGroupPicker(title, sessions)
+      return
+    }
+    if (id === 'unpin' || id === 'pin') {
+      togglePin({ id: menu.agentId, name: menu.agentName })
+      return
+    }
+    if (id === 'unread') {
+      if (unreadIds.includes(menu.agentId)) {
+        setUnreadIds(markAgentRead(menu.agentId))
+      } else {
+        setUnreadIds(markAgentUnread(menu.agentId))
+      }
+      closeMenu()
+      return
+    }
+    if (id === 'edit') {
+      editMenuRow(menu)
+      return
+    }
+    if (id === 'duplicate') {
+      void duplicateMenuRow(menu)
+      return
+    }
+    if (id === 'copy-id') {
+      void copyMenuConversationId(menu)
+      return
+    }
+    if (id === 'hide') {
+      hideAgent(menu.agentId)
+      return
+    }
+    if (id === 'unhide') {
+      unhideAgent(menu.agentId)
+      return
+    }
+    if (id === 'delete') {
+      requestDelete(menu)
+    }
+  }
+
+  const menuItems = menu
+    ? railMenuItems({
+        kind: menu.kind,
+        pinned: menu.pinned,
+        hidden: menu.hidden,
+        unread: unreadIds.includes(menu.agentId),
+        hasSelectAgent: Boolean(menu.sessions && menu.sessions.length > 0),
+        canCopyId:
+          menu.kind === 'cli' || menu.kind === 'remote'
+            ? Boolean(copyableConversationId(menu.kind, menu.agentId, menu.entityId))
+            : true,
+      })
+    : []
+
   const renderAgentRow = (agent: SidebarAgent, hidden: boolean, spillSlot?: number) => {
     const name = agentLabel(agent)
     const herdr = isHerdrAgent(agent)
@@ -1171,7 +1496,7 @@ export default function AgentSidebar({
           onDragOver={(event) => allowRowDrop(event, agent.id)}
           onDrop={(event) => dropReorder(event, agent.id)}
           onClick={pickOrClose}
-          onContextMenu={(event) => openMenu(event, agent.id, name, hidden)}
+          {...rowMenuHandlers(agent.id, name, hidden, isHerdrAgent(agent) ? 'remote' : 'api')}
         >
           {body}
         </a>
@@ -1183,7 +1508,12 @@ export default function AgentSidebar({
       onDragEnd: finishDrag,
       onDragOver: (event: ReactDragEvent) => allowRowDrop(event, agent.id),
       onDrop: (event: ReactDragEvent) => dropReorder(event, agent.id),
-      onContextMenu: (event: ReactMouseEvent) => openMenu(event, agent.id, name, hidden),
+      ...rowMenuHandlers(
+        agent.id,
+        name,
+        hidden,
+        isCliRailAgent(agent) ? 'cli' : isHerdrAgent(agent) ? 'remote' : 'api',
+      ),
     }
 
     if (scaleOut) {
@@ -1283,7 +1613,7 @@ export default function AgentSidebar({
             openGroupPicker(name, sessions)
           }
         }}
-        onContextMenu={(event) => openMenu(event, hideId, name, hidden, 'team', sessions)}
+        {...rowMenuHandlers(hideId, name, hidden, 'team', sessions, team.id)}
       >
         <span className="os-agent-row__avatar-slot relative inline-flex shrink-0 items-center justify-center">
           {totalMembers >= 2 ? (
@@ -1444,7 +1774,7 @@ export default function AgentSidebar({
             openGroupPicker(name, sessions)
           }
         }}
-        onContextMenu={(event) => openMenu(event, hideId, name, hidden, 'remote', sessions)}
+        {...rowMenuHandlers(hideId, name, hidden, 'remote', sessions, remote.id)}
       >
         <span className="os-agent-row__avatar-slot relative inline-flex shrink-0 items-center justify-center">
           {totalMembers >= 2 ? (
@@ -1802,6 +2132,8 @@ export default function AgentSidebar({
                 )}
               </>
             )
+            const pinKind = resolveMenuKind(pin.id)
+            const pinEntityId = pin.id.replace(/^(team|remote):/, '')
             const pinHandlers = {
               draggable: true as const,
               onDragStart: (event: ReactDragEvent) => beginRowDrag(event, pin),
@@ -1809,17 +2141,14 @@ export default function AgentSidebar({
               onDragOver: (event: ReactDragEvent) => allowRowDrop(event, pin.id),
               onDrop: (event: ReactDragEvent) => dropPinReorder(event, pin.id),
               onClick: pickOrClose,
-              onContextMenu: (event: ReactMouseEvent) => {
-                event.preventDefault()
-                setMenu({
-                  agentId: pin.id,
-                  agentName: pinName,
-                  hidden: resolvedHiddenIds.includes(pin.id),
-                  pinned: true,
-                  x: event.clientX,
-                  y: event.clientY,
-                })
-              },
+              ...rowMenuHandlers(
+                pin.id,
+                pinName,
+                resolvedHiddenIds.includes(pin.id),
+                pinKind,
+                undefined,
+                pinEntityId,
+              ),
             }
             if (isHerdrAgent(pin)) {
               return (
@@ -2098,90 +2427,32 @@ export default function AgentSidebar({
       />
 
       {menu && (
-        <div
-          ref={menuRef}
-          role="menu"
-          aria-label={`Actions for ${menu.agentName}`}
-          className="fixed z-50 min-w-[12.5rem] rounded-lg border border-base-300 bg-neutral py-1 text-sm shadow-xl"
-          style={{ left: menu.x, top: menu.y }}
-        >
-          {menu.sessions && menu.sessions.length > 0 && (
-            <button
-              type="button"
-              role="menuitem"
-              className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-base-300/50"
-              onClick={() => {
-                const s = menu.sessions!
-                const title = menu.agentName
-                closeMenu()
-                openGroupPicker(title, s)
-              }}
-            >
-              <Users className="h-4 w-4" aria-hidden="true" />
-              Select Agent
-            </button>
-          )}
-          {menu.hidden ? (
-            <button
-              type="button"
-              role="menuitem"
-              className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-base-300/50"
-              onClick={() => unhideAgent(menu.agentId)}
-            >
-              <Eye className="h-4 w-4" aria-hidden="true" />
-              Unhide
-            </button>
-          ) : (
-            <button
-              type="button"
-              role="menuitem"
-              className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-base-300/50"
-              onClick={() => hideAgent(menu.agentId)}
-            >
-              <EyeOff className="h-4 w-4" aria-hidden="true" />
-              Hide from sidebar
-            </button>
-          )}
-          <button
-            type="button"
-            role="menuitem"
-            className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-base-300/50"
-            onClick={() => {
-              if (unreadIds.includes(menu.agentId)) {
-                setUnreadIds(markAgentRead(menu.agentId))
-              } else {
-                setUnreadIds(markAgentUnread(menu.agentId))
-              }
-              closeMenu()
-            }}
-          >
-            <Circle className="h-4 w-4" aria-hidden="true" />
-            {unreadIds.includes(menu.agentId) ? 'Mark as read' : 'Mark as unread'}
-          </button>
-          <button
-            type="button"
-            role="menuitem"
-            className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-base-300/50"
-            onClick={() => openAgentSettings({ id: menu.agentId, name: menu.agentName })}
-          >
-            <Pencil className="h-4 w-4" aria-hidden="true" />
-            Edit agent
-          </button>
-          <button
-            type="button"
-            role="menuitem"
-            className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-base-300/50"
-            onClick={() => togglePin({ id: menu.agentId, name: menu.agentName })}
-          >
-            {menu.pinned ? (
-              <PinOff className="h-4 w-4" aria-hidden="true" />
-            ) : (
-              <Pin className="h-4 w-4" aria-hidden="true" />
-            )}
-            {menu.pinned ? 'Unpin' : 'Pin'}
-          </button>
-        </div>
+        <RailContextMenu
+          agentName={menu.agentName}
+          x={menu.x}
+          y={menu.y}
+          items={menuItems}
+          menuRef={menuRef}
+          onSelect={handleMenuSelect}
+        />
       )}
+      <ConfirmModal
+        isOpen={Boolean(deleteConfirm)}
+        onClose={() => setDeleteConfirm(null)}
+        onConfirm={confirmDeleteRow}
+        title={`Delete ${deleteConfirm?.agentName ?? 'agent'}?`}
+        confirmText="Delete"
+        cancelText="Cancel"
+        confirmVariant="error"
+      >
+        <p>
+          {deleteConfirm?.kind === 'cli'
+            ? 'This removes the CLI agent from the rail. It does not uninstall the CLI on this machine.'
+            : deleteConfirm?.kind === 'remote'
+              ? 'This removes the configured remote from swarm. It does not change the far-side host.'
+              : 'This deletes the local entity and removes it from the rail. This cannot be undone from Hidden Bots.'}
+        </p>
+      </ConfirmModal>
       <AddAgentWizard
         isOpen={addWizardOpen}
         onClose={() => setAddWizardOpen(false)}

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -2436,23 +2436,25 @@ export default function AgentSidebar({
           onSelect={handleMenuSelect}
         />
       )}
-      <ConfirmModal
-        isOpen={Boolean(deleteConfirm)}
-        onClose={() => setDeleteConfirm(null)}
-        onConfirm={confirmDeleteRow}
-        title={`Delete ${deleteConfirm?.agentName ?? 'agent'}?`}
-        confirmText="Delete"
-        cancelText="Cancel"
-        confirmVariant="error"
-      >
-        <p>
-          {deleteConfirm?.kind === 'cli'
-            ? 'This removes the CLI agent from the rail. It does not uninstall the CLI on this machine.'
-            : deleteConfirm?.kind === 'remote'
-              ? 'This removes the configured remote from swarm. It does not change the far-side host.'
-              : 'This deletes the local entity and removes it from the rail. This cannot be undone from Hidden Bots.'}
-        </p>
-      </ConfirmModal>
+      {deleteConfirm && (
+        <ConfirmModal
+          isOpen
+          onClose={() => setDeleteConfirm(null)}
+          onConfirm={confirmDeleteRow}
+          title={`Delete ${deleteConfirm.agentName}?`}
+          confirmText="Delete"
+          cancelText="Cancel"
+          confirmVariant="error"
+        >
+          <p>
+            {deleteConfirm.kind === 'cli'
+              ? 'This removes the CLI agent from the rail. It does not uninstall the CLI on this machine.'
+              : deleteConfirm.kind === 'remote'
+                ? 'This removes the configured remote from swarm. It does not change the far-side host.'
+                : 'This deletes the local entity and removes it from the rail. This cannot be undone from Hidden Bots.'}
+          </p>
+        </ConfirmModal>
+      )}
       <AddAgentWizard
         isOpen={addWizardOpen}
         onClose={() => setAddWizardOpen(false)}

--- a/webui/frontend/src/components/RailContextMenu.tsx
+++ b/webui/frontend/src/components/RailContextMenu.tsx
@@ -1,0 +1,114 @@
+import { Fragment, type Ref } from 'react'
+import type { LucideIcon } from 'lucide-react'
+import {
+  Circle,
+  ClipboardCopy,
+  CopyPlus,
+  Eye,
+  EyeOff,
+  Pencil,
+  Pin,
+  PinOff,
+  Trash2,
+  Users,
+} from 'lucide-react'
+import type { RailMenuItemId, RailMenuItemSpec } from '../lib/railContextMenu'
+
+const ICONS: Record<RailMenuItemId, LucideIcon> = {
+  'select-agent': Users,
+  unpin: PinOff,
+  pin: Pin,
+  unread: Circle,
+  edit: Pencil,
+  duplicate: CopyPlus,
+  'copy-id': ClipboardCopy,
+  hide: EyeOff,
+  unhide: Eye,
+  delete: Trash2,
+}
+
+export interface RailMenuItemProps {
+  spec: RailMenuItemSpec
+  onSelect: (id: RailMenuItemId) => void
+}
+
+/** Shared icon+label row for rail / section / compacted-card menus (REQ-82). */
+export function RailMenuItem({ spec, onSelect }: RailMenuItemProps) {
+  const Icon = ICONS[spec.id]
+  const danger = Boolean(spec.danger)
+  return (
+    <li className={spec.disabled ? 'disabled' : undefined}>
+      <button
+        type="button"
+        role="menuitem"
+        disabled={spec.disabled}
+        title={spec.reason}
+        data-menu-id={spec.id}
+        className={danger ? 'text-error' : undefined}
+        onClick={() => {
+          if (spec.disabled) return
+          onSelect(spec.id)
+        }}
+      >
+        <Icon
+          className={`h-4 w-4 ${danger ? 'text-error' : ''}`}
+          aria-hidden="true"
+          data-menu-icon={spec.id}
+        />
+        {spec.label}
+      </button>
+    </li>
+  )
+}
+
+export interface RailContextMenuProps {
+  agentName: string
+  x: number
+  y: number
+  items: RailMenuItemSpec[]
+  menuRef?: Ref<HTMLUListElement>
+  onSelect: (id: RailMenuItemId) => void
+}
+
+export default function RailContextMenu({
+  agentName,
+  x,
+  y,
+  items,
+  menuRef,
+  onSelect,
+}: RailContextMenuProps) {
+  const groups: RailMenuItemSpec[][] = []
+  for (const item of items) {
+    const last = groups[groups.length - 1]
+    if (!last || last[0].group !== item.group) {
+      groups.push([item])
+    } else {
+      last.push(item)
+    }
+  }
+
+  return (
+    <ul
+      ref={menuRef}
+      role="menu"
+      aria-label={`Actions for ${agentName}`}
+      className="menu menu-sm rounded-box fixed z-50 min-w-52 border border-base-300 bg-base-100 p-1 shadow-xl"
+      style={{ left: x, top: y }}
+      data-testid="rail-context-menu"
+    >
+      {groups.map((group, index) => (
+        <Fragment key={group[0].id}>
+          {index > 0 ? (
+            <li aria-hidden="true" className="pointer-events-none px-2 py-0.5">
+              <hr className="border-base-300" />
+            </li>
+          ) : null}
+          {group.map((spec) => (
+            <RailMenuItem key={spec.id} spec={spec} onSelect={onSelect} />
+          ))}
+        </Fragment>
+      ))}
+    </ul>
+  )
+}

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -349,7 +349,7 @@ describe('AgentSidebar Grok rail', () => {
     const list = await screen.findByRole('navigation', { name: 'Agent list' })
     const codey = await within(list).findByRole('link', { name: /Codey/ })
     fireEvent.contextMenu(codey)
-    fireEvent.click(await screen.findByRole('menuitem', { name: /^Edit agent$/i }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /^Edit Profile$/i }))
     expect(opened).toEqual([{ agentId: 'codey', agentName: 'Codey' }])
     window.removeEventListener('swarm:open-agent-editor', onOpen)
   })
@@ -661,7 +661,7 @@ describe('AgentSidebar Grok rail', () => {
     window.removeEventListener('swarm:open-settings', onOpen)
   })
 
-  it('reveals a focusable hover-edit on role rows and opens the agent editor via Enter', async () => {
+  it('has no hover-edit pencil on role rows; Edit Profile on the context menu opens the agent editor', async () => {
     // REQ-26 first-load seed hides gate/skeptic; show all roles for this check.
     localStorage.setItem(HIDDEN_AGENTS_STORAGE_KEY, JSON.stringify([]))
     const opened: Array<{ agentId?: string }> = []
@@ -672,15 +672,15 @@ describe('AgentSidebar Grok rail', () => {
     renderSidebar()
 
     const list = await screen.findByRole('navigation', { name: 'Agent list' })
-    const supportEdit = await screen.findByRole('button', { name: 'Edit Support' })
-    expect(screen.getByRole('button', { name: 'Edit Gate' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Edit Skeptic' })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Edit Codey' })).not.toBeInTheDocument()
+    const support = await within(list).findByRole('link', { name: /Support/ })
+    expect(screen.queryByRole('button', { name: 'Edit Support' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Edit Gate' })).not.toBeInTheDocument()
+    expect(document.querySelector('.os-agent-edit')).not.toBeInTheDocument()
     expect(within(list).queryByRole('menuitem', { name: /Hide all/i })).not.toBeInTheDocument()
 
-    supportEdit.focus()
-    fireEvent.keyDown(supportEdit, { key: 'Enter' })
-    expect(opened).toEqual([{ agentId: 'support' }])
+    fireEvent.contextMenu(support)
+    fireEvent.click(await screen.findByRole('menuitem', { name: /^Edit Profile$/i }))
+    expect(opened).toEqual([{ agentId: 'support', agentName: 'Support' }])
     window.removeEventListener('swarm:open-agent-editor', onOpen)
   })
 

--- a/webui/frontend/src/components/__tests__/RailContextMenu.test.tsx
+++ b/webui/frontend/src/components/__tests__/RailContextMenu.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import RailContextMenu from '../RailContextMenu'
+import { railMenuItems } from '../../lib/railContextMenu'
+
+describe('RailContextMenu (REQ-82)', () => {
+  it('renders an icon on every item and styles Delete last as danger/red', () => {
+    const items = railMenuItems({
+      kind: 'api',
+      pinned: true,
+      hidden: false,
+      unread: false,
+    })
+    const onSelect = vi.fn()
+    render(
+      <RailContextMenu agentName="Codey" x={12} y={24} items={items} onSelect={onSelect} />,
+    )
+
+    const menu = screen.getByRole('menu', { name: 'Actions for Codey' })
+    expect(menu).toHaveClass('menu')
+    const menuitems = within(menu).getAllByRole('menuitem')
+    expect(menuitems.map((el) => el.textContent)).toEqual([
+      'Unpin',
+      'Mark as unread',
+      'Edit Profile',
+      'Duplicate',
+      'Copy conversation ID',
+      'Hide from sidebar',
+      'Delete',
+    ])
+    for (const item of menuitems) {
+      expect(item.querySelector('[data-menu-icon]')).toBeTruthy()
+    }
+    const del = menuitems.at(-1)!
+    expect(del).toHaveClass('text-error')
+    expect(del.querySelector('[data-menu-icon="delete"]')).toHaveClass('text-error')
+    fireEvent.click(del)
+    expect(onSelect).toHaveBeenCalledWith('delete')
+  })
+
+  it('omits Edit Profile and Duplicate on CLI menus', () => {
+    const items = railMenuItems({
+      kind: 'cli',
+      pinned: false,
+      hidden: false,
+      unread: false,
+      canCopyId: false,
+    })
+    render(
+      <RailContextMenu agentName="cli_agent" x={0} y={0} items={items} onSelect={() => undefined} />,
+    )
+    expect(screen.queryByRole('menuitem', { name: /Edit Profile/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: /Duplicate/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /Copy conversation ID/i })).toBeDisabled()
+    const menuitems = screen.getAllByRole('menuitem')
+    expect(menuitems.at(-1)).toHaveTextContent('Delete')
+    expect(menuitems.at(-1)).toHaveClass('text-error')
+  })
+})

--- a/webui/frontend/src/components/__tests__/RailContextMenuReq82.test.tsx
+++ b/webui/frontend/src/components/__tests__/RailContextMenuReq82.test.tsx
@@ -1,0 +1,305 @@
+import { createEvent, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import AgentSidebar from '../AgentSidebar'
+import { HIDDEN_AGENTS_STORAGE_KEY } from '../../lib/hiddenAgents'
+import { PINNED_AGENTS_STORAGE_KEY } from '../../lib/pinnedAgents'
+import { DELETED_RAIL_IDS_KEY } from '../../lib/deletedRailIds'
+
+const blueprints = [
+  {
+    id: 'codey',
+    object: 'blueprint' as const,
+    name: 'Codey',
+    description: 'Code assistant',
+    abbreviation: null,
+    required_mcp_servers: [] as string[],
+    tags: [] as string[],
+    installed: true,
+    compiled: true,
+  },
+  {
+    id: 'stewie',
+    object: 'blueprint' as const,
+    name: 'Stewie',
+    description: 'Helpful agent',
+    abbreviation: null,
+    required_mcp_servers: [] as string[],
+    tags: [] as string[],
+    installed: true,
+    compiled: true,
+  },
+]
+
+function mockFetch() {
+  return vi.fn().mockImplementation(async (input: RequestInfo, init?: RequestInit) => {
+    const url = String(input)
+    const method = (init?.method || 'GET').toUpperCase()
+    if (url.includes('/v1/preferences')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          object: 'user_preferences',
+          principal: 'session:test',
+          guest: true,
+          empty: true,
+          favourites: [],
+          hidden_agents: [],
+        }),
+      } as Response
+    }
+    if (url.includes('team_rosters') || url.includes('team-rosters')) {
+      if (method === 'POST') {
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({
+            object: 'team_roster',
+            id: 'research-copy',
+            name: 'Research copy',
+            members: [],
+            wires: { handoff: true, as_tool: true },
+          }),
+        } as Response
+      }
+      if (method === 'DELETE') {
+        return { ok: true, status: 204, json: async () => ({}) } as Response
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          object: 'list',
+          data: [
+            {
+              id: 'research',
+              object: 'team_roster',
+              name: 'Research',
+              members: [{ id: 'ada', kind: 'api', role: 'default', source: 'blueprint:ada' }],
+              wires: { handoff: true, as_tool: true },
+            },
+          ],
+        }),
+      } as Response
+    }
+    if (url.includes('/v1/cli-agents')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          clis: ['grok'],
+          native_consensus: {},
+          catalog: {},
+          rail: [
+            {
+              id: 'cli_agent',
+              object: 'cli.agent',
+              name: 'cli_agent',
+              cli: 'grok',
+              kind: 'cli',
+              description: 'Host CLI',
+              installed: true,
+            },
+            {
+              id: 'api_agent',
+              object: 'cli.agent',
+              name: 'api_agent',
+              cli: '',
+              kind: 'api',
+              description: 'LiteLLM',
+              installed: true,
+            },
+          ],
+        }),
+      } as Response
+    }
+    if (url.includes('/v1/remotes')) {
+      if (method === 'POST') {
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({
+            id: 'omb-copy',
+            kind: 'omb',
+            title: 'OpenMousBot copy',
+            base_url: 'http://localhost:9',
+            source: 'user',
+          }),
+        } as Response
+      }
+      if (method === 'DELETE') {
+        return { ok: true, status: 204, json: async () => ({}) } as Response
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          object: 'list',
+          data: [
+            {
+              id: 'omb',
+              kind: 'omb',
+              title: 'OpenMousBot',
+              source: 'user',
+              configured: true,
+              base_url: 'http://localhost:9',
+              agents: [{ id: 'cos', name: 'Pat' }],
+            },
+          ],
+        }),
+      } as Response
+    }
+    if (url.includes('/v1/herdr-agents')) {
+      return { ok: true, status: 200, json: async () => ({ object: 'list', data: [] }) } as Response
+    }
+    if (url.includes('/v1/blueprints/custom') && method === 'POST') {
+      return {
+        ok: true,
+        status: 201,
+        json: async () => ({
+          id: 'codey-copy',
+          name: 'Codey copy',
+          description: 'Copy of Codey',
+          category: 'ai_assistants',
+          tags: ['api'],
+          code: '# copy',
+        }),
+      } as Response
+    }
+    if (url.includes('/v1/blueprints/custom') && method === 'DELETE') {
+      return { ok: true, status: 204, json: async () => ({}) } as Response
+    }
+    return { ok: true, status: 200, json: async () => ({ object: 'list', data: blueprints }) } as Response
+  })
+}
+
+function renderSidebar() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/chat']}>
+        <AgentSidebar open onClose={() => undefined} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('REQ-82 rail right-click menu', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem(PINNED_AGENTS_STORAGE_KEY, '[]')
+    localStorage.setItem(HIDDEN_AGENTS_STORAGE_KEY, JSON.stringify([]))
+    vi.stubGlobal('fetch', mockFetch())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    localStorage.clear()
+  })
+
+  it('opens a DaisyUI menu on right-click and prevents the browser default', async () => {
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const codey = await within(list).findByRole('link', { name: /Codey/ })
+    const evt = createEvent.contextMenu(codey)
+    fireEvent(codey, evt)
+    expect(evt.defaultPrevented).toBe(true)
+    const menu = await screen.findByRole('menu', { name: 'Actions for Codey' })
+    expect(menu).toHaveClass('menu')
+    expect(document.querySelector('.os-agent-edit')).not.toBeInTheDocument()
+  })
+
+  it('opens the same menu from Shift+F10 on a focused row', async () => {
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const codey = await within(list).findByRole('link', { name: /Codey/ })
+    codey.focus()
+    fireEvent.keyDown(codey, { key: 'F10', shiftKey: true })
+    expect(await screen.findByRole('menu', { name: 'Actions for Codey' })).toBeInTheDocument()
+  })
+
+  it('requires confirm for Delete and keeps Delete last / danger', async () => {
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const codey = await within(list).findByRole('link', { name: /Codey/ })
+    fireEvent.contextMenu(codey)
+    const menu = await screen.findByRole('menu', { name: 'Actions for Codey' })
+    const items = within(menu).getAllByRole('menuitem')
+    expect(items.at(-1)).toHaveTextContent('Delete')
+    expect(items.at(-1)).toHaveClass('text-error')
+    fireEvent.click(items.at(-1)!)
+    const dialog = await screen.findByRole('dialog', { name: /Delete Codey/i })
+    expect(within(list).getByRole('link', { name: /Codey/ })).toBeInTheDocument()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+    expect(within(list).getByRole('link', { name: /Codey/ })).toBeInTheDocument()
+
+    fireEvent.contextMenu(codey)
+    fireEvent.click(await screen.findByRole('menuitem', { name: /^Delete$/i }))
+    fireEvent.click(within(await screen.findByRole('dialog', { name: /Delete Codey/i })).getByRole('button', { name: 'Delete' }))
+    await waitFor(() => {
+      expect(within(list).queryByRole('link', { name: /Codey/ })).not.toBeInTheDocument()
+    })
+    expect(JSON.parse(localStorage.getItem(DELETED_RAIL_IDS_KEY) || '[]')).toContain('codey')
+  })
+
+  it('opens the agent editor for API Edit Profile and the remotes sheet for remotes', async () => {
+    const opened: Array<Record<string, unknown>> = []
+    const onOpen = (event: Event) => {
+      opened.push((event as CustomEvent).detail || {})
+    }
+    window.addEventListener('swarm:open-agent-editor', onOpen)
+    window.addEventListener('swarm:open-settings', onOpen)
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+
+    fireEvent.contextMenu(await within(list).findByRole('link', { name: /Codey/ }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /^Edit Profile$/i }))
+    expect(opened).toContainEqual({ agentId: 'codey', agentName: 'Codey' })
+
+    opened.length = 0
+    fireEvent.contextMenu(await within(list).findByRole('link', { name: /Research \(team\)/ }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /^Edit Profile$/i }))
+    expect(opened).toContainEqual({
+      section: 'definition',
+      definitionKind: 'team',
+      definitionId: 'research',
+      teamId: 'research',
+    })
+
+    opened.length = 0
+    fireEvent.contextMenu(await within(list).findByRole('link', { name: /OpenMousBot \(remote\)/ }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /^Edit Profile$/i }))
+    expect(opened).toContainEqual({ section: 'remotes' })
+
+    fireEvent.contextMenu(await within(list).findByRole('link', { name: /cli_agent/ }))
+    expect(screen.queryByRole('menuitem', { name: /^Edit Profile$/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: /^Duplicate$/i })).not.toBeInTheDocument()
+    window.removeEventListener('swarm:open-agent-editor', onOpen)
+    window.removeEventListener('swarm:open-settings', onOpen)
+  })
+
+  it('copies the stored conversation id via the mocked clipboard', async () => {
+    localStorage.setItem('swarm_agent_chat:codey', 'conv-codey-99')
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    fireEvent.contextMenu(await within(list).findByRole('link', { name: /Codey/ }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Copy conversation ID/i }))
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('conv-codey-99')
+    })
+  })
+
+  it('still hides from the sidebar via the menu', async () => {
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    fireEvent.contextMenu(await within(list).findByRole('link', { name: /Stewie/ }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: /Hide from sidebar/i }))
+    await waitFor(() => {
+      expect(within(list).queryByRole('link', { name: /Stewie/ })).not.toBeInTheDocument()
+    })
+  })
+})

--- a/webui/frontend/src/lib/__tests__/agentChat.test.ts
+++ b/webui/frontend/src/lib/__tests__/agentChat.test.ts
@@ -8,6 +8,7 @@ import {
   conversationIdForTask,
   fetchAgentThread,
   listTaskSessions,
+  peekConversationIdForAgent,
 } from '../agentChat'
 
 describe('agentIdFromBlueprint', () => {
@@ -29,6 +30,12 @@ describe('conversationIdForAgent', () => {
     const second = conversationIdForAgent('codey')
     expect(first).toBe(second)
     expect(conversationIdForAgent('other')).not.toBe(first)
+  })
+
+  it('peeks a stored id without minting', () => {
+    expect(peekConversationIdForAgent('codey')).toBeNull()
+    const minted = conversationIdForAgent('codey')
+    expect(peekConversationIdForAgent('codey')).toBe(minted)
   })
 
   it('reuses the stored id when new chat per task is off', () => {

--- a/webui/frontend/src/lib/__tests__/deletedRailIds.test.ts
+++ b/webui/frontend/src/lib/__tests__/deletedRailIds.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  DELETED_RAIL_IDS_KEY,
+  isRailIdDeleted,
+  loadDeletedRailIds,
+  markRailIdDeleted,
+} from '../deletedRailIds'
+
+describe('deletedRailIds (REQ-82)', () => {
+  afterEach(() => {
+    localStorage.removeItem(DELETED_RAIL_IDS_KEY)
+  })
+
+  it('persists deleted ids and reports membership', () => {
+    expect(loadDeletedRailIds()).toEqual([])
+    const next = markRailIdDeleted('codey')
+    expect(next).toEqual(['codey'])
+    expect(isRailIdDeleted('codey')).toBe(true)
+    expect(isRailIdDeleted('stewie')).toBe(false)
+    expect(JSON.parse(localStorage.getItem(DELETED_RAIL_IDS_KEY) || '[]')).toEqual(['codey'])
+  })
+})

--- a/webui/frontend/src/lib/__tests__/railContextMenu.test.ts
+++ b/webui/frontend/src/lib/__tests__/railContextMenu.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { conversationIdForAgent } from '../agentChat'
+import {
+  RAIL_MENU_REASONS,
+  copyableConversationId,
+  duplicateName,
+  isRailMenuKey,
+  railMenuItems,
+} from '../railContextMenu'
+
+describe('railMenuItems (REQ-82)', () => {
+  const base = {
+    pinned: false,
+    hidden: false,
+    unread: false,
+  }
+
+  it('puts red Delete last and includes Unpin only when pinned', () => {
+    const unpinned = railMenuItems({ ...base, kind: 'api' })
+    expect(unpinned.map((item) => item.id)).toEqual([
+      'pin',
+      'unread',
+      'edit',
+      'duplicate',
+      'copy-id',
+      'hide',
+      'delete',
+    ])
+    expect(unpinned.at(-1)).toMatchObject({ id: 'delete', danger: true, label: 'Delete' })
+    expect(unpinned.some((item) => item.id === 'unpin')).toBe(false)
+
+    const pinned = railMenuItems({ ...base, kind: 'api', pinned: true })
+    expect(pinned[0]).toMatchObject({ id: 'unpin', label: 'Unpin' })
+    expect(pinned.some((item) => item.id === 'pin')).toBe(false)
+    expect(pinned.at(-1)?.id).toBe('delete')
+  })
+
+  it('omits Edit Profile and Duplicate for CLI (honest, not grey lies)', () => {
+    const items = railMenuItems({ ...base, kind: 'cli' })
+    expect(items.map((item) => item.id)).toEqual(['pin', 'unread', 'copy-id', 'hide', 'delete'])
+    expect(items.find((item) => item.id === 'edit')).toBeUndefined()
+    expect(items.find((item) => item.id === 'duplicate')).toBeUndefined()
+    expect(RAIL_MENU_REASONS.cliNoProfile).toMatch(/no swarm-owned profile/i)
+  })
+
+  it('keeps Edit / Duplicate for API, team, and remote', () => {
+    for (const kind of ['api', 'team', 'remote'] as const) {
+      const ids = railMenuItems({ ...base, kind }).map((item) => item.id)
+      expect(ids).toContain('edit')
+      expect(ids).toContain('duplicate')
+      expect(ids.at(-1)).toBe('delete')
+    }
+  })
+
+  it('disables Copy conversation ID when no swarm-side id exists', () => {
+    const items = railMenuItems({ ...base, kind: 'cli', canCopyId: false })
+    const copy = items.find((item) => item.id === 'copy-id')
+    expect(copy?.disabled).toBe(true)
+    expect(copy?.reason).toBe(RAIL_MENU_REASONS.noConversationId)
+  })
+})
+
+describe('copyableConversationId / isRailMenuKey', () => {
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('returns a stored API conversation id and mints when missing', () => {
+    localStorage.setItem('swarm_agent_chat:codey', 'conv-codey-1')
+    expect(copyableConversationId('api', 'codey')).toBe('conv-codey-1')
+    expect(copyableConversationId('api', 'stewie')).toBe(conversationIdForAgent('stewie'))
+  })
+
+  it('disables CLI/remote copy when no swarm-side id exists', () => {
+    expect(copyableConversationId('cli', 'cli_agent')).toBeNull()
+    expect(copyableConversationId('remote', 'remote:omb', 'omb')).toBeNull()
+  })
+
+  it('treats Shift+F10 and ContextMenu as menu keys', () => {
+    expect(isRailMenuKey({ key: 'F10', shiftKey: true })).toBe(true)
+    expect(isRailMenuKey({ key: 'ContextMenu', shiftKey: false })).toBe(true)
+    expect(isRailMenuKey({ key: 'F10', shiftKey: false })).toBe(false)
+    expect(isRailMenuKey({ key: 'Enter', shiftKey: true })).toBe(false)
+  })
+
+  it('appends copy to a display name', () => {
+    expect(duplicateName('Codey')).toBe('Codey copy')
+  })
+})

--- a/webui/frontend/src/lib/agentChat.ts
+++ b/webui/frontend/src/lib/agentChat.ts
@@ -22,15 +22,28 @@ export function agentIdFromBlueprint(blueprintId: string | null | undefined): st
 
 /** Stable per-agent conversation id (localStorage). Survives reload. */
 export function conversationIdForAgent(agentId: string): string {
+  const existing = peekConversationIdForAgent(agentId)
+  if (existing) return existing
+  const minted = newConversationId()
+  try {
+    window.localStorage.setItem(
+      `${STORAGE_PREFIX}${agentIdFromBlueprint(agentId)}`,
+      minted,
+    )
+  } catch {
+    /* private mode / quota */
+  }
+  return minted
+}
+
+/** Stored conversation id only — does not mint. REQ-82 copy-id. */
+export function peekConversationIdForAgent(agentId: string): string | null {
   const key = `${STORAGE_PREFIX}${agentIdFromBlueprint(agentId)}`
   try {
     const existing = window.localStorage.getItem(key)
-    if (existing) return existing
-    const minted = newConversationId()
-    window.localStorage.setItem(key, minted)
-    return minted
+    return existing && existing.trim() ? existing : null
   } catch {
-    return newConversationId()
+    return null
   }
 }
 

--- a/webui/frontend/src/lib/api.ts
+++ b/webui/frontend/src/lib/api.ts
@@ -143,6 +143,20 @@ export async function apiPatch<T>(path: string, body: unknown): Promise<T> {
   return (await response.json()) as T
 }
 
+export async function apiPut<T>(path: string, body: unknown): Promise<T> {
+  const response = await fetch(path, {
+    method: 'PUT',
+    headers: buildHeaders(true),
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    await throwApiError(path, response)
+  }
+
+  return (await response.json()) as T
+}
+
 export async function apiPost<T>(path: string, body: unknown): Promise<T> {
   const response = await fetch(path, {
     method: 'POST',
@@ -388,6 +402,32 @@ export interface TeamRosterRecord {
 
 export function fetchTeamRosters(): Promise<ListResponse<TeamRosterRecord>> {
   return apiGet<ListResponse<TeamRosterRecord>>('/v1/team-rosters/')
+}
+
+export interface CreateTeamRosterRequest {
+  name: string
+  members?: TeamRosterRecord['members']
+  wires?: TeamRosterRecord['wires']
+}
+
+export function createTeamRoster(
+  roster: CreateTeamRosterRequest,
+): Promise<TeamRosterRecord> {
+  return apiPost<TeamRosterRecord>('/v1/team-rosters/', roster)
+}
+
+export function updateTeamRoster(
+  rosterId: string,
+  roster: CreateTeamRosterRequest,
+): Promise<TeamRosterRecord> {
+  return apiPut<TeamRosterRecord>(
+    `/v1/team-rosters/${encodeURIComponent(rosterId)}/`,
+    roster,
+  )
+}
+
+export function deleteTeamRoster(rosterId: string): Promise<void> {
+  return apiDelete(`/v1/team-rosters/${encodeURIComponent(rosterId)}/`)
 }
 
 export function createTeam(team: CreateTeamRequest): Promise<Team> {

--- a/webui/frontend/src/lib/deletedRailIds.ts
+++ b/webui/frontend/src/lib/deletedRailIds.ts
@@ -1,0 +1,45 @@
+/**
+ * REQ-82: Delete is stronger than Hide. Deleted rail ids leave both the
+ * conversation list and Hidden Bots. Persistence is localStorage, same
+ * best-effort pattern as hidden / pinned.
+ */
+
+export const DELETED_RAIL_IDS_KEY = 'swarm_deleted_rail_ids'
+
+export function parseDeletedRailIds(raw: string | null): string[] {
+  if (!raw) return []
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((id): id is string => typeof id === 'string' && id.length > 0)
+  } catch {
+    return []
+  }
+}
+
+export function loadDeletedRailIds(): string[] {
+  try {
+    return parseDeletedRailIds(localStorage.getItem(DELETED_RAIL_IDS_KEY))
+  } catch {
+    return []
+  }
+}
+
+export function saveDeletedRailIds(ids: string[]): string[] {
+  const unique = Array.from(new Set(ids.filter((id) => id.length > 0)))
+  try {
+    localStorage.setItem(DELETED_RAIL_IDS_KEY, JSON.stringify(unique))
+  } catch {
+    /* persistence is best-effort */
+  }
+  return unique
+}
+
+export function markRailIdDeleted(id: string, current: string[] = loadDeletedRailIds()): string[] {
+  if (!id || current.includes(id)) return current
+  return saveDeletedRailIds([...current, id])
+}
+
+export function isRailIdDeleted(id: string, current: string[] = loadDeletedRailIds()): boolean {
+  return Boolean(id) && current.includes(id)
+}

--- a/webui/frontend/src/lib/railContextMenu.ts
+++ b/webui/frontend/src/lib/railContextMenu.ts
@@ -1,0 +1,157 @@
+/**
+ * REQ-82: Agent-rail context menu item contract.
+ *
+ * Visibility is honest per kind — omit Edit/Duplicate on CLI rather than
+ * showing a disabled grey lie. Delete is always last and danger-styled.
+ */
+
+import { conversationIdForAgent, peekConversationIdForAgent } from './agentChat'
+import { loadAgentChatSessions } from './agentChatSessions'
+import { teamThreadId } from './teamRosters'
+
+export const RAIL_LONG_PRESS_MS = 500
+
+export type RailMenuKind = 'api' | 'cli' | 'team' | 'remote'
+
+export type RailMenuItemId =
+  | 'select-agent'
+  | 'unpin'
+  | 'pin'
+  | 'unread'
+  | 'edit'
+  | 'duplicate'
+  | 'copy-id'
+  | 'hide'
+  | 'unhide'
+  | 'delete'
+
+export interface RailMenuItemSpec {
+  id: RailMenuItemId
+  label: string
+  disabled?: boolean
+  reason?: string
+  danger?: boolean
+  group: number
+}
+
+export interface RailMenuOptions {
+  kind: RailMenuKind
+  pinned: boolean
+  hidden: boolean
+  unread: boolean
+  hasSelectAgent?: boolean
+  canCopyId?: boolean
+}
+
+const CLI_NO_PROFILE = 'CLI agents have no swarm-owned profile'
+const CLI_NO_DUPLICATE = 'CLI agents cannot be duplicated from the rail'
+const NO_CONVERSATION_ID = 'No swarm-side conversation id for this row'
+
+export function isRailMenuKey(event: { key: string; shiftKey: boolean }): boolean {
+  return event.key === 'ContextMenu' || (event.key === 'F10' && event.shiftKey)
+}
+
+export function railMenuItems(opts: RailMenuOptions): RailMenuItemSpec[] {
+  const items: RailMenuItemSpec[] = []
+  if (opts.hasSelectAgent) {
+    items.push({ id: 'select-agent', label: 'Select Agent', group: 0 })
+  }
+  if (opts.pinned) {
+    items.push({ id: 'unpin', label: 'Unpin', group: 1 })
+  } else {
+    items.push({ id: 'pin', label: 'Pin', group: 1 })
+  }
+  items.push({
+    id: 'unread',
+    label: opts.unread ? 'Mark as read' : 'Mark as unread',
+    group: 2,
+  })
+
+  if (opts.kind === 'cli') {
+    // Honest omit — no swarm-owned profile / duplicate.
+  } else {
+    items.push({
+      id: 'edit',
+      label: 'Edit Profile',
+      group: 3,
+    })
+    items.push({
+      id: 'duplicate',
+      label: 'Duplicate',
+      group: 3,
+    })
+  }
+
+  const copyEnabled = opts.canCopyId !== false
+  items.push({
+    id: 'copy-id',
+    label: 'Copy conversation ID',
+    group: 3,
+    disabled: !copyEnabled,
+    reason: copyEnabled ? undefined : NO_CONVERSATION_ID,
+  })
+
+  if (opts.hidden) {
+    items.push({ id: 'unhide', label: 'Unhide', group: 4 })
+  } else {
+    items.push({ id: 'hide', label: 'Hide from sidebar', group: 4 })
+  }
+
+  items.push({
+    id: 'delete',
+    label: 'Delete',
+    group: 5,
+    danger: true,
+  })
+
+  return items
+}
+
+/** CLI-only reasons exported for tests / disabled titles if a caller shows them. */
+export const RAIL_MENU_REASONS = {
+  cliNoProfile: CLI_NO_PROFILE,
+  cliNoDuplicate: CLI_NO_DUPLICATE,
+  noConversationId: NO_CONVERSATION_ID,
+} as const
+
+export function peekStoredConversationId(rowId: string): string | null {
+  if (!rowId) return null
+  const fromChat = peekConversationIdForAgent(rowId)
+  if (fromChat) return fromChat
+  try {
+    const session = loadAgentChatSessions()[rowId]
+    if (session?.conversationId) return session.conversationId
+  } catch {
+    /* jsdom / private mode */
+  }
+  return null
+}
+
+/**
+ * Conversation id to copy for a rail row.
+ *
+ * API / team: always an API-owned id (stored, or minted / team thread id).
+ * CLI / remote: existing swarm-side session id only — otherwise null (disable).
+ */
+export function copyableConversationId(
+  kind: RailMenuKind,
+  railId: string,
+  entityId: string = railId,
+): string | null {
+  const candidates = [railId, entityId]
+  if (kind === 'team' && entityId && !entityId.startsWith('team:')) {
+    candidates.push(teamThreadId(entityId))
+  }
+  for (const id of candidates) {
+    const existing = peekStoredConversationId(id)
+    if (existing) return existing
+  }
+  if (kind === 'cli' || kind === 'remote') return null
+  if (kind === 'team') return teamThreadId(entityId.replace(/^team:/, ''))
+  return conversationIdForAgent(entityId || railId)
+}
+
+export function duplicateName(name: string): string {
+  const trimmed = name.trim() || 'Agent'
+  return `${trimmed} copy`
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #435.

**Feasibility:** Full Success fits one focused SPA PR — the rail already had right-click chrome; this adds the missing items, kind-honest actions, red Delete last, and tests.

## Quoted from #435

**Intent:** Right-click (and the touch equivalent) on a left-rail agent/team/remote row opens a DaisyUI menu. There is no hover pencil. The menu covers unpin, unread, edit, duplicate, copy conversation id, hide, and delete, with edit/delete/duplicate behaving per kind.

**Success:**
1. **Trigger:** Right-click a rail row → custom menu, browser default menu suppressed. Keyboard: focused row + Shift+F10 or the menu key also opens it. Touch: long-press (~500ms) opens the same menu (#374 mobile still applies). Click outside / Esc closes. Chat stays mounted (#364).
2. **Retire pencil:** No hover/focus pencil on rail rows (including the #334 role hover-edit icon). Those actions move into this menu.
3. **Menu items (four groups, matching the mock):**
   - Unpin (only enabled if this row is pinned/favourited; otherwise omit or disable)
   - Mark as unread
   - Edit Profile
   - Duplicate
   - Copy conversation ID
   - Hide from sidebar
   - Delete (danger/red)
4. **Edit Profile by kind:**
   - **API agent:** opens the agent editor (#382).
   - **Team:** opens the team editor / Edit blueprint path (#433 / #382 destination).
   - **CLI agent:** do not pretend there is a swarm-owned profile; omit or disable with a reason, unless an existing CLI settings overlay already exists — then open that.
   - **Remote:** opens that remote’s config (Settings Remotes / #409), not a fake local profile.
   - **Role-wired API agent (gate/skeptic/support):** Edit Profile still opens the **agent** editor; blueprint Python stays reachable from there / Blueprints list, not a second pencil.
5. **Other items by kind (honest, not grey lies):**
   - **Unpin / Hide / Mark as unread:** all kinds that appear in the rail.
   - **Duplicate:** API agent and team copy to a new row (new id, same blueprint). CLI: omit/disable. Remote: duplicate the **configured remote** entry, not the far-side host.
   - **Copy conversation ID:** copies the current chat/session id for that row to the clipboard (API-owned id). CLI/remote: copy the swarm-side session/conversation id if one exists, else disable.
   - **Delete:** confirm. API agent/team: delete local entity. Remote: remove the configured remote (#409). CLI: hide-or-remove from rail only, do not uninstall the CLI. Hidden bots already have Hide (#335/#342/#347); Delete is stronger and must confirm.
6. **Tests:** right-click opens menu and prevents default; pencil absent; Edit Profile on API agent opens agent editor; Edit Profile on team opens team editor; Edit Profile on remote opens remotes config; CLI Edit omitted/disabled; Hide still hides; Delete confirm required; Copy conversation ID writes an id string (mocked clipboard). DaisyUI 5 / React 18. No live host.

**Constraints:**
- Distinct from #334 (hover-edit pencil — this Issue **replaces** that affordance), #335/#342/#347 (hide mechanics; this Issue only adds the menu entry), #382 (agent editor), #409 (opt-in remotes), #433 (team blueprint edit). Do not fold into 344.
- DaisyUI 5 / React 18. Native `contextmenu` + long-press; no extra context-menu library required. Chat stays mounted.
- GitHub-only. No live preview. No Neon. No secrets. Do not screenshot real desktops into the repo.

**Owner:** open-swarm engineer + Cursor cloud (after CoS unblocks). CoS: Open Swarm. Skeptic after the PR (text-only PASS/FAIL).

## What landed

- Shared `RailMenuItem` + DaisyUI `menu` with a leading icon on every row; **Delete is last**, `text-error` on icon and label.
- Kind-honest Edit / Duplicate / Copy id / Delete (CLI omits Edit+Duplicate; CLI Delete removes from the rail only).
- Confirm modal before Delete. Deleted ids leave both the list and Hidden Bots.
- Tests for menu open + preventDefault, Delete last/danger, omit-wrong-items per kind, edit destinations, hide, and mocked clipboard copy.
- Chrome source scans retargeted: REQ-130 locks `rowMenuHandlers` + Select Agent (not the retired `openMenu(event, hideId, …)` string). REQ-72 locks Unpin-when-pinned, Delete, and kind-honest Edit in `railContextMenu.ts`.

Pin remains when the row is not favourited so REQ-5c pin/unpin tests and the existing e2e Unpin flow stay intact. Unpin is omitted unless the row is pinned.

## Tests

- `vitest` REQ-82 files: 21 passed
- Sidebar regressions: editor / pin / unpin / Select Agent / cli_agent list / no hover-edit
- `tests/unit/test_req130_req152_team_cos_manage.py` passed
- `tests/unit/test_req72_chrome_contracts.py` passed
- `tests/unit/test_req173_rail_no_pencils.py` passed

Six `AgentSidebar` tests still look for a `Hidden agents` dialog after Hidden Bots now opens the search palette — same failure against `main`’s `AgentSidebar.tsx`. Product UI was not changed to satisfy those old locks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb2f57f1-b49d-4448-a551-bf44f4aea9c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb2f57f1-b49d-4448-a551-bf44f4aea9c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

