### PR TITLE
fix(chat): keep prior_history archive out of model context

### DIFF
--- a/src/swarm/blueprints/common/cli_fusion_support.py
+++ b/src/swarm/blueprints/common/cli_fusion_support.py
@@ -75,8 +75,9 @@ def render_prompt(messages: list[dict[str, Any]]) -> str:
 
     A lone user message is passed through verbatim. A multi-turn conversation
     is rendered as a simple ``ROLE: content`` transcript so a one-shot CLI sees
-    the full context. UI-only status/info rows are dropped (REQ-70). CLI
-    adapters strip a structured ``name`` field, so speaker identity uses the
+    the full context. UI-only status/info rows and the REQ-104 ``prior_history``
+    archive pill are dropped (REQ-70). Real ``system`` instructions stay.
+    CLI adapters strip a structured ``name`` field, so speaker identity uses the
     tested delimiter wrap.
     """
     from swarm.core.speaker_identity import apply_speaker_identity

--- a/src/swarm/core/chat_compact.py
+++ b/src/swarm/core/chat_compact.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import Any, Iterable
 
 from swarm.core.speaker_identity import apply_speaker_identity
-from swarm.core.transcript_roles import is_ui_only_role, messages_for_model
+from swarm.core.transcript_roles import is_ui_only_item, messages_for_model
 from swarm.models import ChatConversation, ChatMessage, ConversationSummary
 
 
@@ -93,7 +93,7 @@ def summarize_items(items: list[dict[str, Any]]) -> str:
             lines.append(f"- [summary] {_clip(str(item.get('body') or ''))}")
             continue
         role = item.get("role") or "user"
-        if is_ui_only_role(role):
+        if is_ui_only_item(item):
             continue
         real.append(item)
         content = item.get("content") or item.get("text") or ""
@@ -113,6 +113,9 @@ def _message_item(message: dict[str, Any], offset: int) -> dict[str, Any]:
     name = message.get("name") or message.get("speaker") or message.get("agent")
     if isinstance(name, str) and name.strip():
         item["name"] = name.strip()
+    src_kind = message.get("kind")
+    if isinstance(src_kind, str) and src_kind.strip():
+        item["source_kind"] = src_kind.strip()
     return item
 
 
@@ -189,7 +192,7 @@ def build_model_context(
             tree = _format_summary_tree(row, by_id) if row is not None else (item.get("body") or "")
             out.append({"role": "system", "content": f"[Conversation summary]\n{tree}"})
             continue
-        if is_ui_only_role(item.get("role")):
+        if is_ui_only_item(item):
             continue
         role = item.get("role") or "user"
         role_s = str(role)
@@ -371,7 +374,7 @@ def compact_backlog(
                 continue
             mix.append(item)
             continue
-        if is_ui_only_role(item.get("role")):
+        if is_ui_only_item(item):
             continue
         offset = item.get("offset")
         if isinstance(offset, int) and start <= offset <= end:

--- a/src/swarm/core/transcript_roles.py
+++ b/src/swarm/core/transcript_roles.py
@@ -60,10 +60,11 @@ def stamp_ui_event(item: dict[str, Any]) -> dict[str, Any]:
 
 
 def messages_for_model(messages: Iterable[Any] | None) -> list[dict[str, Any]]:
-    """Transcript → LLM payload: drop status/info; keep real turns + tool rows.
+    """Transcript → LLM payload: drop status/info and prior_history archive.
 
-    Preserves ``name`` / ``tool_call_id`` / ``tool_calls`` so speaker identity
-    and tool pairing survive. Does not invent content or wrap speakers.
+    Keeps real turns + tool rows. Preserves ``name`` / ``tool_call_id`` /
+    ``tool_calls`` so speaker identity and tool pairing survive. Does not
+    invent content or wrap speakers.
     """
     out: list[dict[str, Any]] = []
     for raw in messages or []:

--- a/src/swarm/core/transcript_roles.py
+++ b/src/swarm/core/transcript_roles.py
@@ -12,7 +12,9 @@ from typing import Any, Iterable
 
 # Bubble-less chrome. ``system`` is kept: compact summaries and real prompts
 # use it. Frontend maps leftover ``system`` rows to status *display* only.
+# ``prior_history`` is the REQ-104 archive pill — same family as status/info.
 UI_ONLY_ROLES = frozenset({"status", "info"})
+UI_ONLY_KINDS = frozenset({"prior_history"})
 MODEL_ROLES = frozenset({"system", "user", "assistant", "tool", "developer"})
 
 
@@ -22,6 +24,19 @@ def _role_of(item: dict[str, Any]) -> str:
 
 def is_ui_only_role(role: Any) -> bool:
     return str(role or "").strip().lower() in UI_ONLY_ROLES
+
+
+def is_ui_only_item(item: Any) -> bool:
+    """True for status/info rows and the prior-history archive pill."""
+    if not isinstance(item, dict):
+        return False
+    if is_ui_only_role(_role_of(item)):
+        return True
+    for key in ("kind", "source_kind"):
+        val = item.get(key)
+        if isinstance(val, str) and val.strip().lower() in UI_ONLY_KINDS:
+            return True
+    return False
 
 
 def message_timestamp(item: dict[str, Any] | None) -> str:
