### PR TITLE
fix: pass suggestions-role agent on prod path (Fixes #441)

### DIFF
--- a/src/swarm/consumers.py
+++ b/src/swarm/consumers.py
@@ -505,6 +505,8 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
             )
             return
 
+        self._blueprint_instance = blueprint_instance
+
         thread_params = {
             "conversation_id": getattr(self, "conversation_id", ""),
             "agent": blueprint_id,
@@ -659,19 +661,28 @@ class DjangoChatConsumer(AsyncWebsocketConsumer):
             },
         )
         await self.send(text_data=final_message_html)
-        await self._emit_suggestions_if_enabled(blueprint_id)
+        await self._emit_suggestions_if_enabled(blueprint_id, blueprint=blueprint_instance)
 
-    async def _emit_suggestions_if_enabled(self, agent_id):
+    async def _emit_suggestions_if_enabled(self, agent_id, blueprint=None):
         """REQ-85: JSON chips after a finished turn (never mid-token, never in LLM context)."""
         try:
-            from swarm.core.suggestions import suggestions_payload_for_turn
+            from swarm.core.suggestions import (
+                resolve_suggestions_agents,
+                suggestions_payload_for_turn,
+            )
 
             target = (
                 agent_id
                 or getattr(self, "active_agent", None)
                 or getattr(self, "default_blueprint", None)
             )
-            payload = suggestions_payload_for_turn(target, getattr(self, "messages", None))
+            instance = blueprint if blueprint is not None else getattr(self, "_blueprint_instance", None)
+            agents = resolve_suggestions_agents(target, blueprint=instance)
+            payload = suggestions_payload_for_turn(
+                target,
+                getattr(self, "messages", None),
+                agents=agents,
+            )
             if payload:
                 await self.emit_tool_event(payload)
         except Exception:

