### PR TITLE
fix(webui): persist selected session across navigate away and remount

### DIFF
--- a/src/swarm/core/chat_store.py
+++ b/src/swarm/core/chat_store.py
@@ -404,8 +404,21 @@ def load(
                 continue
             sid = row.get("session_id") or ""
             if sid:
-                return load(user_key, agent, session_id=sid, base_dir=base_dir)
-            break
+                found = load(user_key, agent, session_id=sid, base_dir=base_dir)
+                if found is not None:
+                    return found
+            path = _active_path(user_key, agent, base)
+            if path is None or not path.is_file():
+                return None
+            record = _read_json(path)
+            if record is None:
+                return None
+            if (record.get("conversation_id") or "") != wanted:
+                return None
+            record["messages"] = _normalize_messages(record.get("messages"))
+            record["cli_sessions"] = normalize_cli_sessions(record.get("cli_sessions"))
+            return record
+        return None
     path = _active_path(user_key, agent, base)
     if path is None or not path.is_file():
         return None

--- a/src/swarm/views/chat_persist_views.py
+++ b/src/swarm/views/chat_persist_views.py
@@ -188,6 +188,7 @@ def chat_thread(request):
         session_id = requested_cid
     turns: list[dict] = []
     events: list[dict] = []
+    session_missing = False
     if fresh_task and not requested_cid:
         # New task: do not hydrate the reused agent transcript.
         record = None
@@ -202,19 +203,29 @@ def chat_thread(request):
         db_messages = [] if record and record.get("messages") else _messages_from_db(
             request.user, db_id
         )
-        turns, events = _thread_channels(record, db_messages)
-        if not record and turns and not session_id:
-            # Upgrade path: mirror an existing Django row onto disk.
-            try:
-                chat_store.save(
-                    user_key,
-                    agent,
-                    turns,
-                    conversation_id=db_id,
-                    ui_events=events,
-                )
-            except OSError:
-                logger.exception("Failed to backfill chat JSON for %s/%s", user_key, agent)
+        if (
+            requested_cid
+            and record is None
+            and not db_messages
+            and requested_cid.startswith(("cli-", "sess-"))
+        ):
+            # Select-minted ids (CLI / Django picker) — honest miss, no swap.
+            session_missing = True
+            turns, events = [], []
+        else:
+            turns, events = _thread_channels(record, db_messages)
+            if not record and turns and not session_id:
+                # Upgrade path: mirror an existing Django row onto disk.
+                try:
+                    chat_store.save(
+                        user_key,
+                        agent,
+                        turns,
+                        conversation_id=db_id,
+                        ui_events=events,
+                    )
+                except OSError:
+                    logger.exception("Failed to backfill chat JSON for %s/%s", user_key, agent)
     if requested_cid:
         conversation_id = requested_cid
     elif record and record.get("conversation_id") and not fresh_task:
@@ -232,13 +243,14 @@ def chat_thread(request):
     sessions = list_active_task_sessions(user_key, agent) if fresh_task else []
     kind = classify_agent_kind(agent_raw or agent)
     session_title = ""
-    try:
-        from swarm.core.agent_sessions import get_or_create_session
+    if not session_missing:
+        try:
+            from swarm.core.agent_sessions import get_or_create_session
 
-        row = get_or_create_session(request.user, conversation_id, agent_id=agent)
-        session_title = row.title or ""
-    except Exception:
-        session_title = ""
+            row = get_or_create_session(request.user, conversation_id, agent_id=agent)
+            session_title = row.title or ""
+        except Exception:
+            session_title = ""
     payload = {
         "agent_id": agent,
         "conversation_id": conversation_id,
@@ -247,6 +259,7 @@ def chat_thread(request):
         "editable": kind == "api",
         "new_chat_per_task": fresh_task,
         "active_sessions": sessions,
+        "session_missing": session_missing,
         "messages": _thread_payload_messages(turns, events),
         "turns": _public_messages(turns),
         "ui_events": _public_messages(events),

--- a/tests/core/test_chat_store.py
+++ b/tests/core/test_chat_store.py
@@ -253,6 +253,35 @@ def test_prune_uses_mtime_when_updated_at_missing(tmp_path):
     assert moved == ["aged"]
 
 
+def test_load_unknown_conversation_id_does_not_swap_default(tmp_path):
+    chat_store.save(
+        "u1",
+        "codey",
+        [{"role": "user", "content": "older session"}],
+        conversation_id="agt-1-codey",
+        base_dir=tmp_path,
+    )
+    chat_store.save(
+        "u1",
+        "codey",
+        [{"role": "user", "content": "selected A"}],
+        conversation_id="sess-notes",
+        session_id="sess-notes",
+        base_dir=tmp_path,
+    )
+    selected = chat_store.load(
+        "u1", "codey", conversation_id="sess-notes", base_dir=tmp_path
+    )
+    assert selected is not None
+    assert selected["messages"][0]["content"] == "selected A"
+    missing = chat_store.load(
+        "u1", "codey", conversation_id="sess-gone", base_dir=tmp_path
+    )
+    assert missing is None
+    default = chat_store.load("u1", "codey", base_dir=tmp_path)
+    assert default["messages"][0]["content"] == "older session"
+
+
 def test_archive_all(tmp_path):
     chat_store.save("u1", "a", [{"role": "user", "content": "1"}], base_dir=tmp_path)
     chat_store.save("u1", "b", [{"role": "user", "content": "2"}], base_dir=tmp_path)

--- a/tests/views/test_chat_retention.py
+++ b/tests/views/test_chat_retention.py
@@ -153,6 +153,24 @@ def test_chat_thread_isolates_two_sessions_and_summaries(client, user):
 
 
 @pytest.mark.django_db
+def test_chat_thread_missing_selected_session_does_not_swap(client, user, tmp_path, monkeypatch):
+    monkeypatch.setenv("SWARM_CHAT_DIR", str(tmp_path))
+    chat_store.save(
+        chat_store.user_key_for(user),
+        "codey",
+        [{"role": "user", "content": "older session"}, {"role": "assistant", "content": "old"}],
+        conversation_id=chat_store.conversation_id_for(user, "codey"),
+    )
+    gone = client.get("/chat/thread/?agent=codey&conversation_id=sess-gone")
+    assert gone.status_code == 200
+    payload = gone.json()
+    assert payload["conversation_id"] == "sess-gone"
+    assert payload["session_missing"] is True
+    assert payload["messages"] == []
+    assert all(row.get("content") != "older session" for row in payload["messages"])
+
+
+@pytest.mark.django_db
 def test_chat_thread_requires_login():
     resp = Client().get("/chat/thread/?agent=jeeves")
     assert resp.status_code == 302

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -136,7 +136,13 @@ import {
   openAgentEditor,
 } from '../lib/agentSettings'
 import { createAgentSession, loadPickerSessions } from '../lib/agentSessions'
-import { activeTaskSessionCount } from '../lib/agentChat'
+import {
+  AGENT_CONVERSATION_EVENT,
+  activeTaskSessionCount,
+  agentChatHref,
+  conversationIdForAgent,
+  setConversationIdForAgent,
+} from '../lib/agentChat'
 import {
   RAIL_LONG_PRESS_MS,
   copyableConversationId,
@@ -168,7 +174,6 @@ import {
   selectCliSession,
   type CliProviderSession,
 } from '../lib/cliSessions'
-import { conversationIdForAgent } from '../lib/agentChat'
 import { openSettingsSheet } from './SettingsSheet'
 import { ConfirmModal } from './DaisyUI'
 import RailContextMenu from './RailContextMenu'
@@ -244,7 +249,7 @@ function isHerdrAgent(agent: { id: string; kind?: string }): boolean {
 
 function sidebarHref(agent: { id: string; kind?: string }): string {
   if (isHerdrAgent(agent)) return '/teams/#herdr-members'
-  return `/chat?blueprint=${encodeURIComponent(agent.id)}`
+  return agentChatHref(agent.id)
 }
 
 function toSidebarCli(row: CliRailAgent): SidebarAgent {
@@ -511,11 +516,13 @@ export default function AgentSidebar({
     const onChange = () => setSessionTick((n) => n + 1)
     window.addEventListener(SCALE_OUT_SESSIONS_EVENT, onChange)
     window.addEventListener(AGENT_CHAT_SESSIONS_EVENT, onChange)
+    window.addEventListener(AGENT_CONVERSATION_EVENT, onChange)
     window.addEventListener(GENERATION_COMPLETE_EVENT, onChange)
     window.addEventListener('storage', onChange)
     return () => {
       window.removeEventListener(SCALE_OUT_SESSIONS_EVENT, onChange)
       window.removeEventListener(AGENT_CHAT_SESSIONS_EVENT, onChange)
+      window.removeEventListener(AGENT_CONVERSATION_EVENT, onChange)
       window.removeEventListener(GENERATION_COMPLETE_EVENT, onChange)
       window.removeEventListener('storage', onChange)
     }
@@ -2418,7 +2425,7 @@ export default function AgentSidebar({
             return (
               <Link
                 key={pin.id}
-                to={`/chat?blueprint=${encodeURIComponent(pin.id)}`}
+                to={agentChatHref(pin.id)}
                 className={pinClass}
                 title={pinName}
                 aria-label={pinName}
@@ -2676,6 +2683,7 @@ export default function AgentSidebar({
         }}
         onSelect={(session) => {
           const agentId = sessionPicker?.agentId || session.agentId
+          setConversationIdForAgent(agentId, session.id)
           navigate(sessionHref(agentId, session.id))
           onClose?.()
         }}

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -532,6 +532,12 @@ describe('AgentSidebar Grok rail', () => {
     expect(within(dialog).getByRole('button', { name: /^New session$/i })).toBeInTheDocument()
     fireEvent.click(within(dialog).getByRole('option', { name: /Notes/ }))
     expect(screen.getByTestId('os-test-search')).toHaveTextContent('session=sess-notes')
+    await waitFor(() => {
+      expect(within(list).getByRole('link', { name: /Codey/ })).toHaveAttribute(
+        'href',
+        expect.stringContaining('session=sess-notes'),
+      )
+    })
 
     fireEvent.contextMenu(await within(list).findByRole('link', { name: /Office \(team\)/ }))
     expect(screen.queryByRole('menuitem', { name: /Select session/i })).not.toBeInTheDocument()

--- a/webui/frontend/src/lib/__tests__/agentChat.test.ts
+++ b/webui/frontend/src/lib/__tests__/agentChat.test.ts
@@ -66,6 +66,8 @@ describe('conversationIdForAgent', () => {
     setConversationIdForAgent('codey', 'sess-b')
     window.removeEventListener(AGENT_CONVERSATION_EVENT, onChange)
     expect(seen).toEqual(['sess-b'])
+    setConversationIdForAgent('codey', 'sess-b')
+    expect(seen).toEqual(['sess-b'])
   })
 
   it('reuses the stored id when new chat per task is off', () => {

--- a/webui/frontend/src/lib/__tests__/agentChat.test.ts
+++ b/webui/frontend/src/lib/__tests__/agentChat.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  AGENT_CONVERSATION_EVENT,
   DEFAULT_AGENT_ID,
   activeTaskSessionCount,
+  agentChatHref,
   agentIdFromBlueprint,
   compactAgentThread,
   conversationIdForAgent,
@@ -9,6 +11,7 @@ import {
   fetchAgentThread,
   listTaskSessions,
   peekConversationIdForAgent,
+  setConversationIdForAgent,
 } from '../agentChat'
 
 describe('agentIdFromBlueprint', () => {
@@ -36,6 +39,33 @@ describe('conversationIdForAgent', () => {
     expect(peekConversationIdForAgent('codey')).toBeNull()
     const minted = conversationIdForAgent('codey')
     expect(peekConversationIdForAgent('codey')).toBe(minted)
+  })
+
+  it('persists a selected session id and rehydrates it after remount', () => {
+    setConversationIdForAgent('codey', 'sess-notes')
+    expect(peekConversationIdForAgent('codey')).toBe('sess-notes')
+    expect(conversationIdForAgent('codey')).toBe('sess-notes')
+    expect(agentChatHref('codey')).toBe('/chat?blueprint=codey&session=sess-notes')
+    expect(agentChatHref('stewie')).toBe('/chat?blueprint=stewie')
+  })
+
+  it('keeps the selected id after the module-level helpers are called again (unmount)', () => {
+    setConversationIdForAgent('cli_agent', 'cli-cli_agent-abc')
+    expect(peekConversationIdForAgent('cli_agent')).toBe('cli-cli_agent-abc')
+    expect(conversationIdForAgent('cli_agent')).toBe('cli-cli_agent-abc')
+    expect(agentChatHref('cli_agent')).toContain('session=cli-cli_agent-abc')
+  })
+
+  it('emits AGENT_CONVERSATION_EVENT when the selected id is stored', () => {
+    const seen: string[] = []
+    const onChange = (event: Event) => {
+      const detail = (event as CustomEvent<{ conversationId?: string }>).detail
+      if (detail?.conversationId) seen.push(detail.conversationId)
+    }
+    window.addEventListener(AGENT_CONVERSATION_EVENT, onChange)
+    setConversationIdForAgent('codey', 'sess-b')
+    window.removeEventListener(AGENT_CONVERSATION_EVENT, onChange)
+    expect(seen).toEqual(['sess-b'])
   })
 
   it('reuses the stored id when new chat per task is off', () => {
@@ -247,6 +277,26 @@ describe('fetchAgentThread', () => {
     const thread = await fetchAgentThread('codey', 'sess-worker-2')
     expect(thread.conversation_id).toBe('sess-worker-2')
     expect(String(fetchMock.mock.calls[0][0])).toContain('conversation_id=sess-worker-2')
+  })
+
+  it('surfaces session_missing so Chat does not swap transcripts', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          agent_id: 'codey',
+          conversation_id: 'sess-gone',
+          session_missing: true,
+          messages: [],
+        }),
+      } as Response),
+    )
+    const thread = await fetchAgentThread('codey', 'sess-gone')
+    expect(thread.session_missing).toBe(true)
+    expect(thread.messages).toEqual([])
+    expect(thread.conversation_id).toBe('sess-gone')
   })
 
   it('returns an empty thread when fetch fails', async () => {

--- a/webui/frontend/src/lib/__tests__/sessionRestore.test.ts
+++ b/webui/frontend/src/lib/__tests__/sessionRestore.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
+  MISSING_SESSION_TEXT,
   RESTORED_SESSION_TEXT,
   hasRestorableTurns,
   isRestoreStatusText,
+  missingSessionNotice,
   restoreKindForAgent,
   restoredSessionNotice,
   switchedSessionNotice,
@@ -63,5 +65,14 @@ describe('withRestoredSession', () => {
     expect(isRestoreStatusText('Switched to session Notes')).toBe(true)
     expect(switchedSessionNotice('Notes')).toBe('Switched to session Notes')
     expect(switchedSessionNotice('')).toBe('Switched to session')
+  })
+})
+
+describe('missingSessionNotice (#794)', () => {
+  it('is honest and never claims restore', () => {
+    expect(missingSessionNotice('sess-gone')).toBe('Stored session sess-gone is gone')
+    expect(missingSessionNotice('')).toBe(MISSING_SESSION_TEXT)
+    expect(isRestoreStatusText('Stored session sess-gone is gone')).toBe(true)
+    expect(isRestoreStatusText('Stored session is gone')).toBe(true)
   })
 })

--- a/webui/frontend/src/lib/agentChat.ts
+++ b/webui/frontend/src/lib/agentChat.ts
@@ -29,6 +29,7 @@ export function setConversationIdForAgent(agentId: string, conversationId: strin
   const agent = agentIdFromBlueprint(agentId)
   const id = String(conversationId || '').trim()
   if (!id) return
+  if (peekConversationIdForAgent(agent) === id) return
   try {
     window.localStorage.setItem(`${STORAGE_PREFIX}${agent}`, id)
   } catch {

--- a/webui/frontend/src/lib/agentChat.ts
+++ b/webui/frontend/src/lib/agentChat.ts
@@ -16,9 +16,33 @@ export const DEFAULT_AGENT_ID = '_default'
 const STORAGE_PREFIX = 'swarm_agent_chat:'
 const TASKS_PREFIX = 'swarm_agent_tasks:'
 
+/** Last selected swarm conversation id changed (CLI or Django). */
+export const AGENT_CONVERSATION_EVENT = 'swarm:agent-conversation'
+
 export function agentIdFromBlueprint(blueprintId: string | null | undefined): string {
   const trimmed = (blueprintId ?? '').trim()
   return trimmed || DEFAULT_AGENT_ID
+}
+
+/** Persist the selected conversation id so remount / browse-back restores it. */
+export function setConversationIdForAgent(agentId: string, conversationId: string): void {
+  const agent = agentIdFromBlueprint(agentId)
+  const id = String(conversationId || '').trim()
+  if (!id) return
+  try {
+    window.localStorage.setItem(`${STORAGE_PREFIX}${agent}`, id)
+  } catch {
+    /* private mode / quota */
+  }
+  try {
+    window.dispatchEvent(
+      new CustomEvent(AGENT_CONVERSATION_EVENT, {
+        detail: { agentId: agent, conversationId: id },
+      }),
+    )
+  } catch {
+    /* jsdom / SSR */
+  }
 }
 
 /** Stable per-agent conversation id (localStorage). Survives reload. */
@@ -26,14 +50,7 @@ export function conversationIdForAgent(agentId: string): string {
   const existing = peekConversationIdForAgent(agentId)
   if (existing) return existing
   const minted = newConversationId()
-  try {
-    window.localStorage.setItem(
-      `${STORAGE_PREFIX}${agentIdFromBlueprint(agentId)}`,
-      minted,
-    )
-  } catch {
-    /* private mode / quota */
-  }
+  setConversationIdForAgent(agentId, minted)
   return minted
 }
 
@@ -46,6 +63,19 @@ export function peekConversationIdForAgent(agentId: string): string | null {
   } catch {
     return null
   }
+}
+
+/** Rail / remount href: keep the last selected session on the URL when known. */
+export function agentChatHref(agentId: string): string {
+  const agent = agentIdFromBlueprint(agentId)
+  const session = peekConversationIdForAgent(agent)
+  if (session) {
+    const params = new URLSearchParams()
+    params.set('blueprint', agent)
+    params.set('session', session)
+    return `/chat?${params.toString()}`
+  }
+  return `/chat?blueprint=${encodeURIComponent(agent)}`
 }
 
 function tasksKey(agentId: string): string {
@@ -123,6 +153,8 @@ export interface AgentThread {
   summaries: ConversationSummary[]
   kind?: AgentKind
   editable?: boolean
+  /** Requested session was not on disk/DB — do not silently swap. */
+  session_missing?: boolean
 }
 
 export interface CompactResult {
@@ -198,6 +230,7 @@ export async function fetchAgentThread(
       summaries: parseSummaries(data?.summaries),
       kind,
       editable: data?.editable === true || (data?.editable !== false && kind === 'api'),
+      session_missing: data?.session_missing === true,
     }
   } catch {
     const kind = classifyAgentKind(agent)

--- a/webui/frontend/src/lib/agentSessions.ts
+++ b/webui/frontend/src/lib/agentSessions.ts
@@ -6,7 +6,7 @@
  */
 
 import { apiGet, apiPost } from './api'
-import { agentIdFromBlueprint } from './agentChat'
+import { agentIdFromBlueprint, setConversationIdForAgent } from './agentChat'
 import { formatRailTimestamp } from './chatTime'
 import {
   listAgentSessions,
@@ -148,6 +148,9 @@ export async function createAgentSession(
       { new: true, empty: true, title: opts?.title || '', labels: opts?.labels || [] },
     )
     const parsed = parseDjangoSession(data, agent)
+    if (parsed?.id) {
+      setConversationIdForAgent(agent, parsed.id)
+    }
     emitAgentSessionsChanged(agent)
     return parsed
   } catch {

--- a/webui/frontend/src/lib/cliSessions.ts
+++ b/webui/frontend/src/lib/cliSessions.ts
@@ -6,7 +6,13 @@
  */
 
 import { apiGet, apiPost } from './api'
-import { agentIdFromBlueprint, conversationIdForAgent } from './agentChat'
+import {
+  agentIdFromBlueprint,
+  conversationIdForAgent,
+  setConversationIdForAgent,
+} from './agentChat'
+
+export { setConversationIdForAgent } from './agentChat'
 
 const SESSION_ID_RE = /^[A-Za-z0-9._:-]{1,128}$/
 const SECRET_PREFIX = /^(sk-|gsk_|xai-|AIza|ghp_|github_pat_|xox[baprs]-|Bearer )/i
@@ -63,15 +69,6 @@ export interface CliSessionSelectResult {
   collapsed_prior: boolean
   import: 'none' | 'full' | 'partial'
   same_session?: boolean
-}
-
-export function setConversationIdForAgent(agentId: string, conversationId: string): void {
-  const key = `swarm_agent_chat:${agentIdFromBlueprint(agentId)}`
-  try {
-    window.localStorage.setItem(key, conversationId)
-  } catch {
-    /* best-effort */
-  }
 }
 
 export async function fetchCliSessions(agentId: string, cli: string): Promise<CliSessionList> {

--- a/webui/frontend/src/lib/sessionRestore.ts
+++ b/webui/frontend/src/lib/sessionRestore.ts
@@ -23,6 +23,14 @@ export function switchedSessionNotice(title?: string | null): string {
   return label ? `Switched to session ${label}` : 'Switched to session'
 }
 
+/** #794: stored session id is gone — never silently swap to another transcript. */
+export const MISSING_SESSION_TEXT = 'Stored session is gone'
+
+export function missingSessionNotice(sessionId?: string | null): string {
+  const id = String(sessionId || '').trim()
+  return id ? `Stored session ${id} is gone` : MISSING_SESSION_TEXT
+}
+
 export function restoreKindForAgent(agentId: string): RestoreKind {
   const id = (agentId || '').trim().toLowerCase()
   if (id.startsWith('team-') || id.startsWith('team:')) return 'team'
@@ -46,7 +54,8 @@ export function isRestoreStatusText(text: string | null | undefined): boolean {
     t.startsWith('resumed ') ||
     t.startsWith('reconnected remote') ||
     t.startsWith('continued chat') ||
-    t.startsWith('switched to session')
+    t.startsWith('switched to session') ||
+    t.startsWith('stored session')
   )
 }
 

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -44,6 +44,7 @@ import {
 } from '../lib/slashMenu'
 import { fetchConfigOptions, fetchBlueprints, fetchCliAgents, fetchCliModels, fetchRemotes } from '../lib/api'
 import {
+  AGENT_CONVERSATION_EVENT,
   agentIdFromBlueprint,
   appendAgentMessage,
   compactAgentThread,
@@ -52,6 +53,8 @@ import {
   DEFAULT_AGENT_ID,
   fetchAgentThread,
   patchAgentMessage,
+  peekConversationIdForAgent,
+  setConversationIdForAgent,
   type ConversationSummary,
 } from '../lib/agentChat'
 import { canEditAgentMessages, classifyAgentKind, type AgentKind } from '../lib/agentKind'
@@ -151,10 +154,12 @@ import {
 import { insertCliSessionNotice } from '../lib/chatTranscript'
 import { fetchAgentSuggestions, shouldShowSuggestionChips } from '../lib/suggestions'
 import {
+  missingSessionNotice,
   restoreKindForAgent,
   restoredSessionNotice,
   switchedSessionNotice,
 } from '../lib/sessionRestore'
+import { CLI_SESSION_SWITCHED_EVENT } from '../lib/cliSessions'
 import {
   SUGGESTION_CHIP_EVENT,
   generationIsInFlight,
@@ -305,6 +310,7 @@ const ChatPage = () => {
       : remoteFromUrl
         ? `remote-${remoteFromUrl}${sessionFromUrl ? `-${sessionFromUrl}` : ''}`
         : sessionFromUrl ||
+          peekConversationIdForAgent(defaultBlueprintId(searchParams.get('blueprint'))) ||
           conversationIdForTask(agentIdFromBlueprint(selectedBlueprint), {
             newChatPerTask: loadLocalNewChatPerTask(
               defaultBlueprintId(searchParams.get('blueprint')),
@@ -641,6 +647,29 @@ const ChatPage = () => {
     setMemberTarget(ALL_MEMBERS_TARGET)
   }, [teamFromUrl, sessionFromUrl])
 
+  // #794: persist the selected swarm conversation (CLI or Django) so remount
+  // and rail browse-back restore the same id — not the prior default.
+  useEffect(() => {
+    if (teamFromUrl || remoteFromUrl || !sessionFromUrl || !selectedBlueprint) return
+    setConversationIdForAgent(selectedBlueprint, sessionFromUrl)
+  }, [sessionFromUrl, selectedBlueprint, teamFromUrl, remoteFromUrl])
+
+  useEffect(() => {
+    const onSwitched = (event: Event) => {
+      const detail = (event as CustomEvent<{ agentId?: string; conversationId?: string }>).detail
+      const agent = agentIdFromBlueprint(selectedBlueprint)
+      if (!detail?.conversationId || teamFromUrl || remoteFromUrl) return
+      if (detail.agentId && agentIdFromBlueprint(detail.agentId) !== agent) return
+      setConversationId(detail.conversationId)
+    }
+    window.addEventListener(CLI_SESSION_SWITCHED_EVENT, onSwitched)
+    window.addEventListener(AGENT_CONVERSATION_EVENT, onSwitched)
+    return () => {
+      window.removeEventListener(CLI_SESSION_SWITCHED_EVENT, onSwitched)
+      window.removeEventListener(AGENT_CONVERSATION_EVENT, onSwitched)
+    }
+  }, [selectedBlueprint, teamFromUrl, remoteFromUrl])
+
   useEffect(() => {
     const onEdits = () => setEditsTick((tick) => tick + 1)
     const onDropdowns = () => setDropdownTick((tick) => tick + 1)
@@ -793,10 +822,12 @@ const ChatPage = () => {
     }
 
     const agent = agentIdFromBlueprint(selectedBlueprint)
-    const fresh = !sessionFromUrl && newChatPerTask
+    const stored = peekConversationIdForAgent(agent)
+    const resolvedSession = sessionFromUrl || stored || ''
+    const fresh = !resolvedSession && newChatPerTask
     const nextId = fresh
       ? conversationIdForTask(agent, { newChatPerTask: true })
-      : sessionFromUrl || conversationIdForAgent(agent)
+      : resolvedSession || conversationIdForAgent(agent)
     const hydrateKey = sessionFromUrl
       ? `${agent}::${sessionFromUrl}`
       : fresh
@@ -807,6 +838,9 @@ const ChatPage = () => {
       lastHydratedAgentRef.current !== hydrateKey
     lastHydratedAgentRef.current = hydrateKey
     setConversationId(nextId)
+    if (resolvedSession) {
+      setConversationIdForAgent(agent, nextId)
+    }
     setEditingKey(null)
     setAgentKind(classifyAgentKind(selectedBlueprint))
     setMessagesEditable(canEditAgentMessages(selectedBlueprint) && !selectedCli)
@@ -823,7 +857,7 @@ const ChatPage = () => {
     }
     let cancelled = false
     ;(async () => {
-      const thread = await fetchAgentThread(agent, sessionFromUrl || undefined)
+      const thread = await fetchAgentThread(agent, resolvedSession || undefined)
       if (cancelled) return
       setAgentKind(thread.kind ?? classifyAgentKind(selectedBlueprint))
       setMessagesEditable(
@@ -835,9 +869,18 @@ const ChatPage = () => {
         ...prev,
         [threadKey]: thread.summaries,
       }))
+      if (thread.session_missing) {
+        setRestoreNotice(missingSessionNotice(resolvedSession || nextId))
+        setThreads((prev) => ({ ...prev, [threadKey]: [] }))
+        setThreadReady(true)
+        return
+      }
       if (switched && sessionFromUrl) {
         setRestoreNotice(switchedSessionNotice(thread.session_title || thread.conversation_id))
-        if (thread.messages.length === 0) return
+        if (thread.messages.length === 0) {
+          setThreadReady(true)
+          return
+        }
       } else if (thread.messages.length === 0) {
         setRestoreNotice(null)
         setThreadReady(true)
@@ -2069,17 +2112,17 @@ const ChatPage = () => {
         }}
       >
         <div className="os-chat-messages space-y-1 flex-1" data-testid="chat-messages-container">
+        {restoreNotice ? (
+          <p className="os-chat-status" data-role="status" data-testid="chat-status">
+            <span>{restoreNotice}</span>
+          </p>
+        ) : null}
         {messages.length === 0 ? (
           <div className="flex h-full min-h-64 flex-col items-center justify-center gap-2 text-center text-base-content/45">
             <p className="text-sm">Message {selectedAgentName}</p>
           </div>
         ) : (
           <>
-          {restoreNotice ? (
-            <p className="os-chat-status" data-role="status" data-testid="chat-status">
-              <span>{restoreNotice}</span>
-            </p>
-          ) : null}
           {displayItems.map((item, idx) => {
             if (item.kind === 'summary') {
               return (

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -2249,6 +2249,155 @@ describe('ChatPage per-agent thread switch (REQ-14 #319)', () => {
   })
 })
 
+describe('ChatPage selected session persist (#794)', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    window.localStorage.clear()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/chat/thread/')) {
+          const cid = new URL(url, 'http://localhost').searchParams.get('conversation_id')
+          if (cid === 'sess-notes') {
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                agent_id: 'codey',
+                conversation_id: 'sess-notes',
+                session_title: 'Notes',
+                messages: [
+                  { role: 'user', content: 'notes from A' },
+                  { role: 'assistant', content: 'reply A' },
+                ],
+              }),
+            } as Response
+          }
+          if (cid === 'sess-old') {
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                agent_id: 'codey',
+                conversation_id: 'sess-old',
+                messages: [
+                  { role: 'user', content: 'older session' },
+                  { role: 'assistant', content: 'old reply' },
+                ],
+              }),
+            } as Response
+          }
+          if (cid === 'sess-gone' || cid === 'cli-cli_agent-gone') {
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                agent_id: cid?.startsWith('cli-') ? 'cli_agent' : 'codey',
+                conversation_id: cid,
+                session_missing: true,
+                messages: [],
+              }),
+            } as Response
+          }
+          if (cid === 'cli-cli_agent-abc') {
+            return {
+              ok: true,
+              status: 200,
+              json: async () => ({
+                agent_id: 'cli_agent',
+                conversation_id: 'cli-cli_agent-abc',
+                messages: [
+                  { role: 'status', content: 'Switched to grok session sid-1.' },
+                  { role: 'user', content: 'from cli A' },
+                ],
+              }),
+            } as Response
+          }
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ agent_id: 'codey', conversation_id: cid, messages: [] }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            data: [
+              { id: 'codey', name: 'Codey', description: 'Code assistant' },
+              { id: 'cli_agent', name: 'CLI Agent', description: 'CLI' },
+            ],
+          }),
+        } as Response
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    resetConversationThreads()
+    window.localStorage.clear()
+  })
+
+  it('rehydrates the selected Django session after unmount without ?session=', async () => {
+    const { setConversationIdForAgent } = await import('../../lib/agentChat')
+    setConversationIdForAgent('codey', 'sess-old')
+    const first = renderChat('/chat?blueprint=codey&session=sess-notes')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+    expect(await screen.findByText('notes from A')).toBeInTheDocument()
+    expect(screen.queryByText('older session')).not.toBeInTheDocument()
+    first.unmount()
+
+    renderChat('/chat?blueprint=codey')
+    await act(async () => {
+      MockWebSocket.instances[MockWebSocket.instances.length - 1]?.open()
+    })
+    expect(await screen.findByText('notes from A')).toBeInTheDocument()
+    expect(screen.queryByText('older session')).not.toBeInTheDocument()
+    const threadCalls = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .map(([input]) => String(input))
+      .filter((url) => url.includes('/chat/thread/'))
+    expect(threadCalls.some((url) => url.includes('conversation_id=sess-notes'))).toBe(true)
+  })
+
+  it('rehydrates the selected CLI conversation after unmount without ?session=', async () => {
+    const { setConversationIdForAgent } = await import('../../lib/agentChat')
+    setConversationIdForAgent('cli_agent', 'cli-cli_agent-abc')
+    const first = renderChat('/chat?blueprint=cli_agent&session=cli-cli_agent-abc')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+    expect(await screen.findByText('from cli A')).toBeInTheDocument()
+    first.unmount()
+
+    renderChat('/chat?blueprint=cli_agent')
+    await act(async () => {
+      MockWebSocket.instances[MockWebSocket.instances.length - 1]?.open()
+    })
+    expect(await screen.findByText('from cli A')).toBeInTheDocument()
+  })
+
+  it('shows honest status when the stored session is gone — no older transcript', async () => {
+    const { setConversationIdForAgent } = await import('../../lib/agentChat')
+    setConversationIdForAgent('codey', 'sess-gone')
+    renderChat('/chat?blueprint=codey')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+    expect(await screen.findByTestId('chat-status')).toHaveTextContent(
+      'Stored session sess-gone is gone',
+    )
+    expect(screen.queryByText('older session')).not.toBeInTheDocument()
+    expect(screen.queryByText('notes from A')).not.toBeInTheDocument()
+  })
+})
+
 describe('ChatPage Support default URL (REQ-5c #322)', () => {
   beforeEach(() => {
     MockWebSocket.instances = []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #794

## Intent
After Select session (CLI or Django-backed), navigating away and returning must restore the **same** selected session and transcript — not silently fall back to an older/previous session.

## What changed
- Persist the selected swarm conversation id (`swarm_agent_chat:`) on both CLI Select and Django Select/New.
- Rail and pin hrefs keep `?session=` so browse-away/back lands on the same id.
- Chat remount without `?session=` rehydrates from the stored id and matching transcript.
- If the stored session is gone (`cli-` / `sess-` miss), return `session_missing` and show **Stored session {id} is gone** — no silent swap to the default/older transcript.
- `chat_store.load(..., conversation_id=)` no longer falls through to the default agent file when the requested id is missing.

## Success
1. Select session A → id + transcript match A.
2. Navigate away (another agent / Settings) then return → still A.
3. Reload / remount without `?session=` still restores A from the stored id.
4. CLI (`cli_session` + bound conversation) and Django Select/New both persist.
5. Honest status if the stored session is gone.

## Tests
- Vitest: persist + peek + `agentChatHref`; ChatPage unmount/remount for Django and CLI; missing-session status; rail href after Django Select.
- Pytest: `chat_store.load` does not swap; `/chat/thread/` returns `session_missing` with empty messages.

Own-diff CI. No live host. No secrets. No `:8001`.

Coord #468/#469/#601/#604/#636/#773/#779/#792.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d02b3388-95f3-4aba-a608-1a3c6e08db96?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d02b3388-95f3-4aba-a608-1a3c6e08db96&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

