### PR TITLE
feat(webui): XOR update/info chrome when SPA is behind the backend (REQ-78)

### DIFF
--- a/src/swarm/consumers.py
+++ b/src/swarm/consumers.py
@@ -31,6 +31,9 @@ IN_MEMORY_CONVERSATIONS = {}
 # so browsers receive a CloseEvent with this code instead of opaque 1006.
 WS_AUTH_REQUIRED_CODE = 4401
 
+# REQ-78 / #423 — advertise the backend's expected SPA bake on connect.
+SPA_HELLO_TYPE = "spa_hello"
+
 
 def _message_ts() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -175,6 +178,7 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
                     )
                     return
             if getattr(self.user, "is_authenticated", False):
+                await self._send_spa_hello()
                 self.active_agent = self.default_blueprint
                 self._pending_tool_decisions = {}
                 try:
@@ -193,6 +197,22 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
                 )
         except Exception:
             logger.exception("post-accept websocket setup failed; socket stays open")
+
+    async def _send_spa_hello(self):
+        """Tell the tab which SPA bake this backend expects (REQ-78)."""
+        try:
+            from swarm.core.app_version import get_app_version
+
+            await self.send(
+                text_data=json.dumps(
+                    {
+                        "type": SPA_HELLO_TYPE,
+                        "spa_version": get_app_version(),
+                    }
+                )
+            )
+        except Exception:
+            logger.debug("spa_hello advertise failed", exc_info=True)
 
     async def disconnect(self, close_code):
         if self.user.is_authenticated:

