### PR TITLE
REQ-83: Settings image-gen endpoint and still agent avatars

### DIFF
--- a/src/swarm/core/image_gen.py
+++ b/src/swarm/core/image_gen.py
@@ -1,0 +1,492 @@
+"""OpenAI-compatible image generation (REQ-83 / #436).
+
+Settings persist an opt-in ``image_gen`` block on ``swarm_config.json``:
+base URL, model id, and an api-key **env name** only. Empty/off never
+guesses a host (no OpenAI / LiteLLM / LAN default). Generated stills are
+PNG/JPEG/WebP files under avatar storage — not GIF/APNG/video, and not
+Blob theme eyes.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import re
+import tempfile
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from swarm.core.chat_store import normalize_agent_id
+from swarm.core.paths import ensure_swarm_directories_exist, get_user_config_dir_for_swarm
+
+logger = logging.getLogger(__name__)
+
+ENV_CONFIG_PATH = "SWARM_CONFIG_PATH"
+ENV_AVATARS_PATH = "SWARM_AGENT_AVATARS_PATH"
+ENV_AVATAR_STORAGE = "SWARM_AVATAR_STORAGE"
+
+_FORBIDDEN_BASE_HINTS = ("fly.dev", "open-litellm", "openlitellm")
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_ID_FILE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+_PNG_SIG = b"\x89PNG\r\n\x1a\n"
+_JPEG_SIG = b"\xff\xd8\xff"
+_GIF_SIGS = (b"GIF87a", b"GIF89a")
+_WEBP_RIFF = b"RIFF"
+_WEBP_WEBP = b"WEBP"
+_ACTL = b"acTL"
+_ANIM = b"ANIM"
+
+_DEFAULT_TIMEOUT_S = 3.0
+_GENERATE_TIMEOUT_S = 30.0
+
+
+class ImageGenError(Exception):
+    """User-facing image-gen failure (not configured, DOWN, not still)."""
+
+
+@dataclass
+class ImageGenSettings:
+    base_url: str = ""
+    model: str = ""
+    api_key: str = ""
+    api_key_env: str = ""
+    source: str = "off"
+
+    def configured(self) -> bool:
+        return bool(self.base_url.strip())
+
+    def public_dict(self) -> dict[str, Any]:
+        key = str(self.api_key or "")
+        return {
+            "object": "image_gen",
+            "configured": self.configured(),
+            "base_url": self.base_url,
+            "model": self.model,
+            "api_key_env": self.api_key_env,
+            "api_key_set": bool(key) and not _is_unresolved_placeholder(key),
+            "source": self.source,
+        }
+
+
+def _placeholder_env_name(value: str) -> str:
+    raw = (value or "").strip()
+    if raw.startswith("${") and raw.endswith("}") and len(raw) > 3:
+        inner = raw[2:-1].strip()
+        if inner and _ENV_NAME_RE.match(inner):
+            return inner
+    return ""
+
+
+def _as_env_name(value: str) -> str:
+    raw = (value or "").strip()
+    derived = _placeholder_env_name(raw)
+    if derived:
+        return derived
+    if raw and _ENV_NAME_RE.match(raw):
+        return raw
+    return ""
+
+
+def _is_unresolved_placeholder(value: str) -> bool:
+    raw = (value or "").strip()
+    return raw.startswith("${") and raw.endswith("}") and len(raw) > 3
+
+
+def _expand(value: Any) -> Any:
+    if isinstance(value, str):
+        expanded = os.path.expandvars(value)
+        if _is_unresolved_placeholder(expanded):
+            return ""
+        return expanded
+    return value
+
+
+def _normalize_base_url(url: str) -> str:
+    raw = (url or "").strip().rstrip("/")
+    if not raw:
+        return ""
+    if "://" not in raw:
+        raw = f"http://{raw}"
+    return raw
+
+
+def _looks_like_forbidden_llm_proxy(url: str) -> bool:
+    lowered = (url or "").lower()
+    return any(hint in lowered for hint in _FORBIDDEN_BASE_HINTS)
+
+
+def resolve_config_path(explicit: str | Path | None = None) -> Path:
+    from swarm.core.config_loader import find_config_file
+
+    if explicit:
+        return Path(explicit).expanduser()
+    found = find_config_file()
+    if found:
+        return found
+    return get_user_config_dir_for_swarm() / "swarm_config.json"
+
+
+def load_raw_config(config_path: str | Path | None = None) -> tuple[dict[str, Any], Path]:
+    path = resolve_config_path(config_path)
+    if path.is_file():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return data, path
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("image_gen: failed to read %s: %s", path, exc)
+    return {}, path
+
+
+def load_settings(config: dict[str, Any] | None = None) -> ImageGenSettings:
+    """Defaults ← swarm_config.json image_gen ← env (env wins for URL/model/key)."""
+    cfg = config if isinstance(config, dict) else load_raw_config()[0]
+    block = cfg.get("image_gen") if isinstance(cfg.get("image_gen"), dict) else {}
+    spec = ImageGenSettings()
+    if isinstance(block, dict) and block:
+        spec.source = "config"
+        if block.get("base_url") is not None:
+            spec.base_url = str(block.get("base_url") or "")
+        if block.get("model") is not None:
+            spec.model = str(block.get("model") or "")
+        if block.get("api_key") is not None:
+            spec.api_key = str(block.get("api_key") or "")
+        if block.get("api_key_env") is not None:
+            spec.api_key_env = str(block.get("api_key_env") or "")
+    env_base = os.environ.get("IMAGE_GEN_BASE_URL", "").strip()
+    if env_base:
+        spec.base_url = env_base
+        spec.source = "env"
+    env_model = os.environ.get("IMAGE_GEN_MODEL", "").strip()
+    if env_model:
+        spec.model = env_model
+    env_key_name = spec.api_key_env or os.environ.get("IMAGE_GEN_API_KEY_ENV", "").strip()
+    if env_key_name:
+        spec.api_key_env = env_key_name
+    env_key = os.environ.get(spec.api_key_env, "").strip() if spec.api_key_env else ""
+    if env_key:
+        spec.api_key = env_key
+    elif spec.api_key:
+        spec.api_key = str(_expand(spec.api_key) or "")
+    if not spec.api_key_env:
+        spec.api_key_env = _placeholder_env_name(str(block.get("api_key") or ""))
+    spec.base_url = _normalize_base_url(spec.base_url)
+    return spec
+
+
+def is_configured(config: dict[str, Any] | None = None) -> bool:
+    return load_settings(config).configured()
+
+
+def persist_settings(
+    *,
+    base_url: str | None = None,
+    model: str | None = None,
+    api_key_env: str | None = None,
+    config_path: str | Path | None = None,
+) -> tuple[ImageGenSettings, Path]:
+    """Merge fields into ``image_gen`` and write swarm_config.json.
+
+    Stores api-key-env as ``${ENV}`` only. Empty base URL stays empty — never
+    invents a host.
+    """
+    cfg, path = load_raw_config(config_path)
+    entry = cfg.get("image_gen") if isinstance(cfg.get("image_gen"), dict) else {}
+    entry = dict(entry)
+    if base_url is not None:
+        normalized = _normalize_base_url(base_url)
+        if normalized and _looks_like_forbidden_llm_proxy(normalized):
+            raise ImageGenError(
+                "Refusing to persist a Fly open-litellm URL as the image-gen host. "
+                "Set the OpenAI-compatible images endpoint you actually run."
+            )
+        entry["base_url"] = normalized
+    if model is not None:
+        entry["model"] = (model or "").strip()
+    if api_key_env is not None:
+        env_name = _as_env_name(api_key_env)
+        entry["api_key_env"] = env_name
+        if env_name:
+            entry["api_key"] = f"${{{env_name}}}"
+        else:
+            entry.pop("api_key", None)
+    cfg["image_gen"] = entry
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(cfg, indent=4) + "\n", encoding="utf-8")
+    logger.info("Persisted image_gen to %s", path)
+    return load_settings(cfg), path
+
+
+def generations_url(base_url: str) -> str:
+    """``{base}/v1/images/generations`` without inventing a host when base is empty."""
+    raw = _normalize_base_url(base_url)
+    if not raw:
+        return ""
+    parsed = urlparse(raw)
+    path = (parsed.path or "").rstrip("/")
+    if path.endswith("/v1/images/generations"):
+        return raw
+    if path.endswith("/images/generations"):
+        return raw
+    if path.endswith("/v1"):
+        return f"{raw}/images/generations"
+    return f"{raw}/v1/images/generations"
+
+
+def probe_status(settings: ImageGenSettings | None = None) -> dict[str, Any]:
+    """Honest reachability. Empty/off does not call any host."""
+    spec = settings if settings is not None else load_settings()
+    pub = spec.public_dict()
+    if not spec.configured():
+        pub["status"] = "off"
+        pub["detail"] = "Image generation is off. No host is used until you set a base URL."
+        return pub
+    url = generations_url(spec.base_url)
+    try:
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=_DEFAULT_TIMEOUT_S) as resp:
+            code = int(getattr(resp, "status", 200) or 200)
+        pub["status"] = "ok"
+        pub["detail"] = f"Image generation endpoint answered HTTP {code}."
+        pub["http_status"] = code
+        return pub
+    except urllib.error.HTTPError as exc:
+        pub["status"] = "ok"
+        pub["detail"] = f"Image generation endpoint answered HTTP {exc.code}."
+        pub["http_status"] = int(exc.code)
+        return pub
+    except Exception as exc:
+        pub["status"] = "down"
+        pub["detail"] = f"Image generation endpoint is DOWN: {exc}"
+        pub["http_status"] = None
+        return pub
+
+
+def _is_still_image(payload: bytes) -> bool:
+    """True for a single-frame PNG/JPEG/WebP. Rejects GIF/APNG/animated WebP."""
+    if not payload:
+        return False
+    if payload.startswith(_GIF_SIGS):
+        return False
+    if payload.startswith(_PNG_SIG):
+        return _ACTL not in payload[:8192] and b"acTL" not in payload
+    if payload.startswith(_JPEG_SIG):
+        return True
+    if payload.startswith(_WEBP_RIFF) and payload[8:12] == _WEBP_WEBP:
+        return _ANIM not in payload[:64] and b"ANIM" not in payload[:256]
+    return False
+
+
+def _decode_generation_body(body: bytes, content_type: str) -> bytes:
+    ctype = (content_type or "").split(";")[0].strip().lower()
+    if ctype.startswith("image/") or body.startswith((_PNG_SIG, _JPEG_SIG) + _GIF_SIGS) or (
+        body.startswith(_WEBP_RIFF) and body[8:12] == _WEBP_WEBP
+    ):
+        return body
+    try:
+        parsed = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ImageGenError("Image generation response was not JSON or image bytes.") from exc
+    data = parsed.get("data") if isinstance(parsed, dict) else None
+    first = data[0] if isinstance(data, list) and data else None
+    if not isinstance(first, dict):
+        raise ImageGenError("Image generation response had no data[0] image.")
+    b64 = first.get("b64_json")
+    if isinstance(b64, str) and b64.strip():
+        try:
+            return base64.b64decode(b64, validate=False)
+        except Exception as exc:
+            raise ImageGenError("Image generation b64_json was not valid base64.") from exc
+    raise ImageGenError("Image generation response had no b64_json still image.")
+
+
+def generate_still(
+    prompt: str,
+    *,
+    settings: ImageGenSettings | None = None,
+    opener=None,
+    timeout: float = _GENERATE_TIMEOUT_S,
+) -> bytes:
+    """POST ``/v1/images/generations``. Empty URL does not call any host."""
+    spec = settings if settings is not None else load_settings()
+    url = generations_url(spec.base_url)
+    if not url:
+        raise ImageGenError(
+            "Image generation is not configured. Set a base URL in Settings → Image generation."
+        )
+    text = (prompt or "").strip()
+    if not text:
+        raise ImageGenError("Provide a prompt for the still avatar.")
+    payload: dict[str, Any] = {
+        "prompt": text,
+        "n": 1,
+        "response_format": "b64_json",
+    }
+    if spec.model.strip():
+        payload["model"] = spec.model.strip()
+    body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if spec.api_key and not _is_unresolved_placeholder(spec.api_key):
+        headers["Authorization"] = f"Bearer {spec.api_key}"
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    call = opener or urllib.request.urlopen
+    try:
+        with call(req, timeout=timeout) as resp:
+            raw = resp.read()
+            ctype = ""
+            try:
+                ctype = resp.headers.get("Content-Type", "")
+            except Exception:
+                ctype = ""
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:240] if exc.fp else ""
+        raise ImageGenError(
+            f"Image generation endpoint returned HTTP {exc.code}. {detail}".strip()
+        ) from exc
+    except ImageGenError:
+        raise
+    except Exception as exc:
+        raise ImageGenError(f"Image generation endpoint is DOWN: {exc}") from exc
+    image = _decode_generation_body(raw, ctype)
+    if not _is_still_image(image):
+        raise ImageGenError("Generated image is not a still (GIF/APNG/video rejected).")
+    return image
+
+
+def avatars_path() -> Path:
+    env = (os.environ.get(ENV_AVATARS_PATH) or "").strip()
+    if env:
+        return Path(env)
+    ensure_swarm_directories_exist()
+    return get_user_config_dir_for_swarm() / "agent_avatars.json"
+
+
+def avatar_storage_dir() -> Path:
+    env = (os.environ.get(ENV_AVATAR_STORAGE) or "").strip()
+    if env:
+        return Path(env)
+    try:
+        from django.conf import settings
+
+        return Path(settings.AVATAR_STORAGE_PATH)
+    except Exception:
+        return Path("avatars")
+
+
+def avatar_url_prefix() -> str:
+    try:
+        from django.conf import settings
+
+        prefix = str(getattr(settings, "AVATAR_URL_PREFIX", "/avatars/") or "/avatars/")
+    except Exception:
+        prefix = "/avatars/"
+    if not prefix.startswith("/"):
+        prefix = "/" + prefix
+    if not prefix.endswith("/"):
+        prefix += "/"
+    return prefix
+
+
+def _empty_avatar_store() -> dict[str, Any]:
+    return {"schema": 1, "avatars": {}}
+
+
+def load_avatar_map() -> dict[str, str]:
+    path = avatars_path()
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    raw = data.get("avatars")
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, str] = {}
+    for key, value in raw.items():
+        agent = normalize_agent_id(str(key))
+        url = ""
+        if isinstance(value, str):
+            url = value.strip()
+        elif isinstance(value, dict):
+            url = str(value.get("avatar_path") or value.get("url") or "").strip()
+        if agent and url:
+            out[agent] = url
+    return out
+
+
+def _write_avatar_map(mapping: dict[str, str]) -> None:
+    path = avatars_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"schema": 1, "avatars": dict(mapping)}
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def avatar_path_for(agent_id: str) -> str | None:
+    agent = normalize_agent_id(agent_id)
+    return load_avatar_map().get(agent)
+
+
+def _safe_stem(agent_id: str) -> str:
+    agent = normalize_agent_id(agent_id)
+    if not _ID_FILE_RE.match(agent):
+        raise ImageGenError("Agent id is not safe for an avatar filename.")
+    return agent
+
+
+def store_still_avatar(agent_id: str, image: bytes) -> str:
+    """Write a still image and record the per-agent slot. Replaces the previous file."""
+    if not _is_still_image(image):
+        raise ImageGenError("Stored avatar must be a still image (not GIF/APNG/video).")
+    stem = _safe_stem(agent_id)
+    root = avatar_storage_dir()
+    root.mkdir(parents=True, exist_ok=True)
+    filename = f"{stem}_still.png"
+    dest = (root / filename).resolve()
+    if not str(dest).startswith(str(root.resolve())):
+        raise ImageGenError("Avatar path escaped storage root.")
+    dest.write_bytes(image)
+    url = f"{avatar_url_prefix()}{filename}"
+    mapping = load_avatar_map()
+    mapping[stem] = url
+    _write_avatar_map(mapping)
+    return url
+
+
+def generate_and_store(
+    agent_id: str,
+    prompt: str,
+    *,
+    settings: ImageGenSettings | None = None,
+    opener=None,
+) -> str:
+    image = generate_still(prompt, settings=settings, opener=opener)
+    return store_still_avatar(agent_id, image)
+
+
+def default_avatar_prompt(name: str, role: str = "") -> str:
+    label = (name or "agent").strip() or "agent"
+    role_bit = (role or "").strip()
+    if role_bit and role_bit != "default":
+        return f"Still portrait avatar of {label}, a {role_bit} agent, simple icon, no animation"
+    return f"Still portrait avatar of {label}, simple icon, no animation"

--- a/src/swarm/urls.py
+++ b/src/swarm/urls.py
@@ -110,6 +110,7 @@ from swarm.views.agent_settings_api import AgentSettingsAPIView, AgentTaskSessio
 from swarm.views.cli_runs_api import CliRunStatusAPIView, CliRunTerminateAPIView
 from swarm.views.cli_sessions_api import CliSessionListAPIView, CliSessionSelectAPIView
 from swarm.views.suggestions_api import AgentSuggestionsAPIView
+from swarm.views.image_gen_api import AgentAvatarGenerateView, ImageGenSettingsView
 from swarm.views.team_rosters_api import TeamRosterDetailAPIView, TeamRostersAPIView
 from swarm.views.teams_api import TeamDetailAPIView, TeamsAPIView
 from swarm.views.web_views import (
@@ -327,6 +328,18 @@ urlpatterns = [
     path("v1/agents/<str:agent_id>/suggestions/", AgentSuggestionsAPIView.as_view(), name="agent-suggestions-api"),
     path("v1/agents/<str:agent_id>/sessions", AgentTaskSessionAPIView.as_view(), name="agent-task-session-api-no-slash"),
     path("v1/agents/<str:agent_id>/sessions/", AgentTaskSessionAPIView.as_view(), name="agent-task-session-api"),
+    path(
+        "v1/agents/<str:agent_id>/avatar/generate",
+        AgentAvatarGenerateView.as_view(),
+        name="agent-avatar-generate-no-slash",
+    ),
+    path(
+        "v1/agents/<str:agent_id>/avatar/generate/",
+        AgentAvatarGenerateView.as_view(),
+        name="agent-avatar-generate",
+    ),
+    path("v1/image-gen", ImageGenSettingsView.as_view(), name="image-gen-settings-no-slash"),
+    path("v1/image-gen/", ImageGenSettingsView.as_view(), name="image-gen-settings"),
     # Settings System section — local store facts (REQ-56). Read-only.
     path("v1/system", LocalStoreView.as_view(), name="system-local-store-no-slash"),
     path("v1/system/", LocalStoreView.as_view(), name="system-local-store"),

--- a/src/swarm/views/image_gen_api.py
+++ b/src/swarm/views/image_gen_api.py
@@ -1,0 +1,163 @@
+"""REST for Settings image-gen + per-agent still avatars (REQ-83 / #436).
+
+GET/PATCH ``/v1/image-gen/`` — base URL, model id, api-key env name only.
+POST ``/v1/agents/<id>/avatar/generate/`` — still avatar from the configured
+OpenAI-compatible ``/v1/images/generations`` endpoint.
+
+Empty/off never guesses a host. Responses never include live tokens.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import serializers, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from swarm.auth import api_permission_classes
+from swarm.core import image_gen as image_gen_core
+from swarm.core.chat_store import normalize_agent_id
+
+logger = logging.getLogger(__name__)
+
+
+def _settings_payload(probe: bool = True) -> dict:
+    spec = image_gen_core.load_settings()
+    if probe:
+        payload = image_gen_core.probe_status(spec)
+    else:
+        payload = spec.public_dict()
+        if spec.configured():
+            payload["status"] = "unknown"
+            payload["detail"] = "Image generation is configured. Status was not probed."
+        else:
+            payload["status"] = "off"
+            payload["detail"] = (
+                "Image generation is off. No host is used until you set a base URL."
+            )
+    payload["avatars"] = image_gen_core.load_avatar_map()
+    return payload
+
+
+class ImageGenSettingsView(APIView):
+    def get_permissions(self):
+        return [perm() for perm in api_permission_classes()]
+
+    @extend_schema(
+        operation_id="v1_image_gen_get",
+        summary="Image generation settings (env name only, no secrets)",
+        responses={200: OpenApiTypes.OBJECT},
+    )
+    def get(self, request, *_args, **_kwargs):
+        probe = str(request.query_params.get("probe") or "1").strip().lower() not in {
+            "0",
+            "false",
+            "no",
+            "off",
+        }
+        return Response(_settings_payload(probe=probe))
+
+    @extend_schema(
+        operation_id="v1_image_gen_patch",
+        summary="Persist image-gen base URL, model, and api-key env name",
+        request=inline_serializer(
+            name="ImageGenPatchRequest",
+            fields={
+                "base_url": serializers.CharField(required=False, allow_blank=True),
+                "model": serializers.CharField(required=False, allow_blank=True),
+                "api_key_env": serializers.CharField(required=False, allow_blank=True),
+            },
+        ),
+        responses={200: OpenApiTypes.OBJECT, 400: OpenApiTypes.OBJECT},
+    )
+    def patch(self, request, *_args, **_kwargs):
+        body = request.data if isinstance(request.data, dict) else {}
+        kwargs: dict[str, str] = {}
+        for field in ("base_url", "model", "api_key_env"):
+            if field in body:
+                kwargs[field] = "" if body[field] is None else str(body[field])
+        if "api_key" in body:
+            return Response(
+                {"error": "Send api_key_env (environment variable name) only. Never a live token."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if not kwargs:
+            return Response(
+                {"error": "Provide at least one of base_url, model, api_key_env."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            spec, path = image_gen_core.persist_settings(**kwargs)
+        except image_gen_core.ImageGenError as exc:
+            return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        except OSError as exc:
+            logger.exception("Failed to persist image_gen")
+            return Response(
+                {"error": f"failed to persist: {exc}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        payload = image_gen_core.probe_status(spec)
+        payload["avatars"] = image_gen_core.load_avatar_map()
+        payload["persisted_to"] = str(path)
+        return Response(payload)
+
+
+class AgentAvatarGenerateView(APIView):
+    def get_permissions(self):
+        return [perm() for perm in api_permission_classes()]
+
+    @extend_schema(
+        operation_id="v1_agent_avatar_generate",
+        summary="Generate a still avatar for one agent via the configured image-gen endpoint",
+        request=inline_serializer(
+            name="AgentAvatarGenerateRequest",
+            fields={
+                "prompt": serializers.CharField(required=False, allow_blank=True),
+                "name": serializers.CharField(required=False, allow_blank=True),
+                "role": serializers.CharField(required=False, allow_blank=True),
+            },
+        ),
+        responses={200: OpenApiTypes.OBJECT, 400: OpenApiTypes.OBJECT},
+    )
+    def post(self, request, agent_id: str, *_args, **_kwargs):
+        agent = normalize_agent_id(agent_id)
+        body = request.data if isinstance(request.data, dict) else {}
+        prompt = str(body.get("prompt") or "").strip()
+        if not prompt:
+            prompt = image_gen_core.default_avatar_prompt(
+                str(body.get("name") or agent),
+                str(body.get("role") or ""),
+            )
+        spec = image_gen_core.load_settings()
+        if not spec.configured():
+            return Response(
+                {
+                    "error": (
+                        "Image generation is not configured. "
+                        "Open Settings → Image generation and set a base URL."
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            avatar_path = image_gen_core.generate_and_store(agent, prompt, settings=spec)
+        except image_gen_core.ImageGenError as exc:
+            return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        except OSError as exc:
+            logger.exception("Failed to store still avatar for %s", agent)
+            return Response(
+                {"error": f"failed to store avatar: {exc}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        return Response(
+            {
+                "object": "agent_avatar",
+                "agent_id": agent,
+                "avatar_path": avatar_path,
+                "still": True,
+                "prompt": prompt,
+            }
+        )

--- a/tests/core/test_image_gen.py
+++ b/tests/core/test_image_gen.py
@@ -1,0 +1,163 @@
+"""REQ-83: image-gen persist, empty URL, still avatars. No live host."""
+
+from __future__ import annotations
+
+import base64
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from swarm.core import image_gen as image_gen_core
+
+# 1x1 still PNG (not animated).
+_STILL_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+_GIF = b"GIF89a\x01\x00\x01\x00\x00\x00\x00;"
+
+
+class _Router(BaseHTTPRequestHandler):
+    routes: dict[tuple[str, str], tuple[int, dict | bytes]] = {}
+    hits: list[tuple[str, str]] = []
+
+    def _handle(self, method: str) -> None:
+        path = self.path.split("?", 1)[0]
+        self.hits.append((method, path))
+        status, body = self.routes.get((method, path), (404, {"error": "no route"}))
+        self.send_response(status)
+        if isinstance(body, bytes):
+            self.send_header("Content-Type", "image/png")
+            payload = body
+        else:
+            self.send_header("Content-Type", "application/json")
+            payload = json.dumps(body).encode("utf-8")
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._handle("GET")
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._handle("POST")
+
+    def log_message(self, *args) -> None:
+        pass
+
+
+@pytest.fixture
+def http_router():
+    server = HTTPServer(("127.0.0.1", 0), _Router)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = "127.0.0.1", server.server_address[1]
+    yield host, port, _Router
+    server.shutdown()
+    _Router.routes = {}
+    _Router.hits = []
+
+
+@pytest.fixture
+def isolated_store(tmp_path: Path, monkeypatch):
+    cfg = tmp_path / "swarm_config.json"
+    cfg.write_text(json.dumps({"llm": {}}), encoding="utf-8")
+    monkeypatch.setenv("SWARM_CONFIG_PATH", str(cfg))
+    monkeypatch.setenv("SWARM_AGENT_AVATARS_PATH", str(tmp_path / "agent_avatars.json"))
+    monkeypatch.setenv("SWARM_AVATAR_STORAGE", str(tmp_path / "avatars"))
+    monkeypatch.delenv("IMAGE_GEN_BASE_URL", raising=False)
+    monkeypatch.delenv("IMAGE_GEN_MODEL", raising=False)
+    yield cfg
+
+
+def test_persist_stores_env_placeholder_not_key(isolated_store: Path):
+    spec, path = image_gen_core.persist_settings(
+        base_url="http://127.0.0.1:9",
+        model="local-still",
+        api_key_env="IMAGE_GEN_API_KEY",
+        config_path=isolated_store,
+    )
+    data = json.loads(isolated_store.read_text(encoding="utf-8"))
+    assert data["image_gen"]["base_url"] == "http://127.0.0.1:9"
+    assert data["image_gen"]["model"] == "local-still"
+    assert data["image_gen"]["api_key"] == "${IMAGE_GEN_API_KEY}"
+    assert data["image_gen"]["api_key_env"] == "IMAGE_GEN_API_KEY"
+    pub = spec.public_dict()
+    assert pub["api_key_env"] == "IMAGE_GEN_API_KEY"
+    assert pub["api_key_set"] is False
+    assert "sk-" not in json.dumps(pub)
+    assert "IMAGE_GEN_API_KEY" not in json.dumps(pub) or pub["api_key_env"] == "IMAGE_GEN_API_KEY"
+    dumped = json.dumps(pub)
+    assert "sk-live" not in dumped
+    assert path == isolated_store
+
+
+def test_empty_url_does_not_call_any_host(isolated_store: Path):
+    spec, _ = image_gen_core.persist_settings(base_url="", config_path=isolated_store)
+    assert spec.configured() is False
+    called = []
+
+    def _boom(*_args, **_kwargs):
+        called.append(True)
+        raise AssertionError("must not call a host when image-gen is off")
+
+    probed = image_gen_core.probe_status(spec)
+    assert probed["status"] == "off"
+    assert "No host" in probed["detail"]
+
+    with pytest.raises(image_gen_core.ImageGenError, match="not configured"):
+        image_gen_core.generate_still("a still portrait", settings=spec, opener=_boom)
+    assert called == []
+
+
+def test_refuse_fly_litellm_persist(isolated_store: Path):
+    with pytest.raises(image_gen_core.ImageGenError, match="open-litellm"):
+        image_gen_core.persist_settings(
+            base_url="https://open-litellm.fly.dev/v1",
+            config_path=isolated_store,
+        )
+
+
+def test_stub_generations_returns_bytes_then_avatar_set(isolated_store: Path, http_router):
+    host, port, router = http_router
+    router.routes[("POST", "/v1/images/generations")] = (
+        200,
+        {"data": [{"b64_json": base64.b64encode(_STILL_PNG).decode("ascii")}]},
+    )
+    spec, _ = image_gen_core.persist_settings(
+        base_url=f"http://{host}:{port}",
+        model="stub-still",
+        api_key_env="IMAGE_GEN_API_KEY",
+        config_path=isolated_store,
+    )
+    url = image_gen_core.generate_and_store("codey", "still portrait of Codey", settings=spec)
+    assert url.endswith("codey_still.png")
+    stored = Path(image_gen_core.avatar_storage_dir()) / "codey_still.png"
+    assert stored.is_file()
+    payload = stored.read_bytes()
+    assert payload.startswith(b"\x89PNG")
+    assert image_gen_core._is_still_image(payload)
+    assert image_gen_core.avatar_path_for("codey") == url
+    assert router.hits == [("POST", "/v1/images/generations")]
+
+
+def test_rejects_gif_as_not_still(isolated_store: Path, http_router):
+    host, port, router = http_router
+    router.routes[("POST", "/v1/images/generations")] = (
+        200,
+        {"data": [{"b64_json": base64.b64encode(_GIF).decode("ascii")}]},
+    )
+    spec, _ = image_gen_core.persist_settings(
+        base_url=f"http://{host}:{port}",
+        config_path=isolated_store,
+    )
+    with pytest.raises(image_gen_core.ImageGenError, match="not a still"):
+        image_gen_core.generate_still("animated", settings=spec)
+    assert image_gen_core.load_avatar_map() == {}
+
+
+def test_is_still_image_rejects_gif_accepts_png():
+    assert image_gen_core._is_still_image(_STILL_PNG) is True
+    assert image_gen_core._is_still_image(_GIF) is False
+    assert image_gen_core._is_still_image(b"") is False

--- a/tests/views/test_image_gen_api.py
+++ b/tests/views/test_image_gen_api.py
@@ -1,0 +1,115 @@
+"""API tests for /v1/image-gen/ and avatar generate (REQ-83)."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from rest_framework.test import APIClient
+
+from swarm.core import image_gen as image_gen_core
+
+_STILL_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_image_gen(tmp_path: Path, monkeypatch):
+    cfg = tmp_path / "swarm_config.json"
+    cfg.write_text(json.dumps({"llm": {}}), encoding="utf-8")
+    monkeypatch.setenv("SWARM_CONFIG_PATH", str(cfg))
+    monkeypatch.setenv("SWARM_AGENT_AVATARS_PATH", str(tmp_path / "agent_avatars.json"))
+    monkeypatch.setenv("SWARM_AVATAR_STORAGE", str(tmp_path / "avatars"))
+    monkeypatch.delenv("IMAGE_GEN_BASE_URL", raising=False)
+    yield cfg
+
+
+def test_get_off_does_not_include_secrets(api_client):
+    resp = api_client.get("/v1/image-gen/?probe=0")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["object"] == "image_gen"
+    assert body["configured"] is False
+    assert body["base_url"] == ""
+    assert body["status"] == "off"
+    assert "api_key" not in body or body.get("api_key") in (None, "")
+    dumped = json.dumps(body)
+    assert "sk-" not in dumped
+    assert body["avatars"] == {}
+
+
+def test_patch_persists_env_name_only(api_client, _isolate_image_gen: Path):
+    live = api_client.patch(
+        "/v1/image-gen/",
+        {"base_url": "http://127.0.0.1:9", "model": "still-1", "api_key": "sk-live-secret"},
+        format="json",
+    )
+    assert live.status_code == 400
+    assert "api_key_env" in live.json()["error"]
+
+    resp = api_client.patch(
+        "/v1/image-gen/",
+        {
+            "base_url": "http://127.0.0.1:9",
+            "model": "still-1",
+            "api_key_env": "IMAGE_GEN_API_KEY",
+        },
+        format="json",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["base_url"] == "http://127.0.0.1:9"
+    assert body["model"] == "still-1"
+    assert body["api_key_env"] == "IMAGE_GEN_API_KEY"
+    assert "sk-" not in json.dumps(body)
+    data = json.loads(_isolate_image_gen.read_text(encoding="utf-8"))
+    assert data["image_gen"]["api_key"] == "${IMAGE_GEN_API_KEY}"
+    assert data["image_gen"]["api_key_env"] == "IMAGE_GEN_API_KEY"
+
+
+def test_generate_disabled_when_unset(api_client):
+    resp = api_client.post(
+        "/v1/agents/codey/avatar/generate/",
+        {"prompt": "still portrait"},
+        format="json",
+    )
+    assert resp.status_code == 400
+    assert "Settings" in resp.json()["error"]
+
+
+def test_generate_stub_sets_still_avatar(api_client, _isolate_image_gen: Path):
+    image_gen_core.persist_settings(
+        base_url="http://127.0.0.1:9",
+        model="stub",
+        api_key_env="IMAGE_GEN_API_KEY",
+        config_path=_isolate_image_gen,
+    )
+
+    def _fake_generate(prompt, *, settings=None, opener=None, timeout=30.0):
+        assert "still" in prompt.lower() or prompt
+        return _STILL_PNG
+
+    with patch("swarm.core.image_gen.generate_still", side_effect=_fake_generate):
+        resp = api_client.post(
+            "/v1/agents/codey/avatar/generate/",
+            {"prompt": "still portrait of Codey"},
+            format="json",
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["object"] == "agent_avatar"
+    assert body["agent_id"] == "codey"
+    assert body["still"] is True
+    assert body["avatar_path"].endswith("codey_still.png")
+    stored = Path(image_gen_core.avatar_storage_dir()) / "codey_still.png"
+    assert stored.is_file()
+    assert stored.read_bytes().startswith(b"\x89PNG")

--- a/webui/frontend/src/components/AgentAvatar.tsx
+++ b/webui/frontend/src/components/AgentAvatar.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react'
+import { useGeneratedAvatar } from '../lib/agentAvatars'
+import { isGeneratedStillSrc } from '../lib/imageGenSettings'
 import { useAvatarTheme } from '../lib/useAvatarTheme'
 import BlobAvatar from './BlobAvatar'
 
@@ -42,7 +44,9 @@ export function agentAvatarKind(src?: string | null): 'custom' | 'default' {
  * Shared agent face for the rail tile, favourites large tiles, and the chat header.
  * Display-only: no click handler. Sizes: rail sm, header/favs lg.
  * Unset or broken avatars resolve to Blobs-with-eyes by default (REQ-155),
- * or bland static circles when opt-in chosen in Settings. Custom faces always win.
+ * or bland static circles when opt-in chosen in Settings. Uploaded custom
+ * faces always win. Generated stills (REQ-83) apply on Bland/Default and
+ * stay unused while Blobs is selected.
  */
 export default function AgentAvatar({
   src,
@@ -55,26 +59,37 @@ export default function AgentAvatar({
 }: AgentAvatarProps) {
   const [broken, setBroken] = useState(false)
   const theme = useAvatarTheme()
+  const generatedSrc = useGeneratedAvatar(agentId)
 
   useEffect(() => {
     setBroken(false)
-  }, [src])
+  }, [src, generatedSrc])
 
   const customSrc = typeof src === 'string' ? src.trim() : ''
-  const isCustom = Boolean(customSrc && !broken)
+  const uploadedSrc =
+    customSrc && !isGeneratedStillSrc(customSrc) ? customSrc : ''
+  const stillSrc =
+    uploadedSrc ||
+    (customSrc && isGeneratedStillSrc(customSrc) ? customSrc : '') ||
+    generatedSrc
+  const showGeneratedStill = Boolean(stillSrc && !uploadedSrc && theme !== 'blobs')
+  const showUploaded = Boolean(uploadedSrc && !broken)
+  const isCustom = showUploaded || (showGeneratedStill && !broken)
 
   if (isCustom) {
+    const faceSrc = uploadedSrc || stillSrc
     return (
       <div
         className={`avatar ${className}`.trim()}
         data-agent-avatar="custom"
         data-avatar-size={size}
+        data-avatar-still={showGeneratedStill ? 'generated' : undefined}
         aria-hidden={alt ? undefined : true}
         style={style}
       >
         <div className={`os-agent-avatar os-agent-avatar--${size} rounded-full`}>
           <img
-            src={customSrc}
+            src={faceSrc}
             alt={alt}
             draggable={false}
             data-agent-avatar="custom"

--- a/webui/frontend/src/components/AgentEditor.tsx
+++ b/webui/frontend/src/components/AgentEditor.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useId, useMemo, useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { Button, Input, Modal, Select } from './DaisyUI'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Button, Input, Modal, Select, Textarea, useToast } from './DaisyUI'
 import InferenceOrderList, { type InferenceCatalogOption } from './InferenceOrderList'
 import {
   fetchBlueprints,
@@ -8,7 +8,9 @@ import {
   fetchCliModels,
   fetchLlmProfiles,
   fetchModels,
+  fetchImageGenSettings,
   fetchRemotes,
+  generateAgentAvatar,
   type AgentRole,
   type Blueprint,
 } from '../lib/api'
@@ -39,6 +41,9 @@ import { agentRole, exampleRoleAgents } from '../lib/agentRoles'
 import { ROLE_BRIEFS } from '../lib/definitionExplain'
 import { agentLabel, catalogLabel, sessionKindForAgent } from '../lib/supportAgent'
 import { isCliBlueprintId } from '../lib/cliAgentContext'
+import { rememberGeneratedAvatar } from '../lib/agentAvatars'
+import { defaultAvatarPrompt, isImageGenConfigured, parseImageGenSettings } from '../lib/imageGenSettings'
+import AgentAvatar from './AgentAvatar'
 import { openSettingsSheet } from './SettingsSheet'
 
 /** Window event so the rail hover-edit and tests can open the agent editor. */
@@ -81,6 +86,8 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
   const id = agentId || ''
   const toggleId = useId()
   const suggestionsToggleId = useId()
+  const { success, error: toastError } = useToast()
+  const queryClient = useQueryClient()
   const [name, setName] = useState('')
   const [role, setRole] = useState<AgentRole>('default')
   const [blueprintId, setBlueprintId] = useState('')
@@ -92,6 +99,7 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
   const [savingSettings, setSavingSettings] = useState(false)
   const [boundRemoteId, setBoundRemoteId] = useState('')
   const [inferenceSeats, setInferenceSeats] = useState<InferenceSeat[]>([])
+  const [avatarPrompt, setAvatarPrompt] = useState('')
 
   const blueprintsQuery = useQuery({
     queryKey: ['blueprints'],
@@ -161,6 +169,15 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
     enabled: isOpen,
     retry: 1,
   })
+
+  const imageGenQuery = useQuery({
+    queryKey: ['image-gen-settings'],
+    queryFn: () => fetchImageGenSettings(false),
+    enabled: isOpen,
+    retry: 1,
+  })
+  const imageGen = parseImageGenSettings(imageGenQuery.data)
+  const canGenerateAvatar = isImageGenConfigured(imageGen)
   const remotesCatalog = remotesListForSelect(
     remotesQuery.data,
     null,
@@ -200,6 +217,9 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
     setProfileOverride(edit.profileOverride || '')
     setBoundRemoteId(loadAgentRemoteBinding(id)?.id || '')
     setInferenceSeats(loadInferenceList(id))
+    const catalogNameForPrompt = catalogAgent?.name || id
+    const roleForPrompt = edit.role || agentRole({ id, name: catalogAgent?.name, role: catalogAgent?.role })
+    setAvatarPrompt(defaultAvatarPrompt(edit.name || catalogNameForPrompt, roleForPrompt))
 
     let cancelled = false
     ;(async () => {
@@ -249,6 +269,36 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
   const persistRole = (next: AgentRole) => {
     setRole(next)
     saveAgentEdit(id, { role: next })
+    setAvatarPrompt((current) => {
+      const derived = defaultAvatarPrompt(name || catalogName, next)
+      if (!current.trim() || current === defaultAvatarPrompt(name || catalogName, role)) {
+        return derived
+      }
+      return current
+    })
+  }
+
+  const generateAvatar = useMutation({
+    mutationFn: () =>
+      generateAgentAvatar(id, {
+        prompt: avatarPrompt.trim() || defaultAvatarPrompt(name || catalogName, role),
+        name: name || catalogName,
+        role,
+      }),
+    onSuccess: (result) => {
+      rememberGeneratedAvatar(id, result.avatar_path)
+      void queryClient.invalidateQueries({ queryKey: ['image-gen-settings'] })
+      void queryClient.invalidateQueries({ queryKey: ['blueprints'] })
+      success('Avatar generated', 'Still image stored for this agent.')
+    },
+    onError: (err: Error) => {
+      toastError('Could not generate avatar', err.message)
+    },
+  })
+
+  const openImageGenSettings = () => {
+    onClose()
+    openSettingsSheet({ section: 'image-gen' })
   }
 
   const persistInference = (next: InferenceSeat[]) => {
@@ -358,6 +408,63 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
           defaultLabel={defaultInferenceLabel}
           onChange={persistInference}
         />
+
+        <div
+          className="space-y-3 rounded-box border border-base-300 bg-base-200/40 p-3"
+          data-testid="agent-editor-avatar"
+        >
+          <div className="flex items-start gap-3">
+            <AgentAvatar
+              agentId={id}
+              alt=""
+              size="lg"
+              className="shrink-0"
+            />
+            <div className="min-w-0 flex-1">
+              <span className="text-sm font-semibold text-base-content/80">Still avatar</span>
+              <p className="text-xs text-base-content/60 mt-0.5">
+                Generated stills apply on Bland. Blobs with eyes stay a separate
+                Rail theme and ignore generated stills.
+              </p>
+            </div>
+          </div>
+          <Textarea
+            label="Avatar prompt"
+            name="agent-avatar-prompt"
+            value={avatarPrompt}
+            onChange={(event) => setAvatarPrompt(event.target.value)}
+            rows={3}
+            spellCheck={false}
+          />
+          {canGenerateAvatar ? (
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              disabled={!id || generateAvatar.isPending}
+              onClick={() => generateAvatar.mutate()}
+            >
+              {generateAvatar.isPending ? 'Generating…' : 'Generate avatar'}
+            </Button>
+          ) : (
+            <div className="space-y-2">
+              <Button type="button" variant="primary" size="sm" disabled>
+                Generate avatar
+              </Button>
+              <p className="text-xs text-base-content/60" data-testid="generate-avatar-disabled-hint">
+                Set a base URL in{' '}
+                <button
+                  type="button"
+                  className="link link-hover font-medium"
+                  onClick={openImageGenSettings}
+                >
+                  Settings → Image generation
+                </button>{' '}
+                first. Empty/off does not guess a host.
+              </p>
+            </div>
+          )}
+        </div>
 
         {/* LLM Override Picker by Kind (REQ-124) */}
         {agentKind === 'remote' && (

--- a/webui/frontend/src/components/AvatarThemePicker.tsx
+++ b/webui/frontend/src/components/AvatarThemePicker.tsx
@@ -28,7 +28,8 @@ export default function AvatarThemePicker({ id = 'os-avatar-theme' }: AvatarThem
       </select>
       <p className="text-xs text-base-content/55">
         Blobs are per-agent shapes with eyes (default). Bland static uses identical grey circles.
-        Custom uploaded faces always win.
+        Custom uploaded faces always win. Generated still avatars from Settings → Image
+        generation apply on Bland and stay unused while Blobs is selected.
       </p>
     </div>
   )

--- a/webui/frontend/src/components/ImageGenSettings.tsx
+++ b/webui/frontend/src/components/ImageGenSettings.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState, type FormEvent } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { AlertCircle, Image as ImageIcon } from 'lucide-react'
+import { Alert, Button, Input, useToast } from './DaisyUI'
+import {
+  EMPTY_IMAGE_GEN,
+  fetchImageGenSettings,
+  patchImageGenSettings,
+} from '../lib/api'
+import {
+  IMAGE_GEN_QUERY_KEY,
+  isImageGenConfigured,
+  parseImageGenSettings,
+} from '../lib/imageGenSettings'
+
+/**
+ * Settings → Image generation (REQ-83). Base URL, model id, api-key env name
+ * only. Empty/off does not guess a host.
+ */
+export default function ImageGenPane() {
+  const { success, error: toastError } = useToast()
+  const queryClient = useQueryClient()
+  const [baseUrl, setBaseUrl] = useState('')
+  const [model, setModel] = useState('')
+  const [apiKeyEnv, setApiKeyEnv] = useState('')
+
+  const settingsQuery = useQuery({
+    queryKey: IMAGE_GEN_QUERY_KEY,
+    queryFn: () => fetchImageGenSettings(true),
+    retry: 1,
+  })
+
+  const parsed = parseImageGenSettings(settingsQuery.data ?? EMPTY_IMAGE_GEN)
+
+  useEffect(() => {
+    if (!settingsQuery.data) return
+    const next = parseImageGenSettings(settingsQuery.data)
+    setBaseUrl(next.base_url)
+    setModel(next.model)
+    setApiKeyEnv(next.api_key_env)
+  }, [settingsQuery.data])
+
+  const saveMutation = useMutation({
+    mutationFn: () =>
+      patchImageGenSettings({
+        base_url: baseUrl.trim(),
+        model: model.trim(),
+        api_key_env: apiKeyEnv.trim(),
+      }),
+    onSuccess: (saved) => {
+      const next = parseImageGenSettings(saved)
+      queryClient.setQueryData(IMAGE_GEN_QUERY_KEY, saved)
+      setBaseUrl(next.base_url)
+      setModel(next.model)
+      setApiKeyEnv(next.api_key_env)
+      success(
+        next.base_url ? 'Image generation saved' : 'Image generation off',
+        next.detail || 'Stored the env name, not a live key.',
+      )
+    },
+    onError: (err: Error) => {
+      toastError('Could not save image generation', err.message)
+    },
+  })
+
+  const handleSave = (event: FormEvent) => {
+    event.preventDefault()
+    saveMutation.mutate()
+  }
+
+  const configured = isImageGenConfigured(parsed)
+  const status = parsed.status || (configured ? 'unknown' : 'off')
+  const statusType =
+    status === 'down' ? 'warning' : status === 'ok' ? 'success' : 'info'
+
+  return (
+    <form className="space-y-4" onSubmit={handleSave} data-testid="settings-image-gen-pane">
+      <div>
+        <h4 className="text-lg font-semibold">Image generation</h4>
+        <p className="mt-1 text-sm text-base-content/70">
+          Opt-in OpenAI-compatible <span className="font-mono">/v1/images/generations</span>{' '}
+          endpoint for still agent avatars. Leave the base URL empty to keep this
+          off — swarm will not guess a host. Store the API key env name only,
+          never a live token. Distinct from Rail → Blobs with eyes.
+        </p>
+      </div>
+
+      {settingsQuery.isPending ? (
+        <p className="text-sm text-base-content/60">Loading image generation…</p>
+      ) : settingsQuery.isError ? (
+        <Alert type="info" icon={<AlertCircle className="h-5 w-5" />}>
+          <span className="text-sm">
+            Could not load image generation settings. The endpoint is treated as
+            off until Settings can read it — no host is guessed.
+          </span>
+        </Alert>
+      ) : (
+        <Alert type={statusType} icon={<ImageIcon className="h-5 w-5" />}>
+          <span className="text-sm" data-testid="image-gen-status">
+            {parsed.detail}
+          </span>
+        </Alert>
+      )}
+
+      <Input
+        label="Base URL"
+        name="image-gen-base-url"
+        value={baseUrl}
+        onChange={(event) => setBaseUrl(event.target.value)}
+        placeholder="Leave empty to keep off"
+        autoComplete="off"
+        spellCheck={false}
+      />
+      <Input
+        label="Model id"
+        name="image-gen-model"
+        value={model}
+        onChange={(event) => setModel(event.target.value)}
+        placeholder="Model id your endpoint expects"
+        autoComplete="off"
+        spellCheck={false}
+      />
+      <Input
+        label="API key env (optional)"
+        name="image-gen-api-key-env"
+        value={apiKeyEnv}
+        onChange={(event) => setApiKeyEnv(event.target.value)}
+        placeholder="IMAGE_GEN_API_KEY"
+        autoComplete="off"
+        spellCheck={false}
+      />
+      <p className="text-xs text-base-content/55">
+        Persist stores <span className="font-mono">${'{ENV}'}</span> names, not keys.
+        Generate avatar in the agent editor stays disabled until a base URL is
+        saved.
+      </p>
+      <Button type="submit" variant="primary" size="sm" disabled={saveMutation.isPending}>
+        Save image generation
+      </Button>
+    </form>
+  )
+}

--- a/webui/frontend/src/components/SettingsSheet.tsx
+++ b/webui/frontend/src/components/SettingsSheet.tsx
@@ -7,6 +7,7 @@ import AvatarThemePicker from './AvatarThemePicker'
 import EnvOverrideBadge from './EnvOverrideBadge'
 import McpServersPane from './McpServersPane'
 import CliAgentsSettingsPane from './CliAgentsSettingsPane'
+import ImageGenPane from './ImageGenSettings'
 import {
   EMPTY_LOCAL_STORE,
   createRemote,
@@ -76,6 +77,7 @@ export type SettingsSection =
   | 'mcp'
   | 'cli-agents'
   | 'rail'
+  | 'image-gen'
   | 'system'
 
 export interface OpenSettingsDetail {
@@ -301,6 +303,16 @@ export default function SettingsSheet({
             <li>
               <button
                 type="button"
+                className={section === 'image-gen' ? 'menu-active' : undefined}
+                aria-current={section === 'image-gen' ? 'page' : undefined}
+                onClick={() => setSection('image-gen')}
+              >
+                Image generation
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
                 className={section === 'system' ? 'menu-active' : undefined}
                 aria-current={section === 'system' ? 'page' : undefined}
                 onClick={() => setSection('system')}
@@ -347,6 +359,7 @@ export default function SettingsSheet({
               }}
             />
           )}
+          {section === 'image-gen' && <ImageGenPane />}
           {section === 'system' && <SystemPane />}
         </div>
       </div>

--- a/webui/frontend/src/components/__tests__/AgentAvatar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentAvatar.test.tsx
@@ -11,10 +11,12 @@ import {
   AVATAR_THEME_STORAGE_KEY,
   saveAvatarTheme,
 } from '../../lib/avatarTheme'
+import { rememberGeneratedAvatar, resetGeneratedAvatars } from '../../lib/agentAvatars'
 
 describe('AgentAvatar', () => {
   afterEach(() => {
     localStorage.removeItem(AVATAR_THEME_STORAGE_KEY)
+    resetGeneratedAvatars()
   })
 
   it('uses Blobs-with-eyes by default when no custom src is set', () => {
@@ -116,6 +118,32 @@ describe('AgentAvatar', () => {
     const blob = container.querySelector('.os-blob-avatar')
     expect(blob).toHaveClass('os-blob-avatar--xs')
     expect(blob).not.toHaveStyle({ width: '100%', height: '100%' })
+  })
+
+  it('uses a generated still on Bland and ignores it while Blobs is selected', () => {
+    rememberGeneratedAvatar('codey', '/avatars/codey_still.png')
+    const blobs = render(<AgentAvatar agentId="codey" />)
+    expect(blobs.container.querySelector('[data-avatar-theme="blobs"]')).toBeInTheDocument()
+    expect(blobs.container.querySelector('[data-avatar-still="generated"]')).not.toBeInTheDocument()
+    blobs.unmount()
+
+    saveAvatarTheme('bland')
+    const bland = render(<AgentAvatar agentId="codey" />)
+    expect(bland.container.querySelector('[data-agent-avatar]')).toHaveAttribute(
+      'data-avatar-still',
+      'generated',
+    )
+    expect(bland.container.querySelector('img')).toHaveAttribute('src', '/avatars/codey_still.png')
+    bland.unmount()
+  })
+
+  it('keeps an uploaded custom face even when a generated still exists', () => {
+    rememberGeneratedAvatar('codey', '/avatars/codey_still.png')
+    const { container } = render(
+      <AgentAvatar agentId="codey" src="/avatars/uploaded.png" alt="Codey" />,
+    )
+    expect(container.querySelector('img')).toHaveAttribute('src', '/avatars/uploaded.png')
+    expect(container.querySelector('[data-avatar-still]')).not.toBeInTheDocument()
   })
 
   it('sizes a custom xs face with the capped class instead of 100% fill', () => {

--- a/webui/frontend/src/components/__tests__/AgentEditorGenerateAvatar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentEditorGenerateAvatar.test.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import AgentEditor from '../AgentEditor'
+import { ToastProvider } from '../DaisyUI'
+import { resetGeneratedAvatars, loadGeneratedAvatar } from '../../lib/agentAvatars'
+
+const catalog = [
+  {
+    id: 'codey',
+    object: 'blueprint' as const,
+    name: 'Codey',
+    description: 'Code assistant',
+    abbreviation: null,
+    required_mcp_servers: [] as string[],
+    tags: [] as string[],
+    installed: true,
+    compiled: true,
+  },
+]
+
+function stubFetch(options: { configured: boolean }) {
+  let generatePayload: Record<string, unknown> | null = null
+  const fetchMock = vi.fn().mockImplementation(async (input: RequestInfo, init?: RequestInit) => {
+    const url = String(input)
+    if (url.includes('/v1/image-gen/')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          object: 'image_gen',
+          configured: options.configured,
+          base_url: options.configured ? 'http://127.0.0.1:9' : '',
+          model: options.configured ? 'still-1' : '',
+          api_key_env: options.configured ? 'IMAGE_GEN_API_KEY' : '',
+          status: options.configured ? 'ok' : 'off',
+          detail: options.configured
+            ? 'Image generation endpoint answered HTTP 200.'
+            : 'Image generation is off. No host is used until you set a base URL.',
+          avatars: {},
+        }),
+      } as Response
+    }
+    if (url.includes('/avatar/generate') && init?.method === 'POST') {
+      generatePayload = JSON.parse(String(init.body))
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          object: 'agent_avatar',
+          agent_id: 'codey',
+          avatar_path: '/avatars/codey_still.png',
+          still: true,
+          prompt: generatePayload?.prompt,
+        }),
+      } as Response
+    }
+    if (url.includes('/v1/models')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ object: 'list', data: [] }),
+      } as Response
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ object: 'list', data: catalog }),
+    } as Response
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return {
+    fetchMock,
+    getGeneratePayload: () => generatePayload,
+  }
+}
+
+function renderEditor() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <AgentEditor isOpen={true} onClose={vi.fn()} agentId="codey" />
+      </ToastProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('AgentEditor Generate avatar (REQ-83)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    resetGeneratedAvatars()
+  })
+
+  it('disables Generate when image-gen is unset and points at Settings', async () => {
+    const { fetchMock } = stubFetch({ configured: false })
+    renderEditor()
+    const dialog = await screen.findByRole('dialog', { name: /Edit /i, hidden: true })
+    const generate = await within(dialog).findByRole('button', { name: 'Generate avatar' })
+    expect(generate).toBeDisabled()
+    expect(within(dialog).getByTestId('generate-avatar-disabled-hint')).toHaveTextContent(
+      /Settings → Image generation/i,
+    )
+    expect(
+      fetchMock.mock.calls.some(([input, init]) => {
+        const url = String(input)
+        return url.includes('/v1/images/generations') || (init as RequestInit | undefined)?.method === 'POST'
+      }),
+    ).toBe(false)
+  })
+
+  it('posts a still prompt and stores the generated avatar path', async () => {
+    const { getGeneratePayload } = stubFetch({ configured: true })
+    renderEditor()
+    const dialog = await screen.findByRole('dialog', { name: /Edit /i, hidden: true })
+    const generate = await within(dialog).findByRole('button', { name: 'Generate avatar' })
+    await waitFor(() => {
+      expect(generate).not.toBeDisabled()
+    })
+    fireEvent.click(generate)
+    await waitFor(() => {
+      expect(getGeneratePayload()).not.toBeNull()
+    })
+    expect(String(getGeneratePayload()?.prompt || '')).toMatch(/still|Codey/i)
+    expect(loadGeneratedAvatar('codey')).toBe('/avatars/codey_still.png')
+  })
+})

--- a/webui/frontend/src/components/__tests__/ImageGenSettings.test.tsx
+++ b/webui/frontend/src/components/__tests__/ImageGenSettings.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import SettingsSheet from '../SettingsSheet'
+import { ToastProvider } from '../DaisyUI'
+
+function renderSheet() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  render(
+    <QueryClientProvider client={client}>
+      <ToastProvider>
+        <SettingsSheet isOpen={true} onClose={vi.fn()} />
+      </ToastProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('Settings Image generation (REQ-83)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('saves base URL, model, and api_key_env only — empty URL stays off', async () => {
+    let patchPayload: Record<string, unknown> | null = null
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo, init?: RequestInit) => {
+        const url = String(input)
+        if (url.includes('/v1/image-gen/') && init?.method === 'PATCH') {
+          patchPayload = JSON.parse(String(init.body))
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'image_gen',
+              configured: Boolean(patchPayload?.base_url),
+              base_url: patchPayload?.base_url || '',
+              model: patchPayload?.model || '',
+              api_key_env: patchPayload?.api_key_env || '',
+              status: patchPayload?.base_url ? 'down' : 'off',
+              detail: patchPayload?.base_url
+                ? 'Image generation endpoint is DOWN: stub'
+                : 'Image generation is off. No host is used until you set a base URL.',
+              avatars: {},
+            }),
+          } as Response
+        }
+        if (url.includes('/v1/image-gen/')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'image_gen',
+              configured: false,
+              base_url: '',
+              model: '',
+              api_key_env: '',
+              status: 'off',
+              detail: 'Image generation is off. No host is used until you set a base URL.',
+              avatars: {},
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ object: 'list', data: [] }),
+        } as Response
+      }),
+    )
+
+    renderSheet()
+    fireEvent.click(screen.getByRole('button', { name: 'Image generation' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('image-gen-status')).toHaveTextContent(/off/i)
+    })
+
+    expect(screen.getByLabelText('Base URL')).toHaveAttribute(
+      'placeholder',
+      'Leave empty to keep off',
+    )
+    expect(screen.getByLabelText(/API key env/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/^API key$/i)).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Base URL'), {
+      target: { value: 'http://127.0.0.1:9' },
+    })
+    fireEvent.change(screen.getByLabelText('Model id'), { target: { value: 'still-1' } })
+    fireEvent.change(screen.getByLabelText(/API key env/i), {
+      target: { value: 'IMAGE_GEN_API_KEY' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save image generation' }))
+
+    await waitFor(() => {
+      expect(patchPayload).not.toBeNull()
+    })
+    expect(patchPayload).toEqual({
+      base_url: 'http://127.0.0.1:9',
+      model: 'still-1',
+      api_key_env: 'IMAGE_GEN_API_KEY',
+    })
+    expect(patchPayload).not.toHaveProperty('api_key')
+
+    fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: '' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save image generation' }))
+    await waitFor(() => {
+      expect(patchPayload?.base_url).toBe('')
+    })
+    expect(patchPayload).not.toHaveProperty('api_key')
+  })
+})

--- a/webui/frontend/src/components/__tests__/SettingsSheet.test.tsx
+++ b/webui/frontend/src/components/__tests__/SettingsSheet.test.tsx
@@ -76,6 +76,7 @@ describe('SettingsSheet', () => {
     expect(screen.getByRole('button', { name: 'MCP servers' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'CLI agents' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Rail' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Image generation' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'System' })).toBeInTheDocument()
   })
 

--- a/webui/frontend/src/lib/__tests__/agentAvatars.test.ts
+++ b/webui/frontend/src/lib/__tests__/agentAvatars.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  GENERATED_AVATARS_KEY,
+  loadGeneratedAvatar,
+  rememberGeneratedAvatar,
+  resetGeneratedAvatars,
+} from '../agentAvatars'
+
+describe('agentAvatars store (REQ-83)', () => {
+  afterEach(() => {
+    resetGeneratedAvatars()
+  })
+
+  it('remembers a still path per agent without storing a token', () => {
+    rememberGeneratedAvatar('codey', '/avatars/codey_still.png')
+    expect(loadGeneratedAvatar('codey')).toBe('/avatars/codey_still.png')
+    const raw = localStorage.getItem(GENERATED_AVATARS_KEY) || ''
+    expect(raw).toContain('/avatars/codey_still.png')
+    expect(raw).not.toMatch(/sk-/)
+  })
+})

--- a/webui/frontend/src/lib/__tests__/imageGenSettings.test.ts
+++ b/webui/frontend/src/lib/__tests__/imageGenSettings.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import {
+  defaultAvatarPrompt,
+  isGeneratedStillSrc,
+  isImageGenConfigured,
+  parseImageGenSettings,
+} from '../imageGenSettings'
+
+describe('imageGenSettings (REQ-83)', () => {
+  it('treats missing/empty payload as off and never invents a host', () => {
+    const empty = parseImageGenSettings(null)
+    expect(empty.configured).toBe(false)
+    expect(empty.base_url).toBe('')
+    expect(empty.status).toBe('off')
+    expect(isImageGenConfigured(empty)).toBe(false)
+    expect(isImageGenConfigured(parseImageGenSettings({ object: 'list', data: [] }))).toBe(false)
+  })
+
+  it('parses env name only and ignores live-looking keys', () => {
+    const parsed = parseImageGenSettings({
+      configured: true,
+      base_url: 'http://127.0.0.1:9',
+      model: 'still-1',
+      api_key_env: 'IMAGE_GEN_API_KEY',
+      api_key: 'sk-should-not-be-required',
+      avatars: { codey: '/avatars/codey_still.png' },
+    })
+    expect(parsed.api_key_env).toBe('IMAGE_GEN_API_KEY')
+    expect(parsed.base_url).toBe('http://127.0.0.1:9')
+    expect(parsed.avatars).toEqual({ codey: '/avatars/codey_still.png' })
+    expect(isImageGenConfigured(parsed)).toBe(true)
+  })
+
+  it('derives a still prompt from name/role and recognizes generated still paths', () => {
+    expect(defaultAvatarPrompt('Codey', 'support')).toMatch(/Codey/)
+    expect(defaultAvatarPrompt('Codey', 'support')).toMatch(/no animation/)
+    expect(isGeneratedStillSrc('/avatars/codey_still.png')).toBe(true)
+    expect(isGeneratedStillSrc('/avatars/codey_avatar.png')).toBe(false)
+    expect(isGeneratedStillSrc('')).toBe(false)
+  })
+})

--- a/webui/frontend/src/lib/agentAvatars.ts
+++ b/webui/frontend/src/lib/agentAvatars.ts
@@ -1,0 +1,124 @@
+/**
+ * Per-agent generated still avatars (REQ-83).
+ *
+ * Server SoT is GET /v1/image-gen/ ``avatars``. This module caches the map so
+ * AgentAvatar can apply a still on Bland/Default without ChatPage / rail edits.
+ * Blobs theme ignores these stills — see AgentAvatar.
+ */
+
+import { useEffect, useState } from 'react'
+import { fetchImageGenSettings } from './api'
+import { parseImageGenSettings } from './imageGenSettings'
+
+export const GENERATED_AVATARS_CHANGED_EVENT = 'swarm:generated-avatars-changed'
+export const GENERATED_AVATARS_KEY = 'swarm_generated_avatars'
+
+type AvatarMap = Record<string, string>
+
+let memory: AvatarMap = {}
+let hydrated = false
+let hydratePromise: Promise<void> | null = null
+
+function readLocal(): AvatarMap {
+  try {
+    const raw = localStorage.getItem(GENERATED_AVATARS_KEY)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    const out: AvatarMap = {}
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof value === 'string' && value.trim()) out[key] = value.trim()
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
+function writeLocal(map: AvatarMap): void {
+  try {
+    localStorage.setItem(GENERATED_AVATARS_KEY, JSON.stringify(map))
+  } catch {
+    /* best-effort */
+  }
+}
+
+function emitChange(agentId?: string): void {
+  try {
+    window.dispatchEvent(
+      new CustomEvent(GENERATED_AVATARS_CHANGED_EVENT, { detail: { agentId } }),
+    )
+  } catch {
+    /* jsdom / detached */
+  }
+}
+
+function replaceMap(next: AvatarMap): void {
+  memory = { ...next }
+  writeLocal(memory)
+  emitChange()
+}
+
+export function resetGeneratedAvatars(): void {
+  memory = {}
+  hydrated = false
+  hydratePromise = null
+  try {
+    localStorage.removeItem(GENERATED_AVATARS_KEY)
+  } catch {
+    /* ignore */
+  }
+}
+
+export function loadGeneratedAvatar(agentId: string): string {
+  if (!agentId) return ''
+  if (memory[agentId]) return memory[agentId]
+  const local = readLocal()
+  return local[agentId] || ''
+}
+
+export function rememberGeneratedAvatar(agentId: string, avatarPath: string): void {
+  if (!agentId) return
+  const path = avatarPath.trim()
+  if (!path) return
+  memory = { ...readLocal(), ...memory, [agentId]: path }
+  writeLocal(memory)
+  emitChange(agentId)
+}
+
+export async function hydrateGeneratedAvatars(): Promise<void> {
+  if (hydrated) return
+  if (!hydratePromise) {
+    hydratePromise = (async () => {
+      memory = { ...readLocal(), ...memory }
+      try {
+        const raw = await fetchImageGenSettings(false)
+        const parsed = parseImageGenSettings(raw)
+        if (parsed.avatars && Object.keys(parsed.avatars).length > 0) {
+          memory = { ...memory, ...parsed.avatars }
+          writeLocal(memory)
+        }
+      } catch {
+        /* offline / tests without a stub */
+      }
+      hydrated = true
+      emitChange()
+    })()
+  }
+  await hydratePromise
+}
+
+export function useGeneratedAvatar(agentId?: string | null): string {
+  const id = agentId || ''
+  const [src, setSrc] = useState(() => loadGeneratedAvatar(id))
+
+  useEffect(() => {
+    setSrc(loadGeneratedAvatar(id))
+    void hydrateGeneratedAvatars()
+    const onChange = () => setSrc(loadGeneratedAvatar(id))
+    window.addEventListener(GENERATED_AVATARS_CHANGED_EVENT, onChange)
+    return () => window.removeEventListener(GENERATED_AVATARS_CHANGED_EVENT, onChange)
+  }, [id])
+
+  return src
+}

--- a/webui/frontend/src/lib/api.ts
+++ b/webui/frontend/src/lib/api.ts
@@ -836,6 +836,69 @@ export function fetchLocalStore(): Promise<LocalStoreFacts> {
   return apiGet<LocalStoreFacts>('/v1/system/')
 }
 
+/**
+ * GET/PATCH /v1/image-gen/ and POST /v1/agents/<id>/avatar/generate/
+ * (swarm/views/image_gen_api.py). Opt-in OpenAI-compat image endpoint.
+ * Auth is an env-var *name* only; never send a live token.
+ */
+export interface ImageGenSettings {
+  object?: 'image_gen'
+  configured: boolean
+  base_url: string
+  model: string
+  api_key_env: string
+  api_key_set?: boolean
+  status?: string
+  detail?: string
+  avatars?: Record<string, string>
+  source?: string
+}
+
+export interface ImageGenPatchRequest {
+  base_url?: string
+  model?: string
+  api_key_env?: string
+}
+
+export interface GeneratedAgentAvatar {
+  object?: 'agent_avatar'
+  agent_id: string
+  avatar_path: string
+  still: boolean
+  prompt?: string
+}
+
+export const EMPTY_IMAGE_GEN: ImageGenSettings = {
+  object: 'image_gen',
+  configured: false,
+  base_url: '',
+  model: '',
+  api_key_env: '',
+  api_key_set: false,
+  status: 'off',
+  detail: 'Image generation is off. No host is used until you set a base URL.',
+  avatars: {},
+}
+
+export function fetchImageGenSettings(probe = true): Promise<ImageGenSettings> {
+  const q = probe ? '' : '?probe=0'
+  return apiGet<ImageGenSettings>(`/v1/image-gen/${q}`)
+}
+
+export function patchImageGenSettings(body: ImageGenPatchRequest): Promise<ImageGenSettings> {
+  return apiPatch<ImageGenSettings>('/v1/image-gen/', body)
+}
+
+export function generateAgentAvatar(
+  agentId: string,
+  body: { prompt?: string; name?: string; role?: string } = {},
+): Promise<GeneratedAgentAvatar> {
+  return apiPost<GeneratedAgentAvatar>(
+    `/v1/agents/${encodeURIComponent(agentId)}/avatar/generate/`,
+    body,
+  )
+}
+
 /** GET /v1/blueprints/<id>/source — read-only blueprint source (file list + content). */
 export interface BlueprintSource {
   id: string

--- a/webui/frontend/src/lib/imageGenSettings.ts
+++ b/webui/frontend/src/lib/imageGenSettings.ts
@@ -1,0 +1,66 @@
+/**
+ * Settings helpers for the opt-in OpenAI-compat image-gen endpoint (REQ-83).
+ * Persist stores ${ENV} names, not keys. Empty URL is off — never guess a host.
+ */
+
+import { EMPTY_IMAGE_GEN, type ImageGenSettings } from './api'
+
+export const IMAGE_GEN_QUERY_KEY = ['image-gen-settings'] as const
+
+export function parseImageGenSettings(raw: unknown): ImageGenSettings {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ...EMPTY_IMAGE_GEN }
+  }
+  const row = raw as Record<string, unknown>
+  const baseUrl = typeof row.base_url === 'string' ? row.base_url.trim() : ''
+  const model = typeof row.model === 'string' ? row.model.trim() : ''
+  const apiKeyEnv = typeof row.api_key_env === 'string' ? row.api_key_env.trim() : ''
+  const avatars =
+    row.avatars && typeof row.avatars === 'object' && !Array.isArray(row.avatars)
+      ? Object.fromEntries(
+          Object.entries(row.avatars as Record<string, unknown>).filter(
+            (entry): entry is [string, string] =>
+              typeof entry[0] === 'string' && typeof entry[1] === 'string' && Boolean(entry[1].trim()),
+          ),
+        )
+      : {}
+  const configured =
+    typeof row.configured === 'boolean' ? row.configured : Boolean(baseUrl)
+  return {
+    object: 'image_gen',
+    configured,
+    base_url: baseUrl,
+    model,
+    api_key_env: apiKeyEnv,
+    api_key_set: row.api_key_set === true,
+    status: typeof row.status === 'string' ? row.status : configured ? 'unknown' : 'off',
+    detail:
+      typeof row.detail === 'string' && row.detail.trim()
+        ? row.detail
+        : configured
+          ? 'Image generation is configured.'
+          : EMPTY_IMAGE_GEN.detail,
+    avatars,
+    source: typeof row.source === 'string' ? row.source : undefined,
+  }
+}
+
+export function isImageGenConfigured(settings?: ImageGenSettings | null): boolean {
+  if (!settings) return false
+  return Boolean(settings.configured && settings.base_url.trim())
+}
+
+export function defaultAvatarPrompt(name: string, role?: string | null): string {
+  const label = name.trim() || 'agent'
+  const roleBit = (role || '').trim()
+  if (roleBit && roleBit !== 'default') {
+    return `Still portrait avatar of ${label}, a ${roleBit} agent, simple icon, no animation`
+  }
+  return `Still portrait avatar of ${label}, simple icon, no animation`
+}
+
+export function isGeneratedStillSrc(src?: string | null): boolean {
+  const trimmed = typeof src === 'string' ? src.trim() : ''
+  if (!trimmed) return false
+  return /\/avatars\/[^/?#]+_still\.(png|jpe?g|webp)$/i.test(trimmed)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #436

## Intent
Users who already run an OpenAI-compatible image API can set it in Settings and generate a still avatar for any agent. Distinct from Blob theme eyes.

## What landed
- **Settings → Image generation:** opt-in base URL, model id, and api-key env name only. Empty/off does not guess a host. Missing/DOWN is an honest info line.
- **Agent editor → Generate avatar:** prompt derived from name/role (editable). Disabled with a pointer to Settings when no endpoint is configured.
- **Apply:** generated stills show via `AgentAvatar` on Bland/Default. Blobs theme keeps blobs and ignores generated stills. Uploaded custom faces still always win.
- Persist stores `${ENV}` names, not keys. No tokens or live hosts in the repo.

## Tests (own-diff, no live host)
- `uv run pytest tests/core/test_image_gen.py tests/views/test_image_gen_api.py` — 10 passed
- Vitest: Settings pane, AgentEditor generate, AgentAvatar theme rule, SettingsSheet nav — 55 passed
- Persist `${ENV}` names, not keys
- Empty URL does not call any host
- Stub `/v1/images/generations` returns bytes → avatar set
- Generate disabled when unset
- Stored avatar is a still (GIF rejected)

## Files
Settings lane plus agent editor generate control and shared `AgentAvatar` apply. ChatPage and rail menu files were left alone.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62859859-861f-4c3b-bc93-6cfa0247cd0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62859859-861f-4c3b-bc93-6cfa0247cd0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

