### PR TITLE
Persist per-agent CLI / model / remote dropdown choice

### DIFF
--- a/src/swarm/core/user_preferences.py
+++ b/src/swarm/core/user_preferences.py
@@ -41,7 +41,9 @@ SECRET_KEY_FRAGMENTS = (
 FAVOURITES_KEY = "favourites"
 HIDDEN_KEY = "hidden_agents"
 HOSTNAME_KEY = "hostname_override"
+AGENT_DROPDOWNS_KEY = "agent_dropdowns"
 HOSTNAME_MAX_LEN = 255
+AGENT_DROPDOWN_FIELDS = ("cli", "model", "remote", "blueprint", "api")
 
 
 def is_secret_key(name: str) -> bool:
@@ -122,6 +124,37 @@ def normalize_id_list(raw: Any) -> list[str]:
     return ids
 
 
+def normalize_agent_dropdown_choice(raw: Any) -> dict[str, str] | None:
+    """Non-secret CLI / API / remote / blueprint ids only."""
+    if not isinstance(raw, dict):
+        return None
+    choice: dict[str, str] = {}
+    for field in AGENT_DROPDOWN_FIELDS:
+        value = raw.get(field)
+        if not isinstance(value, str):
+            continue
+        trimmed = value.strip()
+        if trimmed:
+            choice[field] = trimmed
+    return choice or None
+
+
+def normalize_agent_dropdowns(raw: Any) -> dict[str, dict[str, str]]:
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, dict[str, str]] = {}
+    for agent_id, value in raw.items():
+        if not isinstance(agent_id, str) or not agent_id.strip():
+            continue
+        if is_secret_key(agent_id):
+            continue
+        choice = normalize_agent_dropdown_choice(value)
+        if choice is None:
+            continue
+        out[agent_id.strip()] = choice
+    return out
+
+
 def normalize_hostname_override(raw: Any) -> str:
     """Display label only — strip controls and cap length.
 
@@ -156,6 +189,8 @@ def coerce_values(raw: Any) -> dict[str, Any]:
             out[key] = normalize_id_list(value)
         elif key == HOSTNAME_KEY:
             out[key] = normalize_hostname_override(value)
+        elif key == AGENT_DROPDOWNS_KEY:
+            out[key] = normalize_agent_dropdowns(value)
         else:
             out[key] = value
     out.setdefault(FAVOURITES_KEY, [])
@@ -176,6 +211,8 @@ def merge_values(current: dict[str, Any], patch: dict[str, Any]) -> dict[str, An
             merged[key] = normalize_id_list(value)
         elif key == HOSTNAME_KEY:
             merged[key] = normalize_hostname_override(value)
+        elif key == AGENT_DROPDOWNS_KEY:
+            merged[key] = normalize_agent_dropdowns(value)
         else:
             merged[key] = value
     return merged
@@ -214,6 +251,7 @@ def public_payload(
 
 # Re-export so views can stamp token principals without importing auth twice.
 __all__ = [
+    "AGENT_DROPDOWNS_KEY",
     "FAVOURITES_KEY",
     "HIDDEN_KEY",
     "HOSTNAME_KEY",
@@ -223,6 +261,7 @@ __all__ = [
     "extras_bag",
     "is_secret_key",
     "merge_values",
+    "normalize_agent_dropdowns",
     "normalize_favourites",
     "normalize_hostname_override",
     "normalize_id_list",

--- a/tests/core/test_user_preferences.py
+++ b/tests/core/test_user_preferences.py
@@ -7,6 +7,7 @@ from swarm.core.user_preferences import (
     coerce_values,
     is_secret_key,
     merge_values,
+    normalize_agent_dropdowns,
     normalize_favourites,
     normalize_hostname_override,
     preference_identity,
@@ -62,6 +63,18 @@ def test_public_payload_marks_empty_and_lists_registry():
         "hidden_agents",
         "hostname_override",
     ]
+
+
+def test_normalize_agent_dropdowns_keeps_safe_fields_only():
+    cleaned = normalize_agent_dropdowns(
+        {
+            "cli_agent": {"cli": " grok ", "model": "grok-4", "api_key": "sk-nope"},
+            "": {"cli": "agy"},
+            "api_key": {"cli": "grok"},
+            "codey": "grok",
+        }
+    )
+    assert cleaned == {"cli_agent": {"cli": "grok", "model": "grok-4"}}
 
 
 def test_normalize_hostname_override_strips_controls_and_caps_length():

--- a/tests/unit/test_req133_cli_api_dropdowns_models.py
+++ b/tests/unit/test_req133_cli_api_dropdowns_models.py
@@ -37,6 +37,7 @@ def test_chat_page_renders_cli_dropdowns_with_models():
     # Status tracking on remaining dropdowns
     assert "recordDropdownChange('cli'" in tsx
     assert "recordDropdownChange('model'" in tsx
+    assert "persistAgentDropdownChoice" in tsx
 
 
 def test_chat_status_and_cli_context_contracts():

--- a/tests/views/test_preferences_api.py
+++ b/tests/views/test_preferences_api.py
@@ -167,6 +167,32 @@ def test_patch_normalizes_duplicate_and_string_pins(api_client):
 
 
 @pytest.mark.django_db
+def test_agent_dropdowns_roundtrip_and_drop_secrets(api_client):
+    response = api_client.patch(
+        "/v1/preferences/",
+        {
+            "values": {
+                "agent_dropdowns": {
+                    "cli_agent": {"cli": "grok", "model": "grok-4", "token": "x"},
+                    "starter-remote": {"remote": "omb", "blueprint": "codey"},
+                }
+            }
+        },
+        format="json",
+    )
+    assert response.status_code == 200
+    dropdowns = response.json()["values"]["agent_dropdowns"]
+    assert dropdowns["cli_agent"] == {"cli": "grok", "model": "grok-4"}
+    assert dropdowns["starter-remote"] == {"remote": "omb", "blueprint": "codey"}
+    blob = json.dumps(response.json())
+    assert "token" not in dropdowns["cli_agent"]
+    assert "sk-" not in blob
+
+    again = api_client.get("/v1/preferences/")
+    assert again.json()["values"]["agent_dropdowns"]["cli_agent"]["cli"] == "grok"
+
+
+@pytest.mark.django_db
 def test_hostname_override_must_be_a_string(api_client):
     response = api_client.patch(
         "/v1/preferences/",

--- a/webui/frontend/src/lib/__tests__/agentDropdownPrefs.test.ts
+++ b/webui/frontend/src/lib/__tests__/agentDropdownPrefs.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  AGENT_DROPDOWNS_STORAGE_KEY,
+  applyLocalAgentDropdowns,
+  loadAgentDropdownChoice,
+  loadAllLocalAgentDropdowns,
+  parseAgentDropdowns,
+  saveLocalAgentDropdown,
+  seedAgentDropdownsFromLegacyStore,
+} from '../agentSettings'
+
+describe('agent dropdown prefs (REQ-180)', () => {
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('parses safe fields and drops secrets / empty ids', () => {
+    expect(
+      parseAgentDropdowns({
+        cli_agent: { cli: ' grok ', model: 'grok-4', api_key: 'sk-nope', token: 'x' },
+        '': { cli: 'agy' },
+        remote: { remote: 'omb', blueprint: 'codey', api: 'auxiliary' },
+      }),
+    ).toEqual({
+      cli_agent: { cli: 'grok', model: 'grok-4' },
+      remote: { remote: 'omb', blueprint: 'codey', api: 'auxiliary' },
+    })
+  })
+
+  it('persists per agent and reloads the last choice', () => {
+    expect(loadAgentDropdownChoice('cli_agent')).toEqual({})
+    expect(saveLocalAgentDropdown('cli_agent', { cli: 'grok', model: 'grok-4' })).toEqual({
+      cli: 'grok',
+      model: 'grok-4',
+    })
+    expect(loadAgentDropdownChoice('cli_agent')).toEqual({ cli: 'grok', model: 'grok-4' })
+    saveLocalAgentDropdown('cli_agent', { model: '' })
+    expect(loadAgentDropdownChoice('cli_agent')).toEqual({ cli: 'grok' })
+    expect(JSON.parse(localStorage.getItem(AGENT_DROPDOWNS_STORAGE_KEY) || '{}')).toEqual({
+      cli_agent: { cli: 'grok' },
+    })
+  })
+
+  it('seeds from /agents overlay keys and applies server bags back onto them', () => {
+    localStorage.setItem('agent_backends', JSON.stringify({ 'starter-cli': 'cli:agy' }))
+    localStorage.setItem('agent_cli_models', JSON.stringify({ 'starter-cli': 'custom-id' }))
+    localStorage.setItem('agent_blueprints', JSON.stringify({ router: 'codey' }))
+    expect(seedAgentDropdownsFromLegacyStore()).toEqual({
+      'starter-cli': { cli: 'agy', model: 'custom-id' },
+      router: { blueprint: 'codey' },
+    })
+    expect(loadAllLocalAgentDropdowns()['starter-cli']).toEqual({
+      cli: 'agy',
+      model: 'custom-id',
+    })
+    applyLocalAgentDropdowns({
+      'starter-cli': { cli: 'grok', model: 'grok-4' },
+      router: { blueprint: 'jeeves', api: 'orchestration' },
+    })
+    expect(JSON.parse(localStorage.getItem('agent_backends') || '{}')['starter-cli']).toBe(
+      'cli:grok',
+    )
+    expect(JSON.parse(localStorage.getItem('agent_cli_models') || '{}')['starter-cli']).toBe(
+      'grok-4',
+    )
+    expect(JSON.parse(localStorage.getItem('agent_blueprints') || '{}').router).toBe('jeeves')
+    expect(JSON.parse(localStorage.getItem('agent_llm_profiles') || '{}').router).toBe(
+      'orchestration',
+    )
+  })
+})

--- a/webui/frontend/src/lib/__tests__/userPrefs.test.ts
+++ b/webui/frontend/src/lib/__tests__/userPrefs.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { HIDDEN_AGENTS_STORAGE_KEY } from '../hiddenAgents'
 import { DEFAULT_PINNED_SUPPORT, PINNED_AGENTS_STORAGE_KEY } from '../pinnedAgents'
 import { HOSTNAME_OVERRIDE_KEY } from '../settingsPrefs'
+import { AGENT_DROPDOWNS_STORAGE_KEY } from '../agentSettings'
 import {
   USER_PREFS_PATH,
   hydrateRailPrefs,
@@ -51,6 +52,56 @@ describe('userPrefs', () => {
       hidden_agents: ['gate', 'skeptic'],
       hostname_override: 'lab-box',
       values: {},
+      agent_dropdowns: {},
+    })
+  })
+
+  it('reads agent_dropdowns from values and top-level', () => {
+    expect(
+      parseUserPrefs({
+        object: 'user_preferences',
+        empty: false,
+        favourites: [],
+        hidden_agents: [],
+        hostname_override: '',
+        values: {
+          agent_dropdowns: {
+            cli_agent: { cli: 'grok', model: 'grok-4', api_key: 'sk-nope' },
+            '': { cli: 'agy' },
+          },
+        },
+      })?.agent_dropdowns,
+    ).toEqual({ cli_agent: { cli: 'grok', model: 'grok-4' } })
+    expect(
+      parseUserPrefs({
+        object: 'user_preferences',
+        empty: false,
+        favourites: [],
+        hidden_agents: [],
+        hostname_override: '',
+        agent_dropdowns: { starter: { remote: 'omb', blueprint: 'codey' } },
+      })?.agent_dropdowns,
+    ).toEqual({ starter: { remote: 'omb', blueprint: 'codey' } })
+  })
+
+  it('applies server agent_dropdowns onto the local cache', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        jsonResponse({
+          object: 'user_preferences',
+          empty: false,
+          favourites: [{ id: 'support', name: 'Support' }],
+          hidden_agents: [],
+          hostname_override: '',
+          values: { agent_dropdowns: { cli_agent: { cli: 'antigravity', model: 'grok-4' } } },
+        }),
+      ),
+    )
+    const next = await hydrateRailPrefs()
+    expect(next.source).toBe('server')
+    expect(JSON.parse(localStorage.getItem(AGENT_DROPDOWNS_STORAGE_KEY) || '{}')).toEqual({
+      cli_agent: { cli: 'antigravity', model: 'grok-4' },
     })
   })
 
@@ -196,5 +247,27 @@ describe('userPrefs', () => {
     expect(call).toBeTruthy()
     expect(String(call?.[0])).toContain(USER_PREFS_PATH)
     expect(JSON.parse(String(call?.[1]?.body || '{}')).hostname_override).toBe('lab-box')
+  })
+
+  it('saveUserPrefs writes agent_dropdowns inside values', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        object: 'user_preferences',
+        empty: false,
+        favourites: [],
+        hidden_agents: [],
+        hostname_override: '',
+        values: { agent_dropdowns: { cli_agent: { cli: 'grok' } } },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const saved = await saveUserPrefs({
+      agent_dropdowns: { cli_agent: { cli: 'grok' } },
+    })
+    expect(saved?.agent_dropdowns).toEqual({ cli_agent: { cli: 'grok' } })
+    const call = fetchMock.mock.calls.find((entry) => entry[1]?.method === 'PATCH')
+    expect(JSON.parse(String(call?.[1]?.body || '{}')).values).toEqual({
+      agent_dropdowns: { cli_agent: { cli: 'grok' } },
+    })
   })
 })

--- a/webui/frontend/src/lib/agentSettings.ts
+++ b/webui/frontend/src/lib/agentSettings.ts
@@ -8,9 +8,17 @@ export const NEW_CHAT_PER_TASK_TOOLTIP =
   'Agents reuse one session by default so they remember the thread. Turn this on for a worker that scales out: each task gets a fresh chat, and several can run at once.'
 
 export const AGENT_SETTINGS_CHANGED_EVENT = 'swarm:agent-settings-changed'
+export const AGENT_DROPDOWNS_CHANGED_EVENT = 'swarm:agent-dropdowns-changed'
 export const OPEN_AGENT_EDITOR_EVENT = 'swarm:open-agent-editor'
 
 const STORAGE_PREFIX = 'swarm_agent_settings:'
+export const AGENT_DROPDOWNS_STORAGE_KEY = 'swarm_agent_dropdowns'
+
+/** Header dropdown fields that persist per agent (REQ-180 / #636). */
+export const AGENT_DROPDOWN_FIELDS = ['cli', 'model', 'remote', 'blueprint', 'api'] as const
+export type AgentDropdownField = (typeof AGENT_DROPDOWN_FIELDS)[number]
+export type AgentDropdownChoice = Partial<Record<AgentDropdownField, string>>
+export type AgentDropdowns = Record<string, AgentDropdownChoice>
 
 export interface AgentSettings {
   agent_id: string
@@ -47,6 +55,175 @@ export function loadLocalNewChatPerTask(agentId: string): boolean {
   } catch {
     return false
   }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+export function parseAgentDropdownChoice(value: unknown): AgentDropdownChoice | null {
+  const rec = asRecord(value)
+  if (!rec) return null
+  const choice: AgentDropdownChoice = {}
+  for (const field of AGENT_DROPDOWN_FIELDS) {
+    const raw = rec[field]
+    if (typeof raw !== 'string') continue
+    const trimmed = raw.trim()
+    if (!trimmed) continue
+    choice[field] = trimmed
+  }
+  return Object.keys(choice).length > 0 ? choice : null
+}
+
+export function parseAgentDropdowns(raw: unknown): AgentDropdowns {
+  const rec = asRecord(raw)
+  if (!rec) return {}
+  const out: AgentDropdowns = {}
+  for (const [agentId, value] of Object.entries(rec)) {
+    const id = agentId.trim()
+    if (!id) continue
+    const choice = parseAgentDropdownChoice(value)
+    if (choice) out[id] = choice
+  }
+  return out
+}
+
+function readDropdownMap(): AgentDropdowns {
+  try {
+    const raw = window.localStorage.getItem(AGENT_DROPDOWNS_STORAGE_KEY)
+    if (!raw) return {}
+    return parseAgentDropdowns(JSON.parse(raw))
+  } catch {
+    return {}
+  }
+}
+
+function writeDropdownMap(map: AgentDropdowns): void {
+  try {
+    window.localStorage.setItem(AGENT_DROPDOWNS_STORAGE_KEY, JSON.stringify(map))
+  } catch {
+    /* persistence is best-effort */
+  }
+}
+
+function emitDropdownsChanged(agentId?: string): void {
+  try {
+    window.dispatchEvent(
+      new CustomEvent(AGENT_DROPDOWNS_CHANGED_EVENT, { detail: { agentId } }),
+    )
+  } catch {
+    /* tests / non-browser */
+  }
+}
+
+function readLegacyJson(key: string): Record<string, unknown> {
+  try {
+    const raw = window.localStorage.getItem(key)
+    if (!raw) return {}
+    return asRecord(JSON.parse(raw)) ?? {}
+  } catch {
+    return {}
+  }
+}
+
+/** Import /agents overlay keys so one prefs bag covers both chat surfaces. */
+export function seedAgentDropdownsFromLegacyStore(): AgentDropdowns {
+  const backends = readLegacyJson('agent_backends')
+  const models = readLegacyJson('agent_cli_models')
+  const llms = readLegacyJson('agent_llm_profiles')
+  const remotes = readLegacyJson('agent_remote_members')
+  const blueprints = readLegacyJson('agent_blueprints')
+  const ids = new Set([
+    ...Object.keys(backends),
+    ...Object.keys(models),
+    ...Object.keys(llms),
+    ...Object.keys(remotes),
+    ...Object.keys(blueprints),
+  ])
+  const out: AgentDropdowns = {}
+  for (const id of ids) {
+    const choice: AgentDropdownChoice = {}
+    const backend = typeof backends[id] === 'string' ? backends[id].trim() : ''
+    if (backend.startsWith('cli:')) choice.cli = backend.slice(4)
+    if (typeof models[id] === 'string' && models[id].trim()) choice.model = models[id].trim()
+    if (typeof llms[id] === 'string' && llms[id].trim()) choice.api = llms[id].trim()
+    if (typeof remotes[id] === 'string' && remotes[id].trim()) choice.remote = remotes[id].trim()
+    if (typeof blueprints[id] === 'string' && blueprints[id].trim()) {
+      choice.blueprint = blueprints[id].trim()
+    }
+    if (Object.keys(choice).length > 0) out[id] = choice
+  }
+  return out
+}
+
+export function loadAllLocalAgentDropdowns(): AgentDropdowns {
+  const stored = readDropdownMap()
+  if (Object.keys(stored).length > 0) return stored
+  const seeded = seedAgentDropdownsFromLegacyStore()
+  if (Object.keys(seeded).length > 0) writeDropdownMap(seeded)
+  return seeded
+}
+
+export function loadAgentDropdownChoice(agentId: string): AgentDropdownChoice {
+  const agent = agentIdFromBlueprint(agentId)
+  return loadAllLocalAgentDropdowns()[agent] ?? {}
+}
+
+export function applyLocalAgentDropdowns(map: AgentDropdowns): AgentDropdowns {
+  const next = parseAgentDropdowns(map)
+  writeDropdownMap(next)
+  applyAgentDropdownsToLegacyStore(next)
+  emitDropdownsChanged()
+  return next
+}
+
+function applyAgentDropdownsToLegacyStore(map: AgentDropdowns): void {
+  const backends = { ...readLegacyJson('agent_backends') }
+  const models = { ...readLegacyJson('agent_cli_models') }
+  const llms = { ...readLegacyJson('agent_llm_profiles') }
+  const remotes = { ...readLegacyJson('agent_remote_members') }
+  const blueprints = { ...readLegacyJson('agent_blueprints') }
+  for (const [agentId, choice] of Object.entries(map)) {
+    if (choice.cli) backends[agentId] = `cli:${choice.cli}`
+    if (choice.model) models[agentId] = choice.model
+    if (choice.api) llms[agentId] = choice.api
+    if (choice.remote) remotes[agentId] = choice.remote
+    if (choice.blueprint) blueprints[agentId] = choice.blueprint
+  }
+  const write = (key: string, value: Record<string, unknown>) => {
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value))
+    } catch {
+      /* best-effort */
+    }
+  }
+  write('agent_backends', backends)
+  write('agent_cli_models', models)
+  write('agent_llm_profiles', llms)
+  write('agent_remote_members', remotes)
+  write('agent_blueprints', blueprints)
+}
+
+export function saveLocalAgentDropdown(
+  agentId: string,
+  patch: AgentDropdownChoice,
+): AgentDropdownChoice {
+  const agent = agentIdFromBlueprint(agentId)
+  const map = loadAllLocalAgentDropdowns()
+  const current = { ...(map[agent] ?? {}) }
+  for (const field of AGENT_DROPDOWN_FIELDS) {
+    if (patch[field] === undefined) continue
+    const trimmed = patch[field].trim()
+    if (!trimmed) delete current[field]
+    else current[field] = trimmed
+  }
+  if (Object.keys(current).length === 0) delete map[agent]
+  else map[agent] = current
+  writeDropdownMap(map)
+  emitDropdownsChanged(agent)
+  return current
 }
 
 export function saveLocalNewChatPerTask(agentId: string, value: boolean): void {

--- a/webui/frontend/src/lib/userPrefs.ts
+++ b/webui/frontend/src/lib/userPrefs.ts
@@ -1,7 +1,8 @@
 /**
  * Django-backed UI preferences (REQ-144 / #540, REQ-168 / #592).
  *
- * Favourites, Hidden Bots, and hostname override load from GET
+ * Favourites, Hidden Bots, hostname override, and per-agent dropdown
+ * choices (CLI / model / remote / blueprint) load from GET
  * /v1/preferences/ and persist on change via PATCH. localStorage stays a
  * cache: if the server bag is empty and this browser already has values,
  * import once, then the server wins.
@@ -25,11 +26,22 @@ import {
   savePinnedAgents,
   type PinnedAgent,
 } from './pinnedAgents'
+import { saveAgentRemoteBinding } from './agentRemote'
+import {
+  applyLocalAgentDropdowns,
+  loadAllLocalAgentDropdowns,
+  parseAgentDropdowns,
+  saveLocalAgentDropdown,
+  type AgentDropdownChoice,
+  type AgentDropdowns,
+} from './agentSettings'
 import {
   hasHostnameOverrideStorage,
   loadHostnameOverride,
   saveHostnameOverride,
 } from './settingsPrefs'
+
+export type { AgentDropdownChoice, AgentDropdowns }
 
 export const USER_PREFS_PATH = '/v1/preferences/'
 
@@ -42,6 +54,7 @@ export interface UserPrefs {
   hidden_agents: string[]
   hostname_override: string
   values?: Record<string, unknown>
+  agent_dropdowns: AgentDropdowns
 }
 
 export type RailPrefs = {
@@ -83,6 +96,12 @@ export function parseUserPrefs(raw: unknown): UserPrefs | null {
     : []
   const hostname =
     typeof rec.hostname_override === 'string' ? rec.hostname_override.trim() : ''
+  const values =
+    rec.values && typeof rec.values === 'object' && !Array.isArray(rec.values)
+      ? (rec.values as Record<string, unknown>)
+      : {}
+  const fromTop = parseAgentDropdowns(rec.agent_dropdowns)
+  const fromValues = parseAgentDropdowns(values.agent_dropdowns)
   return {
     object: 'user_preferences',
     principal: typeof rec.principal === 'string' ? rec.principal : '',
@@ -91,8 +110,16 @@ export function parseUserPrefs(raw: unknown): UserPrefs | null {
     favourites: pins,
     hidden_agents: Array.from(new Set(hidden)),
     hostname_override: hostname,
-    values: rec.values && typeof rec.values === 'object' ? (rec.values as Record<string, unknown>) : {},
+    values,
+    agent_dropdowns:
+      Object.keys(fromTop).length > 0 ? fromTop : fromValues,
   }
+}
+
+export function prefsAgentDropdowns(prefs: UserPrefs | null | undefined): AgentDropdowns {
+  if (!prefs) return {}
+  if (Object.keys(prefs.agent_dropdowns).length > 0) return prefs.agent_dropdowns
+  return parseAgentDropdowns(prefs.values?.agent_dropdowns)
 }
 
 export function applyHostnameOverride(value: string): string {
@@ -140,17 +167,28 @@ export async function saveUserPrefs(patch: {
   favourites?: PinnedAgent[]
   hidden_agents?: string[]
   hostname_override?: string
+  values?: Record<string, unknown>
+  agent_dropdowns?: AgentDropdowns
 }): Promise<UserPrefs | null> {
   if (
     patch.favourites === undefined &&
     patch.hidden_agents === undefined &&
-    patch.hostname_override === undefined
+    patch.hostname_override === undefined &&
+    patch.values === undefined &&
+    patch.agent_dropdowns === undefined
   ) {
     return null
   }
+  const body: Record<string, unknown> = {}
+  if (patch.favourites !== undefined) body.favourites = patch.favourites
+  if (patch.hidden_agents !== undefined) body.hidden_agents = patch.hidden_agents
+  if (patch.hostname_override !== undefined) body.hostname_override = patch.hostname_override
+  const values = { ...(patch.values || {}) }
+  if (patch.agent_dropdowns !== undefined) values.agent_dropdowns = patch.agent_dropdowns
+  if (Object.keys(values).length > 0) body.values = values
   try {
     await ensureCsrfCookie()
-    const data = await apiPatch<unknown>(USER_PREFS_PATH, patch)
+    const data = await apiPatch<unknown>(USER_PREFS_PATH, body)
     const parsed = parseUserPrefs(data)
     if (parsed && !parsed.empty) {
       applyPrefsToLocal(parsed)
@@ -159,6 +197,21 @@ export async function saveUserPrefs(patch: {
   } catch {
     return null
   }
+}
+
+const DROPDOWN_SAVE_MS = 300
+let dropdownSaveTimer: ReturnType<typeof setTimeout> | undefined
+
+export function persistAgentDropdownChoice(
+  agentId: string,
+  patch: AgentDropdownChoice,
+): AgentDropdownChoice {
+  const next = saveLocalAgentDropdown(agentId, patch)
+  if (dropdownSaveTimer) clearTimeout(dropdownSaveTimer)
+  dropdownSaveTimer = setTimeout(() => {
+    void saveUserPrefs({ agent_dropdowns: loadAllLocalAgentDropdowns() })
+  }, DROPDOWN_SAVE_MS)
+  return next
 }
 
 export function localRailSnapshot(
@@ -181,6 +234,15 @@ export async function hydrateRailPrefs(
   const server = await fetchUserPrefs()
   if (server && !server.empty) {
     applyPrefsToLocal(server)
+    const dropdowns = prefsAgentDropdowns(server)
+    if (Object.keys(dropdowns).length > 0) {
+      applyLocalAgentDropdowns(dropdowns)
+      for (const [agentId, choice] of Object.entries(dropdowns)) {
+        if (choice.remote) {
+          saveAgentRemoteBinding(agentId, { id: choice.remote, kind: choice.remote })
+        }
+      }
+    }
     return {
       pins: server.favourites,
       hidden: server.hidden_agents,
@@ -189,11 +251,13 @@ export async function hydrateRailPrefs(
     }
   }
   const local = localRailSnapshot(catalog)
+  const localDropdowns = loadAllLocalAgentDropdowns()
   if (server?.empty) {
     await saveUserPrefs({
       favourites: local.pins,
       hidden_agents: local.hidden,
       hostname_override: local.hostnameOverride,
+      agent_dropdowns: localDropdowns,
     })
     return { ...local, source: 'import' }
   }

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -18,11 +18,14 @@ import { TOAST_KIND_WS_DISCONNECT, useToast } from '../components/DaisyUI'
 import ThemeToggle from '../components/ThemeToggle'
 import { OPEN_SETTINGS_EVENT, openSettingsSheet } from '../components/SettingsSheet'
 import {
+  AGENT_DROPDOWNS_CHANGED_EVENT,
   AGENT_SETTINGS_CHANGED_EVENT,
+  loadAgentDropdownChoice,
   loadLocalNewChatPerTask,
   openAgentEditor,
   type AgentSettingsChangedDetail,
 } from '../lib/agentSettings'
+import { persistAgentDropdownChoice } from '../lib/userPrefs'
 import { persistableMessages, putAgentChatSession } from '../lib/agentChatSessions'
 import { useRailChrome } from '../components/RailChrome'
 import { ComputerControlStub } from '../components/ComputerControlStub'
@@ -261,6 +264,7 @@ const ChatPage = () => {
     !searchParams.get('remote'),
   )
   const [, setEditsTick] = useState(0)
+  const [dropdownTick, setDropdownTick] = useState(0)
   const [selectedRemoteId, setSelectedRemoteId] = useState('')
   const [conversationId, setConversationId] = useState(() =>
     teamFromUrl
@@ -498,16 +502,29 @@ const ChatPage = () => {
       !isCliAgent,
   )
 
+  const dropdownAgentId = teamFromUrl
+    ? `team-${teamFromUrl}`
+    : remoteFromUrl || selectedBlueprint || DEFAULT_AGENT_ID
+  const persistedDropdown = useMemo(
+    () => loadAgentDropdownChoice(dropdownAgentId),
+    [dropdownAgentId, dropdownTick],
+  )
+
   const discoveredClis = useMemo(
-    () => discoverChatClis(cliQuery.data, searchParams.get('cli') || selectedCli?.cli),
-    [cliQuery.data, searchParams, selectedCli],
+    () =>
+      discoverChatClis(
+        cliQuery.data,
+        searchParams.get('cli') || persistedDropdown.cli || selectedCli?.cli,
+      ),
+    [cliQuery.data, searchParams, persistedDropdown.cli, selectedCli],
   )
   const currentCli = useMemo(() => {
     const fromParam = (searchParams.get('cli') ?? '').trim()
     if (fromParam) return fromParam
+    if (persistedDropdown.cli) return persistedDropdown.cli
     if (selectedCli?.cli) return selectedCli.cli
     return preferredChatCli(discoveredClis, '')
-  }, [searchParams, selectedCli, discoveredClis])
+  }, [searchParams, persistedDropdown.cli, selectedCli, discoveredClis])
 
   const cliModelsQuery = useQuery({
     queryKey: ['cli-models', currentCli],
@@ -517,14 +534,19 @@ const ChatPage = () => {
   })
   const availableCliModels = useMemo(() => {
     const list = cliModelsQuery.data?.models ?? (cliQuery.data as any)?.list_models?.[currentCli] ?? []
-    return list.length ? list : ['default']
-  }, [cliModelsQuery.data, cliQuery.data, currentCli])
+    const merged = list.length ? [...list] : ['default']
+    const saved = (persistedDropdown.model || '').trim()
+    if (saved && !merged.includes(saved)) merged.push(saved)
+    return merged
+  }, [cliModelsQuery.data, cliQuery.data, currentCli, persistedDropdown.model])
 
   const currentCliModel = useMemo(() => {
     const fromParam = (searchParams.get('model') ?? '').trim()
     if (fromParam && availableCliModels.includes(fromParam)) return fromParam
+    const saved = (persistedDropdown.model || '').trim()
+    if (saved && availableCliModels.includes(saved)) return saved
     return availableCliModels[0] || 'default'
-  }, [searchParams, availableCliModels])
+  }, [searchParams, availableCliModels, persistedDropdown.model])
   const recordDropdownChange = useCallback(
     (kind: DropdownKind, fromLabel: string, toLabel: string) => {
       if (!shouldRecordDropdownChange(fromLabel, toLabel)) return
@@ -572,11 +594,14 @@ const ChatPage = () => {
 
   useEffect(() => {
     const onEdits = () => setEditsTick((tick) => tick + 1)
+    const onDropdowns = () => setDropdownTick((tick) => tick + 1)
     window.addEventListener(AGENT_EDITS_CHANGED_EVENT, onEdits)
     window.addEventListener(AGENT_REMOTE_BINDINGS_CHANGED_EVENT, onEdits)
+    window.addEventListener(AGENT_DROPDOWNS_CHANGED_EVENT, onDropdowns)
     return () => {
       window.removeEventListener(AGENT_EDITS_CHANGED_EVENT, onEdits)
       window.removeEventListener(AGENT_REMOTE_BINDINGS_CHANGED_EVENT, onEdits)
+      window.removeEventListener(AGENT_DROPDOWNS_CHANGED_EVENT, onDropdowns)
     }
   }, [])
 
@@ -1105,7 +1130,11 @@ const ChatPage = () => {
       })
         ? supportTurnExtras()
         : undefined
-      const selectedModelParam = (searchParams.get('model') ?? '').trim()
+      const persistedModel = (persistedDropdown.model || persistedDropdown.api || '').trim()
+      const selectedModelParam = (
+        (searchParams.get('model') ?? '').trim() ||
+        (isCliAgent ? currentCliModel : persistedModel)
+      ).trim()
       const agentIdForInference =
         runtimeBlueprint || selectedBlueprint || SUPPORT_AGENT_ID
       const inferenceSeats = loadInferenceList(agentIdForInference)
@@ -1155,7 +1184,10 @@ const ChatPage = () => {
       isCliAgent,
       currentCli,
       currentCliModel,
+      persistedDropdown.model,
+      persistedDropdown.api,
       isApiAgent,
+      searchParams,
       teamFromUrl,
       memberTarget,
       newChatPerTask,
@@ -1647,8 +1679,10 @@ const ChatPage = () => {
                     id: remote.id,
                     kind: remote.kind || remote.id,
                   })
+                  persistAgentDropdownChoice(bindingAgentId, { remote: remote.id })
                 } else if (bindingAgentId && !nextId) {
                   saveAgentRemoteBinding(bindingAgentId, null)
+                  persistAgentDropdownChoice(bindingAgentId, { remote: '' })
                 }
                 if (remoteFromUrl && nextId && nextId !== remoteFromUrl) {
                   setSearchParams((prev) => {
@@ -1713,6 +1747,7 @@ const ChatPage = () => {
                     return
                   }
                   const prev = currentCli
+                  persistAgentDropdownChoice(dropdownAgentId, { cli: nextCli })
                   setSearchParams(
                     (prevParams) => {
                       const nextParams = new URLSearchParams(prevParams)
@@ -1742,6 +1777,7 @@ const ChatPage = () => {
                 onChange={(e) => {
                   const nextModel = e.target.value
                   const prev = currentCliModel
+                  persistAgentDropdownChoice(dropdownAgentId, { model: nextModel })
                   setSearchParams(
                     (prevParams) => {
                       const nextParams = new URLSearchParams(prevParams)

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -2914,3 +2914,103 @@ describe('ChatPage dropdown status lines (REQ-46)', () => {
   })
 })
 
+describe('ChatPage per-agent dropdown persist (REQ-180)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    window.localStorage.clear()
+    resetConversationThreads()
+  })
+
+  function stubCliChat() {
+    MockWebSocket.instances = []
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/v1/cli-agents/') && url.includes('/models')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ cli: 'antigravity', models: ['default', 'grok-4'] }),
+          } as Response
+        }
+        if (url.includes('/v1/cli-agents')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              clis: ['grok', 'antigravity'],
+              installed: ['grok', 'antigravity'],
+              configured: ['grok', 'antigravity'],
+            }),
+          } as Response
+        }
+        if (url.includes('/v1/preferences')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'user_preferences',
+              empty: true,
+              favourites: [],
+              hidden_agents: [],
+              hostname_override: '',
+              values: {},
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: [{ id: 'cli_agent', name: 'CLI agent', description: 'CLI' }],
+            messages: [],
+          }),
+        } as Response
+      }),
+    )
+  }
+
+  it('keeps CLI + model after reload and uses them on the next send', async () => {
+    stubCliChat()
+
+    const first = renderChat('/chat?blueprint=cli_agent&mode=cli&cli=grok')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+
+    const cliSelect = await screen.findByRole('combobox', { name: 'CLI' })
+    fireEvent.change(cliSelect, { target: { value: 'antigravity' } })
+    await screen.findByRole('option', { name: 'grok-4' })
+    const modelSelect = await screen.findByRole('combobox', { name: 'Model' })
+    fireEvent.change(modelSelect, { target: { value: 'grok-4' } })
+    expect(cliSelect).toHaveValue('antigravity')
+    expect(modelSelect).toHaveValue('grok-4')
+
+    first.unmount()
+    renderChat('/chat?blueprint=cli_agent&mode=cli')
+    await act(async () => {
+      MockWebSocket.instances[MockWebSocket.instances.length - 1]?.open()
+    })
+
+    const restoredCli = await screen.findByRole('combobox', { name: 'CLI' })
+    const restoredModel = await screen.findByRole('combobox', { name: 'Model' })
+    await waitFor(() => {
+      expect(restoredCli).toHaveValue('antigravity')
+      expect(restoredModel).toHaveValue('grok-4')
+    })
+
+    const composer = screen.getByRole('textbox', { name: 'Chat message' })
+    fireEvent.change(composer, { target: { value: 'run with saved pin' } })
+    fireEvent.submit(composer.closest('form')!)
+    const ws = MockWebSocket.instances[MockWebSocket.instances.length - 1]!
+    expect(JSON.parse(ws.send.mock.calls[0][0] as string)).toEqual({
+      message: 'run with saved pin',
+      blueprint: 'cli_agent',
+      params: { cli: 'antigravity', model: 'grok-4' },
+    })
+  })
+})
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Header CLI, model, and remote dropdowns are a lasting per-agent setting, not a one-shot URL flicker.

Changing a dropdown writes the choice immediately to localStorage and PATCHes `/v1/preferences/` `values.agent_dropdowns` (same prefs bag as favourites). Reload / reopen chat shows the last saved value; the next Send uses that CLI and model. Cross-browser once the prefs API has a row; same-browser storage works until then.

Secret-shaped keys are dropped. Existing AgentSidebar context-menu work is untouched.

Fixes #636

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba61582b-9223-41d7-bc85-b3a52765c2f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba61582b-9223-41d7-bc85-b3a52765c2f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

