### PR TITLE
docs: rewrite VISION.md to current product truth (Fixes #772)

### DIFF
--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,190 +1,268 @@
 # Open Swarm — Vision
 
-> **One sentence:** Open Swarm turns the agentic CLIs you already have — `claude`,
-> `gemini`, `grok`, `codex`, `opencode`, and any future one — into a single
-> OpenAI-compatible endpoint, and lets you **orchestrate them as a team**:
-> consensus, routing, divide-and-conquer, sequential refinement, debate, and
-> planner-led delegation.
+> **One sentence:** Open Swarm is a Grok-like WebUI and an OpenAI-compatible
+> API that seats four kinds of agents — **CLI**, **API** (true inference),
+> **Blueprint** (programmatic / openai-agents), and **Remote** (Hermes /
+> OpenMousBot / Rakazo / Herdr) — and composes them with **handoff** and
+> **agent-as-tool**. The same blueprint runs from `swarm-cli` and from
+> `/v1/chat/completions`.
 
 This document is the front door. It states where we are going, then gives an
-**honest** account of what is built and what is not. For the mechanics of each
-orchestration pattern with sequence diagrams, see
-[ORCHESTRATION_PATTERNS.md](./ORCHESTRATION_PATTERNS.md). For per-feature
-evidence see [FEATURE_STATUS.md](../FEATURE_STATUS.md); for the nested checklist
-see [ROADMAP.md](../ROADMAP.md).
+**honest** account of what is true on `main` now. For pattern mechanics with
+sequence diagrams, see [ORCHESTRATION_PATTERNS.md](./ORCHESTRATION_PATTERNS.md).
+For per-feature evidence see [FEATURE_STATUS.md](../FEATURE_STATUS.md); for the
+nested checklist see [ROADMAP.md](../ROADMAP.md). Vocabulary:
+[GLOSSARY.md](./GLOSSARY.md).
 
 ---
 
 ## The vision
 
-The agent ecosystem fractured into excellent, mutually-incompatible **agentic
-CLIs**. Each vendor ships its own terminal tool with its own auth, its own tool
-calling, its own model access. They do not talk to each other, and none of them
-expose a standard API you can point an OpenAI client at.
+The agent world is not one CLI and not one SDK. People already run **host
+CLIs** (`claude`, `gemini`, `grok`, `codex`, …), **OpenAI-compatible
+inference** (a base URL, a model, a key-env), **coded recipes** (handoff
+graphs, MoA, custom Python), and **other harnesses** (Hermes, OpenMousBot,
+Rakazo, Herdr, another Open Swarm). Those seats do not share a chrome, and
+they do not share a graph.
 
-Open Swarm closes that gap on two axes:
+Open Swarm closes that gap on three axes:
 
-1. **Adapt** — wrap any agentic CLI as a first-class backend behind the
-   OpenAI-compatible REST API (`/v1/chat/completions`, `/v1/responses`,
-   `/v1/models`). Point Open WebUI, Cursor, the OpenAI SDK, or `curl` at one URL
-   and reach every CLI on the box. The CLI keeps its own auth and tools; Open
-   Swarm just gives it a standard door.
+1. **Seat** — four user-facing kinds (Matthew lock): **CLI | API | Blueprint |
+   Remote**. Each kind is a different *how this agent runs*, not a different
+   product.
+2. **Compose** — openai-agents **handoff / `as_tool`** so members can see and
+   talk. A **Team** is that composition (a Blueprint subtype), not a fifth
+   kind. Grok Bot / Rakazo / OpenMousBot can run many concurrent seats; they
+   do not host this programmatic graph.
+3. **Surface** — a **Grok-like WebUI** (rail, remotes, sessions) is
+   first-class, and the same work is reachable as an OpenAI-compatible API
+   (`/v1/chat/completions`, `/v1/responses`, `/v1/models`) and as `swarm-cli`.
 
-2. **Orchestrate** — compose those CLIs into multi-agent *teams* using named
-   orchestration patterns, exposed as **blueprints** (each is a `model` id). The
-   patterns are deliberately the same primitives the field has converged on —
-   the ones Microsoft's Agent Framework calls sequential, concurrent, handoff,
-   group-chat, and Magentic-One — but realized over heterogeneous CLIs instead
-   of a single SDK's agents.
-
-The thesis: **you do not need one model to be best at everything.** You need a
-cheap fast model to triage, a strong model to arbitrate, and a way to make them
-deliberate. A `gemini` flash panelist, a `claude` judge, and a `grok` dissenter
-will, between them, beat any one of them alone on the questions that matter —
-and Open Swarm makes wiring that a one-line `model:` choice.
-
-### Why CLIs (not raw API keys)
-
-- **Auth you already have.** Each CLI carries its own login (OAuth, subscription,
-  or key). Open Swarm never sees or stores those credentials.
-- **Tools you already have.** `claude` and `gemini` ship real tool calling — they
-  read files, run commands, browse. Wrapping the CLI inherits that agentic
-  behaviour for free (proven below).
-- **No lock-in.** Add a CLI by adding a config block. Nothing in a blueprint
-  names a vendor; backends are chosen by name, by failover chain, or by
-  *inference profile* (desired traits, not a brand).
+The thesis: **you do not need one model, one CLI, or one harness to be best
+at everything.** You need a cheap inference seat to triage, a strong CLI or
+remote when the work is native to that tool, and a blueprint when the
+topology must be enforced. Open Swarm is the place that wires those together
+without pretending they are the same kind.
 
 ---
 
-## What is built today (v0.5.4)
+## Kinds (Matthew lock)
 
-This is verified, shipped, and covered by a 1200+ test suite. Status marks:
-✅ working · 🟡 partial.
-
-| Capability | Status | Where |
+| Kind | Meaning | What you create |
 |---|---|---|
-| OpenAI-compatible API — `/v1/chat/completions` (+SSE), `/v1/models` | ✅ | `src/swarm/views/chat_views.py` |
-| **Stateful** `/v1/responses` — `store`, `previous_response_id` chaining, GET/DELETE | ✅ | `src/swarm/views/responses_views.py`, `swarm/core/responses_store.py` |
-| OpenAPI schema at `/api/schema/` (+ Swagger UI) | ✅ | `drf-spectacular` |
-| **`cli_agent`** — expose one CLI, with failover and self-consensus | ✅ | `blueprints/cli_agent/` |
-| **`cli_fusion`** — panel → judge → synthesize, bounded master-plan loop | ✅ | `blueprints/cli_fusion/` |
-| **`cli_orchestrator`** — cheap router, escalate to a panel only when high-stakes | ✅ | `blueprints/cli_orchestrator/` |
-| **`cli_map`** — decompose → distribute → reduce (divide-and-conquer) | ✅ | `blueprints/cli_map/` |
-| **`cli_pipeline`** — sequential refinement (draft → review → polish) | ✅ | `blueprints/cli_pipeline/` |
-| **`cli_roundtable`** — group-chat debate, moderated to a conclusion | ✅ | `blueprints/cli_roundtable/` |
-| **`cli_planner`** — Magentic-One-style task ledger, re-plans on stall | ✅ | `blueprints/cli_planner/` |
-| CLI autodiscovery + auth probe (`swarm-cli cli-agents --init/--check-auth`) | ✅ | `swarm/core/cli_adapter.py`, `cli_catalog.py` |
-| Per-panelist **git-worktree isolation** for write-mode CLIs | ✅ | `cli_fusion` |
-| **Inference profiles** — pick a backend by traits (intelligence/speed/cost), not brand | ✅ | `docs/examples/inference-profile-routing.md` |
-| **Skills** — Anthropic Agent-Skills `SKILL.md`, applied to any CLI via `skill=` | ✅ | `docs/SKILLS_AND_CONSENSUS_WALKTHROUGH.md` |
-| **Tool capabilities** — declare an abstract need, resolve to an MCP provider | 🟡 | `swarm/core/tool_capabilities.py` |
-| Web UI dashboard + live websocket chat | 🟡 | Django operator UI is canonical ([ADR-001](./ADR-001-primary-ui.md)); SPA mounts `/` + `/chat` only; leftover SPA operator pages deleted |
-| Opt-in cross-conversation **memory** (mem0) | 🟡 | wired, not yet validated against a live mem0 |
+| **CLI** | Host executable (`grok`, `agy`, `claude`, `gemini`, …). Native session. | Name, command, optional folder. |
+| **API** | **True inference seat** — OpenAI-compatible chat completions. Not a graph. | Name, base URL, model, key-env name (or an existing LLM profile). |
+| **Blueprint** | **Programmatic recipe** — `BlueprintBase` / openai-agents handoffs, MoA, custom Python. May *use* inference underneath; the seat is the recipe. | Pick or write a recipe. Same id via CLI and API. |
+| **Remote** | **Abstract harness.** Another agentic framework. Implementations: **Hermes**, **OpenMousBot**, **Rakazo**, **Herdr** (and nested Open Swarm). Variants are adapters, not extra top-level kinds. | Kind + base URL (+ auth-env name). |
 
-### Proof it actually works (captured live, this repo)
+Kinds are **how a seat runs**. Strategies on a Blueprint (MoA, persona swarm,
+`cli_fusion`, `sdlc_handoff`, …) are **not** new kinds. See
+[ADR-006](./adr/006-api-vs-blueprint-kinds.md) and
+[ADR-005](./adr/005-kind-bases.md). Remote as one interface:
+[#680](https://github.com/matthewhand/open-swarm/issues/680).
 
-These are **real CLI transcripts**, not mocks. Re-runnable; raw output committed
-under [`docs/proofs/`](./proofs/).
+### Honest mid-flight: stored `api` is still the leftover bucket
 
-- **Cross-CLI consensus** — one prompt fanned to `gemini` + `claude` + `grok`
-  concurrently, a `claude` judge synthesizing, with consensus / contradictions /
-  gaps / unique-insight analysis across the three models in **27 s**. See
-  [`docs/proofs/tri_cli_fusion_run.txt`](./proofs/tri_cli_fusion_run.txt).
-- **Routing / escalation** — a `gemini` router resolves low-stakes questions
-  directly with a stated reason, reserving the panel for contested ones. See
-  [`docs/proofs/orchestrator_escalation_run.txt`](./proofs/orchestrator_escalation_run.txt).
-- **Tool calling** — `gemini` and `claude` each *read a real file*
-  (`pyproject.toml`) via their own tools and returned the exact version string.
-  See [`docs/proofs/tool_calling_run.txt`](./proofs/tool_calling_run.txt).
-- **Sequential / group-chat / planner** — `cli_pipeline` (gemini draft → claude
-  review), `cli_roundtable` (gemini + grok debate, claude moderator concludes),
-  and `cli_planner` (claude plans a ledger, a worker executes, planner concludes
-  with a 12-point checklist). See the `pipeline_run`, `roundtable_run`, and
-  `planner_run` transcripts in [`docs/proofs/`](./proofs/).
-- **Full permutation matrix** — every installed CLI through every framework mode,
-  12/12 passing: `scripts/prove_cli_permutations.py`.
+**Target** is the four-kind table above. **On `main` today** the user-facing
+classifiers are still **API | CLI | Remote**. Stored `api` means “not CLI,
+not remote”: coded blueprints, personality/swarm designs, and the Add-agent
+“API” form (which writes a custom `BlueprintBase`) all classify as API.
+There is **no** first-class “wire this OpenAI-compat endpoint” seat yet.
+
+[#652](https://github.com/matthewhand/open-swarm/issues/652) / ADR-006:
+**rename** those leftover `api` seats to `blueprint`, then **introduce** a
+true `api` inference seat. Phase 0 (this ADR) is on tree; Phase 1 UI and
+Phase 2 runtime are still open. Until they land, UI copy still says “API”
+for recipes. Prefer the target names in **new** docs.
+
+Add-agent tabs on `main` are still **CLI | API | Remote**
+([#640](https://github.com/matthewhand/open-swarm/issues/640)). The fourth
+tab is the #652 follow-through, not a fifth kind.
+
+---
+
+## Team is a Blueprint subtype
+
+A **Team** is a roster plus openai-agents **handoff / agent-as-tool** so
+CLI, API, Blueprint, and Remote members can see and talk. It is **not** a
+fifth kind.
+
+- Composition store: `team_rosters.json` / `GET /v1/team-rosters/` /
+  `PATCH /v1/agent-team/`. Nested child roster is `kind=team` + `team_id`
+  (a member row, still not a harness).
+- Remotes join as placed members (`consult_hermes`, `consult_omb`,
+  `consult_rakazo`, `consult_swarm`). Herdr is a Remote implementation, not
+  a sibling of Remote.
+- Django `/teams/` and `/v1/teams/` are **Profiles** (LLM-profile aliases
+  via `DynamicTeamBlueprint`). Do not call those aliases a Team.
+
+See [GLOSSARY.md](./GLOSSARY.md) and [TEAM_ISOLATION.md](./TEAM_ISOLATION.md).
+
+---
+
+## WebUI is first-class
+
+The product chrome is a **Grok-like** left rail + the selected agent’s chat
+(`/` and `/chat`): Search palette, favourite tiles, remotes, sessions,
+Settings sheet. `/agents` is the Agent Router (own chrome). This is not an
+afterthought to “wrap CLIs behind `/v1`.”
+
+Operator dumps stay on Django trailing-slash routes (`/blueprint-library/`,
+`/agent-creator/`, `/settings/`, `/sessions/`, `/teams/launch/`, …)
+([ADR-001](./ADR-001-primary-ui.md)). Bare `/teams`, `/blueprints`,
+`/settings`, `/agent-creator` redirect there. Do not remount deleted SPA
+operator pages.
+
+Honesty: Grok-Bot chrome is **partial** (session cookie for websocket; bearer
+does not auth WS; anonymous sockets close **4401**). Screenshot recapture
+and virtualized history are still open. Evidence:
+[FEATURE_STATUS.md](../FEATURE_STATUS.md) §4–5.
+
+---
+
+## Differentiator
+
+**openai-agents handoff / agent-as-tool**, and **the same blueprint via CLI
+and API**.
+
+| What others do | What Open Swarm does |
+|---|---|
+| Grok Bot / Rakazo / OpenMousBot: many **concurrent seats** in one chrome | One programmatic **graph** (forced sequence, circular skeptic, as-tool specialists) **inside Blueprint seats** |
+| CLI wrappers that only expose one binary | CLI is a kind; fusion/MoA patterns are blueprints you can also `curl` |
+| “Teams” as a second product noun | Team = Blueprint composition, runnable as `swarm-cli launch …` or `model:` on `/v1/chat/completions` |
+
+Limit (up front): the graph runs **inside Blueprint seats** (today’s leftover
+`api` bucket). CLI and Remote stay **native sessions** — we do not inject
+openai-agents into those harnesses. A cross-kind Team still works: a
+Blueprint coordinator can sit with a Grok CLI and a Hermes Remote.
+
+Worked graphs: [openai-agents-handoff-graphs](./examples/openai-agents-handoff-graphs/README.md)
+(REQ-156). Kind templates: [ADR-005](./adr/005-kind-bases.md).
+
+---
+
+## What is built today
+
+Status marks: ✅ working · 🟡 partial · 📋 planned. This is **not** a second
+source of truth — rows point at [FEATURE_STATUS.md](../FEATURE_STATUS.md).
+Published package cut is **0.5.4**; `main` is ahead. No hosted Fly / live
+SaaS product is claimed here.
+
+| Capability | Status | Notes |
+|---|---|---|
+| OpenAI-compatible API — `/v1/chat/completions` (+SSE), `/v1/models`, stateful `/v1/responses` | ✅ | Same `model` id as `swarm-cli launch` |
+| Blueprint discovery + `BlueprintBase.run` + openai-agents SDK | ✅ | Handoff graphs: `sdlc_handoff` + tests |
+| Kind-base stubs (`ApiKindBase` / `CliKindBase` / `RemoteKindBase`) | ✅ | Docs + Support prefer these; wizard still emits `BlueprintBase` |
+| CLI kind — adapter, autodiscovery, auth probe, session resume | ✅ | `cli_agent` and the CLI-fusion / MoA family |
+| CLI orchestration examples (`cli_fusion`, `cli_orchestrator`, `cli_map`, `cli_pipeline`, `cli_roundtable`, `cli_planner`) | ✅ | Patterns + [proofs](./proofs/); `cli_fusion` is also a MoA alias |
+| Remote catalog (opt-in) — Hermes / OpenMousBot / Rakazo / Herdr / nested swarm | 🟡 | Hermes list/send ✅; OMB HTTP ✅; Rakazo send 🟡 (Better Auth 401); Herdr CLI ✅. Not a concurrent-seat clone. |
+| Team roster + place remotes + isolation | 🟡 | `/v1/agent-team/`, `/v1/team-rosters/`; Django `/teams/` stays Profiles |
+| WebUI — Grok-like SPA chrome + Django operator | 🟡 | First-class product; WS needs session cookie |
+| Skills (`SKILL.md`) + inference profiles | ✅ | Applied via CLI / config; not a kind |
+| Tool capabilities → MCP provider | 🟡 | Client works; `ENABLE_MCP_SERVER` is still a flag |
+| Cross-conversation memory (mem0) | 🟡 | Wired, not validated against a live mem0 |
+| True **API** inference seat (no `BlueprintBase`) | 📋 | ADR-006 Phase 2; today’s “API” tab writes a blueprint |
+| Desktop zip (pywebview) | 📋 | [ADR-003](./adr/003-desktop-packaging.md) — no installer |
+| Hosted Fly / public live demo | — | **Not claimed.** Deploy workflow exists; this doc does not sell a running cloud. |
+
+### Proof the CLI path is real (not mocks)
+
+Re-runnable transcripts under [`docs/proofs/`](./proofs/):
+
+- **Cross-CLI consensus** — `gemini` + `claude` + `grok`, a `claude` judge, ~27 s. [`tri_cli_fusion_run.txt`](./proofs/tri_cli_fusion_run.txt)
+- **Routing / escalation** — cheap router, panel only when high-stakes. [`orchestrator_escalation_run.txt`](./proofs/orchestrator_escalation_run.txt)
+- **Tool calling** — `gemini` / `claude` read a real `pyproject.toml`. [`tool_calling_run.txt`](./proofs/tool_calling_run.txt)
+- **Pipeline / roundtable / planner** — sequential, debate, Magentic-One-style ledger in the same proofs directory.
+
+Those proofs show **CLI + Blueprint** orchestration. They do not prove a
+hosted SaaS, a true API inference seat, or live remotes on this writer’s
+network.
 
 ---
 
 ## What remains (honest)
 
-### Orchestration patterns — complete ✅
+- **#652 Phase 1/2** — Add-agent / rail / runtime split: leftover `api` →
+  `blueprint`; new `api` = inference only. Do not close #652 from this
+  docs PR.
+- **#680** — Remote stays one kind; Hermes / OpenMousBot / Rakazo / Herdr
+  implement an abstract harness. Herdr is not a fifth kind.
+- **README** — sibling rewrite [#466](https://github.com/matthewhand/open-swarm/issues/466).
+  This file leads direction; README sells.
+- **SPA depth** — virtualized history ([ADR-004](./adr/004-virtualized-chat-history.md))
+  planned; computer-control chrome is a stub ([ADR-007](./adr/007-local-computer-control.md));
+  golden-journey screenshots on HOLD.
+- **MCP server mode** (`ENABLE_MCP_SERVER`) — flag warns; blueprints are not
+  MCP tools until the bridge is ported.
+- **Memory** — mem0 opt-in, not live-validated; `langmem` / `papr` are
+  placeholders.
+- **Desktop** — ADR only; no installer.
 
-The standard pattern set is now built end to end: concurrent (`cli_fusion`),
-handoff/escalation (`cli_orchestrator`), map-reduce (`cli_map`), sequential
-(`cli_pipeline`), group-chat (`cli_roundtable`), and Magentic-One
-(`cli_planner`). Each has a sequence diagram in
-[ORCHESTRATION_PATTERNS.md](./ORCHESTRATION_PATTERNS.md), tests under
-`tests/blueprints/`, and a live cross-CLI transcript in
-[`docs/proofs/`](./proofs/). Remaining work here is depth, not coverage:
-richer streaming progress for the multi-round patterns, and per-stage usage
-accounting.
-
-### Other known gaps (unchanged from the roadmap)
-
-- **SPA vs Django** — [ADR-001](./ADR-001-primary-ui.md) keeps the SPA at `/` +
-  `/chat` only; Django trailing-slash UI is the supported operator surface.
-  Full React SPA parity / remounting Builder is **rejected** as a v1 goal.
-- **MCP server mode** (`ENABLE_MCP_SERVER`) — aspirational; the flag warns loudly.
-- **Memory** — mem0 wired and opt-in, not yet validated end-to-end against a live
-  mem0; `letta`/`langmem` are placeholders.
-- **Deprecation-shim sunset** — done (ROADMAP §2.1); use `swarm.core.*` /
-  `swarm.ux.ansi_box`.
+Do not treat [ROADMAP.md](../ROADMAP.md) as rewritten here. Granular rows
+stay on FEATURE_STATUS / ROADMAP.
 
 ---
 
 ## How the pieces fit
 
 ```mermaid
-flowchart LR
-    Client["OpenAI client - SDK, Open WebUI, curl"] -->|v1 chat completions| API[Open Swarm API]
-    API -->|model selects| BP{Blueprint}
-    BP -->|single| A[cli_agent]
-    BP -->|concurrent| F[cli_fusion]
-    BP -->|handoff| O[cli_orchestrator]
-    BP -->|map reduce| M[cli_map]
-    BP -->|sequential| P[cli_pipeline]
-    BP -->|group chat| R[cli_roundtable]
-    BP -->|planner| PL[cli_planner]
-    A --> REG[CLI adapter registry]
-    F --> REG
-    O --> REG
-    M --> REG
-    P --> REG
-    R --> REG
-    PL --> REG
-    REG --> g[gemini]
-    REG --> c[claude]
-    REG --> k[grok]
-    REG --> x[codex and others]
+flowchart TB
+  subgraph surfaces [First-class surfaces]
+    UI["WebUI — Grok-like rail + chat"]
+    CLI_UX["swarm-cli"]
+    CLIENT["OpenAI client — SDK, curl, Open WebUI"]
+  end
+  OS[Open Swarm]
+  UI --> OS
+  CLI_UX --> OS
+  CLIENT -->|"/v1 chat or responses"| OS
+  OS --> KCLI[CLI]
+  OS --> KAPI["API — inference seat"]
+  OS --> KBP[Blueprint]
+  OS --> KREM[Remote]
+  KBP --> Graph["openai-agents handoff / as_tool"]
+  Graph --> Team["Team — Blueprint subtype"]
+  Team --- KCLI
+  Team --- KAPI
+  Team --- KREM
+  KCLI --> Host["claude / gemini / grok / …"]
+  KAPI --> Infer["base URL + model + key-env"]
+  KREM --> Impl["Hermes / OpenMousBot / Rakazo / Herdr"]
 ```
 
-Every blueprint resolves backends through one **CLI adapter registry** built from
-the `cli_agents` config block. Adding a CLI never touches a blueprint.
+A Blueprint may *call* an API seat or a CLI underneath; the **seat kind**
+stays Blueprint. Adding a CLI or a remote does not invent a new kind.
 
 ---
 
 ## Design principles
 
-1. **OpenAI-compatible or it does not exist.** Every capability ships as a
-   `model` id reachable from a stock OpenAI client.
-2. **Blueprints name patterns, not vendors.** Backend selection is by name,
-   failover, or inference profile — never hardcoded.
-3. **Credentials stay with the CLI.** Open Swarm never reads or stores a CLI's
-   auth. Config holds command-lines, not secrets.
-4. **Honest status.** Partial is marked partial; planned is marked planned;
-   proofs are real transcripts you can re-run.
-5. **Graceful degradation.** A dead panelist must not sink a round; consensus
-   comes from survivors, and failures are surfaced, not swallowed.
+1. **Four kinds, named honestly.** CLI, API (inference), Blueprint
+   (programmatic), Remote (abstract). Team is composition, not a kind.
+2. **Same blueprint, two doors.** `swarm-cli launch <id>` and
+   `model: "<id>"` on the OpenAI-compatible API are the same recipe.
+3. **WebUI is a product, not a demo.** Grok-like chrome, remotes, and
+   sessions are in scope; Django remains the operator dump.
+4. **Credentials stay out of the repo.** CLI auth stays with the CLI.
+   API / Remote records store **env-var names**, not secrets
+   ([ADR-002](./adr/002-config-ownership.md)).
+5. **Honest status.** Partial is marked partial; planned is marked planned;
+   no Fly / live claims without a URL you can hit. Proofs are transcripts
+   you can re-run.
+6. **Graceful degradation.** A dead panelist or remote must not sink a
+   round; failures are surfaced, not swallowed.
 
 ---
 
 ## See also
 
-- [ORCHESTRATION_PATTERNS.md](./ORCHESTRATION_PATTERNS.md) — sequence diagrams for every pattern
-- [CLI_FUSION.md](./CLI_FUSION.md) — the CLI-fusion blueprints in depth
-- [ADR-001](./ADR-001-primary-ui.md) — Django operator UI canonical; SPA `/` + `/chat` only
-- [ADR-003](./adr/003-desktop-packaging.md) — Windows desktop = loopback `swarm-api` + pywebview (planned; no installer yet)
-- [AUTH.md](./AUTH.md) — Bearer vs session, WS 4401, Explorer bridge, workdir / blueprint trust
+- [GLOSSARY.md](./GLOSSARY.md) — kinds, Team vs Profiles, roles
+- [ORCHESTRATION_PATTERNS.md](./ORCHESTRATION_PATTERNS.md) — sequence diagrams
+- [CLI_FUSION.md](./CLI_FUSION.md) — CLI adapters and fusion examples
+- [REMOTE_HARNESSES.md](./REMOTE_HARNESSES.md) — Hermes / OpenMousBot / Rakazo / nested swarm
+- [HERDR.md](./HERDR.md) — Herdr as a Remote implementation
+- [ADR-001](./ADR-001-primary-ui.md) — Django operator; SPA `/` + `/chat` (+ `/agents` router)
+- [ADR-005](./adr/005-kind-bases.md) · [ADR-006](./adr/006-api-vs-blueprint-kinds.md) — kind bases; API ≠ Blueprint
+- [AUTH.md](./AUTH.md) — Bearer vs session, WS 4401
 - [ROADMAP.md](../ROADMAP.md) · [FEATURE_STATUS.md](../FEATURE_STATUS.md) — granular status
 - [docs/archive/](./archive/) — superseded architectures, kept for the record


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #772.

`docs/VISION.md` was still selling “wrap agentic CLIs into one OpenAI endpoint + blueprint orchestration.” That is no longer the product. This PR rewrites the front door so it matches what is true on `main` and where the project is going — without turning VISION into a second copy of FEATURE_STATUS or ROADMAP.

## What changed

- **Kinds (Matthew lock):** CLI | API (true inference seat) | Blueprint (programmatic / openai-agents) | Remote (abstract harness; Hermes / OpenMousBot / Rakazo / Herdr implement).
- **Honest mid-flight:** stored `api` is still the leftover recipe bucket. [#652](https://github.com/matthewhand/open-swarm/issues/652) / [ADR-006](https://github.com/matthewhand/open-swarm/blob/main/docs/adr/006-api-vs-blueprint-kinds.md) rename-then-introduce is called out; this PR does **not** close #652.
- **Team** is a Blueprint subtype (roster + handoff / agent-as-tool), not a fifth kind. Django `/teams/` stays Profiles.
- **WebUI** is first-class Grok-like chrome (rail, remotes, sessions), with Django as the operator dump ([ADR-001](https://github.com/matthewhand/open-swarm/blob/main/docs/ADR-001-primary-ui.md)).
- **Differentiator:** openai-agents handoff / `as_tool`; the same blueprint via `swarm-cli` and `/v1/chat/completions`. Contrasted with poly-agent concurrent seats in Grok Bot / Rakazo / OpenMousBot.
- **Built vs not:** short table + links. No Fly / live SaaS claim. True API inference seat, MCP server mode, live mem0, and desktop installer stay marked not-done.
- **README:** one-line Vision callout only. Full README rewrite remains [#466](https://github.com/matthewhand/open-swarm/issues/466).

No runtime, no ROADMAP rewrite, no secrets.

## Intent / success (from #772)

**Intent:** VISION.md is again an honest front door: where we are going **and** what is true on `main` now — without a stale CLI-only thesis or missing WebUI / kinds / remotes.

**Success:** front door rewrite; four kinds + mid-flight `api`→blueprint note; Team not a fifth kind; WebUI first-class; openai-agents differentiator; honest built-vs-not; no invented shipped features.

**Constraints:** docs-only preferred; do not rewrite all of ROADMAP / FEATURE_STATUS; VISION leads, README can follow.

**Owner:** Cursor cloud ASAP; open-swarm engineer squash. CoS: Open Swarm.

## How to review

Read `docs/VISION.md` top to bottom. Check the kinds table, the stored-`api` honesty paragraph, the Team section, the WebUI section, and the built-vs-not table. Confirm FEATURE_STATUS / ROADMAP were not rewritten.

## Verification

A phrase-and-diff contract against #772 passed 22/22 (VISION + README pointer only; no secrets; stale CLI-only thesis gone).

[VISION kinds table and one-sentence thesis](https://cursor.com/agents/bc-cf096fdf-e9be-4e8d-9202-2198c96d1250/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvision_preview_kinds.png)
[VISION honesty, Team, WebUI, differentiator, built-vs-not](https://cursor.com/agents/bc-cf096fdf-e9be-4e8d-9202-2198c96d1250/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvision_preview_honesty.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf096fdf-e9be-4e8d-9202-2198c96d1250?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf096fdf-e9be-4e8d-9202-2198c96d1250&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

