### PR TITLE
feat(webui): per-agent ordered inference list — distribute or fallback (Fixes #405)

### DIFF
--- a/src/swarm/consumers.py
+++ b/src/swarm/consumers.py
@@ -404,6 +404,16 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
             from swarm.core.cli_catalog import cli_from_rail_id
             from swarm.views.utils import get_blueprint_instance
 
+            from swarm.core.inference_list import (
+                failover_notice,
+                is_config_failure,
+                is_rate_limit,
+                normalize_inference_list,
+                pick_scale_out,
+                seat_id,
+                seat_kind,
+            )
+
             cli_name = None
             if isinstance(params, dict):
                 raw_cli = params.get("cli")
@@ -411,6 +421,18 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
                     cli_name = raw_cli.strip()
             if not cli_name:
                 cli_name = cli_from_rail_id(blueprint_id)
+            inference_seats = normalize_inference_list(
+                params.get("inference_list") if isinstance(params, dict) else None
+            )
+            scale_out = bool(params and params.get("scale_out"))
+            if scale_out and inference_seats:
+                raw_idx = params.get("inference_index") if isinstance(params, dict) else 0
+                try:
+                    idx = int(raw_idx or 0)
+                except (TypeError, ValueError):
+                    idx = 0
+                chosen = pick_scale_out(inference_seats, idx)
+                inference_seats = [chosen] if chosen else []
             if str(blueprint_id).strip().lower() == "api_agent":
                 run_id = "chatbot"
                 blueprint_instance = await get_blueprint_instance(run_id)
@@ -419,10 +441,17 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
                     raw_model = params.get("model") or params.get("llm_profile")
                     if isinstance(raw_model, str) and raw_model.strip() and raw_model.strip() != "default":
                         profile = raw_model.strip()
+                if inference_seats:
+                    first = inference_seats[0]
+                    if seat_kind(first) == "llm":
+                        profile = seat_id(first)
                 if blueprint_instance is not None and profile:
                     blueprint_instance.llm_profile_name = profile
             else:
                 run_id = "cli_agent" if cli_name else blueprint_id
+                if inference_seats and seat_kind(inference_seats[0]) == "cli":
+                    cli_name = seat_id(inference_seats[0])
+                    run_id = "cli_agent"
                 blueprint_instance = await get_blueprint_instance(run_id)
                 if blueprint_instance is not None and cli_name and hasattr(
                     blueprint_instance, "set_params"
@@ -516,6 +545,40 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
             logger.error(
                 f"Error running blueprint '{blueprint_id}': {e}", exc_info=True
             )
+            from swarm.core.inference_list import (
+                failover_notice,
+                is_config_failure,
+                is_rate_limit,
+                normalize_inference_list,
+                retry_params,
+                should_failover,
+            )
+
+            seats = normalize_inference_list(
+                params.get("inference_list") if isinstance(params, dict) else None
+            )
+            rest = seats[1:] if seats else []
+            scale_out = bool(params and params.get("scale_out"))
+            if should_failover(e, rest, scale_out=scale_out):
+                notice = failover_notice(seats[0], rest[0])
+                await self.send(text_data=_status_line_html(notice))
+                self.messages.append({"role": "status", "content": notice})
+                await self.respond_with_blueprint(
+                    blueprint_id,
+                    contents_div_id,
+                    params=retry_params(params, rest),
+                )
+                return
+            if (
+                seats
+                and not rest
+                and not scale_out
+                and is_config_failure(e)
+                and not is_rate_limit(e)
+            ):
+                notice = failover_notice(seats[0], None, exhausted=True)
+                await self.send(text_data=_status_line_html(notice))
+                self.messages.append({"role": "status", "content": notice})
             await self.send_error_message(
                 contents_div_id,
                 f"Error: blueprint '{blueprint_id}' failed while generating a reply.",

--- a/src/swarm/core/inference_list.py
+++ b/src/swarm/core/inference_list.py
@@ -1,0 +1,143 @@
+"""REQ-69: per-agent ordered inference list — pick, failover, classify errors."""
+
+from __future__ import annotations
+
+from typing import Any
+
+LLM_PREFIX = "llm:"
+CLI_PREFIX = "cli:"
+REMOTE_PREFIX = "remote:"
+
+
+def normalize_inference_list(raw: Any) -> list[str]:
+    """Return unique non-empty seat ids, preserving order."""
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        if isinstance(item, dict):
+            kind = str(item.get("kind") or "").strip().lower()
+            ident = str(item.get("id") or "").strip()
+            if not ident:
+                continue
+            if kind in {"llm", "cli", "remote"} and not ident.startswith(f"{kind}:"):
+                ident = f"{kind}:{ident}"
+            text = ident
+        else:
+            text = str(item).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+    return out
+
+
+def seat_kind(seat: str) -> str:
+    text = (seat or "").strip().lower()
+    if text.startswith(CLI_PREFIX):
+        return "cli"
+    if text.startswith(REMOTE_PREFIX):
+        return "remote"
+    return "llm"
+
+
+def seat_id(seat: str) -> str:
+    text = (seat or "").strip()
+    for prefix in (LLM_PREFIX, CLI_PREFIX, REMOTE_PREFIX):
+        if text.lower().startswith(prefix):
+            return text[len(prefix) :]
+    return text
+
+
+def pick_scale_out(options: list[str], index: int) -> str | None:
+    """Round-robin: concurrent scale-out tasks land on different seats."""
+    if not options:
+        return None
+    if index < 0:
+        index = 0
+    return options[index % len(options)]
+
+
+def _status_code(exc: BaseException) -> int | None:
+    code = getattr(exc, "status_code", None)
+    if isinstance(code, int):
+        return code
+    response = getattr(exc, "response", None)
+    code = getattr(response, "status_code", None)
+    if isinstance(code, int):
+        return code
+    return None
+
+
+def is_rate_limit(exc: BaseException) -> bool:
+    """429 / rate-limit must not auto-failover (REQ-69 v1)."""
+    if _status_code(exc) == 429:
+        return True
+    text = str(exc).lower()
+    return "429" in text or "rate limit" in text or "rate_limit" in text
+
+
+def is_config_failure(exc: BaseException) -> bool:
+    """Missing key, bad URL, unknown model, provider 4xx that is not 429."""
+    if is_rate_limit(exc):
+        return False
+    code = _status_code(exc)
+    if code in {400, 401, 403, 404}:
+        return True
+    text = str(exc).lower()
+    needles = (
+        "api key",
+        "apikey",
+        "api_key",
+        "missing key",
+        "invalid api",
+        "authentication",
+        "unauthorized",
+        "unknown model",
+        "model not found",
+        "does not exist",
+        "base_url",
+        "connection refused",
+        "name or service not known",
+        "nodename nor servname",
+        "failed to resolve",
+        "config",
+    )
+    return any(n in text for n in needles)
+
+
+def should_failover(exc: BaseException, remaining: list[str], *, scale_out: bool) -> bool:
+    """Walk to the next seat only for config failures on a sequential list."""
+    if scale_out or not remaining:
+        return False
+    return is_config_failure(exc) and not is_rate_limit(exc)
+
+
+def retry_params(params: dict | None, rest: list[str]) -> dict:
+    """Build WS params for the next seat after a config failure."""
+    retry = dict(params or {})
+    retry["inference_list"] = rest
+    if not rest:
+        return retry
+    nxt = rest[0]
+    if seat_kind(nxt) == "cli":
+        retry["cli"] = seat_id(nxt)
+    elif seat_kind(nxt) == "llm":
+        retry["model"] = seat_id(nxt)
+        retry["llm_profile"] = seat_id(nxt)
+    elif seat_kind(nxt) == "remote":
+        retry["remote_id"] = seat_id(nxt)
+    return retry
+
+
+def failover_notice(failed: str, nxt: str | None, *, exhausted: bool = False) -> str:
+    if exhausted:
+        return f"Inference list exhausted after {failed}. Stopped."
+    if nxt:
+        return f"Inference {failed} failed (config). Trying {nxt}."
+    return f"Inference {failed} failed (config)."

--- a/tests/core/test_inference_list.py
+++ b/tests/core/test_inference_list.py
@@ -1,0 +1,87 @@
+"""REQ-69 ordered inference helpers."""
+
+from swarm.core.inference_list import (
+    failover_notice,
+    is_config_failure,
+    is_rate_limit,
+    normalize_inference_list,
+    pick_scale_out,
+    seat_id,
+    seat_kind,
+)
+
+
+def test_normalize_preserves_order_and_dedupes():
+    assert normalize_inference_list(["llm:orchestration", "cli:grok", "llm:orchestration"]) == [
+        "llm:orchestration",
+        "cli:grok",
+    ]
+    assert normalize_inference_list(None) == []
+    assert normalize_inference_list([{"kind": "cli", "id": "agy"}]) == ["cli:agy"]
+
+
+def test_empty_list_is_settings_default():
+    assert normalize_inference_list([]) == []
+    assert pick_scale_out([], 0) is None
+
+
+def test_scale_out_round_robin_two_tasks_two_providers():
+    seats = ["llm:a", "llm:b"]
+    assert pick_scale_out(seats, 0) == "llm:a"
+    assert pick_scale_out(seats, 1) == "llm:b"
+    assert pick_scale_out(seats, 2) == "llm:a"
+
+
+def test_config_fail_is_not_rate_limit():
+    class MissingKey(Exception):
+        pass
+
+    class Rate(Exception):
+        status_code = 429
+
+    class Auth(Exception):
+        status_code = 401
+
+    assert is_config_failure(MissingKey("API key not set for grok"))
+    assert is_config_failure(Auth("unauthorized"))
+    assert not is_rate_limit(Auth("unauthorized"))
+    assert is_rate_limit(Rate("too many requests"))
+    assert not is_config_failure(Rate("429 rate limit"))
+
+
+def test_should_failover_and_retry_params():
+    from swarm.core.inference_list import retry_params, should_failover
+
+    class Missing(Exception):
+        pass
+
+    class Rate(Exception):
+        status_code = 429
+
+    seats = ["llm:a", "llm:b"]
+    assert should_failover(Missing("unknown model"), seats[1:], scale_out=False)
+    assert not should_failover(Missing("unknown model"), seats[1:], scale_out=True)
+    assert not should_failover(Rate("429"), seats[1:], scale_out=False)
+    retry = retry_params({"inference_list": seats}, ["llm:b"])
+    assert retry["inference_list"] == ["llm:b"]
+    assert retry["llm_profile"] == "b"
+
+
+def test_429_does_not_jump():
+    class Rate(Exception):
+        status_code = 429
+
+    assert is_rate_limit(Rate("429"))
+    assert not is_config_failure(Rate("429"))
+
+
+def test_failover_notice_exhausted():
+    assert "Trying llm:b" in failover_notice("llm:a", "llm:b")
+    assert "exhausted" in failover_notice("llm:b", None, exhausted=True).lower()
+
+
+def test_seat_kind_and_id():
+    assert seat_kind("cli:grok") == "cli"
+    assert seat_id("cli:grok") == "grok"
+    assert seat_kind("orchestration") == "llm"
+    assert seat_id("llm:auxiliary") == "auxiliary"

--- a/tests/core/test_req69_consumer_failover.py
+++ b/tests/core/test_req69_consumer_failover.py
@@ -1,0 +1,22 @@
+"""REQ-69: consumer uses should_failover so 429 stays put."""
+
+from swarm.core.inference_list import should_failover
+
+
+class _ConfigFail(Exception):
+    status_code = 401
+
+
+class _RateLimit(Exception):
+    status_code = 429
+
+
+def test_config_fail_walks_to_second():
+    rest = ["llm:b"]
+    assert should_failover(_ConfigFail("missing api key"), rest, scale_out=False)
+
+
+def test_429_on_first_does_not_jump_to_second():
+    rest = ["llm:b"]
+    assert not should_failover(_RateLimit("429 rate limit"), rest, scale_out=False)
+    assert not should_failover(_ConfigFail("missing api key"), rest, scale_out=True)

--- a/tests/unit/test_req69_ordered_inference.py
+++ b/tests/unit/test_req69_ordered_inference.py
@@ -1,0 +1,36 @@
+"""REQ-69: per-agent ordered inference list (Fixes #405)."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+EDITOR = ROOT / "webui/frontend/src/components/AgentEditor.tsx"
+LIST = ROOT / "webui/frontend/src/components/InferenceOrderList.tsx"
+EDITS = ROOT / "webui/frontend/src/lib/agentEdits.ts"
+CORE = ROOT / "src/swarm/core/inference_list.py"
+CONSUMER = ROOT / "src/swarm/consumers.py"
+
+
+def test_editor_has_ordered_list_not_only_select():
+    tsx = EDITOR.read_text(encoding="utf-8")
+    ui = LIST.read_text(encoding="utf-8")
+    assert "InferenceOrderList" in tsx
+    assert 'data-testid="inference-order-list"' in ui
+    assert "draggable" in ui
+    assert "onDrop" in ui
+
+
+def test_edits_persist_inference_list():
+    ts = EDITS.read_text(encoding="utf-8")
+    assert "inferenceList?: string[]" in ts
+    assert "saveInferenceList" in ts
+    assert "loadInferenceList" in ts
+
+
+def test_backend_failover_and_429_policy():
+    py = CORE.read_text(encoding="utf-8")
+    cons = CONSUMER.read_text(encoding="utf-8")
+    assert "is_rate_limit" in py
+    assert "is_config_failure" in py
+    assert "pick_scale_out" in py
+    assert "inference_list" in cons
+    assert "Trying" in py or "failed (config)" in py

--- a/webui/frontend/src/components/AgentEditor.tsx
+++ b/webui/frontend/src/components/AgentEditor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Button, Input, Modal, Select } from './DaisyUI'
+import InferenceOrderList, { type InferenceCatalogOption } from './InferenceOrderList'
 import {
   fetchBlueprints,
   fetchCliAgents,
@@ -21,8 +22,11 @@ import {
 import {
   assignedBlueprintId,
   loadAgentEdit,
+  loadInferenceList,
   saveAgentEdit,
+  saveInferenceList,
 } from '../lib/agentEdits'
+import type { InferenceSeat } from '../lib/inferenceList'
 import {
   NEW_CHAT_PER_TASK_LABEL,
   NEW_CHAT_PER_TASK_TOOLTIP,
@@ -82,6 +86,7 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
   const [newChatPerTask, setNewChatPerTask] = useState(false)
   const [savingSettings, setSavingSettings] = useState(false)
   const [boundRemoteId, setBoundRemoteId] = useState('')
+  const [inferenceSeats, setInferenceSeats] = useState<InferenceSeat[]>([])
 
   const blueprintsQuery = useQuery({
     queryKey: ['blueprints'],
@@ -118,7 +123,7 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
   const cliQuery = useQuery({
     queryKey: ['cli-agents'],
     queryFn: fetchCliAgents,
-    enabled: Boolean(isOpen && agentKind === 'cli'),
+    enabled: isOpen,
     retry: 1,
   })
 
@@ -134,7 +139,7 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
   const llmProfilesQuery = useQuery({
     queryKey: ['llm-profiles'],
     queryFn: fetchLlmProfiles,
-    enabled: Boolean(isOpen && agentKind === 'api'),
+    enabled: isOpen,
     retry: 1,
   })
 
@@ -148,7 +153,7 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
   const remotesQuery = useQuery({
     queryKey: ['remotes-list'],
     queryFn: fetchRemotes,
-    enabled: Boolean(isOpen && agentKind === 'remote'),
+    enabled: isOpen,
     retry: 1,
   })
   const remotesCatalog = remotesListForSelect(
@@ -189,6 +194,7 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
     setCliOverride(edit.cliOverride || '')
     setProfileOverride(edit.profileOverride || '')
     setBoundRemoteId(loadAgentRemoteBinding(id)?.id || '')
+    setInferenceSeats(loadInferenceList(id))
 
     let cancelled = false
     ;(async () => {
@@ -225,6 +231,39 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
     setRole(next)
     saveAgentEdit(id, { role: next })
   }
+
+  const persistInference = (next: InferenceSeat[]) => {
+    setInferenceSeats(next)
+    saveInferenceList(id, next)
+  }
+
+  const inferenceCatalog = useMemo<InferenceCatalogOption[]>(() => {
+    const rows: InferenceCatalogOption[] = []
+    const profiles = llmProfilesQuery.data?.profiles ?? []
+    if (profiles.length) {
+      for (const p of profiles) {
+        rows.push({ id: p.id, kind: 'llm', label: p.name || p.id })
+      }
+    } else {
+      for (const id of ['orchestration', 'auxiliary', 'delegation']) {
+        rows.push({ id, kind: 'llm', label: id })
+      }
+    }
+    for (const cli of cliQuery.data?.clis ?? []) {
+      rows.push({ id: cli, kind: 'cli', label: cli })
+    }
+    for (const remote of configuredRemoteRows) {
+      rows.push({
+        id: remote.id,
+        kind: 'remote',
+        label: remote.label || remote.id,
+      })
+    }
+    return rows
+  }, [llmProfilesQuery.data, cliQuery.data, configuredRemoteRows])
+
+  const defaultInferenceLabel =
+    llmProfilesQuery.data?.default_llm_profile || 'orchestration'
 
   const openBlueprintInSettings = () => {
     const assigned = assignedBlueprintId(id) || blueprintId || id
@@ -293,6 +332,13 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
             </option>
           ))}
         </Select>
+
+        <InferenceOrderList
+          seats={inferenceSeats}
+          catalog={inferenceCatalog}
+          defaultLabel={defaultInferenceLabel}
+          onChange={persistInference}
+        />
 
         {/* LLM Override Picker by Kind (REQ-124) */}
         {agentKind === 'remote' && (

--- a/webui/frontend/src/components/InferenceOrderList.tsx
+++ b/webui/frontend/src/components/InferenceOrderList.tsx
@@ -1,0 +1,142 @@
+import { useRef, useState } from 'react'
+import { GripVertical, Plus, X } from 'lucide-react'
+import type { InferenceKind, InferenceSeat } from '../lib/inferenceList'
+import { seatKey } from '../lib/inferenceList'
+
+export interface InferenceCatalogOption {
+  id: string
+  kind: InferenceKind
+  label: string
+}
+
+interface InferenceOrderListProps {
+  seats: InferenceSeat[]
+  catalog: InferenceCatalogOption[]
+  defaultLabel: string
+  onChange: (next: InferenceSeat[]) => void
+}
+
+/**
+ * Prominent ordered inference list (REQ-69). Native HTML5 drag to reorder.
+ * Not a single <select> of the live order.
+ */
+export default function InferenceOrderList({
+  seats,
+  catalog,
+  defaultLabel,
+  onChange,
+}: InferenceOrderListProps) {
+  const [addValue, setAddValue] = useState('')
+  const dragFrom = useRef<number | null>(null)
+
+  const unused = catalog.filter(
+    (opt) => !seats.some((seat) => seat.kind === opt.kind && seat.id === opt.id),
+  )
+
+  const move = (from: number, to: number) => {
+    if (from === to || from < 0 || to < 0 || from >= seats.length || to >= seats.length) return
+    const next = seats.slice()
+    const [row] = next.splice(from, 1)
+    next.splice(to, 0, row)
+    onChange(next)
+  }
+
+  const add = () => {
+    if (!addValue) return
+    const opt = unused.find((item) => seatKey(item) === addValue)
+    if (!opt) return
+    onChange([...seats, { id: opt.id, kind: opt.kind, label: opt.label }])
+    setAddValue('')
+  }
+
+  return (
+    <div
+      className="space-y-3 rounded-box border border-base-300 bg-base-200/40 p-3"
+      data-testid="inference-order-list"
+    >
+      <div>
+        <span className="text-sm font-semibold text-base-content/80">Ordered inference</span>
+        <p className="text-xs text-base-content/60 mt-0.5">
+          First is preference 1. Scale-out spreads work down this list. Config
+          failures try the next. Empty uses Settings default ({defaultLabel}).
+        </p>
+      </div>
+
+      {seats.length === 0 ? (
+        <p className="text-sm text-base-content/60" data-testid="inference-list-empty">
+          Empty list — using {defaultLabel}.
+        </p>
+      ) : (
+        <ol className="space-y-1" data-testid="inference-list-items">
+          {seats.map((seat, index) => (
+            <li
+              key={seatKey(seat)}
+              draggable
+              data-testid="inference-list-row"
+              data-seat={seatKey(seat)}
+              data-index={index}
+              className="flex items-center gap-2 rounded-box border border-base-300 bg-base-100 px-2 py-1.5 cursor-grab active:cursor-grabbing"
+              onDragStart={(event) => {
+                dragFrom.current = index
+                event.dataTransfer.effectAllowed = 'move'
+                event.dataTransfer.setData('text/plain', String(index))
+              }}
+              onDragOver={(event) => {
+                event.preventDefault()
+                event.dataTransfer.dropEffect = 'move'
+              }}
+              onDrop={(event) => {
+                event.preventDefault()
+                const from = dragFrom.current
+                dragFrom.current = null
+                if (from === null) return
+                move(from, index)
+              }}
+            >
+              <GripVertical className="h-4 w-4 shrink-0 text-base-content/40" aria-hidden="true" />
+              <span className="badge badge-ghost badge-sm font-mono">{index + 1}</span>
+              <span className="flex-1 truncate text-sm">
+                {seat.label || seat.id}
+                <span className="ml-1 text-xs text-base-content/50">{seat.kind}</span>
+              </span>
+              <button
+                type="button"
+                className="btn btn-ghost btn-xs btn-square"
+                aria-label={`Remove ${seat.id}`}
+                onClick={() => onChange(seats.filter((_, i) => i !== index))}
+              >
+                <X className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      <div className="flex gap-2">
+        <select
+          className="select select-bordered select-sm flex-1"
+          aria-label="Add inference option"
+          data-testid="inference-list-add"
+          value={addValue}
+          onChange={(event) => setAddValue(event.target.value)}
+        >
+          <option value="">Add from catalog…</option>
+          {unused.map((opt) => (
+            <option key={seatKey(opt)} value={seatKey(opt)}>
+              {opt.label} ({opt.kind})
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className="btn btn-sm btn-outline"
+          disabled={!addValue}
+          aria-label="Add inference seat"
+          onClick={add}
+        >
+          <Plus className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/webui/frontend/src/components/__tests__/InferenceOrderList.test.tsx
+++ b/webui/frontend/src/components/__tests__/InferenceOrderList.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import InferenceOrderList from '../InferenceOrderList'
+import type { InferenceSeat } from '../../lib/inferenceList'
+
+const catalog = [
+  { id: 'orchestration', kind: 'llm' as const, label: 'orchestration' },
+  { id: 'grok', kind: 'cli' as const, label: 'grok' },
+]
+
+describe('InferenceOrderList', () => {
+  it('adds from catalog and reports empty default', () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <InferenceOrderList
+        seats={[]}
+        catalog={catalog}
+        defaultLabel="orchestration"
+        onChange={onChange}
+      />,
+    )
+    expect(screen.getByTestId('inference-list-empty')).toHaveTextContent('orchestration')
+    fireEvent.change(screen.getByTestId('inference-list-add'), {
+      target: { value: 'cli:grok' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add inference seat' }))
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'grok', kind: 'cli' }),
+    ])
+
+    const seats: InferenceSeat[] = [{ id: 'grok', kind: 'cli', label: 'grok' }]
+    rerender(
+      <InferenceOrderList
+        seats={seats}
+        catalog={catalog}
+        defaultLabel="orchestration"
+        onChange={onChange}
+      />,
+    )
+    expect(screen.getByTestId('inference-list-row')).toHaveAttribute('data-seat', 'cli:grok')
+  })
+})

--- a/webui/frontend/src/lib/__tests__/inferenceList.test.ts
+++ b/webui/frontend/src/lib/__tests__/inferenceList.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  nextInferenceIndex,
+  normalizeInferenceList,
+  pickScaleOut,
+  serializeInferenceList,
+} from '../inferenceList'
+import {
+  AGENT_EDITS_KEY,
+  loadInferenceList,
+  saveInferenceList,
+} from '../agentEdits'
+
+afterEach(() => {
+  localStorage.clear()
+  sessionStorage.clear()
+})
+
+describe('REQ-69 inference list', () => {
+  it('persists order on the agent', () => {
+    saveInferenceList('support', [
+      { id: 'orchestration', kind: 'llm' },
+      { id: 'grok', kind: 'cli' },
+    ])
+    const loaded = loadInferenceList('support')
+    expect(loaded.map((s) => `${s.kind}:${s.id}`)).toEqual(['llm:orchestration', 'cli:grok'])
+    const raw = JSON.parse(localStorage.getItem(AGENT_EDITS_KEY) || '{}')
+    expect(raw.support.inferenceList[0]).toBe('llm:orchestration')
+  })
+
+  it('empty list is Settings default', () => {
+    expect(normalizeInferenceList([])).toEqual([])
+    expect(loadInferenceList('nobody')).toEqual([])
+    expect(serializeInferenceList([])).toEqual([])
+  })
+
+  it('scale-out two tasks hit two different seats', () => {
+    const seats = [
+      { id: 'a', kind: 'llm' as const },
+      { id: 'b', kind: 'llm' as const },
+    ]
+    const i0 = nextInferenceIndex('worker', 2)
+    const i1 = nextInferenceIndex('worker', 2)
+    expect(pickScaleOut(seats, i0)?.id).not.toBe(pickScaleOut(seats, i1)?.id)
+    expect(new Set([pickScaleOut(seats, i0)?.id, pickScaleOut(seats, i1)?.id])).toEqual(
+      new Set(['a', 'b']),
+    )
+  })
+})

--- a/webui/frontend/src/lib/agentEdits.ts
+++ b/webui/frontend/src/lib/agentEdits.ts
@@ -11,6 +11,11 @@
  */
 
 import type { AgentRole } from './api'
+import {
+  normalizeInferenceList,
+  serializeInferenceList,
+  type InferenceSeat,
+} from './inferenceList'
 
 export const AGENT_EDITS_KEY = 'swarm_agent_edits'
 export const AGENT_EDITS_CHANGED_EVENT = 'swarm:agent-edits-changed'
@@ -30,6 +35,8 @@ export interface AgentEdit {
   command?: string
   cliOverride?: string
   profileOverride?: string
+  /** REQ-69 ordered inference seats (`llm:…` / `cli:…` / `remote:…`). Empty = Settings default. */
+  inferenceList?: string[]
 }
 
 export type AgentEditMap = Record<string, AgentEdit>
@@ -119,11 +126,41 @@ export function saveAgentEdit(agentId: string, patch: AgentEdit): AgentEdit {
     if (profile) next.profileOverride = profile
     else delete next.profileOverride
   }
+  if (patch.inferenceList !== undefined) {
+    const seats = serializeInferenceList(patch.inferenceList)
+    if (seats.length) next.inferenceList = seats
+    else delete next.inferenceList
+  }
 
   if (Object.keys(next).length === 0) delete map[agentId]
   else map[agentId] = next
   writeMap(map)
   emitChange(agentId)
+  return next
+}
+
+/** REQ-69 ordered inference seats for this agent. Empty = Settings default. */
+export function loadInferenceList(agentId: string): InferenceSeat[] {
+  if (!agentId) return []
+  const edit = loadAgentEdit(agentId)
+  const fromList = normalizeInferenceList(edit.inferenceList)
+  if (fromList.length) return fromList
+  // One-item fallback from the older single override fields.
+  if (edit.cliOverride?.trim()) {
+    return [{ id: edit.cliOverride.trim(), kind: 'cli', label: edit.cliOverride.trim() }]
+  }
+  if (edit.profileOverride?.trim()) {
+    return [{ id: edit.profileOverride.trim(), kind: 'llm', label: edit.profileOverride.trim() }]
+  }
+  if (edit.llmOverride?.trim()) {
+    return [{ id: edit.llmOverride.trim(), kind: 'llm', label: edit.llmOverride.trim() }]
+  }
+  return []
+}
+
+export function saveInferenceList(agentId: string, seats: InferenceSeat[]): InferenceSeat[] {
+  const next = normalizeInferenceList(seats)
+  saveAgentEdit(agentId, { inferenceList: serializeInferenceList(next) })
   return next
 }
 

--- a/webui/frontend/src/lib/inferenceList.ts
+++ b/webui/frontend/src/lib/inferenceList.ts
@@ -1,0 +1,84 @@
+/**
+ * REQ-69: ordered per-agent inference seats (LLM / CLI / remote).
+ *
+ * Empty list means Settings default. Scale-out round-robins; sequential
+ * failover is a server concern (config errors only, not 429).
+ */
+
+export type InferenceKind = 'llm' | 'cli' | 'remote'
+
+export interface InferenceSeat {
+  id: string
+  kind: InferenceKind
+  label?: string
+}
+
+const RR_PREFIX = 'swarm_inference_rr:'
+
+export function seatKey(seat: InferenceSeat): string {
+  return `${seat.kind}:${seat.id}`
+}
+
+export function parseSeatKey(raw: string): InferenceSeat | null {
+  const text = String(raw || '').trim()
+  if (!text) return null
+  const match = /^(llm|cli|remote):(.+)$/i.exec(text)
+  if (match) {
+    const kind = match[1].toLowerCase() as InferenceKind
+    const id = match[2].trim()
+    if (!id) return null
+    return { id, kind, label: id }
+  }
+  return { id: text, kind: 'llm', label: text }
+}
+
+export function normalizeInferenceList(raw: unknown): InferenceSeat[] {
+  if (!Array.isArray(raw)) return []
+  const out: InferenceSeat[] = []
+  const seen = new Set<string>()
+  for (const item of raw) {
+    let seat: InferenceSeat | null = null
+    if (typeof item === 'string') seat = parseSeatKey(item)
+    else if (item && typeof item === 'object') {
+      const rec = item as Record<string, unknown>
+      const id = typeof rec.id === 'string' ? rec.id.trim() : ''
+      const kind = rec.kind
+      if (!id) continue
+      if (kind === 'llm' || kind === 'cli' || kind === 'remote') {
+        seat = { id, kind, label: typeof rec.label === 'string' ? rec.label : id }
+      } else {
+        seat = parseSeatKey(id)
+      }
+    }
+    if (!seat) continue
+    const key = seatKey(seat)
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(seat)
+  }
+  return out
+}
+
+export function serializeInferenceList(seats: InferenceSeat[]): string[] {
+  return normalizeInferenceList(seats).map(seatKey)
+}
+
+/** Round-robin index for scale-out (new chat per task). Session-scoped. */
+export function nextInferenceIndex(agentId: string, n: number): number {
+  if (n <= 0 || !agentId) return 0
+  let i = 0
+  try {
+    i = Number(sessionStorage.getItem(RR_PREFIX + agentId)) || 0
+    sessionStorage.setItem(RR_PREFIX + agentId, String(i + 1))
+  } catch {
+    /* jsdom / private mode */
+  }
+  return ((i % n) + n) % n
+}
+
+export function pickScaleOut(seats: InferenceSeat[], index: number): InferenceSeat | null {
+  const list = normalizeInferenceList(seats)
+  if (!list.length) return null
+  const i = ((index % list.length) + list.length) % list.length
+  return list[i]
+}

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -121,7 +121,8 @@ import { workingLabel } from '../lib/chatBubble'
 import { isExperimentalEnabled } from '../experimental/flags'
 import { ChatMessageActions } from '../experimental/ChatMessageActions'
 import { agentRole, exampleRoleAgents, isChiefOfStaff, isExampleRole } from '../lib/agentRoles'
-import { assignedBlueprintId, AGENT_EDITS_CHANGED_EVENT, editedAgentLabel } from '../lib/agentEdits'
+import { assignedBlueprintId, AGENT_EDITS_CHANGED_EVENT, editedAgentLabel, loadInferenceList } from '../lib/agentEdits'
+import { nextInferenceIndex, serializeInferenceList } from '../lib/inferenceList'
 import {
   agentLabel,
   defaultBlueprintId,
@@ -1100,6 +1101,16 @@ const ChatPage = () => {
         ? supportTurnExtras()
         : undefined
       const selectedModelParam = (searchParams.get('model') ?? '').trim()
+      const agentIdForInference =
+        runtimeBlueprint || selectedBlueprint || SUPPORT_AGENT_ID
+      const inferenceSeats = loadInferenceList(agentIdForInference)
+      const inferenceKeys = serializeInferenceList(inferenceSeats)
+      let inferenceIndex: number | undefined
+      let scaleSeat = inferenceSeats[0]
+      if (newChatPerTask && inferenceSeats.length > 0) {
+        inferenceIndex = nextInferenceIndex(agentIdForInference, inferenceSeats.length)
+        scaleSeat = inferenceSeats[inferenceIndex]
+      }
       const cliParams = isCliAgent
         ? {
             cli: currentCli,
@@ -1112,12 +1123,22 @@ const ChatPage = () => {
             : newChatPerTask
               ? { new_session: messages.length === 0 }
               : undefined
+      const inferenceParams =
+        inferenceKeys.length > 0
+          ? {
+              inference_list: inferenceKeys,
+              ...(inferenceIndex !== undefined ? { inference_index: inferenceIndex, scale_out: true } : {}),
+              ...(scaleSeat?.kind === 'llm' ? { llm_profile: scaleSeat.id, model: scaleSeat.id } : {}),
+              ...(scaleSeat?.kind === 'cli' ? { cli: scaleSeat.id } : {}),
+              ...(scaleSeat?.kind === 'remote' ? { remote_id: scaleSeat.id } : {}),
+            }
+          : undefined
       ws.send(
         buildChatWsFrame(
           trimmed,
           runtimeBlueprint || selectedBlueprint || undefined,
-          supportParams || cliParams
-            ? { ...cliParams, ...supportParams }
+          supportParams || cliParams || inferenceParams
+            ? { ...cliParams, ...inferenceParams, ...supportParams }
             : undefined,
         ),
       )


### PR DESCRIPTION
# Summary
REQ-69 (#405): each agent can keep an **ordered inference list** in the agent editor (HTML5 drag to reorder, add/remove from the LLM / CLI / remote catalog). Empty list uses the Settings default. Scale-out (new chat per task) round-robins seats; sequential chats fail over on **config** errors with a bubble-less info line and do **not** fail over on 429.

## Problem it solves
Quoting #405: *Each agent has an ordered list of inference options (not a single dropdown). Scale-out agents spread work across that list. Non-scale-out agents try the first, and on config failure (not rate-limit) log an info line in chat and try the next.* The editor only had a single LLM/CLI override.

## How it works
- `agentEdits.inferenceList` persists `llm:` / `cli:` / `remote:` seats in `localStorage` (same store as REQ-58).
- `InferenceOrderList` is the prominent DaisyUI list (native drag, not a `<select>` of live order).
- Chat WS sends `inference_list` (+ `inference_index` / `scale_out` when new-chat-per-task is on).
- `swarm.core.inference_list` classifies config vs 429; `DjangoChatConsumer` walks the list and emits status lines.

## Measured impact
n/a — policy/control-flow, not a hot path. 16 pytest + 12 vitest on the new surfaces.

## Test coverage
- `tests/core/test_inference_list.py` — persist-shape, empty=default, round-robin two providers, config vs 429, retry params
- `tests/core/test_req69_consumer_failover.py` — failover yes on 401/missing key, no on 429 / scale-out
- `tests/unit/test_req69_ordered_inference.py` — editor + consumer contract
- `webui/frontend/src/lib/__tests__/inferenceList.test.ts` — persist order, empty default, two-task distribution
- `InferenceOrderList.test.tsx` — add from catalog
- Existing REQ-124 editor tests still pass

## Risks / follow-ups
- Failover only triggers when `blueprint.run()` raises; silent empty replies do not walk the list.
- Remotes still keep their own models in the old override pane (REQ-124); they can still be added to the ordered list.
- Did not deploy `:8001` (issue constraint).

## Build footprint
None — no new deps, ports, or services. Native HTML5 DnD + DaisyUI 5.