### PR TITLE
fix(webui): queue suggestion-chip clicks during an in-flight generation

### DIFF
--- a/.github/workflows/req90-queued-sends.yml
+++ b/.github/workflows/req90-queued-sends.yml
@@ -9,7 +9,9 @@ on:
       - "webui/frontend/src/components/__tests__/QueuedSendPane.test.tsx"
       - "webui/frontend/src/pages/ChatPage.tsx"
       - "webui/frontend/src/pages/__tests__/ChatPage.queued.test.tsx"
+      - "webui/frontend/src/pages/__tests__/ChatPage.suggestions.test.tsx"
       - "webui/frontend/src/pages/__tests__/ChatPage.test.tsx"
+      - "webui/frontend/src/components/SuggestionChips.tsx"
       - "webui/frontend/src/index.css"
       - ".github/workflows/req90-queued-sends.yml"
   push:
@@ -21,7 +23,9 @@ on:
       - "webui/frontend/src/components/__tests__/QueuedSendPane.test.tsx"
       - "webui/frontend/src/pages/ChatPage.tsx"
       - "webui/frontend/src/pages/__tests__/ChatPage.queued.test.tsx"
+      - "webui/frontend/src/pages/__tests__/ChatPage.suggestions.test.tsx"
       - "webui/frontend/src/pages/__tests__/ChatPage.test.tsx"
+      - "webui/frontend/src/components/SuggestionChips.tsx"
       - "webui/frontend/src/index.css"
       - ".github/workflows/req90-queued-sends.yml"
 
@@ -49,6 +53,8 @@ jobs:
           npx vitest run \
             src/lib/__tests__/chatQueue.test.ts \
             src/components/__tests__/QueuedSendPane.test.tsx \
-            src/pages/__tests__/ChatPage.queued.test.tsx
+            src/pages/__tests__/ChatPage.queued.test.tsx \
+            src/pages/__tests__/ChatPage.suggestions.test.tsx \
+            src/components/__tests__/SuggestionChips.test.tsx
           npx vitest run src/pages/__tests__/ChatPage.test.tsx \
             -t "Send path with mock inference|Send button honesty|team member dropdown"

--- a/webui/frontend/src/components/SuggestionChips.tsx
+++ b/webui/frontend/src/components/SuggestionChips.tsx
@@ -26,6 +26,7 @@ export function SuggestionChips({
           className="btn btn-soft btn-sm os-suggestion-chip"
           disabled={disabled}
           data-testid="suggestion-chip"
+          data-suggestion-chip={chip}
           onClick={() => {
             if (disabled) return
             onChoose(chip)

--- a/webui/frontend/src/components/__tests__/SuggestionChips.test.tsx
+++ b/webui/frontend/src/components/__tests__/SuggestionChips.test.tsx
@@ -10,6 +10,7 @@ describe('SuggestionChips', () => {
     expect(row).toHaveAttribute('role', 'group')
     const buttons = screen.getAllByTestId('suggestion-chip')
     expect(buttons[0]).toHaveClass('btn')
+    expect(buttons[0]).toHaveAttribute('data-suggestion-chip', 'Ask about setup')
     fireEvent.click(buttons[0]!)
     expect(onChoose).toHaveBeenCalledWith('Ask about setup')
   })

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -1377,18 +1377,9 @@ const ChatPage = () => {
       const text = suggestionChipText(event)
       if (text.trim()) submitUserText(text)
     }
-    const onClick = (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null
-      const chip = target?.closest('[data-suggestion-chip]')
-      if (!chip) return
-      const text = chip.getAttribute('data-suggestion-chip') || chip.textContent || ''
-      if (text.trim()) submitUserText(text)
-    }
     window.addEventListener(SUGGESTION_CHIP_EVENT, onChip)
-    document.addEventListener('click', onClick)
     return () => {
       window.removeEventListener(SUGGESTION_CHIP_EVENT, onChip)
-      document.removeEventListener('click', onClick)
     }
   }, [submitUserText])
 
@@ -1535,7 +1526,7 @@ const ChatPage = () => {
   }, [plusOpen])
 
   const streamingMessage = messages.find((message) => message.streaming)
-  const chipsDisabled = Boolean(streamingMessage) || status !== 'open'
+  const chipsDisabled = status !== 'open'
   const showSuggestionChips = shouldShowSuggestionChips({
     enabled: useSuggestions,
     chips: suggestionChips,
@@ -1570,10 +1561,10 @@ const ChatPage = () => {
 
   const chooseSuggestion = useCallback(
     (text: string) => {
-      if (chipsDisabled) return
-      sendText(text)
+      if (status !== 'open') return
+      submitUserText(text)
     },
-    [chipsDisabled, sendText],
+    [status, submitUserText],
   )
 
   const wasStreamingRef = useRef(false)

--- a/webui/frontend/src/pages/__tests__/ChatPage.suggestions.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.suggestions.test.tsx
@@ -191,7 +191,14 @@ describe('ChatPage REQ-85 suggestion chips', () => {
         }),
       )
     })
-    expect(screen.getAllByTestId('suggestion-chip').every((el) => (el as HTMLButtonElement).disabled)).toBe(true)
+    expect(
+      screen.getAllByTestId('suggestion-chip').every((el) => !(el as HTMLButtonElement).disabled),
+    ).toBe(true)
+    fireEvent.click(screen.getByRole('button', { name: KICKSTART[0] }))
+    expect(ws.send).not.toHaveBeenCalled()
+    const queued = screen.getAllByTestId('queued-row')
+    expect(queued).toHaveLength(1)
+    expect(queued[0]).toHaveTextContent(KICKSTART[0])
     await act(async () => {
       ws.onmessage?.(
         new MessageEvent('message', {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
REQ-90: send or click a suggestion chip while a reply is streaming queues that text instead of starting a second generation.

#802 is already on `main`. This follow-up is the remaining gap after #441 chips landed: chips still called `sendText` and disabled themselves while streaming.

## Changes

- `chooseSuggestion` goes through `submitUserText` (queue-or-send).
- Chips stay clickable while a reply streams (`chipsDisabled` is only when the session is not open).
- `data-suggestion-chip` on the chip buttons for the existing ChatPage queue tests.
- REQ-98 contract test reads On/Off labels from `railContextMenu.ts` (labels moved out of `AgentSidebar.tsx` on `main`).

## Queue contract (already on `main` from #802)

- Composer send or chip click during in-flight generation appends a **queued** user row (`status=queued`).
- In-flight / just-finished assistant stays **above** the queued block.
- Oldest-first drain when idle; skip/hold a row whose editor is focused or dirty; deleted rows never send.
- Queued pane is ~1/3 of the transcript viewport with internal scroll; empty queue hides the pane.
- Persist queued rows with the conversation (local store, not Neon).

## Tests

- `webui/frontend/src/pages/__tests__/ChatPage.queued.test.tsx`
- `webui/frontend/src/lib/__tests__/chatQueue.test.ts`
- `webui/frontend/src/components/__tests__/QueuedSendPane.test.tsx`
- `tests/unit/test_req98_agent_notifications.py`

Fixes #447

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d876bb64-1612-4baf-982b-16e48737b530?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d876bb64-1612-4baf-982b-16e48737b530&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

