### PR TITLE
fix(config): designer LLM list uses shared SoT after #775

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **#776 CI after #775 example-only SoT:** `GET /v1/agents/llm-profiles/` reads the shared `SWARM_CONFIG_PATH` / XDG loader (not a hunt for a committed live file). Designer + Codey tests use placeholder fixtures. README points at `swarm_config.example.json`.
 - **Tidy repo root (#775):** Move PyInstaller helpers to `scripts/packaging/` and Pinokio install/start/update/menu into `pinokio/`. Root `pinokio.js` and `manage.py` stay (Pinokio and Django require those paths). Replace committed `swarm_config.json` with sanitized `swarm_config.example.json`; gitignore a local `swarm_config.json`. Fixes #775.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ git clone https://github.com/matthewhand/open-swarm.git
 cd open-swarm
 uv sync --all-extras
 cp .env.example .env          # set OPENAI_API_KEY, API_AUTH_TOKEN, DJANGO_SECRET_KEY
+cp swarm_config.example.json swarm_config.json   # optional local SoT; secrets stay ${VAR} in .env
 make frontend                 # builds webui/frontend/dist/
 docker compose up --build
 # open http://localhost:8000
@@ -138,7 +139,7 @@ Then **Install** → **Start** → **Open App**. Compose sets `SWARM_RUNTIME=san
 - [docs/GLOSSARY.md](docs/GLOSSARY.md) — kinds, Team vs Profiles vs roster
 - [USERGUIDE.md](./USERGUIDE.md) — `swarm-cli` tasks
 - [docs/REMOTE_HARNESSES.md](docs/REMOTE_HARNESSES.md) · [docs/HERDR.md](docs/HERDR.md)
-- [docs/AUTH.md](docs/AUTH.md) · [CONFIGURATION.md](./CONFIGURATION.md)
+- [docs/AUTH.md](docs/AUTH.md) · [CONFIGURATION.md](./CONFIGURATION.md) (`swarm_config.example.json`)
 - [FEATURE_STATUS.md](./FEATURE_STATUS.md) · [ROADMAP.md](./ROADMAP.md)
 - [docs/DEVELOPER.md](docs/DEVELOPER.md) — gateway, `/v1/responses`, dated history, contribution pointers
 - [CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/src/swarm/views/agent_router_views.py
+++ b/src/swarm/views/agent_router_views.py
@@ -652,51 +652,38 @@ def launch_remote_framework(request):
 
 @require_http_methods(["GET"])
 def list_llm_profiles(request):
-    """Named LLM profiles (provider + model) agents can use or override."""
-    from pathlib import Path
-
-    from swarm.core.paths import get_user_config_dir_for_swarm
-    from swarm.settings import BASE_DIR, ENABLE_API_AUTH
+    """Named LLM profiles from the #776 swarm_config SoT (never secrets)."""
+    from swarm.core.remotes import load_raw_config
+    from swarm.settings import ENABLE_API_AUTH
     from swarm.utils.env_utils import get_default_llm
 
     profiles = []
     seen = set()
     default_name = get_default_llm() or ""
     try:
-        paths = [
-            get_user_config_dir_for_swarm() / "swarm_config.json",
-            Path(BASE_DIR).parent / "swarm_config.json",
-            Path(BASE_DIR) / "swarm_config.json",
-        ]
-        for path in paths:
-            if not path.is_file():
+        cfg, _path = load_raw_config()
+        llm = cfg.get("llm") if isinstance(cfg, dict) else {}
+        if not isinstance(llm, dict):
+            llm = {}
+        settings = cfg.get("settings") if isinstance(cfg.get("settings"), dict) else {}
+        if not default_name:
+            default_name = str(settings.get("default_llm_profile") or "")
+        iterable = llm.get("profiles") if isinstance(llm.get("profiles"), dict) else llm
+        if not isinstance(iterable, dict):
+            iterable = {}
+        for name, data in iterable.items():
+            if name in seen or name == "profiles" or not isinstance(data, dict):
                 continue
-            try:
-                cfg = json.loads(path.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
+            if not data.get("provider") and not data.get("model"):
                 continue
-            llm = cfg.get("llm") if isinstance(cfg, dict) else {}
-            if not isinstance(llm, dict):
-                continue
-            settings = cfg.get("settings") if isinstance(cfg.get("settings"), dict) else {}
-            if not default_name:
-                default_name = str(settings.get("default_llm_profile") or "")
-            iterable = llm.get("profiles") if isinstance(llm.get("profiles"), dict) else llm
-            if not isinstance(iterable, dict):
-                continue
-            for name, data in iterable.items():
-                if name in seen or name == "profiles" or not isinstance(data, dict):
-                    continue
-                if not data.get("provider") and not data.get("model"):
-                    continue
-                seen.add(name)
-                profiles.append({
-                    "name": name,
-                    "provider": data.get("provider") or "litellm",
-                    "model": data.get("model") or name,
-                    "base_url": data.get("base_url") or "",
-                    "description": data.get("description") or "",
-                })
+            seen.add(name)
+            profiles.append({
+                "name": name,
+                "provider": data.get("provider") or "litellm",
+                "model": data.get("model") or name,
+                "base_url": data.get("base_url") or "",
+                "description": data.get("description") or "",
+            })
     except Exception:
         profiles = []
     if not default_name and profiles:

--- a/tests/blueprints/test_codey_basic.py
+++ b/tests/blueprints/test_codey_basic.py
@@ -173,8 +173,27 @@ class TestCodeyConfiguration:
         assert config is not None
         assert isinstance(config, dict)
 
-    def test_llm_profile_access(self, codey_blueprint):
-        """Test that LLM profiles can be accessed"""
-        assert hasattr(codey_blueprint, 'llm_profile')
+    def test_llm_profile_access(self, tmp_path, monkeypatch):
+        """LLM profile comes from a fixture SoT — not a committed live file."""
+        import json
+
+        cfg = {
+            "llm": {
+                "default": {
+                    "provider": "openai",
+                    "model": "gpt-4o-mini",
+                    "api_key": "${OPENAI_API_KEY}",
+                }
+            },
+            "settings": {"default_llm_profile": "default"},
+        }
+        path = tmp_path / "swarm_config.json"
+        path.write_text(json.dumps(cfg), encoding="utf-8")
+        monkeypatch.setenv("SWARM_CONFIG_PATH", str(path))
+        # Codey maps its config_path positional onto BlueprintBase.config —
+        # discover via SWARM_CONFIG_PATH instead.
+        codey_blueprint = CodeyBlueprint(blueprint_id="test_codey_config")
+        assert hasattr(codey_blueprint, "llm_profile")
         profile = codey_blueprint.llm_profile
         assert profile is not None
+        assert profile.get("model") == "gpt-4o-mini"

--- a/tests/test_agent_router.py
+++ b/tests/test_agent_router.py
@@ -16,16 +16,37 @@ def blueprint():
 
 
 @pytest.mark.django_db
-def test_llm_profiles_lists_named_providers(client):
+def test_llm_profiles_lists_named_providers(client, tmp_path, monkeypatch):
+    # After #775/#786 the live file is not committed. Point at a fixture SoT
+    # (placeholders only — no secrets) via the shared SWARM_CONFIG_PATH loader.
+    fixture = {
+        "llm": {
+            "default": {
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+                "api_key": "${OPENAI_API_KEY}",
+            },
+            "litellm": {
+                "provider": "litellm",
+                "model": "${LITELLM_MODEL}",
+                "api_key": "${LITELLM_API_KEY}",
+            },
+        },
+        "settings": {"default_llm_profile": "default"},
+    }
+    path = tmp_path / "swarm_config.json"
+    path.write_text(json.dumps(fixture), encoding="utf-8")
+    monkeypatch.setenv("SWARM_CONFIG_PATH", str(path))
     resp = client.get("/v1/agents/llm-profiles/")
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] == "success"
     names = [p["name"] for p in body["profiles"]]
-    # auxiliary is a task class, not a profile name in swarm_config.json
+    # auxiliary is a task class, not a profile name
     assert "default" in names
     assert "litellm" in names or "litellm-fast" in names
     assert all("api_key" not in p for p in body["profiles"])
+    assert "sk-" not in json.dumps(body)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

#787 (`Fixes #776`, **Full** coverage) merged, then CI on that commit failed. Two of the five failures were already fixed on later `main` (#792 rail Select session, #796 prior_history). The rest were #775/#786 **example-only** SoT: no committed live `swarm_config.json`, so designer/Codey tests expected a `default` profile that CI no longer ships.

## Decision (unchanged)

**Full** (ADR-002 hybrid). Settings owns non-secret product keys. Secrets stay env-only. Example file stays `swarm_config.example.json` — not a second live SoT.

## What this PR does

- `GET /v1/agents/llm-profiles/` reads the shared `load_raw_config()` loader (`SWARM_CONFIG_PATH` → XDG → cwd). It no longer hunts a committed live file.
- Designer + Codey tests use `${VAR}` fixtures (no secrets).
- README points at `swarm_config.example.json` (satisfies `test_docs_point_at_example_config`).

Related: #776 #775 #787

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1704e355-2894-4192-b236-670d0ee509f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1704e355-2894-4192-b236-670d0ee509f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

