### PR TITLE
fix(chat): write CLI/PR chrome to ui_events (REQ-70 reconstruction)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- **REQ-70 reconstruction (#789):** Status/info/hop chrome is stored as side-channel `ui_events` (timestamp + `seq`). The UI reconstructs those lines; the JSON `messages` list and Django `ChatMessage` rows are real turns only. The landed #765 `messages_for_model` filter stays as a safety belt. Docs describe reconstruction / UI metadata, not filter-as-Success. Fixes #789.
+- **REQ-70 reconstruction (#789):** Status/info/hop chrome is stored as side-channel `ui_events` (timestamp + `seq`). The UI reconstructs those lines; the JSON `messages` list and Django `ChatMessage` rows are real turns only. The landed #765 `messages_for_model` filter stays as a safety belt. CLI session select and PR-opened persist write chrome via `append_event`, not mixed `messages.append({role:status})`. Docs describe reconstruction / UI metadata, not filter-as-Success. Fixes #789.
 - **REQ-90 queued sends while a generation is in flight:** Composer send or suggestion-chip click during an in-flight reply appends a labelled queued row instead of starting a second run. The queued pane sits below the in-flight assistant, caps at about one-third of the transcript, and scrolls. Rows are editable (held while focused) and removable; idle drain is oldest-first. Queued rows persist with the conversation (local store, not Neon). Fixes #447.
 
 ### Changed

--- a/docs/requirements/REQ-70.md
+++ b/docs/requirements/REQ-70.md
@@ -3,3 +3,5 @@
 https://github.com/matthewhand/open-swarm/issues/789
 
 Parent [#407](https://github.com/matthewhand/open-swarm/issues/407) was closed by the landed [#765](https://github.com/matthewhand/open-swarm/pull/765) filter belt. Reconstruction Success is [#789](https://github.com/matthewhand/open-swarm/issues/789).
+
+Status/info/hop/PR-opened/prior-history chrome is written to the `ui_events` side channel (`append_event`). CLI session select and PR-opened persist do not `messages.append({role: status})`. The #765 `messages_for_model` / `is_ui_only_role` helpers remain a belt. The UI reconstructs display from `turns` + `ui_events`.

--- a/docs/websocket_chat.md
+++ b/docs/websocket_chat.md
@@ -80,8 +80,10 @@ that line as **UI metadata** (`ui_events`) and does **not** invoke a blueprint
 or LLM.
 
 REQ-70 reconstruction: status/info/hop chrome lives in `ui_events` (side
-channel). The UI reconstructs those lines into transcript chrome. Model
-context is built from real user/assistant/tool turns only. Exclude helpers
+channel). CLI session select and PR-opened persist append those events via
+`append_event`; they do not write `role=status` onto the model-turn list.
+The UI reconstructs those lines into transcript chrome. Model context is
+built from real user/assistant/tool turns only. Exclude helpers
 (`messages_for_model`) remain a safety belt if mixed rows still exist
 temporarily — they are not the Success architecture. Compact-fallback and
 CLI `render_prompt` use the same turns-only payload.

--- a/src/swarm/core/cli_session_select.py
+++ b/src/swarm/core/cli_session_select.py
@@ -346,14 +346,13 @@ def list_cli_sessions(
 
 
 def _visible_turns(messages: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    from swarm.core.transcript_roles import is_chrome_message
+
     out: list[dict[str, Any]] = []
     for row in messages or []:
         if not isinstance(row, dict):
             continue
-        if row.get("kind") == PRIOR_HISTORY_KIND:
-            continue
-        role = row.get("role") or ""
-        if role == "status":
+        if is_chrome_message(row):
             continue
         content = str(row.get("content") or "").strip()
         if not content:
@@ -364,6 +363,8 @@ def _visible_turns(messages: list[dict[str, Any]] | None) -> list[dict[str, Any]
 
 def format_prior_history(messages: list[dict[str, Any]] | None) -> str:
     """Markdown archive for the expandable pill. Not sent as CLI turns."""
+    from swarm.core.transcript_roles import is_chrome_message
+
     lines: list[str] = []
     for row in messages or []:
         if not isinstance(row, dict):
@@ -374,9 +375,25 @@ def format_prior_history(messages: list[dict[str, Any]] | None) -> str:
         if row.get("kind") == PRIOR_HISTORY_KIND:
             lines.append(f"**{PRIOR_HISTORY_LABEL}**\n{content}")
             continue
+        if is_chrome_message(row):
+            continue
         role = str(row.get("role") or "user").capitalize()
         lines.append(f"**{role}:** {content}")
     return "\n\n".join(lines).strip()
+
+
+def _transcript_payload(
+    turns: list[dict[str, Any]],
+    events: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Reconstructed display plus the split store (REQ-70 / #789)."""
+    from swarm.core.transcript_roles import reconstruct_display
+
+    return {
+        "messages": reconstruct_display(turns, events),
+        "turns": turns,
+        "ui_events": events,
+    }
 
 
 def _same_bound_session(
@@ -429,6 +446,7 @@ def select_cli_session(
     if prior is None:
         prior = chat_store.load(user_key, agent, base_dir=base_dir)
     prior_messages = list((prior or {}).get("messages") or [])
+    prior_events = list((prior or {}).get("ui_events") or [])
     prior_visible = _visible_turns(prior_messages)
     stored = get_cli_session(user_key, agent, cli, base_dir=base_dir)
     prior_cid = (prior or {}).get("conversation_id") or from_conversation_id or ""
@@ -446,7 +464,7 @@ def select_cli_session(
             "cli": cli,
             "conversation_id": prior_cid,
             "cli_session_id": stored,
-            "messages": prior_messages,
+            **_transcript_payload(prior_messages, prior_events),
             "status": (
                 session_notice_text(cli, resumed=True)
                 if stored
@@ -457,47 +475,56 @@ def select_cli_session(
             "same_session": True,
         }
 
+    from swarm.core.transcript_roles import append_event, append_turn, is_chrome_message
+
     new_cid = mint_cli_conversation_id(agent)
-    messages: list[dict[str, Any]] = []
+    turns: list[dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
     collapsed = False
     if prior_visible:
         archive = format_prior_history(prior_messages)
         if archive:
-            messages.append(
-                {
-                    "role": "system",
-                    "kind": PRIOR_HISTORY_KIND,
-                    "content": archive,
-                    "from_conversation_id": prior_cid,
-                }
+            append_event(
+                turns,
+                events,
+                "system",
+                archive,
+                kind=PRIOR_HISTORY_KIND,
+                from_conversation_id=prior_cid,
             )
             collapsed = True
 
     import_kind = "none"
     if imported_messages:
-        cleaned = []
+        imported_turns = False
         for row in imported_messages:
             if not isinstance(row, dict):
                 continue
-            role = row.get("role") or "assistant"
+            role = str(row.get("role") or "assistant")
             content = str(row.get("content") or "")
-            if role not in ("user", "assistant", "status") or not content.strip():
+            if not content.strip():
                 continue
-            cleaned.append({"role": role, "content": content})
-        if cleaned:
-            messages.extend(cleaned)
+            if is_chrome_message(row) or role in ("status", "info"):
+                append_event(turns, events, "status", content)
+                continue
+            if role not in ("user", "assistant"):
+                continue
+            append_turn(turns, events, role, content)
+            imported_turns = True
+        if imported_turns:
             import_kind = "full"
 
     notice = switch_notice_text(cli, sid, start_new=start_new)
-    messages.append({"role": "status", "content": notice})
+    append_event(turns, events, "status", notice)
 
     chat_store.save(
         user_key,
         agent,
-        messages,
+        turns,
         conversation_id=new_cid,
         session_id=new_cid,
         cli_sessions={cli: sid} if sid else {},
+        ui_events=events,
         base_dir=base_dir,
     )
     # REQ-52 resume reads the default agent file + settings — bind the id
@@ -528,7 +555,7 @@ def select_cli_session(
         )
 
     if user is not None:
-        _bind_django_conversation(user, new_cid, messages)
+        _bind_django_conversation(user, new_cid, turns)
 
     return {
         "object": "cli_session_select",
@@ -536,7 +563,7 @@ def select_cli_session(
         "cli": cli,
         "conversation_id": new_cid,
         "cli_session_id": sid,
-        "messages": messages,
+        **_transcript_payload(turns, events),
         "status": notice,
         "collapsed_prior": collapsed,
         "import": import_kind,
@@ -546,7 +573,11 @@ def select_cli_session(
 
 
 def _bind_django_conversation(user, conversation_id: str, messages: list[dict[str, Any]]) -> None:
-    """Create the new Django conversation. Never deletes the prior thread."""
+    """Create the new Django conversation. Never deletes the prior thread.
+
+    ``messages`` is the model-turn list only. Status/info chrome stays in
+    the file-store ``ui_events`` side channel.
+    """
     try:
         from swarm.models import ChatConversation, ChatMessage
     except Exception:
@@ -567,7 +598,7 @@ def _bind_django_conversation(user, conversation_id: str, messages: list[dict[st
             [
                 ChatMessage(
                     conversation=chat,
-                    sender=str(item.get("role") or "status"),
+                    sender=str(item.get("role") or "user"),
                     content=str(item.get("content") or ""),
                 )
                 for item in messages

--- a/src/swarm/core/pr_opened.py
+++ b/src/swarm/core/pr_opened.py
@@ -194,15 +194,18 @@ def persist_pr_opened_message(
     *,
     events: list[dict[str, Any]] | None = None,
 ) -> None:
-    """Record a PR-opened chrome event (UI metadata, not model context)."""
+    """Record a PR-opened chrome event on the UI side channel.
+
+    Never writes ``role=status`` onto the model-turn list. Callers must
+    pass ``events`` (the ``ui_events`` store). Omitting it is a no-op so
+    leftover mixed-store writes cannot come back through this helper.
+    """
+    if events is None:
+        return
     content = json.dumps(payload, separators=(",", ":"))
-    target = events if events is not None else messages
-    for row in target:
+    for row in events:
         if row.get("role") == "status" and row.get("content") == content:
             return
-    if events is not None:
-        from swarm.core.transcript_roles import append_event
+    from swarm.core.transcript_roles import append_event
 
-        append_event(messages, events, "status", content, kind="pr_opened")
-        return
-    messages.append({"role": "status", "content": content, "kind": "pr_opened"})
+    append_event(messages, events, "status", content, kind="pr_opened")

--- a/src/swarm/core/transcript_roles.py
+++ b/src/swarm/core/transcript_roles.py
@@ -166,10 +166,16 @@ def _as_turn(item: dict[str, Any]) -> dict[str, Any]:
 
 def _as_event(item: dict[str, Any]) -> dict[str, Any]:
     row = stamp_ui_event(dict(item))
+    kind = event_kind(row)
+    row["kind"] = kind
+    if kind == "prior_history":
+        # Archive pill stays system+kind so the UI reconstructs the REQ-104 card.
+        if _role_of(row) != "system":
+            row["role"] = "system"
+        return row
     role = _role_of(row)
     if role not in UI_ONLY_ROLES:
         row["role"] = "status"
-    row["kind"] = event_kind(row)
     return row
 
 
@@ -271,8 +277,15 @@ def append_event(
     **extra: Any,
 ) -> dict[str, Any]:
     """Append UI chrome to the side channel (never the model-turn list)."""
+    kind = extra.get("kind")
+    if isinstance(kind, str) and kind.strip().lower() == "prior_history":
+        stored_role = "system"
+    elif is_ui_only_role(role):
+        stored_role = role
+    else:
+        stored_role = "status"
     row: dict[str, Any] = {
-        "role": role if is_ui_only_role(role) else "status",
+        "role": stored_role,
         "content": content,
         "seq": next_seq(turns, events),
     }

--- a/tests/core/test_cli_session_select.py
+++ b/tests/core/test_cli_session_select.py
@@ -142,6 +142,9 @@ def test_select_updates_stored_id_and_mints_new_conversation(tmp_path, monkeypat
     assert "old question" in pill["content"]
     assert "old answer" in pill["content"]
     assert any(m.get("content") == "from cli" for m in first["messages"])
+    assert not any(m.get("role") in ("status", "info") for m in first["turns"])
+    assert any(e.get("content") == first["status"] for e in first["ui_events"])
+    assert any(e.get("kind") == PRIOR_HISTORY_KIND for e in first["ui_events"])
 
     old = chat_store.load("u1", "cli_agent", conversation_id="agt-1-cli_agent", base_dir=tmp_path)
     assert old is not None
@@ -156,6 +159,9 @@ def test_select_updates_stored_id_and_mints_new_conversation(tmp_path, monkeypat
     )
     assert new is not None
     assert new["conversation_id"] == first["conversation_id"]
+    assert not any(m.get("role") in ("status", "info") for m in new["messages"])
+    assert any(e.get("content") == first["status"] for e in new["ui_events"])
+    assert any(e.get("kind") == PRIOR_HISTORY_KIND for e in new["ui_events"])
 
 
 def test_select_same_session_does_not_double_collapse(tmp_path, monkeypatch):
@@ -210,6 +216,8 @@ def test_start_new_clears_id_and_collapses_prior(tmp_path, monkeypatch):
     assert get_cli_session("u1", "cli_agent", "echo", base_dir=tmp_path) is None
     assert settings_store.stored_cli_session_id("cli_agent") is None
     assert any(m.get("kind") == PRIOR_HISTORY_KIND for m in result["messages"])
+    assert not any(m.get("role") in ("status", "info") for m in result["turns"])
+    assert any(e.get("content") == result["status"] for e in result["ui_events"])
 
 
 def test_old_compressions_are_not_copied(tmp_path, monkeypatch):
@@ -272,3 +280,4 @@ def test_format_prior_history_skips_empty():
     )
     assert "**User:** q" in text
     assert "**Assistant:** a" in text
+    assert "Started a new echo session." not in text

--- a/tests/core/test_pr_opened.py
+++ b/tests/core/test_pr_opened.py
@@ -62,9 +62,18 @@ def test_parse_rejects_markdown_and_lone_links():
 
 def test_persist_status_row_is_idempotent():
     messages: list[dict] = []
+    events: list[dict] = []
     payload = {"type": "pr_opened", "url": GH, "number": 416}
-    persist_pr_opened_message(messages, payload)
-    persist_pr_opened_message(messages, payload)
-    assert len(messages) == 1
-    assert messages[0]["role"] == "status"
-    assert '"type":"pr_opened"' in messages[0]["content"]
+    persist_pr_opened_message(messages, payload, events=events)
+    persist_pr_opened_message(messages, payload, events=events)
+    assert messages == []
+    assert len(events) == 1
+    assert events[0]["role"] == "status"
+    assert events[0]["kind"] == "pr_opened"
+    assert '"type":"pr_opened"' in events[0]["content"]
+
+
+def test_persist_without_events_does_not_mix_into_turns():
+    messages: list[dict] = [{"role": "user", "content": "hi"}]
+    persist_pr_opened_message(messages, {"type": "pr_opened", "url": GH, "number": 416})
+    assert messages == [{"role": "user", "content": "hi"}]

--- a/tests/core/test_req70_reconstruction.py
+++ b/tests/core/test_req70_reconstruction.py
@@ -181,3 +181,24 @@ def test_thread_post_status_lands_in_ui_events():
     assert all(row["role"] != "status" for row in loaded["messages"])
     assert loaded["ui_events"][-1]["content"] == STATUS_CLI
     assert loaded["ui_events"][-1]["ts"]
+
+
+def test_prior_history_stays_system_chrome_not_a_turn():
+    turns, events = split_store(
+        [
+            {
+                "role": "system",
+                "kind": "prior_history",
+                "content": "**User:** old",
+            },
+            {"role": "user", "content": "next"},
+        ]
+    )
+    assert [row["role"] for row in turns] == ["user"]
+    assert events[0]["kind"] == "prior_history"
+    assert events[0]["role"] == "system"
+    payload = build_model_context_from_store(turns, events)
+    assert payload == [{"role": "user", "content": "next"}]
+    display = reconstruct_display(turns, events)
+    assert display[0]["kind"] == "prior_history"
+    assert display[0]["role"] == "system"

--- a/tests/views/test_cli_sessions_api.py
+++ b/tests/views/test_cli_sessions_api.py
@@ -59,6 +59,9 @@ def test_select_paste_id_mints_conversation_and_stores_id(api_client, tmp_path):
     assert body["collapsed_prior"] is True
     assert get_cli_session("u0", "cli_agent", "echo") == "sid-pasted"
     assert any(m.get("kind") == "prior_history" for m in body["messages"])
+    assert not any(m.get("role") in ("status", "info") for m in body["turns"])
+    assert any(e.get("kind") == "prior_history" for e in body["ui_events"])
+    assert any(e.get("content") == body["status"] for e in body["ui_events"])
 
 
 def test_select_start_new(api_client):

--- a/webui/frontend/src/lib/cliSessions.ts
+++ b/webui/frontend/src/lib/cliSessions.ts
@@ -11,6 +11,7 @@ import {
   conversationIdForAgent,
   setConversationIdForAgent,
 } from './agentChat'
+import { messagesFromThreadPayload } from './transcriptReconstruct'
 
 export { setConversationIdForAgent } from './agentChat'
 
@@ -65,6 +66,8 @@ export interface CliSessionSelectResult {
     kind?: string
     from_conversation_id?: string
   }>
+  turns?: Array<{ role: string; content: string; kind?: string }>
+  ui_events?: Array<{ role: string; content: string; kind?: string; ts?: string }>
   status: string
   collapsed_prior: boolean
   import: 'none' | 'full' | 'partial'
@@ -100,7 +103,10 @@ export async function selectCliSession(opts: {
   if (data.conversation_id) {
     setConversationIdForAgent(opts.agentId, data.conversation_id)
   }
-  return data
+  return {
+    ...data,
+    messages: messagesFromThreadPayload(data),
+  }
 }
 
 export function dispatchCliSessionSwitched(detail: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #789

## Intent
Status/info chrome (dropdown changes, session notices, Messaged/Message-from, rate-limit/config-fail lines, etc.) must live as **UI-only metadata outside** the raw model/transcript context store. The UI **reconstructs** those chrome lines for humans; the model sees **real turns only**. Exclude helpers (`messages_for_model` / `is_ui_only_role`) are a **belt**, not the Success architecture.

Parent #407 was closed by #765 (`5b381dd`), which skeptic **FAIL**ed post-merge: mixed `messages.append({role:status})` + filter-as-Success. Do **not** thrash/revert #765. This change is the Success **delta** for leftover write paths after #788.

## Success
1. Status/info events are **not** stored as mixed `role=status|info` rows inside the same message list that is the primary model context source. Prefer a side channel / metadata store (`ui_events`) the UI reads to reconstruct chrome.
2. UI reconstructs status/info chrome (with timestamps / reload persistence) from that metadata.
3. Model context paths include real user/assistant/tool turns only; zero status/info / Messaged chrome strings in the LLM payload (tests prove this against the reconstructed architecture, not only filter-on-mixed).
4. Compact (#350) summarises real messages only.
5. Speaker identity (named assistant vs delimiter) + adapter table from #765 may remain; must not depend on stuffing chrome into the mixed store.
6. #405 rate-limit/config-fail info lines follow the same reconstructed-metadata rule.
7. Docs/PR text say **reconstruction / UI metadata**, not “filter/omit as Success.”
8. Tests; no live host; no secrets.

## What this PR changes
#788 landed reconstruction storage + persist/GET. Two writers still did the #765 FAIL pattern:

- CLI session select appended `{role: status}` onto the in-memory `messages` list (and Django bind copied it).
- `persist_pr_opened_message` fell back to `messages.append` when `events` was omitted.

This PR writes those chrome lines with `append_event` onto `ui_events`. Select returns reconstructed `messages` plus `turns` / `ui_events`. The #765 belt is unchanged.

## Constraints
- Child of #407; builds on landed #765 filter belt (kept).
- Coord #362 / #350 / #405. Distinct from #366.
- GitHub-only. No `:8001`. No Neon. No secrets in Issues/PRs/diffs.
- Own-diff CI; ignore pre-existing main red unless this PR worsens it.

## Owner
Cursor (+ open-swarm engineer squash after skeptic PASS). CoS: Open Swarm. Skeptic text-only PASS/FAIL.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10dbce2c-c2f5-4586-bf0a-8923eaceedd7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10dbce2c-c2f5-4586-bf0a-8923eaceedd7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

