### PR TITLE
Inter-bot stack / N Bots opens a dropdown to pick the exact bot

### DIFF
--- a/webui/frontend/src/components/InterBotLine.tsx
+++ b/webui/frontend/src/components/InterBotLine.tsx
@@ -1,12 +1,22 @@
+import { useEffect, useId, useRef, useState, type KeyboardEvent } from 'react'
+import { Link } from 'react-router-dom'
 import { LoadingDots } from './DaisyUI'
 import { agentMarkColor, agentMarkIndex } from '../lib/hiddenAgents'
-import type { InterBotHop, InterBotLine as InterBotLineData } from '../lib/interBot'
+import {
+  botCountLabel,
+  interBotChatHref,
+  uniqueHopsInOrder,
+  type InterBotHop,
+  type InterBotLine as InterBotLineData,
+} from '../lib/interBot'
 
 function HopAvatar({ hop, stacked }: { hop: InterBotHop; stacked: boolean }) {
   const color = agentMarkColor(hop.agentId || hop.name)
   return (
     <span
-      className={`os-interbot-avatar ${stacked ? 'os-interbot-avatar--stacked' : ''}`}
+      className={`os-interbot-avatar inline-block h-4 w-4 shrink-0 rounded-full border border-base-100 ${
+        stacked ? 'os-interbot-avatar--stacked -ms-1.5 first:ms-0' : ''
+      }`}
       data-mark={String(agentMarkIndex(hop.agentId || hop.name))}
       data-agent={hop.agentId}
       title={hop.name}
@@ -16,7 +26,17 @@ function HopAvatar({ hop, stacked }: { hop: InterBotHop; stacked: boolean }) {
   )
 }
 
-export default function InterBotLine({ line }: { line: InterBotLineData }) {
+export interface InterBotLineProps {
+  line: InterBotLineData
+  /** Optional override; default is /chat?blueprint= via the row Link. */
+  onSelectAgent?: (hop: InterBotHop) => void
+}
+
+function jumpToHop(hop: InterBotHop, onSelectAgent?: (hop: InterBotHop) => void) {
+  onSelectAgent?.(hop)
+}
+
+export default function InterBotLine({ line, onSelectAgent }: InterBotLineProps) {
   if (line.kind === 'progress') {
     return (
       <div className="os-interbot-line" data-pending="true" role="status">
@@ -27,25 +47,181 @@ export default function InterBotLine({ line }: { line: InterBotLineData }) {
 
   if (line.kind === 'single') {
     return (
-      <div className="os-interbot-line" data-kind="single" role="status">
+      <div className="os-interbot-line inline-flex items-center gap-1.5 text-xs" data-kind="single">
         <span>Message from</span>
-        <HopAvatar hop={line.hop} stacked={false} />
-        <span className="os-interbot-name">{line.hop.name}</span>
+        <Link
+          to={interBotChatHref(line.hop.agentId)}
+          className="os-interbot-jump inline-flex items-center gap-1.5 rounded-md px-0.5 py-0.5 hover:bg-base-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          data-testid="os-interbot-single-jump"
+          aria-label={line.hop.name}
+          onClick={() => jumpToHop(line.hop, onSelectAgent)}
+        >
+          <HopAvatar hop={line.hop} stacked={false} />
+          <span className="os-interbot-name">{line.hop.name}</span>
+        </Link>
       </div>
     )
   }
 
+  return <MultiHopLine line={line} onSelectAgent={onSelectAgent} />
+}
+
+function MultiHopLine({
+  line,
+  onSelectAgent,
+}: {
+  line: Extract<InterBotLineData, { kind: 'multi' }>
+  onSelectAgent?: (hop: InterBotHop) => void
+}) {
+  const hops = uniqueHopsInOrder(line.hops)
+  const [open, setOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const itemRefs = useRef<Array<HTMLAnchorElement | null>>([])
+  const menuId = useId()
+  const countLabel = botCountLabel(line.hops.length)
+  const triggerLabel = `Messaged ${countLabel}`
+
+  useEffect(() => {
+    if (!open) return
+    const onDocMouse = (event: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const onDocKey = (event: globalThis.KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setOpen(false)
+        triggerRef.current?.focus()
+      }
+    }
+    document.addEventListener('mousedown', onDocMouse)
+    document.addEventListener('keydown', onDocKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocMouse)
+      document.removeEventListener('keydown', onDocKey)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    itemRefs.current[activeIndex]?.focus()
+  }, [open, activeIndex])
+
+  const move = (delta: number) => {
+    if (hops.length === 0) return
+    setActiveIndex((current) => (current + delta + hops.length) % hops.length)
+  }
+
+  const openMenu = (index = 0) => {
+    setActiveIndex(index)
+    setOpen(true)
+  }
+
+  const handleTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      openMenu(0)
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      openMenu(Math.max(0, hops.length - 1))
+    } else if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      if (open) setOpen(false)
+      else openMenu(0)
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      setOpen(false)
+      triggerRef.current?.focus()
+    }
+  }
+
+  const handleMenuKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      move(1)
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      move(-1)
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      setActiveIndex(0)
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      setActiveIndex(Math.max(0, hops.length - 1))
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      setOpen(false)
+      triggerRef.current?.focus()
+    }
+  }
+
   return (
-    <div className="os-interbot-line" data-kind="multi" role="status">
+    <div className="os-interbot-line inline-flex items-center gap-1.5 text-xs" data-kind="multi">
       <span>Messaged</span>
-      <span className="os-interbot-avatars" aria-hidden="true">
-        {line.hops.map((hop) => (
-          <HopAvatar key={hop.id} hop={hop} stacked />
-        ))}
-      </span>
-      <span>
-        {line.hops.length} {line.hops.length === 1 ? 'Bot' : 'Bots'}
-      </span>
+      <div
+        ref={rootRef}
+        className={`dropdown ${open ? 'dropdown-open' : ''}`}
+        data-testid="os-interbot-dropdown"
+      >
+        <button
+          ref={triggerRef}
+          type="button"
+          className="os-interbot-picker btn btn-ghost btn-xs h-auto min-h-0 gap-1.5 px-1 py-0.5 font-normal"
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-controls={menuId}
+          aria-label={triggerLabel}
+          data-testid="os-interbot-multi-trigger"
+          onClick={() => {
+            setOpen((value) => !value)
+            setActiveIndex(0)
+          }}
+          onKeyDown={handleTriggerKeyDown}
+        >
+          <span className="os-interbot-avatars inline-flex items-center" aria-hidden="true">
+            {line.hops.map((hop) => (
+              <HopAvatar key={hop.id} hop={hop} stacked />
+            ))}
+          </span>
+          <span data-testid="os-interbot-count">{countLabel}</span>
+        </button>
+        {open ? (
+          <ul
+            id={menuId}
+            role="menu"
+            aria-label={triggerLabel}
+            tabIndex={-1}
+            data-testid="os-interbot-menu"
+            className="dropdown-content menu menu-sm bg-base-100 rounded-box z-20 mt-1 min-w-44 p-2 shadow"
+            onKeyDown={handleMenuKeyDown}
+          >
+            {hops.map((hop, index) => (
+              <li key={hop.id} role="none">
+                <Link
+                  ref={(node) => {
+                    itemRefs.current[index] = node
+                  }}
+                  role="menuitem"
+                  tabIndex={index === activeIndex ? 0 : -1}
+                  to={interBotChatHref(hop.agentId)}
+                  aria-label={hop.name}
+                  className={`inline-flex items-center gap-2 ${index === activeIndex ? 'active' : ''}`}
+                  onClick={() => {
+                    jumpToHop(hop, onSelectAgent)
+                    setOpen(false)
+                  }}
+                >
+                  <HopAvatar hop={hop} stacked={false} />
+                  <span>{hop.name}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
     </div>
   )
 }

--- a/webui/frontend/src/components/__tests__/InterBotLine.test.tsx
+++ b/webui/frontend/src/components/__tests__/InterBotLine.test.tsx
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import InterBotLine from '../InterBotLine'
+import { hopFromAssistantName, type InterBotHop, type InterBotLine as InterBotLineData } from '../../lib/interBot'
+
+function hop(id: string, name: string): InterBotHop {
+  return hopFromAssistantName(id, name, false)
+}
+
+function LocationProbe() {
+  const loc = useLocation()
+  return <div data-testid="interbot-loc">{`${loc.pathname}${loc.search}`}</div>
+}
+
+function renderLine(line: InterBotLineData, onSelectAgent?: (hop: InterBotHop) => void) {
+  return render(
+    <MemoryRouter initialEntries={['/chat?blueprint=support']}>
+      <Routes>
+        <Route
+          path="/chat"
+          element={
+            <>
+              <InterBotLine line={line} onSelectAgent={onSelectAgent} />
+              <LocationProbe />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('InterBotLine multi-hop picker', () => {
+  const multi: InterBotLineData = {
+    kind: 'multi',
+    hops: [hop('1', 'HASS'), hop('2', 'Codey'), hop('3', 'Stewie')],
+  }
+
+  it('renders the stack and N Bots trigger without a menu until clicked', () => {
+    renderLine(multi)
+    expect(screen.getByText('Messaged')).toBeInTheDocument()
+    expect(screen.getByTestId('os-interbot-count')).toHaveTextContent('3 Bots')
+    expect(screen.getByTestId('os-interbot-multi-trigger')).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Cursor/i)).not.toBeInTheDocument()
+  })
+
+  it('opens a DaisyUI menu of every bot from the stack or N Bots label', () => {
+    renderLine(multi)
+    fireEvent.click(screen.getByTestId('os-interbot-multi-trigger'))
+    const menu = screen.getByRole('menu', { name: 'Messaged 3 Bots' })
+    expect(menu).toHaveClass('dropdown-content')
+    expect(menu).toHaveClass('menu')
+    expect(within(menu).getByRole('menuitem', { name: 'HASS' })).toBeInTheDocument()
+    expect(within(menu).getByRole('menuitem', { name: 'Codey' })).toBeInTheDocument()
+    expect(within(menu).getByRole('menuitem', { name: 'Stewie' })).toBeInTheDocument()
+    expect(within(menu).getAllByRole('menuitem')).toHaveLength(3)
+  })
+
+  it('navigates to /chat?blueprint= when a menu row is chosen', () => {
+    const onSelect = vi.fn()
+    renderLine(multi, onSelect)
+    fireEvent.click(screen.getByTestId('os-interbot-multi-trigger'))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Codey' }))
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ name: 'Codey', agentId: 'codey' }))
+    expect(screen.getByTestId('interbot-loc')).toHaveTextContent('/chat?blueprint=codey')
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('opens with Enter or Space and closes with Escape', () => {
+    renderLine(multi)
+    const trigger = screen.getByTestId('os-interbot-multi-trigger')
+    trigger.focus()
+    fireEvent.keyDown(trigger, { key: 'Enter' })
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+
+    fireEvent.keyDown(trigger, { key: ' ' })
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    fireEvent.keyDown(trigger, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('moves the active menu row with arrow keys', () => {
+    renderLine(multi)
+    fireEvent.click(screen.getByTestId('os-interbot-multi-trigger'))
+    const menu = screen.getByRole('menu')
+    expect(screen.getByRole('menuitem', { name: 'HASS' })).toHaveClass('active')
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    expect(screen.getByRole('menuitem', { name: 'Codey' })).toHaveClass('active')
+    fireEvent.keyDown(menu, { key: 'ArrowDown' })
+    expect(screen.getByRole('menuitem', { name: 'Stewie' })).toHaveClass('active')
+    fireEvent.keyDown(menu, { key: 'ArrowUp' })
+    expect(screen.getByRole('menuitem', { name: 'Codey' })).toHaveClass('active')
+  })
+})
+
+describe('InterBotLine single-hop', () => {
+  it('jumps directly to the named agent without a menu', () => {
+    const onSelect = vi.fn()
+    renderLine({ kind: 'single', hop: hop('1', 'HASS') }, onSelect)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    const jump = screen.getByTestId('os-interbot-single-jump')
+    expect(jump).toHaveAttribute('href', '/chat?blueprint=hass')
+    fireEvent.click(jump)
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ name: 'HASS', agentId: 'hass' }))
+    expect(screen.getByTestId('interbot-loc')).toHaveTextContent('/chat?blueprint=hass')
+    expect(screen.queryByText(/Cursor/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('InterBotLine progress', () => {
+  it('keeps pending hops as dots only', () => {
+    renderLine({ kind: 'progress' })
+    expect(document.querySelector('.os-interbot-line[data-pending="true"]')).toBeTruthy()
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Bots/i)).not.toBeInTheDocument()
+  })
+})

--- a/webui/frontend/src/lib/__tests__/interBot.test.ts
+++ b/webui/frontend/src/lib/__tests__/interBot.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
+  botCountLabel,
   collapseInterBotHops,
   groupChatItems,
   hopFromAssistantName,
+  interBotChatHref,
   parseHandoffAssistant,
+  uniqueHopsInOrder,
   type ChatItem,
   type InterBotHop,
 } from '../interBot'
@@ -56,5 +59,26 @@ describe('groupChatItems', () => {
       expect(rows[1].hops).toHaveLength(2)
     }
     expect(rows[2]).toMatchObject({ type: 'message' })
+  })
+})
+
+describe('interBotChatHref', () => {
+  it('uses the same /chat?blueprint= destination as rail jumps', () => {
+    expect(interBotChatHref('hass')).toBe('/chat?blueprint=hass')
+    expect(interBotChatHref('cli:grok')).toBe('/chat?blueprint=cli%3Agrok')
+  })
+})
+
+describe('uniqueHopsInOrder', () => {
+  it('keeps first-seen hop order and drops later duplicates', () => {
+    const hops = [hop('1', 'A'), hop('2', 'B'), hop('3', 'A'), hop('4', 'C')]
+    expect(uniqueHopsInOrder(hops).map((row) => row.name)).toEqual(['A', 'B', 'C'])
+  })
+})
+
+describe('botCountLabel', () => {
+  it('pluralizes the consolidated count', () => {
+    expect(botCountLabel(1)).toBe('1 Bot')
+    expect(botCountLabel(4)).toBe('4 Bots')
   })
 })

--- a/webui/frontend/src/lib/interBot.ts
+++ b/webui/frontend/src/lib/interBot.ts
@@ -63,6 +63,28 @@ export function hopFromAssistantName(
   }
 }
 
+/** Same /chat?blueprint= destination as rail tiles and Search bot rows. */
+export function interBotChatHref(agentId: string): string {
+  return `/chat?blueprint=${encodeURIComponent(agentId)}`
+}
+
+/** First-seen hop order; one row per agent so the picker is unambiguous. */
+export function uniqueHopsInOrder(hops: readonly InterBotHop[]): InterBotHop[] {
+  const seen = new Set<string>()
+  const out: InterBotHop[] = []
+  for (const hop of hops) {
+    const key = (hop.agentId || hop.name).trim().toLowerCase()
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    out.push(hop)
+  }
+  return out
+}
+
+export function botCountLabel(count: number): string {
+  return `${count} ${count === 1 ? 'Bot' : 'Bots'}`
+}
+
 /**
  * Collapse one adjacent hop run.
  * Any in-flight hop → dots only (no avatars). One completed hop → Message from.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #767.

**Feasibility:** InterBotLine already collapses hops; this PR makes the stack / “N Bots” control a DaisyUI menu whose rows use the same `/chat?blueprint=` jump as the rail.

## Intent
Consolidated hop metadata stays compact, but one click reveals the full participant list and lets the user jump to a specific bot’s chat/context.

## Success
1. Multi-hop / consolidated inter-bot line is **clickable** on the avatar stack and on the “N Bots” (or equivalent) text.
2. Click opens a DaisyUI dropdown/menu listing **all** bots in that consolidation (avatar + name), in a stable order (e.g. hop order).
3. Choosing a row **navigates** to that agent’s chat (or focuses that agent in-rail) — same destination language as other in-app agent jumps; never invent Cursor branding.
4. Single-hop “Message from {Name}” may stay a direct jump (or same menu with one item) — document choice in PR; multi-hop **must** use the menu.
5. Keyboard: open with Enter/Space when focused; Escape closes; arrow keys move list.
6. Tests: multi-hop renders menu with all names; pick navigates; single-hop behaviour as chosen; no secrets.

## Constraints
React 18 + Vite + Tailwind 4 + DaisyUI 5. Reuse `InterBotLine` / `interBot.ts`. Chat stays mounted (#364). UI chrome only — reconstruction world (#407): this line is status/chrome, not LLM context. GitHub PR with `Fixes #N`. Wave discipline. Preview FF on Matthew GO.

## Owner
Cursor cloud when capacity; open-swarm engineer squash + FF `:8001` on Matthew GO.

## What landed
- Multi-hop `InterBotLine`: the stacked avatars and “N Bots” label are one DaisyUI dropdown trigger. The menu lists each unique bot in hop order (avatar + name).
- Choosing a row goes to `/chat?blueprint=<agentId>` (same as rail tiles / Search bot rows). Optional `onSelectAgent` lets a parent observe the pick.
- **Single-hop choice:** “Message from {Name}” is a **direct jump** (no one-item menu). Progress (pending hops) stays dots-only.
- Helpers in `interBot.ts`: `interBotChatHref`, `uniqueHopsInOrder`, `botCountLabel`.
- Tests cover menu contents, navigation, keyboard open/move/close, single-hop href, and no Cursor branding.

ChatPage is unchanged: hop chrome stays in `InterBotLine` so this surface can be mounted without rewriting the thread renderer.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48a405bd-ad0d-42f3-99dc-8c2706004933?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48a405bd-ad0d-42f3-99dc-8c2706004933&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

