### PR TITLE
docs: VISION What remains points at #791, not unfinished README #466

### DIFF
--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -190,6 +190,11 @@ network.
   docs PR.
 - **#680** — Remote stays one kind; Hermes / OpenMousBot / Rakazo / Herdr
   implement an abstract harness. Herdr is not a fifth kind.
+- **README** — WebUI-first front door + `docs/DEVELOPER.md` is
+  [#791](https://github.com/matthewhand/open-swarm/issues/791), not the old
+  #466 rewrite (that cut already landed in
+  [#785](https://github.com/matthewhand/open-swarm/pull/785)). This file
+  leads; README sells.
 - **SPA depth** — virtualized history ([ADR-004](./adr/004-virtualized-chat-history.md))
   planned; computer-control chrome is a stub ([ADR-007](./adr/007-local-computer-control.md));
   golden-journey screenshots on HOLD.

--- a/tests/unit/test_req102_readme_rewrite.py
+++ b/tests/unit/test_req102_readme_rewrite.py
@@ -81,13 +81,17 @@ def test_developer_doc_holds_moved_internals():
 
 
 def test_vision_points_at_current_readme_not_stale_466():
-    """#782 skeptic nit: VISION must not list README #466 as remaining work."""
+    """#782 skeptic nit: What remains points at #791, not unfinished README #466."""
     text = (repo_root() / "docs" / "VISION.md").read_text(encoding="utf-8")
     remains = text.split("## What remains", 1)[-1].split("## How the pieces fit", 1)[0]
-    assert "#466" not in remains
+    assert "#791" in remains
+    assert "DEVELOPER.md" in remains
     assert "sibling rewrite" not in remains.lower()
+    assert "unfinished" not in remains.lower()
+    if "#466" in remains:
+        assert "#785" in remains
+        assert "not the old" in remains.lower() or "already landed" in remains.lower()
     assert "[README](../README.md)" in text or "[README.md](../README.md)" in text
-    assert "#791" in text
     lowered = text.lower()
     for needle in ("sk-", "github_pat_", "ghp_"):
         assert needle not in lowered


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #791

## Why

[#797](https://github.com/matthewhand/open-swarm/pull/797) removed the stale README row from VISION **What remains**. This PR puts the pointer back the way Matthew asked: do **not** list README **#466** as unfinished ([#785](https://github.com/matthewhand/open-swarm/pull/785) already merged that rewrite). Point at **#791** for the WebUI-first + `docs/DEVELOPER.md` shape instead.

## What changed

- **What remains** README row: WebUI-first + DEVELOPER.md → [#791](https://github.com/matthewhand/open-swarm/issues/791). #466 appears only as already landed in #785.
- Contract updated so remains must name #791 and must not treat #466 as the open README job.

No README rewrite. No #785 content thrash. No secrets.

## Review

Read VISION **What remains**. The README bullet should name **#791**, not an open #466 rewrite.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b7e332c-1045-4e7b-8d2f-18b11e22635a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b7e332c-1045-4e7b-8d2f-18b11e22635a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