--- a/src/swarm/core/suggestions.py
+++ b/src/swarm/core/suggestions.py
@@ -53,6 +53,20 @@ CONTINUE_CANNED = (
 SuggestFn = Callable[[str, str], Any]
 
 
+class SuggestionsSpecialist:
+    """Role-stamped specialist used when the consumer has no roster seat.
+
+    CLI / API / remote consumers still get chips when **Use suggestions** is on
+    (Success-5). Team rosters with a ``suggestions`` member take precedence.
+    """
+
+    name = "suggestions"
+    instructions = SUGGESTIONS_INSTRUCTIONS
+
+    def __init__(self) -> None:
+        attach_role(self, ROLE_SUGGESTIONS)
+
+
 def parse_suggestions(raw: Any) -> list[str]:
     """Normalize a suggestions payload into 1–5 short unique strings.
 
@@ -204,6 +218,141 @@ def _mode_prompt(mode: str, messages: list[dict[str, Any]] | None) -> str:
     )
 
 
+def _as_agent_list(agents: Any) -> list[Any]:
+    if agents is None:
+        return []
+    if isinstance(agents, dict):
+        return [item for item in agents.values() if item is not None]
+    try:
+        return [item for item in agents if item is not None]
+    except TypeError:
+        return [agents]
+
+
+def live_agents_from_blueprint(blueprint: Any) -> list[Any]:
+    """Pull a live roster off a blueprint instance (``_agents`` / ``_build_agents``)."""
+    if blueprint is None:
+        return []
+    for attr in ("_agents", "agents"):
+        live = getattr(blueprint, attr, None)
+        if live:
+            return _as_agent_list(live)
+    build = getattr(blueprint, "_build_agents", None)
+    if callable(build):
+        try:
+            return _as_agent_list(build())
+        except Exception:
+            logger.debug("suggestions roster build skipped", exc_info=True)
+    meta = getattr(blueprint, "metadata", None)
+    meta_role = normalize_agent_role(meta.get("role")) if isinstance(meta, dict) else ""
+    start = getattr(blueprint, "create_starting_agent", None)
+    if callable(start) and meta_role == ROLE_SUGGESTIONS:
+        try:
+            agent = start([])
+            if agent is not None:
+                attach_role(agent, ROLE_SUGGESTIONS)
+                return [agent]
+        except Exception:
+            logger.debug("suggestions starting agent skipped", exc_info=True)
+    if isinstance(meta, dict) and normalize_agent_role(meta.get("role")) == ROLE_SUGGESTIONS:
+        return [SuggestionsSpecialist()]
+    return []
+
+
+def _specialist_from_catalog(catalog: Any, consumer_id: str | None) -> Any | None:
+    if not isinstance(catalog, dict):
+        return None
+    wanted_name = ""
+    consumer = (consumer_id or "").strip()
+    if consumer and consumer in catalog:
+        row = catalog[consumer]
+        meta = row.get("metadata") if isinstance(row, dict) else {}
+        if isinstance(meta, dict):
+            wanted_name = str(meta.get("suggestions_agent") or "").strip()
+            if normalize_agent_role(meta.get("role")) == ROLE_SUGGESTIONS:
+                return _specialist_from_catalog_row(row)
+            roster = meta.get("agents")
+            named = find_role_agent(roster, ROLE_SUGGESTIONS)
+            if named is not None:
+                attach_role(named, ROLE_SUGGESTIONS)
+                return named
+    for key, row in catalog.items():
+        if key in {"suggestion", "suggestions"} or key == wanted_name:
+            agent = _specialist_from_catalog_row(row)
+            if agent is not None:
+                return agent
+        meta = row.get("metadata") if isinstance(row, dict) else {}
+        if isinstance(meta, dict) and normalize_agent_role(meta.get("role")) == ROLE_SUGGESTIONS:
+            agent = _specialist_from_catalog_row(row)
+            if agent is not None:
+                return agent
+    return None
+
+
+def _specialist_from_catalog_row(row: Any) -> Any | None:
+    if not isinstance(row, dict):
+        return None
+    cls = row.get("class_type")
+    if cls is None:
+        return None
+    try:
+        instance = cls(blueprint_id=str(row.get("id") or "suggestion"))
+        live = live_agents_from_blueprint(instance)
+        return live[0] if live else None
+    except Exception:
+        logger.debug("catalog suggestions specialist skipped", exc_info=True)
+        return None
+
+
+def resolve_suggestions_agents(
+    consumer_id: str | None,
+    *,
+    blueprint: Any = None,
+    catalog: Any = None,
+    extra_agents: Any = None,
+) -> list[Any]:
+    """Roster that includes the suggestions-role agent for this consumer.
+
+    Never returns ``None``. Call sites must pass this into ``run_suggestions``
+    / ``suggestions_payload_for_turn`` — do not substitute ``agents=None``.
+    """
+    roster = _as_agent_list(extra_agents) + live_agents_from_blueprint(blueprint)
+    if find_role_agent(roster, ROLE_SUGGESTIONS) is not None:
+        return roster
+    specialist = _specialist_from_catalog(catalog, consumer_id)
+    if specialist is not None:
+        roster.append(specialist)
+        return roster
+    roster.append(SuggestionsSpecialist())
+    return roster
+
+
+def load_continue_messages(
+    user: Any,
+    agent_id: str,
+    conversation_id: str = "",
+) -> list[dict[str, Any]]:
+    """Transcript turns for continue chips. Empty list when none are readable."""
+    try:
+        from swarm.core.chat_store import load, user_key_for
+
+        pk = getattr(user, "pk", None)
+        if pk is None:
+            pk = getattr(user, "id", None)
+        if pk is None:
+            return []
+        record = load(
+            user_key_for(user),
+            agent_id,
+            conversation_id=(conversation_id or "").strip(),
+        )
+        rows = (record or {}).get("messages") or []
+        return [row for row in rows if isinstance(row, dict)]
+    except Exception:
+        logger.debug("continue messages omitted", exc_info=True)
+        return []
+
+
 def run_suggestions(
     *,
     mode: str = "kickstart",
@@ -215,11 +364,11 @@ def run_suggestions(
     kind = "kickstart" if str(mode).strip().lower() != "continue" else "continue"
     try:
         if suggest_fn is not None:
-            agent = find_role_agent(agents, ROLE_SUGGESTIONS) if agents else None
+            agent = find_role_agent(agents, ROLE_SUGGESTIONS)
             return _invoke_suggestions(agent, _mode_prompt(kind, messages), suggest_fn=suggest_fn)
         if os.environ.get("SWARM_TEST_MODE"):
             return canned_kickstart() if kind == "kickstart" else canned_continue(messages)
-        agent = find_role_agent(agents, ROLE_SUGGESTIONS) if agents else None
+        agent = find_role_agent(agents, ROLE_SUGGESTIONS)
         if agent is None:
             return []
         return _invoke_suggestions(agent, _mode_prompt(kind, messages))
@@ -233,6 +382,8 @@ def suggestions_payload_for_turn(
     messages: list[dict[str, Any]] | None = None,
     *,
     agents: Any = None,
+    blueprint: Any = None,
+    catalog: Any = None,
 ) -> dict[str, Any] | None:
     """WS/API payload after a finished turn, or ``None`` when chips should hide."""
     from swarm.core.agent_settings import is_use_suggestions
@@ -243,10 +394,17 @@ def suggestions_payload_for_turn(
         isinstance(row, dict) and row.get("role") == "assistant"
         for row in (messages or [])
     )
+    roster = agents
+    if roster is None:
+        roster = resolve_suggestions_agents(
+            agent_id,
+            blueprint=blueprint,
+            catalog=catalog,
+        )
     chips = run_suggestions(
         mode="continue" if has_assistant else "kickstart",
         messages=messages,
-        agents=agents,
+        agents=roster,
     )
     if not chips:
         return None

--- a/src/swarm/views/suggestions_api.py
+++ b/src/swarm/views/suggestions_api.py
@@ -16,7 +16,11 @@ from rest_framework.views import APIView
 
 from swarm.core.agent_settings import is_use_suggestions
 from swarm.core.chat_store import normalize_agent_id
-from swarm.core.suggestions import run_suggestions
+from swarm.core.suggestions import (
+    load_continue_messages,
+    resolve_suggestions_agents,
+    run_suggestions,
+)
 from swarm.views.agent_settings_api import SETTINGS_API_PERMISSIONS
 
 logger = logging.getLogger(__name__)
@@ -41,8 +45,15 @@ class AgentSuggestionsAPIView(APIView):
             )
         raw_mode = str(request.query_params.get("mode") or "kickstart").strip().lower()
         mode = "continue" if raw_mode == "continue" else "kickstart"
+        conversation_id = str(request.query_params.get("conversation_id") or "").strip()
+        messages = (
+            load_continue_messages(request.user, agent, conversation_id)
+            if mode == "continue"
+            else []
+        )
+        agents = resolve_suggestions_agents(agent)
         try:
-            chips = run_suggestions(mode=mode)
+            chips = run_suggestions(mode=mode, messages=messages, agents=agents)
         except Exception:
             logger.debug("suggestions API omitted for %s", agent, exc_info=True)
             chips = []

--- a/tests/core/test_suggestions.py
+++ b/tests/core/test_suggestions.py
@@ -79,6 +79,53 @@ def test_attach_suggestions_as_tool_unwired_is_noop():
     assert attach_suggestions_as_tool(Coord(), None).tools == []
 
 
+def test_prod_run_without_agents_is_empty(monkeypatch):
+    monkeypatch.delenv("SWARM_TEST_MODE", raising=False)
+    assert run_suggestions(mode="kickstart", agents=None) == []
+    assert run_suggestions(mode="continue", agents=[]) == []
+
+
+def test_prod_run_invokes_wired_suggestions_agent(monkeypatch):
+    monkeypatch.delenv("SWARM_TEST_MODE", raising=False)
+
+    class Stub:
+        role = "suggestions"
+        name = "suggester"
+
+        def suggest(self, prompt):
+            assert "follow-up" in prompt or "empty" in prompt or "Suggest" in prompt
+            return ["From specialist", "Second chip"]
+
+    chips = run_suggestions(mode="kickstart", agents=[Stub()])
+    assert chips == ["From specialist", "Second chip"]
+
+
+def test_resolve_includes_specialist_for_cli_api_remote():
+    from swarm.core.agent_roles import ROLE_SUGGESTIONS, find_role_agent
+    from swarm.core.suggestions import resolve_suggestions_agents
+
+    for consumer in ("cli_agent", "api_agent", "remote_harness"):
+        roster = resolve_suggestions_agents(consumer)
+        assert find_role_agent(roster, ROLE_SUGGESTIONS) is not None
+
+
+def test_resolve_prefers_consumer_roster_specialist():
+    from swarm.core.agent_roles import ROLE_SUGGESTIONS, find_role_agent
+    from swarm.core.suggestions import resolve_suggestions_agents
+
+    class TeamSuggest:
+        role = "suggestions"
+        name = "team-suggester"
+
+    class Blueprint:
+        _agents = {"worker": object(), "suggester": TeamSuggest()}
+
+    roster = resolve_suggestions_agents("cli_agent", blueprint=Blueprint())
+    found = find_role_agent(roster, ROLE_SUGGESTIONS)
+    assert found is not None
+    assert getattr(found, "name", "") == "team-suggester"
+
+
 def test_suggestions_payload_respects_toggle(tmp_path, monkeypatch):
     monkeypatch.setenv("SWARM_AGENT_SETTINGS_PATH", str(tmp_path / "agent_settings.json"))
     monkeypatch.setenv("SWARM_TEST_MODE", "1")

--- a/tests/test_consumers.py
+++ b/tests/test_consumers.py
@@ -989,6 +989,71 @@ class TestBlueprintSelection:
         store.reset_agent_settings_cache()
 
     @pytest.mark.asyncio
+    async def test_suggestions_prod_path_passes_wired_agent(self, consumer, monkeypatch, tmp_path):
+        """Outside TEST_MODE the WS emit must pass the suggestions-role agent + turn."""
+        monkeypatch.delenv("SWARM_TEST_MODE", raising=False)
+        monkeypatch.setenv("SWARM_AGENT_SETTINGS_PATH", str(tmp_path / "agent_settings.json"))
+        from swarm.core import agent_settings as store
+        from swarm.core.agent_roles import ROLE_SUGGESTIONS, find_role_agent
+        import swarm.core.suggestions as sug
+
+        store.reset_agent_settings_cache()
+        store.update_settings("cli_agent", {"use_suggestions": True})
+        consumer.messages = [{"role": "user", "content": "Hello there"}]
+        consumer.active_agent = "cli_agent"
+
+        class Stub:
+            role = "suggestions"
+            name = "suggester"
+
+            def suggest(self, prompt):
+                assert "Hello there" in prompt
+                return ["Wired chip", "Another chip"]
+
+        instance = MagicMock()
+
+        async def fake_run(messages, **kwargs):
+            yield {"messages": [{"role": "assistant", "content": "done"}]}
+
+        instance.run = fake_run
+        instance._agents = {"suggester": Stub()}
+        instance.metadata = {}
+        instance.agents = None
+
+        seen: dict = {}
+        real = sug.run_suggestions
+
+        def wrap(*, mode, messages=None, agents=None, suggest_fn=None):
+            seen["mode"] = mode
+            seen["messages"] = messages
+            seen["agents"] = agents
+            return real(mode=mode, messages=messages, agents=agents, suggest_fn=suggest_fn)
+
+        monkeypatch.setattr(sug, "run_suggestions", wrap)
+
+        with patch("swarm.views.utils.get_blueprint_instance", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = instance
+            with patch.object(consumer, "send", new_callable=AsyncMock) as mock_send:
+                await consumer.respond_with_blueprint("cli_agent", "message-response-prod-sug")
+                frames = [
+                    call.kwargs.get("text_data") or call.args[0]
+                    for call in mock_send.await_args_list
+                ]
+        json_frames = [frame for frame in frames if str(frame).startswith("{")]
+        assert json_frames, frames
+        payload = json.loads(json_frames[-1])
+        assert payload["type"] == "suggestions"
+        assert payload["suggestions"] == ["Wired chip", "Another chip"]
+        assert seen.get("agents") is not None
+        assert find_role_agent(seen["agents"], ROLE_SUGGESTIONS) is not None
+        assert any(
+            isinstance(row, dict) and row.get("content") == "Hello there"
+            for row in (seen.get("messages") or [])
+        )
+        assert all(m.get("role") != "suggestions" for m in consumer.messages)
+        store.reset_agent_settings_cache()
+
+    @pytest.mark.asyncio
     async def test_blueprint_run_failure_sends_error_partial(self, consumer, monkeypatch):
         """Exceptions from blueprint.run() surface as an error partial."""
         monkeypatch.delenv("SWARM_TEST_MODE", raising=False)

--- a/tests/views/test_suggestions_api.py
+++ b/tests/views/test_suggestions_api.py
@@ -41,6 +41,93 @@ def test_suggestions_on_kickstart(api_client):
     assert all(isinstance(item, str) and item for item in chips)
 
 
+def test_prod_path_passes_suggestions_agent(authenticated_client, monkeypatch):
+    """Outside SWARM_TEST_MODE the API must pass a suggestions-role agent."""
+    monkeypatch.delenv("SWARM_TEST_MODE", raising=False)
+    store.update_settings("cli_agent", {"use_suggestions": True})
+
+    class Stub:
+        role = "suggestions"
+        name = "suggester"
+
+        def suggest(self, _prompt):
+            return ["From specialist", "Second chip"]
+
+    seen: dict = {}
+
+    def wrap(*, mode, messages=None, agents=None, suggest_fn=None):
+        seen["mode"] = mode
+        seen["messages"] = messages
+        seen["agents"] = agents
+        from swarm.core.suggestions import run_suggestions as real
+
+        return real(mode=mode, messages=messages, agents=agents, suggest_fn=suggest_fn)
+
+    monkeypatch.setattr("swarm.views.suggestions_api.run_suggestions", wrap)
+    monkeypatch.setattr(
+        "swarm.views.suggestions_api.resolve_suggestions_agents",
+        lambda *_args, **_kwargs: [Stub()],
+    )
+
+    response = authenticated_client.get("/v1/agents/cli_agent/suggestions/?mode=kickstart")
+    assert response.status_code == 200
+    assert response.json()["suggestions"] == ["From specialist", "Second chip"]
+    from swarm.core.agent_roles import ROLE_SUGGESTIONS, find_role_agent
+
+    assert seen.get("agents") is not None
+    assert find_role_agent(seen["agents"], ROLE_SUGGESTIONS) is not None
+
+
+def test_prod_continue_passes_turn_messages(authenticated_client, monkeypatch, test_user):
+    """Continue mode must load the consumer transcript, not omit messages."""
+    monkeypatch.delenv("SWARM_TEST_MODE", raising=False)
+    store.update_settings("api_agent", {"use_suggestions": True})
+
+    from swarm.core.chat_store import save, user_key_for
+
+    turns = [
+        {"role": "user", "content": "Hello there"},
+        {"role": "assistant", "content": "Hi back"},
+    ]
+    save(user_key_for(test_user), "api_agent", turns, conversation_id="conv-1")
+
+    class Stub:
+        role = "suggestions"
+        name = "suggester"
+
+        def suggest(self, prompt):
+            assert "Hello there" in prompt
+            return ["Go deeper on: Hello there", "What are the main risks?"]
+
+    seen: dict = {}
+
+    def wrap(*, mode, messages=None, agents=None, suggest_fn=None):
+        seen["mode"] = mode
+        seen["messages"] = messages
+        seen["agents"] = agents
+        from swarm.core.suggestions import run_suggestions as real
+
+        return real(mode=mode, messages=messages, agents=agents, suggest_fn=suggest_fn)
+
+    monkeypatch.setattr("swarm.views.suggestions_api.run_suggestions", wrap)
+    monkeypatch.setattr(
+        "swarm.views.suggestions_api.resolve_suggestions_agents",
+        lambda *_args, **_kwargs: [Stub()],
+    )
+
+    response = authenticated_client.get(
+        "/v1/agents/api_agent/suggestions/?mode=continue&conversation_id=conv-1"
+    )
+    assert response.status_code == 200
+    assert seen.get("mode") == "continue"
+    assert seen.get("messages")
+    assert seen["messages"][0]["content"] == "Hello there"
+    from swarm.core.agent_roles import ROLE_SUGGESTIONS, find_role_agent
+
+    assert find_role_agent(seen["agents"], ROLE_SUGGESTIONS) is not None
+    assert "Go deeper on: Hello there" in response.json()["suggestions"]
+
+
 def test_settings_roundtrip_use_suggestions(api_client):
     first = api_client.get("/v1/agents/worker/settings/")
     assert first.json()["use_suggestions"] is False

--- a/webui/frontend/src/lib/__tests__/suggestions.test.ts
+++ b/webui/frontend/src/lib/__tests__/suggestions.test.ts
@@ -43,5 +43,8 @@ describe('suggestionsUrl', () => {
   it('builds the kickstart and continue endpoints', () => {
     expect(suggestionsUrl('codey')).toBe('/v1/agents/codey/suggestions/?mode=kickstart')
     expect(suggestionsUrl('codey', 'continue')).toBe('/v1/agents/codey/suggestions/?mode=continue')
+    expect(suggestionsUrl('codey', 'continue', 'conv-1')).toBe(
+      '/v1/agents/codey/suggestions/?mode=continue&conversation_id=conv-1',
+    )
   })
 })

--- a/webui/frontend/src/lib/suggestions.ts
+++ b/webui/frontend/src/lib/suggestions.ts
@@ -66,19 +66,27 @@ export function shouldShowSuggestionChips(opts: {
   return parseSuggestions(opts.chips ?? []).length > 0
 }
 
-export function suggestionsUrl(agentId: string, mode: 'kickstart' | 'continue' = 'kickstart'): string {
+export function suggestionsUrl(
+  agentId: string,
+  mode: 'kickstart' | 'continue' = 'kickstart',
+  conversationId?: string,
+): string {
   const id = encodeURIComponent(agentId)
-  return `/v1/agents/${id}/suggestions/?mode=${mode}`
+  const params = new URLSearchParams({ mode })
+  const conversation = (conversationId || '').trim()
+  if (conversation) params.set('conversation_id', conversation)
+  return `/v1/agents/${id}/suggestions/?${params}`
 }
 
 export async function fetchAgentSuggestions(
   agentId: string,
   mode: 'kickstart' | 'continue' = 'kickstart',
+  conversationId?: string,
 ): Promise<string[]> {
   const agent = (agentId || '').trim()
   if (!agent) return []
   try {
-    const response = await fetch(suggestionsUrl(agent, mode), {
+    const response = await fetch(suggestionsUrl(agent, mode, conversationId), {
       headers: { Accept: 'application/json' },
     })
     if (!response.ok) return []

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -1408,7 +1408,7 @@ const ChatPage = () => {
     if (!agent) return
     let cancelled = false
     const mode = messages.length === 0 ? 'kickstart' : 'continue'
-    void fetchAgentSuggestions(agent, mode).then((chips) => {
+    void fetchAgentSuggestions(agent, mode, conversationId).then((chips) => {
       if (!cancelled && chips.length > 0) setSuggestionChips(chips)
     })
     return () => {
@@ -1422,6 +1422,7 @@ const ChatPage = () => {
     selectedBlueprint,
     messages.length,
     threadKey,
+    conversationId,
   ])
 
   const chooseSuggestion = useCallback(

--- a/webui/frontend/src/pages/__tests__/ChatPage.suggestions.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.suggestions.test.tsx
@@ -84,6 +84,18 @@ function stubFetch(opts: { useSuggestions?: boolean; cli?: boolean } = {}) {
               description: 'CLI seat',
               tags: ['cli'],
             },
+            {
+              id: 'api_agent',
+              name: 'API',
+              description: 'API seat',
+              tags: ['api'],
+            },
+            {
+              id: 'remote_harness',
+              name: 'Remote',
+              description: 'Remote seat',
+              tags: ['remote'],
+            },
           ],
         }),
       } as Response
@@ -212,6 +224,26 @@ describe('ChatPage REQ-85 suggestion chips', () => {
     )
     stubFetch({ cli: true })
     await openChat('/chat?blueprint=cli_agent')
+    expect(await screen.findByTestId('suggestion-chips')).toBeInTheDocument()
+  })
+
+  it('API agent with suggestions on still shows chips', async () => {
+    window.localStorage.setItem(
+      localSettingsKey('api_agent'),
+      JSON.stringify({ use_suggestions: true }),
+    )
+    stubFetch()
+    await openChat('/chat?blueprint=api_agent')
+    expect(await screen.findByTestId('suggestion-chips')).toBeInTheDocument()
+  })
+
+  it('remote agent with suggestions on still shows chips', async () => {
+    window.localStorage.setItem(
+      localSettingsKey('remote_harness'),
+      JSON.stringify({ use_suggestions: true }),
+    )
+    stubFetch()
+    await openChat('/chat?blueprint=remote_harness')
     expect(await screen.findByTestId('suggestion-chips')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #441.

Follow-up to merged #781. REST and WS now resolve the consumer’s suggestions-role agent and pass that roster plus continue transcript into `run_suggestions` / `suggestions_payload_for_turn`. Call sites do not pass `agents=None`.

## Accepted deviation (Success-5)
Original issue text said chips were API-owned and CLI/remote UIs should omit them. Matthew 2026-09-04 superseded that: chips must work for **CLI, API, and remote** when **Use suggestions** is on. This PR keeps that lock.

## Testing
Own-diff: Python resolver/API/consumer prod-path tests (fail if the specialist is omitted) + Vitest chip/URL tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6c8521d-3ea0-4541-a8d0-76d8479900a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6c8521d-3ea0-4541-a8d0-76d8479900a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