@@ -55,7 +70,7 @@ def messages_for_model(messages: Iterable[Any] | None) -> list[dict[str, Any]]:
         if not isinstance(raw, dict):
             continue
         role = _role_of(raw)
-        if is_ui_only_role(role):
+        if is_ui_only_item(raw):
             continue
         if role not in MODEL_ROLES:
             # Unknown chrome (e.g. leftover ``suggestions``) stays out of context.

--- a/tests/core/test_req70_ui_only_context.py
+++ b/tests/core/test_req70_ui_only_context.py
@@ -58,6 +58,22 @@ def test_messages_for_model_keeps_pair_and_tool_drops_chrome():
     _assert_no_chrome(payload)
 
 
+def test_messages_for_model_drops_prior_history_keeps_system_prompt():
+    payload = messages_for_model(
+        [
+            {"role": "system", "kind": "prior_history", "content": "old thread"},
+            {"role": "system", "content": "be terse"},
+            {"role": "status", "content": STATUS_CLI},
+            {"role": "user", "content": "next"},
+        ]
+    )
+    assert [(m["role"], m["content"]) for m in payload] == [
+        ("system", "be terse"),
+        ("user", "next"),
+    ]
+    assert "old thread" not in context_blob(payload)
+
+
 def test_build_model_context_excludes_status_info():
     payload = build_model_context(_thread(), [])
     assert [(m["role"], m["content"]) for m in payload] == [
@@ -67,6 +83,22 @@ def test_build_model_context_excludes_status_info():
     ]
     assert payload[1].get("name") == "jeeves"
     _assert_no_chrome(payload)
+
+
+def test_build_model_context_excludes_prior_history():
+    payload = build_model_context(
+        [
+            {"role": "system", "kind": "prior_history", "content": "old thread"},
+            {"role": "system", "content": "be terse"},
+            {"role": "user", "content": "next"},
+        ],
+        [],
+    )
+    assert [(m["role"], m["content"]) for m in payload] == [
+        ("system", "be terse"),
+        ("user", "next"),
+    ]
+    assert "old thread" not in context_blob(payload)
 
 
 def test_context_for_conversation_no_cid_filters_chrome():
@@ -81,6 +113,12 @@ def test_summarize_items_skips_status_info():
         [
             {"kind": "message", "role": "status", "content": STATUS_CLI},
             {"kind": "message", "role": "info", "content": INFO_CONNECTING},
+            {
+                "kind": "message",
+                "source_kind": "prior_history",
+                "role": "system",
+                "content": "old thread",
+            },
             {"kind": "message", "role": "user", "content": "alpha question"},
             {"kind": "message", "role": "assistant", "content": "alpha answer"},
         ]
@@ -89,6 +127,7 @@ def test_summarize_items_skips_status_info():
     assert "alpha answer" in body
     assert STATUS_CLI not in body
     assert INFO_CONNECTING not in body
+    assert "old thread" not in body
     assert "status" not in body
     assert "Summary of 2 items" in body
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #765 (REQ-70). After that merge, `test_render_prompt_skips_prior_history_and_status` failed because `messages_for_model` kept `role=system` + `kind=prior_history` as a real system prompt.

**Feasibility:** One shared filter — drop `kind=prior_history` the same way as `role=status`/`info`. Real `system` instructions stay.

## Intent
The REQ-104 **Prior history** pill is a UI archive of the previous swarm thread. It must not be prepended as CLI turns or LLM context. Status/info remain UI-only.

## Success
- `render_prompt([prior_history, status, user])` returns the user text only (`"next"`).
- `messages_for_model` / `build_model_context` drop `kind=prior_history` and keep a real `system` prompt such as `"be terse"`.
- Compact `summarize_items` does not re-inject archive text.

## Constraints
- GitHub-only. No `:8001`. No Neon. No secrets.
- Own-diff CI only. No live paid provider calls.
- Does not fold into 344 / 376 / 379.

## Where exclusion is enforced
- `swarm.core.transcript_roles.messages_for_model` / `is_ui_only_item` — `status`, `info`, and `kind=prior_history`
- `build_model_context` / `summarize_items` / compact mix (`chat_compact.py`) via `source_kind`
- `render_prompt` (`cli_fusion_support.py`) uses the shared filter

## Tests
- `tests/blueprints/test_cli_agent.py::test_render_prompt_skips_prior_history_and_status`
- `tests/core/test_req70_ui_only_context.py` — prior_history dropped; real system prompt kept

Local own-diff: 14 REQ-70/render_prompt + 38 speaker/session/store tests passed.

Left untouched (pre-existing on `main`, not worsened by this diff): `test_llm_profiles_lists_named_providers`, `test_llm_profile_access`, `test_docs_point_at_example_config`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c999b9a-78a8-42b9-985b-5bd19a9e39c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c999b9a-78a8-42b9-985b-5bd19a9e39c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

