### PR TITLE
test: point REQ-98 menu lock at railContextMenu

### DIFF
--- a/tests/unit/test_req98_agent_notifications.py
+++ b/tests/unit/test_req98_agent_notifications.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 NOTIFY_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "agentNotifications.ts"
+RAIL_MENU_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "railContextMenu.ts"
 SIDEBAR_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
 CHAT_PAGE_TSX = REPO_ROOT / "webui" / "frontend" / "src" / "pages" / "ChatPage.tsx"
 RAIL_ORDER_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "railOrder.ts"
@@ -22,9 +23,11 @@ def test_notify_store_is_local_swarm_key_not_neon():
 
 
 def test_sidebar_menu_has_notifications_toggle():
+    menu = RAIL_MENU_TS.read_text(encoding="utf-8")
+    assert "id: 'notify'" in menu
+    assert "Notifications: On" in menu
+    assert "Notifications: Off" in menu
     content = SIDEBAR_TSX.read_text(encoding="utf-8")
-    assert "Notifications: On" in content
-    assert "Notifications: Off" in content
     assert "maybeNotifyAgentTurn" in content
     assert "enableAgentNotifications" in content
     assert "notify-permission-hint" in content


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The REQ-98 source lock still looked for **Notifications: On / Off** in `AgentSidebar.tsx`. Those labels now live in `railContextMenu.ts` after the shared rail menu extraction, which failed `test_sidebar_menu_has_notifications_toggle` on the #798 CI run (all three Python versions).

This updates the lock to assert the `notify` menu item and On/Off labels in `railContextMenu.ts`, and keeps the sidebar wiring checks (`maybeNotifyAgentTurn`, permission hint, OpenMousBot `remoteDisplayName`, no hover pencil).

Own-diff: `uv run pytest tests/unit/test_req98_agent_notifications.py` — 4 passed.

The other three CI failures on that run (`test_llm_profiles_lists_named_providers`, `test_llm_profile_access`, `test_docs_point_at_example_config`) were already red on the base commit and are out of this lock.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93da519e-b607-4188-b811-156d803736fc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93da519e-b607-4188-b811-156d803736fc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