--- a/src/swarm/core/app_version.py
+++ b/src/swarm/core/app_version.py
@@ -1,0 +1,65 @@
+"""Running Open Swarm version (pyproject / installed package).
+
+Used by the chat websocket ``spa_hello`` advertise (REQ-78 / #423).
+No secrets. No GitHub tokens.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_PACKAGE_NAME = "open-swarm"
+_UNKNOWN = "0.0.0"
+
+
+def _parse_pyproject_version(text: str) -> str | None:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("version") and "=" in stripped:
+            _, _, raw = stripped.partition("=")
+            value = raw.strip().strip('"').strip("'")
+            if value:
+                return value
+    return None
+
+
+def _version_from_metadata() -> str | None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+    except ImportError:
+        return None
+    try:
+        found = version(_PACKAGE_NAME)
+    except PackageNotFoundError:
+        return None
+    except Exception:
+        logger.debug("importlib.metadata version lookup failed", exc_info=True)
+        return None
+    return found or None
+
+
+def _version_from_pyproject() -> str | None:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "pyproject.toml"
+        if not candidate.is_file():
+            continue
+        try:
+            text = candidate.read_text(encoding="utf-8")
+        except OSError:
+            logger.debug("could not read %s", candidate, exc_info=True)
+            continue
+        parsed = _parse_pyproject_version(text)
+        if parsed:
+            return parsed
+    return None
+
+
+@lru_cache(maxsize=1)
+def get_app_version() -> str:
+    """Advertised running version: installed package, else pyproject.toml."""
+    return _version_from_metadata() or _version_from_pyproject() or _UNKNOWN

--- a/tests/core/test_app_version.py
+++ b/tests/core/test_app_version.py
@@ -1,0 +1,23 @@
+"""REQ-78 advertised app version. No secrets."""
+
+from swarm.core.app_version import (
+    _parse_pyproject_version,
+    get_app_version,
+)
+
+
+def test_parse_pyproject_version():
+    text = '[project]\nname = "open-swarm"\nversion = "0.5.4"\n'
+    assert _parse_pyproject_version(text) == "0.5.4"
+
+
+def test_parse_pyproject_version_ignores_noise():
+    assert _parse_pyproject_version("name = 'x'\n") is None
+    assert _parse_pyproject_version('version = ""\n') is None
+
+
+def test_get_app_version_matches_pyproject():
+    version = get_app_version()
+    assert version
+    assert version != "0.0.0"
+    assert version[0].isdigit()

--- a/tests/test_asgi_routing.py
+++ b/tests/test_asgi_routing.py
@@ -38,6 +38,7 @@ from django.contrib.auth import get_user_model
 from django.test import Client
 
 from swarm.asgi import application
+from swarm.consumers import SPA_HELLO_TYPE
 
 WS_PATH = "/ws/ai-demo/asgi-test-conv/"
 # The dev/test default ALLOWED_HOSTS is ['localhost', '127.0.0.1'] (see
@@ -209,6 +210,7 @@ class TestWebsocketRoundTrip:
         with patcher:
             connected, _ = await communicator.connect()
             assert connected
+            await expect_spa_hello(communicator)
 
             await communicator.send_to(text_data=json.dumps({"message": "Ping?"}))
 
@@ -265,6 +267,15 @@ def swarm_test_mode(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-dummy-test-mode")
 
 
+async def expect_spa_hello(communicator, timeout=1):
+    """REQ-78: authenticated connect advertises spa_version before chat frames."""
+    raw = await communicator.receive_from(timeout=timeout)
+    payload = json.loads(raw)
+    assert payload.get("type") == SPA_HELLO_TYPE
+    assert payload.get("spa_version")
+    return payload
+
+
 async def _drain_reply(communicator, prompt):
     """Send a prompt dict and collect (user_echo, placeholder, frames-until-final)."""
     await communicator.send_to(text_data=json.dumps(prompt))
@@ -297,6 +308,7 @@ class TestWebsocketBlueprintSelection:
         )
         connected, _ = await communicator.connect()
         assert connected
+        await expect_spa_hello(communicator)
 
         user_html, contents_div_id, frames = await _drain_reply(
             communicator, {"message": "ping", "blueprint": "jeeves"}
@@ -321,6 +333,7 @@ class TestWebsocketBlueprintSelection:
         )
         connected, _ = await communicator.connect()
         assert connected
+        await expect_spa_hello(communicator)
 
         _, _, frames = await _drain_reply(communicator, {"message": "ping"})
         assert JEEVES_CANNED_MARKER in frames[-1]
@@ -338,6 +351,7 @@ class TestWebsocketBlueprintSelection:
         )
         connected, _ = await communicator.connect()
         assert connected
+        await expect_spa_hello(communicator)
 
         _, _, frames = await _drain_reply(
             communicator, {"message": "hello", "blueprint": "no-such-blueprint"}
@@ -371,6 +385,7 @@ class TestWebsocketBlueprintSelection:
         with patcher:
             connected, _ = await communicator.connect()
             assert connected
+            await expect_spa_hello(communicator)
             _, _, frames = await _drain_reply(communicator, {"message": "ping"})
             assert "legacy path" in frames[-1]
             client.chat.completions.create.assert_awaited_once()

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -22,6 +22,7 @@ from django.contrib.auth.models import AnonymousUser
 
 from swarm.consumers import (
     IN_MEMORY_CONVERSATIONS,
+    SPA_HELLO_TYPE,
     DjangoChatConsumer,
     _conversation_cache_key,
 )
@@ -125,6 +126,44 @@ class TestConnect:
                 mock_accept.assert_called_once()
                 mock_fetch.assert_called_once_with("test-conv-123")
                 assert order == ["accept", "fetch"]
+
+    @pytest.mark.asyncio
+    async def test_connect_authenticated_sends_spa_hello(self, consumer):
+        """REQ-78: authenticated connect advertises expected SPA version."""
+        with patch.object(consumer, "fetch_conversation", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = []
+            with patch.object(consumer, "accept", new_callable=AsyncMock):
+                with patch.object(consumer, "send", new_callable=AsyncMock) as mock_send:
+                    with patch(
+                        "swarm.core.app_version.get_app_version",
+                        return_value="0.5.4",
+                    ):
+                        await consumer.connect()
+
+        mock_send.assert_awaited()
+        payload = json.loads(mock_send.await_args.kwargs["text_data"])
+        assert payload == {"type": SPA_HELLO_TYPE, "spa_version": "0.5.4"}
+
+    @pytest.mark.asyncio
+    async def test_connect_unauthenticated_does_not_send_spa_hello(
+        self, mock_scope_unauthenticated
+    ):
+        """Anonymous close must not emit spa_hello (no false update)."""
+        from swarm.consumers import WS_AUTH_REQUIRED_CODE
+
+        consumer = DjangoChatConsumer()
+        consumer.scope = mock_scope_unauthenticated
+        with patch("swarm.consumers.swarm_allow_anonymous", return_value=False):
+            with patch.object(consumer, "accept", new_callable=AsyncMock):
+                with patch.object(consumer, "send", new_callable=AsyncMock) as mock_send:
+                    with patch.object(consumer, "close", new_callable=AsyncMock) as mock_close:
+                        await consumer.connect()
+
+        mock_send.assert_not_called()
+        mock_close.assert_called_once_with(
+            code=WS_AUTH_REQUIRED_CODE,
+            reason="authentication required",
+        )
 
     @pytest.mark.asyncio
     async def test_connect_accepts_even_if_fetch_raises(self, consumer):

--- a/tests/unit/test_req78_update_chrome.py
+++ b/tests/unit/test_req78_update_chrome.py
@@ -1,0 +1,65 @@
+"""REQ-78 (#423) chrome contracts: XOR update/info right of system name.
+
+Locks placement, colours, public GitHub call-home (no tokens), and local-over-upstream
+priority so a later rail rewrite cannot drop the slot or invent secrets.
+"""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SIDEBAR = REPO / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+UPDATE = REPO / "webui" / "frontend" / "src" / "components" / "UpdateChrome.tsx"
+CSS = REPO / "webui" / "frontend" / "src" / "index.css"
+SPA_UPDATE = REPO / "webui" / "frontend" / "src" / "lib" / "spaUpdate.ts"
+GITHUB = REPO / "webui" / "frontend" / "src" / "lib" / "githubRelease.ts"
+CONSUMERS = REPO / "src" / "swarm" / "consumers.py"
+CHAT_WS = REPO / "webui" / "frontend" / "src" / "lib" / "chatWs.ts"
+CHAT_PAGE = REPO / "webui" / "frontend" / "src" / "pages" / "ChatPage.tsx"
+
+
+def test_update_chrome_sits_right_of_system_name_not_on_server_icon():
+    sidebar = SIDEBAR.read_text(encoding="utf-8")
+    css = CSS.read_text(encoding="utf-8")
+    assert "import UpdateChrome from './UpdateChrome'" in sidebar
+    assert "<UpdateChrome />" in sidebar
+    hostname_idx = sidebar.index('id="os-rail-hostname"')
+    chrome_idx = sidebar.index("<UpdateChrome />")
+    server_idx = sidebar.index('data-testid="rail-server-icon"')
+    assert server_idx < hostname_idx < chrome_idx
+    assert "os-rail-update-chrome--local" in css
+    assert "os-rail-update-chrome--upstream" in css
+    assert "#d97706" in css
+    assert "#38bdf8" in css
+    assert "#d46a6a" in css  # #372 WS drop stays a different red
+
+
+def test_xor_priority_and_click_targets():
+    chrome = UPDATE.read_text(encoding="utf-8")
+    logic = SPA_UPDATE.read_text(encoding="utf-8")
+    assert "kind === 'local'" in chrome
+    assert "kind === 'upstream'" in chrome
+    assert "GITHUB_ISSUES_URL" in chrome
+    assert "window.location.reload" in chrome or "reload()" in chrome
+    assert "kind: 'local'" in logic
+    assert "alsoUpstream" in logic
+    assert "if (localMismatch)" in logic
+    assert "if (upstreamNewer)" in logic
+
+
+def test_github_call_home_is_public_and_tokenless():
+    src = GITHUB.read_text(encoding="utf-8")
+    assert "api.github.com/repos/matthewhand/open-swarm/releases/latest" in src
+    assert "Authorization" not in src
+    assert "GITHUB_TOKEN" not in src
+    assert "Bearer" not in src
+    assert "token" not in src.lower() or "No tokens" in src
+
+
+def test_backend_advertises_spa_hello_on_authenticated_connect():
+    consumer = CONSUMERS.read_text(encoding="utf-8")
+    ws = CHAT_WS.read_text(encoding="utf-8")
+    page = CHAT_PAGE.read_text(encoding="utf-8")
+    assert 'SPA_HELLO_TYPE = "spa_hello"' in consumer
+    assert "_send_spa_hello" in consumer
+    assert 'kind: \'spa_hello\'' in ws or 'kind: "spa_hello"' in ws
+    assert "publishExpectedSpaVersion" in page

--- a/tests/unit/test_req78_update_chrome.py
+++ b/tests/unit/test_req78_update_chrome.py
@@ -48,11 +48,13 @@ def test_xor_priority_and_click_targets():
 
 def test_github_call_home_is_public_and_tokenless():
     src = GITHUB.read_text(encoding="utf-8")
-    assert "api.github.com/repos/matthewhand/open-swarm/releases/latest" in src
+    assert "api.github.com/repos/" in src
+    assert "releases/latest" in src
+    assert "GITHUB_REPO = 'matthewhand/open-swarm'" in src
     assert "Authorization" not in src
     assert "GITHUB_TOKEN" not in src
     assert "Bearer" not in src
-    assert "token" not in src.lower() or "No tokens" in src
+    assert "No tokens" in src
 
 
 def test_backend_advertises_spa_hello_on_authenticated_connect():

--- a/webui/frontend/e2e/req78-update-chrome.spec.ts
+++ b/webui/frontend/e2e/req78-update-chrome.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+import path from 'node:path'
+
+const ARTIFACTS = process.env.ARTIFACTS_DIR || '/opt/cursor/artifacts'
+
+const BLUEPRINTS = {
+  object: 'list',
+  data: [
+    {
+      id: 'codey',
+      object: 'blueprint',
+      name: 'Codey',
+      description: 'Code assistant',
+      abbreviation: null,
+      required_mcp_servers: [],
+      tags: [],
+      installed: true,
+      compiled: true,
+    },
+  ],
+}
+
+async function stubApis(page: import('@playwright/test').Page, githubTag: string | null) {
+  await page.route('**/api.github.com/**', async (route) => {
+    if (githubTag) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          tag_name: githubTag,
+          html_url: `https://github.com/matthewhand/open-swarm/releases/tag/${githubTag}`,
+        }),
+      })
+      return
+    }
+    await route.fulfill({ status: 503, contentType: 'application/json', body: '{}' })
+  })
+  await page.route('**/v1/blueprints**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(BLUEPRINTS),
+    })
+  })
+  await page.route('**/v1/models**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ object: 'list', data: [] }),
+    })
+  })
+  await page.route('**/v1/teams**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ object: 'list', data: [] }),
+    })
+  })
+  await page.route('**/v1/remotes**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ object: 'list', kinds: [], configured: [], data: [] }),
+    })
+  })
+  await page.route('**/health**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'ok' }),
+    })
+  })
+}
+
+function shot(name: string): string {
+  mkdirSync(ARTIFACTS, { recursive: true })
+  return path.join(ARTIFACTS, name)
+}
+
+test('REQ-78 XOR chrome sits right of the system name', async ({ page }) => {
+  await stubApis(page, null)
+  await page.goto('/chat')
+
+  const hostname = page.getByLabel('Hostname')
+  const chrome = page.getByTestId('rail-update-chrome')
+  const server = page.getByTestId('rail-server-icon')
+  await expect(hostname).toBeVisible()
+  await expect(chrome).toBeVisible()
+  await expect(server).toBeVisible()
+  await expect(chrome).toHaveAttribute('data-kind', 'idle')
+  await expect(chrome).toHaveAttribute('aria-label', 'Open Swarm issues')
+
+  const order = await page.evaluate(() => {
+    const row = document.querySelector('.os-rail-hostname-row')
+    const ids = [row?.querySelector('[data-testid="rail-server-icon"]') ? 'server' : '', 'hostname']
+    if (row?.querySelector('[data-testid="rail-update-chrome"]')) ids.push('chrome')
+    return ids.filter(Boolean)
+  })
+  expect(order).toEqual(['server', 'hostname', 'chrome'])
+
+  await page.locator('.os-rail-hostname-row').screenshot({
+    path: shot('req78-idle-info.png'),
+  })
+  await page.locator('[data-testid="os-agent-rail"]').screenshot({
+    path: shot('req78-rail-idle.png'),
+  })
+
+  await page.evaluate(() => {
+    window.dispatchEvent(new CustomEvent('swarm:spa-hello', { detail: '9.9.9' }))
+  })
+  await expect(chrome).toHaveAttribute('data-kind', 'local')
+  await expect(chrome).toHaveAttribute('aria-label', 'Reload to update this tab')
+  await page.locator('.os-rail-hostname-row').screenshot({
+    path: shot('req78-local-amber.png'),
+  })
+})
+
+test('REQ-78 GitHub newer only paints the sky cloud', async ({ page }) => {
+  await stubApis(page, 'v99.0.0')
+  await page.goto('/chat')
+  const chrome = page.getByTestId('rail-update-chrome')
+  await expect(chrome).toHaveAttribute('data-kind', 'upstream')
+  await expect(chrome).toHaveAttribute('aria-label', 'Newer Open Swarm release available')
+  await page.locator('.os-rail-hostname-row').screenshot({
+    path: shot('req78-upstream-sky.png'),
+  })
+})

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -94,6 +94,7 @@ import { fetchTeamRosters, teamHideId, type TeamRoster } from '../lib/teamRoster
 import { fetchConfiguredRemotes, remoteHideId, type RemoteEntry } from '../lib/remotesCatalog'
 import { configuredRemotes } from '../lib/remotes'
 import RemoteSessionsPopup from './RemoteSessionsPopup'
+import UpdateChrome from './UpdateChrome'
 import {
   CHAT_CONNECTION_EVENT,
   getChatConnection,
@@ -2030,6 +2031,7 @@ export default function AgentSidebar({
                 }
               }}
             />
+            <UpdateChrome />
             {remotesPopupOpen && (
               <RemoteSessionsPopup
                 isOpen={remotesPopupOpen}

--- a/webui/frontend/src/components/UpdateChrome.tsx
+++ b/webui/frontend/src/components/UpdateChrome.tsx
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Cloud, Info } from 'lucide-react'
+import {
+  GITHUB_ISSUES_URL,
+  fetchLatestGithubRelease,
+  releasePageUrl,
+  type GithubReleaseHit,
+} from '../lib/githubRelease'
+import { SPA_HELLO_EVENT, getExpectedSpaVersion } from '../lib/spaHello'
+import { getBakedSpaVersion } from '../lib/spaVersion'
+import { resolveUpdateChrome, type UpdateChromeKind } from '../lib/spaUpdate'
+
+const ISSUES_LABEL = 'Open Swarm issues'
+const LOCAL_LABEL = 'Reload to update this tab'
+const UPSTREAM_LABEL = 'Newer Open Swarm release available'
+
+const LOCAL_TOOLTIP =
+  'This tab’s SPA is behind the connected backend. Reload to fetch the new UI.'
+const LOCAL_AND_UPSTREAM_TOOLTIP =
+  'This tab’s SPA is behind the connected backend. Reload to fetch the new UI. A newer GitHub release is also available.'
+const UPSTREAM_TOOLTIP =
+  'A newer Open Swarm release is on GitHub. Opens that release page.'
+const IDLE_TOOLTIP = 'Open Swarm issues on GitHub'
+
+export function updateChromeAriaLabel(kind: UpdateChromeKind): string {
+  if (kind === 'local') return LOCAL_LABEL
+  if (kind === 'upstream') return UPSTREAM_LABEL
+  return ISSUES_LABEL
+}
+
+export function updateChromeTooltip(
+  kind: UpdateChromeKind,
+  alsoUpstream: boolean,
+): string {
+  if (kind === 'local') {
+    return alsoUpstream ? LOCAL_AND_UPSTREAM_TOOLTIP : LOCAL_TOOLTIP
+  }
+  if (kind === 'upstream') return UPSTREAM_TOOLTIP
+  return IDLE_TOOLTIP
+}
+
+export default function UpdateChrome({
+  reload = () => window.location.reload(),
+  openUrl = (url: string) => {
+    window.open(url, '_blank', 'noopener,noreferrer')
+  },
+}: {
+  reload?: () => void
+  openUrl?: (url: string) => void
+}) {
+  const bakedVersion = getBakedSpaVersion()
+  const [backendVersion, setBackendVersion] = useState<string | null>(
+    () => getExpectedSpaVersion(),
+  )
+  const [github, setGithub] = useState<GithubReleaseHit | null>(null)
+
+  useEffect(() => {
+    const onHello = (event: Event) => {
+      const detail = (event as CustomEvent<string | null>).detail
+      setBackendVersion(typeof detail === 'string' && detail.trim() ? detail : null)
+    }
+    window.addEventListener(SPA_HELLO_EVENT, onHello)
+    return () => window.removeEventListener(SPA_HELLO_EVENT, onHello)
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    void fetchLatestGithubRelease().then((hit) => {
+      if (!cancelled) setGithub(hit)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const resolved = useMemo(
+    () =>
+      resolveUpdateChrome({
+        bakedVersion,
+        backendVersion,
+        githubLatest: github?.tag ?? null,
+      }),
+    [bakedVersion, backendVersion, github],
+  )
+
+  const onClick = useCallback(() => {
+    if (resolved.kind === 'local') {
+      reload()
+      return
+    }
+    if (resolved.kind === 'upstream') {
+      openUrl(github?.htmlUrl || releasePageUrl(github?.tag ?? ''))
+      return
+    }
+    openUrl(GITHUB_ISSUES_URL)
+  }, [github, openUrl, reload, resolved.kind])
+
+  const label = updateChromeAriaLabel(resolved.kind)
+  const tip = updateChromeTooltip(resolved.kind, resolved.alsoUpstream)
+  const Icon = resolved.kind === 'idle' ? Info : Cloud
+
+  return (
+    <button
+      type="button"
+      className={`os-rail-update-chrome os-rail-update-chrome--${resolved.kind} btn btn-ghost btn-xs btn-square h-5 w-5 min-h-0`}
+      data-testid="rail-update-chrome"
+      data-kind={resolved.kind}
+      data-also-upstream={resolved.alsoUpstream ? 'true' : 'false'}
+      aria-label={label}
+      title={tip}
+      onClick={onClick}
+    >
+      <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+    </button>
+  )
+}

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -126,6 +126,9 @@ function mockFetch(extraBlueprints = blueprints, extraRosters = rosters) {
         }),
       } as Response
     }
+    if (url.includes('api.github.com')) {
+      return { ok: false, status: 404, json: async () => ({}) } as Response
+    }
     if (url.includes('/v1/herdr-agents')) {
       return {
         ok: true,
@@ -409,6 +412,23 @@ describe('AgentSidebar Grok rail', () => {
 
     fireEvent.keyDown(window, { key: 'Escape' })
     expect(screen.queryByTestId('remote-sessions-popup')).toBeNull()
+  })
+
+  it('places XOR update/info chrome immediately right of the system name (REQ-78)', async () => {
+    renderSidebar()
+    await screen.findByRole('navigation', { name: 'Agent list' })
+    const server = screen.getByTestId('rail-server-icon')
+    const hostname = screen.getByLabelText('Hostname')
+    const chrome = screen.getByTestId('rail-update-chrome')
+    const row = hostname.closest('.os-rail-hostname-row')
+    expect(row).toBeTruthy()
+    expect(row?.contains(server)).toBe(true)
+    expect(row?.contains(chrome)).toBe(true)
+    expect(server.compareDocumentPosition(hostname) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(hostname.compareDocumentPosition(chrome) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(chrome).toHaveAttribute('data-kind', 'idle')
+    expect(chrome.querySelectorAll('svg')).toHaveLength(1)
+    expect(screen.queryAllByTestId('rail-update-chrome')).toHaveLength(1)
   })
 
   it('paints a red dot on rail-server-icon when local WS is disconnected (REQ-195)', async () => {

--- a/webui/frontend/src/components/__tests__/UpdateChrome.test.tsx
+++ b/webui/frontend/src/components/__tests__/UpdateChrome.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
+import UpdateChrome from '../UpdateChrome'
+import { publishExpectedSpaVersion, resetExpectedSpaVersion } from '../../lib/spaHello'
+import { setBakedSpaVersionForTests } from '../../lib/spaVersion'
+import { GITHUB_ISSUES_URL, resetGithubReleaseCache } from '../../lib/githubRelease'
+
+function stubGithub(tag: string | null) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('api.github.com') && tag) {
+        return {
+          ok: true,
+          json: async () => ({
+            tag_name: tag,
+            html_url: `https://github.com/matthewhand/open-swarm/releases/tag/${tag}`,
+          }),
+        } as Response
+      }
+      return { ok: false, status: 503, json: async () => ({}) } as Response
+    }),
+  )
+}
+
+describe('UpdateChrome (REQ-78)', () => {
+  beforeEach(() => {
+    resetExpectedSpaVersion()
+    resetGithubReleaseCache()
+    setBakedSpaVersionForTests('0.5.4')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    resetExpectedSpaVersion()
+    resetGithubReleaseCache()
+    setBakedSpaVersionForTests(null)
+  })
+
+  it('match → ⓘ and click opens Issues (never stacks a cloud)', async () => {
+    stubGithub('0.5.4')
+    const openUrl = vi.fn()
+    render(<UpdateChrome openUrl={openUrl} />)
+    const btn = screen.getByTestId('rail-update-chrome')
+    expect(btn).toHaveAttribute('data-kind', 'idle')
+    expect(btn).toHaveAttribute('aria-label', 'Open Swarm issues')
+    fireEvent.click(btn)
+    expect(openUrl).toHaveBeenCalledWith(GITHUB_ISSUES_URL)
+    expect(screen.queryByTestId('rail-update-chrome')).toHaveAttribute('data-kind', 'idle')
+  })
+
+  it('SPA mismatch only → amber cloud and reload', async () => {
+    stubGithub(null)
+    const reload = vi.fn()
+    const openUrl = vi.fn()
+    render(<UpdateChrome reload={reload} openUrl={openUrl} />)
+    act(() => {
+      publishExpectedSpaVersion('0.5.5')
+    })
+    const btn = await screen.findByLabelText('Reload to update this tab')
+    expect(btn).toHaveAttribute('data-kind', 'local')
+    expect(btn).toHaveClass('os-rail-update-chrome--local')
+    fireEvent.click(btn)
+    expect(reload).toHaveBeenCalledTimes(1)
+    expect(openUrl).not.toHaveBeenCalled()
+  })
+
+  it('GitHub newer only → sky cloud and release link', async () => {
+    stubGithub('v0.5.6')
+    const reload = vi.fn()
+    const openUrl = vi.fn()
+    render(<UpdateChrome reload={reload} openUrl={openUrl} />)
+    act(() => {
+      publishExpectedSpaVersion('0.5.4')
+    })
+    const btn = await screen.findByLabelText('Newer Open Swarm release available')
+    expect(btn).toHaveAttribute('data-kind', 'upstream')
+    expect(btn).toHaveClass('os-rail-update-chrome--upstream')
+    fireEvent.click(btn)
+    expect(reload).not.toHaveBeenCalled()
+    expect(openUrl).toHaveBeenCalledWith(
+      'https://github.com/matthewhand/open-swarm/releases/tag/v0.5.6',
+    )
+  })
+
+  it('API fail → no upstream cloud', async () => {
+    stubGithub(null)
+    render(<UpdateChrome />)
+    act(() => {
+      publishExpectedSpaVersion('0.5.4')
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('rail-update-chrome')).toHaveAttribute('data-kind', 'idle')
+    })
+  })
+
+  it('both → local priority, tooltip mentions upstream, one icon only', async () => {
+    stubGithub('v0.5.6')
+    const reload = vi.fn()
+    render(<UpdateChrome reload={reload} />)
+    act(() => {
+      publishExpectedSpaVersion('0.5.5')
+    })
+    const btn = await screen.findByLabelText('Reload to update this tab')
+    expect(btn).toHaveAttribute('data-kind', 'local')
+    expect(btn).toHaveAttribute('data-also-upstream', 'true')
+    expect(btn.getAttribute('title') || '').toMatch(/GitHub release/i)
+    expect(btn.querySelectorAll('svg')).toHaveLength(1)
+    fireEvent.click(btn)
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+})

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -1008,6 +1008,29 @@ button.os-agent-row {
   background: color-mix(in srgb, var(--color-base-300) 40%, transparent);
 }
 
+/* REQ-78: XOR update/info slot to the right of the system name.
+   Colour A (local SPA/backend mismatch) is amber/warning.
+   Colour B (GitHub newer release) is sky/info. Distinct from #372 WS red. */
+.os-rail-update-chrome {
+  flex-shrink: 0;
+  display: inline-flex;
+}
+.os-rail-update-chrome--idle {
+  color: color-mix(in srgb, var(--color-base-content) 55%, transparent);
+}
+.os-rail-update-chrome--idle:hover,
+.os-rail-update-chrome--idle:focus-visible {
+  color: var(--color-base-content);
+}
+.os-rail-update-chrome--local,
+.os-rail-update-chrome--local[data-kind="local"] {
+  color: #d97706;
+}
+.os-rail-update-chrome--upstream,
+.os-rail-update-chrome--upstream[data-kind="upstream"] {
+  color: #38bdf8;
+}
+
 .os-chat-header {
   display: flex;
   align-items: center;

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -992,9 +992,11 @@ button.os-agent-row {
   color: #d46a6a;
 }
 .os-rail-hostname {
-  min-width: 0;
-  flex: 1;
-  width: 100%;
+  min-width: 4rem;
+  flex: 0 1 auto;
+  width: auto;
+  max-width: 10rem;
+  field-sizing: content;
   background: transparent;
   border: 0;
   border-radius: 0.35rem;

--- a/webui/frontend/src/lib/__tests__/chatWs.test.ts
+++ b/webui/frontend/src/lib/__tests__/chatWs.test.ts
@@ -145,6 +145,18 @@ describe('parseChatWsMessage', () => {
     expect(parseChatWsMessage(weird)).toEqual({ kind: 'unknown', raw: weird })
   })
 
+  it('parses spa_hello and ignores an empty version', () => {
+    expect(
+      parseChatWsMessage(JSON.stringify({ type: 'spa_hello', spa_version: '0.5.4' })),
+    ).toEqual({ kind: 'spa_hello', spaVersion: '0.5.4' })
+    expect(
+      parseChatWsMessage(JSON.stringify({ type: 'spa_hello', spa_version: '  ' })),
+    ).toEqual({
+      kind: 'unknown',
+      raw: JSON.stringify({ type: 'spa_hello', spa_version: '  ' }),
+    })
+  })
+
   it('parses JSON tool_status and tool_approval frames', () => {
     expect(
       parseChatWsMessage(

--- a/webui/frontend/src/lib/__tests__/githubRelease.test.ts
+++ b/webui/frontend/src/lib/__tests__/githubRelease.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  GITHUB_API_LATEST,
+  GITHUB_API_TAGS,
+  GITHUB_RELEASES_URL,
+  fetchLatestGithubRelease,
+  releasePageUrl,
+  resetGithubReleaseCache,
+} from '../githubRelease'
+
+describe('githubRelease call-home', () => {
+  afterEach(() => {
+    resetGithubReleaseCache()
+    vi.unstubAllGlobals()
+  })
+
+  it('builds an honest release-page URL', () => {
+    expect(releasePageUrl('v0.5.5')).toBe(`${GITHUB_RELEASES_URL}/tag/v0.5.5`)
+    expect(releasePageUrl('')).toBe(GITHUB_RELEASES_URL)
+  })
+
+  it('reads releases/latest and caches for the session', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        tag_name: 'v0.5.5',
+        html_url: 'https://github.com/matthewhand/open-swarm/releases/tag/v0.5.5',
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const first = await fetchLatestGithubRelease()
+    const second = await fetchLatestGithubRelease()
+    expect(first).toEqual({
+      tag: 'v0.5.5',
+      htmlUrl: 'https://github.com/matthewhand/open-swarm/releases/tag/v0.5.5',
+    })
+    expect(second).toEqual(first)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(GITHUB_API_LATEST)
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined
+    expect(JSON.stringify(init?.headers || {})).not.toMatch(/authorization/i)
+    expect(JSON.stringify(init?.headers || {})).not.toMatch(/token/i)
+  })
+
+  it('falls back to tags when latest is missing and treats fetch failure as no signal', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 404, json: async () => ({}) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ name: 'v0.5.5' }],
+      })
+    vi.stubGlobal('fetch', fetchMock)
+    const hit = await fetchLatestGithubRelease()
+    expect(hit).toEqual({
+      tag: 'v0.5.5',
+      htmlUrl: `${GITHUB_RELEASES_URL}/tag/v0.5.5`,
+    })
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe(GITHUB_API_TAGS)
+
+    resetGithubReleaseCache()
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+    expect(await fetchLatestGithubRelease()).toBeNull()
+  })
+})

--- a/webui/frontend/src/lib/__tests__/spaHello.test.ts
+++ b/webui/frontend/src/lib/__tests__/spaHello.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  SPA_HELLO_EVENT,
+  getExpectedSpaVersion,
+  publishExpectedSpaVersion,
+  resetExpectedSpaVersion,
+} from '../spaHello'
+
+describe('spaHello bus', () => {
+  afterEach(() => {
+    resetExpectedSpaVersion()
+  })
+
+  it('starts empty so first paint cannot show a false update', () => {
+    expect(getExpectedSpaVersion()).toBeNull()
+  })
+
+  it('publishes a trimmed version and can reset', () => {
+    const seen: Array<string | null> = []
+    const onHello = (event: Event) => {
+      seen.push((event as CustomEvent<string | null>).detail)
+    }
+    window.addEventListener(SPA_HELLO_EVENT, onHello)
+    publishExpectedSpaVersion('  0.5.4  ')
+    expect(getExpectedSpaVersion()).toBe('0.5.4')
+    resetExpectedSpaVersion()
+    expect(getExpectedSpaVersion()).toBeNull()
+    window.removeEventListener(SPA_HELLO_EVENT, onHello)
+    expect(seen).toEqual(['0.5.4'])
+  })
+})

--- a/webui/frontend/src/lib/__tests__/spaUpdate.test.ts
+++ b/webui/frontend/src/lib/__tests__/spaUpdate.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isNewerVersion,
+  normalizeVersion,
+  resolveUpdateChrome,
+  versionsEqual,
+} from '../spaUpdate'
+
+describe('spaUpdate version helpers', () => {
+  it('strips a leading v and compares equality', () => {
+    expect(normalizeVersion(' v0.5.4 ')).toBe('0.5.4')
+    expect(versionsEqual('v0.5.4', '0.5.4')).toBe(true)
+    expect(versionsEqual('0.5.4', '0.5.5')).toBe(false)
+  })
+
+  it('detects a strictly newer dotted release', () => {
+    expect(isNewerVersion('0.5.5', '0.5.4')).toBe(true)
+    expect(isNewerVersion('v0.6.0', '0.5.9')).toBe(true)
+    expect(isNewerVersion('0.5.4', '0.5.4')).toBe(false)
+    expect(isNewerVersion('0.5.3', '0.5.4')).toBe(false)
+    expect(isNewerVersion('not-a-version', '0.5.4')).toBe(false)
+  })
+})
+
+describe('resolveUpdateChrome (REQ-78 XOR + priority)', () => {
+  it('match → idle ⓘ (first paint: no hello, no GitHub)', () => {
+    expect(
+      resolveUpdateChrome({
+        bakedVersion: '0.5.4',
+        backendVersion: null,
+        githubLatest: null,
+      }),
+    ).toEqual({ kind: 'idle', alsoUpstream: false })
+    expect(
+      resolveUpdateChrome({
+        bakedVersion: '0.5.4',
+        backendVersion: 'v0.5.4',
+        githubLatest: '0.5.4',
+      }),
+    ).toEqual({ kind: 'idle', alsoUpstream: false })
+  })
+
+  it('SPA mismatch only → colour A (local)', () => {
+    expect(
+      resolveUpdateChrome({
+        bakedVersion: '0.5.3',
+        backendVersion: '0.5.4',
+        githubLatest: null,
+      }),
+    ).toEqual({ kind: 'local', alsoUpstream: false })
+  })
+
+  it('GitHub newer only → colour B (upstream)', () => {
+    expect(
+      resolveUpdateChrome({
+        bakedVersion: '0.5.4',
+        backendVersion: '0.5.4',
+        githubLatest: '0.5.5',
+      }),
+    ).toEqual({ kind: 'upstream', alsoUpstream: false })
+  })
+
+  it('API fail / missing GitHub → no B', () => {
+    expect(
+      resolveUpdateChrome({
+        bakedVersion: '0.5.4',
+        backendVersion: '0.5.4',
+        githubLatest: null,
+      }),
+    ).toEqual({ kind: 'idle', alsoUpstream: false })
+  })
+
+  it('both → local A wins and notes upstream in alsoUpstream', () => {
+    expect(
+      resolveUpdateChrome({
+        bakedVersion: '0.5.3',
+        backendVersion: '0.5.4',
+        githubLatest: '0.5.5',
+      }),
+    ).toEqual({ kind: 'local', alsoUpstream: true })
+  })
+})

--- a/webui/frontend/src/lib/chatWs.ts
+++ b/webui/frontend/src/lib/chatWs.ts
@@ -51,6 +51,7 @@ export type ChatWsEvent =
     }
   | { kind: 'status'; text: string }
   | { kind: 'pr_opened'; event: PrOpenedEvent }
+  | { kind: 'spa_hello'; spaVersion: string }
   | {
       kind: 'interbot_hop'
       id: string
@@ -153,6 +154,11 @@ function parseToolJsonFrame(raw: string): ChatWsEvent | null {
     if (type === 'pr_opened') {
       const event = parsePrOpened(payload)
       if (event) return { kind: 'pr_opened', event }
+    }
+    if (type === 'spa_hello') {
+      const spaVersion = String(payload.spa_version || '').trim()
+      if (!spaVersion) return { kind: 'unknown', raw }
+      return { kind: 'spa_hello', spaVersion }
     }
   } catch {
     return null

--- a/webui/frontend/src/lib/githubRelease.ts
+++ b/webui/frontend/src/lib/githubRelease.ts
@@ -1,0 +1,132 @@
+/**
+ * Public GitHub call-home for a newer open-swarm release (REQ-78).
+ * Unauthenticated only. Failure → no upstream signal. No tokens.
+ */
+
+export const GITHUB_REPO = 'matthewhand/open-swarm'
+export const GITHUB_ISSUES_URL = `https://github.com/${GITHUB_REPO}/issues`
+export const GITHUB_RELEASES_URL = `https://github.com/${GITHUB_REPO}/releases`
+export const GITHUB_API_LATEST = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`
+export const GITHUB_API_TAGS = `https://api.github.com/repos/${GITHUB_REPO}/tags`
+
+export const GITHUB_RELEASE_CACHE_KEY = 'swarm_github_latest_release'
+export const GITHUB_RELEASE_TTL_MS = 6 * 60 * 60 * 1000
+
+export interface GithubReleaseHit {
+  tag: string
+  htmlUrl: string
+}
+
+interface CachedHit {
+  tag: string
+  htmlUrl: string
+  checkedAt: number
+}
+
+let memoryCache: CachedHit | null = null
+
+function isUsableCache(entry: CachedHit | null, now: number): entry is CachedHit {
+  return Boolean(entry && now - entry.checkedAt < GITHUB_RELEASE_TTL_MS)
+}
+
+function readSessionCache(now: number): CachedHit | null {
+  if (typeof sessionStorage === 'undefined') return null
+  try {
+    const raw = sessionStorage.getItem(GITHUB_RELEASE_CACHE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as CachedHit
+    if (
+      typeof parsed?.tag !== 'string' ||
+      typeof parsed?.htmlUrl !== 'string' ||
+      typeof parsed?.checkedAt !== 'number'
+    ) {
+      return null
+    }
+    return isUsableCache(parsed, now) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function writeCache(hit: CachedHit): void {
+  memoryCache = hit
+  if (typeof sessionStorage === 'undefined') return
+  try {
+    sessionStorage.setItem(GITHUB_RELEASE_CACHE_KEY, JSON.stringify(hit))
+  } catch {
+    /* quota / private mode */
+  }
+}
+
+export function resetGithubReleaseCache(): void {
+  memoryCache = null
+  if (typeof sessionStorage === 'undefined') return
+  try {
+    sessionStorage.removeItem(GITHUB_RELEASE_CACHE_KEY)
+  } catch {
+    /* ignore */
+  }
+}
+
+export function releasePageUrl(tag: string): string {
+  const cleaned = tag.trim()
+  if (!cleaned) return GITHUB_RELEASES_URL
+  return `${GITHUB_RELEASES_URL}/tag/${encodeURIComponent(cleaned)}`
+}
+
+function parseLatestPayload(payload: unknown): GithubReleaseHit | null {
+  if (!payload || typeof payload !== 'object') return null
+  const rec = payload as Record<string, unknown>
+  const tag = typeof rec.tag_name === 'string' ? rec.tag_name.trim() : ''
+  if (!tag) return null
+  const htmlUrl =
+    typeof rec.html_url === 'string' && rec.html_url.trim()
+      ? rec.html_url.trim()
+      : releasePageUrl(tag)
+  return { tag, htmlUrl }
+}
+
+function parseTagsPayload(payload: unknown): GithubReleaseHit | null {
+  if (!Array.isArray(payload) || payload.length === 0) return null
+  const first = payload[0]
+  if (!first || typeof first !== 'object') return null
+  const name = (first as Record<string, unknown>).name
+  const tag = typeof name === 'string' ? name.trim() : ''
+  if (!tag) return null
+  return { tag, htmlUrl: releasePageUrl(tag) }
+}
+
+async function fetchJson(url: string): Promise<unknown | null> {
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: 'application/vnd.github+json' },
+    })
+    if (!response.ok) return null
+    return await response.json()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Latest public release/tag, or null when GitHub is unreachable / unusable.
+ * Cached per session (and up to 6 hours) so we do not hammer the API.
+ */
+export async function fetchLatestGithubRelease(
+  now = Date.now(),
+): Promise<GithubReleaseHit | null> {
+  if (isUsableCache(memoryCache, now)) {
+    return { tag: memoryCache.tag, htmlUrl: memoryCache.htmlUrl }
+  }
+  const sessionHit = readSessionCache(now)
+  if (sessionHit) {
+    memoryCache = sessionHit
+    return { tag: sessionHit.tag, htmlUrl: sessionHit.htmlUrl }
+  }
+
+  const latest = parseLatestPayload(await fetchJson(GITHUB_API_LATEST))
+  const hit = latest ?? parseTagsPayload(await fetchJson(GITHUB_API_TAGS))
+  if (!hit) return null
+  writeCache({ ...hit, checkedAt: now })
+  return hit
+}

--- a/webui/frontend/src/lib/spaHello.ts
+++ b/webui/frontend/src/lib/spaHello.ts
@@ -1,0 +1,25 @@
+/**
+ * Backend-advertised SPA version from the chat websocket hello (REQ-78).
+ * ChatPage publishes; the rail UpdateChrome subscribes.
+ */
+
+export const SPA_HELLO_EVENT = 'swarm:spa-hello'
+
+let current: string | null = null
+
+export function getExpectedSpaVersion(): string | null {
+  return current
+}
+
+export function resetExpectedSpaVersion(): void {
+  current = null
+}
+
+export function publishExpectedSpaVersion(version: string): void {
+  const trimmed = version.trim()
+  current = trimmed || null
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(
+    new CustomEvent<string | null>(SPA_HELLO_EVENT, { detail: current }),
+  )
+}

--- a/webui/frontend/src/lib/spaUpdate.ts
+++ b/webui/frontend/src/lib/spaUpdate.ts
@@ -1,0 +1,78 @@
+/**
+ * REQ-78 update chrome: local SPA/backend mismatch vs GitHub newer release.
+ *
+ * Priority: local mismatch (A, reload) wins over GitHub newer (B, release page).
+ * Missing signals never alarm — first paint and API failure stay idle (ⓘ).
+ */
+
+export type UpdateChromeKind = 'idle' | 'local' | 'upstream'
+
+export interface UpdateChromeState {
+  kind: UpdateChromeKind
+  alsoUpstream: boolean
+}
+
+export function normalizeVersion(value: string): string {
+  return value.trim().replace(/^v/i, '')
+}
+
+export function versionsEqual(left: string, right: string): boolean {
+  return normalizeVersion(left) === normalizeVersion(right)
+}
+
+function parseVersionParts(value: string): number[] | null {
+  const normalized = normalizeVersion(value)
+  if (!normalized) return null
+  const chunks = normalized.split('.')
+  const parts: number[] = []
+  for (const chunk of chunks) {
+    const match = /^(\d+)/.exec(chunk)
+    if (!match) return null
+    parts.push(Number(match[1]))
+  }
+  return parts.length > 0 ? parts : null
+}
+
+/** True when candidate is a strictly newer dotted version than current. */
+export function isNewerVersion(candidate: string, current: string): boolean {
+  const left = parseVersionParts(candidate)
+  const right = parseVersionParts(current)
+  if (!left || !right) return false
+  const len = Math.max(left.length, right.length)
+  for (let i = 0; i < len; i += 1) {
+    const a = left[i] ?? 0
+    const b = right[i] ?? 0
+    if (a > b) return true
+    if (a < b) return false
+  }
+  return false
+}
+
+/**
+ * Resolve the single XOR chrome slot.
+ * `backendVersion` null = no hello yet (do not treat as mismatch).
+ * `githubLatest` null = no upstream signal (fail / not fetched).
+ */
+export function resolveUpdateChrome(input: {
+  bakedVersion: string
+  backendVersion: string | null
+  githubLatest: string | null
+}): UpdateChromeState {
+  const baked = input.bakedVersion.trim()
+  const backend = input.backendVersion?.trim() || null
+  const github = input.githubLatest?.trim() || null
+
+  const localMismatch = Boolean(backend && baked && !versionsEqual(baked, backend))
+  const advertised = backend || baked
+  const upstreamNewer = Boolean(
+    github && advertised && isNewerVersion(github, advertised),
+  )
+
+  if (localMismatch) {
+    return { kind: 'local', alsoUpstream: upstreamNewer }
+  }
+  if (upstreamNewer) {
+    return { kind: 'upstream', alsoUpstream: false }
+  }
+  return { kind: 'idle', alsoUpstream: false }
+}

--- a/webui/frontend/src/lib/spaVersion.ts
+++ b/webui/frontend/src/lib/spaVersion.ts
@@ -1,0 +1,16 @@
+/**
+ * Baked SPA version string (Vite injects pyproject version at build).
+ * Overridable in unit tests. No secrets.
+ */
+
+let override: string | null = null
+
+export function getBakedSpaVersion(): string {
+  if (override !== null) return override
+  const fromEnv = import.meta.env.VITE_SPA_VERSION
+  return typeof fromEnv === 'string' ? fromEnv : ''
+}
+
+export function setBakedSpaVersionForTests(version: string | null): void {
+  override = version
+}

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -84,6 +84,7 @@ import {
   type ToolCallState,
 } from '../lib/safety'
 import { notifyGenerationComplete } from '../lib/railOrder'
+import { publishExpectedSpaVersion } from '../lib/spaHello'
 import {
   ALL_MEMBERS_TARGET,
   MANAGE_TEAMS_HREF,
@@ -805,6 +806,10 @@ const ChatPage = () => {
     (event: ChatWsEvent) => {
       if (event.kind === 'unknown') {
         console.warn('Unrecognised chat websocket frame:', event.raw)
+        return
+      }
+      if (event.kind === 'spa_hello') {
+        publishExpectedSpaVersion(event.spaVersion)
         return
       }
       if (event.kind === 'tool_status') {

--- a/webui/frontend/src/pages/__tests__/ChatPage.spaHello.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.spaHello.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import ChatPage from '../ChatPage'
+import { ToastProvider } from '../../components/DaisyUI'
+import { resetConversationThreads } from '../../lib/chatMeter'
+import {
+  SPA_HELLO_EVENT,
+  getExpectedSpaVersion,
+  resetExpectedSpaVersion,
+} from '../../lib/spaHello'
+
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  static instances: MockWebSocket[] = []
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((ev?: Event) => void) | null = null
+  onmessage: ((ev?: MessageEvent) => void) | null = null
+  onclose: ((ev?: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor(_url: string) {
+    MockWebSocket.instances.push(this)
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+}
+
+describe('ChatPage spa_hello (REQ-78)', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    resetExpectedSpaVersion()
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [] }),
+      } as Response),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    resetConversationThreads()
+    resetExpectedSpaVersion()
+  })
+
+  it('publishes the backend SPA version from a mocked WS hello', async () => {
+    const seen: string[] = []
+    const onHello = (event: Event) => {
+      const detail = (event as CustomEvent<string | null>).detail
+      if (detail) seen.push(detail)
+    }
+    window.addEventListener(SPA_HELLO_EVENT, onHello)
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={client}>
+        <ToastProvider>
+          <MemoryRouter initialEntries={['/chat']}>
+            <ChatPage />
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>,
+    )
+
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+    expect(getExpectedSpaVersion()).toBeNull()
+
+    await act(async () => {
+      MockWebSocket.instances[0]?.onmessage?.(
+        new MessageEvent('message', {
+          data: JSON.stringify({ type: 'spa_hello', spa_version: '0.5.4' }),
+        }),
+      )
+    })
+
+    expect(getExpectedSpaVersion()).toBe('0.5.4')
+    expect(seen).toEqual(['0.5.4'])
+    window.removeEventListener(SPA_HELLO_EVENT, onHello)
+  })
+})

--- a/webui/frontend/src/setupTests.ts
+++ b/webui/frontend/src/setupTests.ts
@@ -1,8 +1,14 @@
 import '@testing-library/jest-dom';
 import { resetChatConnection } from './lib/chatConnection';
+import { resetExpectedSpaVersion } from './lib/spaHello';
+import { resetGithubReleaseCache } from './lib/githubRelease';
+import { setBakedSpaVersionForTests } from './lib/spaVersion';
 
 afterEach(() => {
     resetChatConnection();
+    resetExpectedSpaVersion();
+    resetGithubReleaseCache();
+    setBakedSpaVersionForTests(null);
 });
 
 if (!HTMLDialogElement.prototype.showModal) {

--- a/webui/frontend/src/vite-env.d.ts
+++ b/webui/frontend/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SPA_VERSION: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/webui/frontend/vite.config.ts
+++ b/webui/frontend/vite.config.ts
@@ -1,9 +1,26 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+function readPyprojectVersion(): string {
+    try {
+        const text = readFileSync(resolve(__dirname, '../../pyproject.toml'), 'utf8')
+        const match = /^version\s*=\s*"([^"]+)"/m.exec(text)
+        return match?.[1] ?? '0.0.0'
+    } catch {
+        return '0.0.0'
+    }
+}
+
+const spaVersion = readPyprojectVersion()
+
 // https://vitejs.dev/config/
 export default defineConfig({
+    define: {
+        'import.meta.env.VITE_SPA_VERSION': JSON.stringify(spaVersion),
+    },
     plugins: [
         react(),
         tailwindcss(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #423

## Quoted from #423

**Intent:** Bottom-left, right of the **system name**: show either a **cloud-update** icon (when an update applies) or an **ⓘ** (when idle). Updates come from **two sources**, with **different cloud colours** so the user can tell them apart.

**Success:**
1. **Placement:** Immediately right of system name. Distinct from hostname WS blob (#372). XOR: one of {upstream cloud, local cloud, ⓘ} — never stack two clouds + ⓘ.
2. **Source A — local SPA vs backend (existing):** On WS connect/reconnect, server advertises expected SPA version; SPA compares to baked-in version. **Mismatch → cloud colour A** (e.g. amber/warning). Click → **reload** tab to fetch new SPA. First paint: no false “update.”
3. **Source B — GitHub newer release:** Periodically or on connect, **call home** to public GitHub (Releases/latest or tags API for `matthewhand/open-swarm` — no auth, no secrets). Compare latest released version to the running app’s advertised version (pyproject / bake string). **Newer release → cloud colour B** (distinct from A, e.g. info/sky). Click → honest destination (prefer that release page or repo Releases; document). Rate-limit / cache (e.g. once per session or every N hours); failure to reach GitHub → treat as “no upstream signal,” don’t alarm.
4. **Priority if both A and B:** Prefer showing **A** (local reload fixes the tab) with optional badge/tooltip mentioning upstream also newer; or show A and note B in tooltip. Don’t leave the user only on upstream when a reload would fix the SPA. Document chosen priority in PR.
5. **Idle:** Neither A nor B → **ⓘ**. Click → `https://github.com/matthewhand/open-swarm/issues` (new tab, noopener).
6. **Tests:** match → ⓘ; SPA mismatch only → colour A + reload; GitHub newer only → colour B + link; API fail → no B; both → priority rule held. No live host required for unit tests (mock GH + WS). No secrets.
7. DaisyUI 5 / React 18. Chat mounted (#364). GitHub-only until unblocked.

**Constraints:**
- Public GitHub API only; graceful offline. No Neon. No tokens in frontend.
- Parked / one cloud when capacity. `Fixes` this Issue.
- Distinct from #372.

**Owner:** open-swarm engineer + Cursor cloud. CoS: Open Swarm. Skeptic text-only PASS/FAIL.

## Feasibility

Feasible in the existing rail footer + chat WS hello: one XOR slot, two colours, mocked unit tests, no secrets.

## What landed

- Authenticated `DjangoChatConsumer.connect` sends `{"type":"spa_hello","spa_version":"<pyproject/package>"}`. Anonymous 4401 still sends nothing (no false update).
- Vite bakes `VITE_SPA_VERSION` from `pyproject.toml`.
- Rail footer, **immediately right of the hostname/system name** (server icon stays left, #499 / #372 unchanged): one of
  - **ⓘ** idle → Issues (`https://github.com/matthewhand/open-swarm/issues`, `noopener`)
  - **amber cloud (A)** local SPA ≠ backend hello → `location.reload()`
  - **sky cloud (B)** public GitHub newer than advertised/baked version → that release page (`html_url` or `/releases/tag/<tag>`)
- **Priority:** A wins over B. When both apply, the amber cloud stays and the tooltip notes that a newer GitHub release is also available.
- GitHub call-home is unauthenticated `releases/latest` with tags fallback, cached in-memory + `sessionStorage` for 6 hours. Failure → no B.
- First paint is idle until a hello or a successful newer-release read.

## Tests (own-diff)

- Vitest: match → ⓘ; SPA mismatch only → amber + reload; GitHub newer only → sky + release URL; API fail → no B; both → A wins + tooltip notes B. Mock GH + WS.
- Playwright `e2e/req78-update-chrome.spec.ts` (stubbed APIs, no live host).
- Consumer hello + ASGI drain of `spa_hello` before chat frames.
- Source-lock `test_req78_update_chrome.py`.

No Neon. No tokens. Chat stays mounted.

[Idle info icon right of localhost](https://cursor.com/agents/bc-f5575956-22f3-44e6-8662-07e9b5b9ba0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freq78-idle-info.png)
[Amber local-mismatch cloud](https://cursor.com/agents/bc-f5575956-22f3-44e6-8662-07e9b5b9ba0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freq78-local-amber.png)
[Sky GitHub-newer cloud](https://cursor.com/agents/bc-f5575956-22f3-44e6-8662-07e9b5b9ba0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freq78-upstream-sky.png)
[Full rail with idle chrome](https://cursor.com/agents/bc-f5575956-22f3-44e6-8662-07e9b5b9ba0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freq78-rail-idle.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5575956-22f3-44e6-8662-07e9b5b9ba0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5575956-22f3-44e6-8662-07e9b5b9ba0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

