### PR TITLE
fix(webui): theme inline chat markdown with DaisyUI tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Inline chat markdown follows light/dark theme:** Code fences, inline code, tables, blockquotes, links, and other in-bubble chrome (status/history pills, suggestion chips, support cards) use DaisyUI / #464 Grok tokens instead of a stuck dark palette. Fixes #804.
+
 ### Added
 - **REQ-70 reconstruction (#789):** Status/info/hop chrome is stored as side-channel `ui_events` (timestamp + `seq`). The UI reconstructs those lines; the JSON `messages` list and Django `ChatMessage` rows are real turns only. The landed #765 `messages_for_model` filter stays as a safety belt. Docs describe reconstruction / UI metadata, not filter-as-Success. Fixes #789.
 - **REQ-90 queued sends while a generation is in flight:** Composer send or suggestion-chip click during an in-flight reply appends a labelled queued row instead of starting a second run. The queued pane sits below the in-flight assistant, caps at about one-third of the transcript, and scrolls. Rows are editable (held while focused) and removable; idle drain is oldest-first. Queued rows persist with the conversation (local store, not Neon). Fixes #447.

--- a/tests/unit/test_req804_chat_markdown_theme.py
+++ b/tests/unit/test_req804_chat_markdown_theme.py
@@ -1,0 +1,105 @@
+"""REQ-804: inline chat markdown follows light/dark theme tokens (Fixes #804)."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INDEX_CSS = REPO_ROOT / "webui" / "frontend" / "src" / "index.css"
+BUBBLE = REPO_ROOT / "webui" / "frontend" / "src" / "components" / "ChatMessageBubble.tsx"
+AGENT_BUBBLE = (
+    REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentChat" / "AgentMessageBubble.tsx"
+)
+MARKDOWN = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "markdown.ts"
+THEME_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "theme.ts"
+
+
+def _css() -> str:
+    return INDEX_CSS.read_text(encoding="utf-8")
+
+
+def _markdown_css(css: str) -> str:
+    start = css.index("/* REQ-804: in-bubble markdown")
+    end = css.index("/* Large dashboard action cards", start)
+    return css[start:end]
+
+
+def _chrome_css(css: str) -> str:
+    start = css.index("/* REQ-804: in-bubble chrome")
+    return css[start:]
+
+
+def test_theme_module_still_resolves_light_dark_system():
+    ts = THEME_TS.read_text(encoding="utf-8")
+    assert "resolveTheme" in ts
+    assert "subscribeSystemTheme" in ts
+    assert "'system'" in ts
+
+
+def test_index_css_reuses_grok_tokens_with_light_variants():
+    css = _css()
+    assert "--os-grok-code-inline: #ff5667" in css
+    assert "--os-grok-link: #4194eb" in css
+    light = css.split('[data-theme="light"]')[1]
+    assert "--os-grok-code-inline: #c43d4e" in light
+    assert "--os-grok-link: var(--color-primary)" in light
+
+
+def test_chat_markdown_uses_theme_tokens_not_bare_black_white():
+    md_css = _markdown_css(_css())
+    for needle in (
+        ".chat-md a",
+        ".os-chat-md a",
+        "var(--os-grok-link",
+        ".chat-md code:not(pre code)",
+        "var(--os-grok-code-inline",
+        ".chat-md pre",
+        "var(--color-base-300)",
+        ".chat-md blockquote",
+        ".chat-md table",
+        ".chat-md th",
+        ".chat-md hr",
+    ):
+        assert needle in md_css, needle
+    lowered = md_css.lower()
+    assert "#fff" not in lowered
+    assert "#ffffff" not in lowered
+    assert "#000" not in lowered
+    assert "#000000" not in lowered
+    css = _css()
+    assert "#101218" not in css
+    assert "#d6deeb" not in css
+
+
+def test_in_bubble_chrome_uses_daisyui_tokens():
+    css = _css()
+    assert ".os-chat-status" in css
+    assert "var(--color-base-content)" in css
+    chrome = _chrome_css(css)
+    for needle in (
+        ".os-handoff-chip",
+        ".os-briefing-popover",
+        ".os-question-card",
+        ".os-question-choice",
+        ".os-suggestion-chip",
+        ".os-attach-chip",
+        ".os-chat-gap",
+        ".os-chat-new",
+        "var(--color-base-content)",
+    ):
+        assert needle in css, needle
+    lowered = chrome.lower()
+    assert "#fff" not in lowered
+    assert "#000" not in lowered
+
+
+def test_bubbles_still_render_safe_markdown():
+    bubble = BUBBLE.read_text(encoding="utf-8")
+    agent = AGENT_BUBBLE.read_text(encoding="utf-8")
+    md = MARKDOWN.read_text(encoding="utf-8")
+    assert "renderSafeMarkdown" in bubble
+    assert 'data-testid="chat-md"' in bubble
+    assert "chat-md" in bubble
+    assert "chat-md" in agent
+    assert "os-chat-md" in agent
+    assert "TABLE" in md
+    assert "BLOCKQUOTE" in md
+    assert "HR" in md

--- a/tests/unit/test_req804_chat_markdown_theme.py
+++ b/tests/unit/test_req804_chat_markdown_theme.py
@@ -9,6 +9,7 @@ AGENT_BUBBLE = (
     REPO_ROOT / "webui" / "frontend" / "src" / "components" / "AgentChat" / "AgentMessageBubble.tsx"
 )
 MARKDOWN = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "markdown.ts"
+HTML_SAFE = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "htmlSafe.ts"
 THEME_TS = REPO_ROOT / "webui" / "frontend" / "src" / "lib" / "theme.ts"
 
 
@@ -38,7 +39,8 @@ def test_index_css_reuses_grok_tokens_with_light_variants():
     css = _css()
     assert "--os-grok-code-inline: #ff5667" in css
     assert "--os-grok-link: #4194eb" in css
-    light = css.split('[data-theme="light"]')[1]
+    light_idx = css.index('[data-theme="light"] {\n  --os-chrome-sidebar')
+    light = css[light_idx : light_idx + 400]
     assert "--os-grok-code-inline: #c43d4e" in light
     assert "--os-grok-link: var(--color-primary)" in light
 
@@ -95,11 +97,13 @@ def test_bubbles_still_render_safe_markdown():
     bubble = BUBBLE.read_text(encoding="utf-8")
     agent = AGENT_BUBBLE.read_text(encoding="utf-8")
     md = MARKDOWN.read_text(encoding="utf-8")
+    html_safe = HTML_SAFE.read_text(encoding="utf-8")
     assert "renderSafeMarkdown" in bubble
     assert 'data-testid="chat-md"' in bubble
     assert "chat-md" in bubble
     assert "chat-md" in agent
     assert "os-chat-md" in agent
-    assert "TABLE" in md
-    assert "BLOCKQUOTE" in md
-    assert "HR" in md
+    assert "renderSafeMarkdown" in md
+    assert "TABLE" in html_safe
+    assert "BLOCKQUOTE" in html_safe
+    assert "HR" in html_safe

--- a/webui/frontend/src/components/AgentChat/AgentMessageBubble.tsx
+++ b/webui/frontend/src/components/AgentChat/AgentMessageBubble.tsx
@@ -244,7 +244,7 @@ export function AgentMessageBubble({
             message.text
           ) : (
             <div
-              className="os-chat-md break-words [&_p]:my-1 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-1 [&_ol]:list-decimal [&_ol]:pl-5 [&_a]:underline"
+              className="chat-md os-chat-md break-words [&_p]:my-1 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:my-1 [&_ol]:list-decimal [&_ol]:pl-5 [&_a]:underline"
               dangerouslySetInnerHTML={{ __html: renderSafeMarkdown(message.text) }}
             />
           )}

--- a/webui/frontend/src/components/__tests__/ChatMarkdownTheme.test.tsx
+++ b/webui/frontend/src/components/__tests__/ChatMarkdownTheme.test.tsx
@@ -111,33 +111,40 @@ describe('REQ-804: chat markdown follows data-theme tokens', () => {
     expect(chrome).not.toMatch(/#000(?:000)?\b/i)
   })
 
-  it('renders themed markdown nodes and flips link/code tokens with data-theme', () => {
-    const style = document.createElement('style')
-    style.id = 'os-md-theme-contract'
-    style.textContent = markdownCssContract(css)
-    document.head.appendChild(style)
-
-    const { container, unmount } = render(<ChatBubbleBody text={SAMPLE_MD} streaming={false} />)
+  it('renders markdown nodes that the themed chat-md selectors target', () => {
+    applyResolvedTheme('dark')
+    const { unmount } = render(<ChatBubbleBody text={SAMPLE_MD} streaming={false} />)
     const root = screen.getByTestId('chat-md')
     expect(root).toHaveClass('chat-md')
     expect(root.querySelector('code:not(pre code)')).toBeTruthy()
-    expect(root.querySelector('a')).toBeTruthy()
+    expect(root.querySelector('a')?.getAttribute('href')).toBe('https://example.com/docs')
     expect(root.querySelector('blockquote')).toBeTruthy()
     expect(root.querySelector('table')).toBeTruthy()
     expect(root.querySelector('hr')).toBeTruthy()
     expect(root.querySelector('pre.os-code-python')).toBeTruthy()
-
-    applyResolvedTheme('dark')
-    const darkLink = getComputedStyle(root.querySelector('a')!).color
-    const darkCode = getComputedStyle(root.querySelector('code:not(pre code)')!).color
+    expect(root.querySelector('.os-py-kw')).toBeTruthy()
+    unmount()
 
     applyResolvedTheme('light')
-    const lightLink = getComputedStyle(root.querySelector('a')!).color
-    const lightCode = getComputedStyle(root.querySelector('code:not(pre code)')!).color
+    render(<ChatBubbleBody text={SAMPLE_MD} streaming={false} />)
+    const lightRoot = screen.getByTestId('chat-md')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+    expect(lightRoot).toHaveClass('chat-md')
+    expect(lightRoot.querySelector('table')).toBeTruthy()
+    expect(lightRoot.querySelector('blockquote')).toBeTruthy()
+    expect(lightRoot.querySelector('code:not(pre code)')).toBeTruthy()
+  })
 
-    expect(darkLink).not.toBe(lightLink)
-    expect(darkCode).not.toBe(lightCode)
-    expect(container.querySelector('[data-testid="chat-md"]')).toBeInTheDocument()
-    unmount()
+  it('uses different token values for dark vs light data-theme', () => {
+    const darkInline = css.match(/--os-grok-code-inline:\s*(#[0-9a-fA-F]+)/)?.[1]
+    const lightInline = css.match(
+      /\[data-theme="light"\][\s\S]*?--os-grok-code-inline:\s*(#[0-9a-fA-F]+)/,
+    )?.[1]
+    const darkLink = css.match(/--os-grok-link:\s*(#[0-9a-fA-F]+)/)?.[1]
+    expect(darkInline).toBe('#ff5667')
+    expect(lightInline).toBe('#c43d4e')
+    expect(darkLink).toBe('#4194eb')
+    expect(css).toMatch(/\[data-theme="light"\][\s\S]*--os-grok-link:\s*var\(--color-primary\)/)
+    expect(darkInline).not.toBe(lightInline)
   })
 })

--- a/webui/frontend/src/components/__tests__/ChatMarkdownTheme.test.tsx
+++ b/webui/frontend/src/components/__tests__/ChatMarkdownTheme.test.tsx
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import fs from 'node:fs'
+import path from 'node:path'
+import { ChatBubbleBody } from '../ChatMessageBubble'
+
+const cssPath = path.resolve(__dirname, '../../index.css')
+const css = fs.readFileSync(cssPath, 'utf8')
+
+const SAMPLE_MD = [
+  'Prose with `inline` and a [link](https://example.com/docs).',
+  '',
+  '> quoted note',
+  '',
+  '| Col | Val |',
+  '| --- | --- |',
+  '| a | 1 |',
+  '',
+  '```python',
+  'def hello():',
+  '    return "ok"',
+  '```',
+  '',
+  '---',
+].join('\n')
+
+function markdownCssContract(source: string): string {
+  const start = source.indexOf('/* REQ-804: in-bubble markdown')
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf('/* Large dashboard action cards', start)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+function chromeCssContract(source: string): string {
+  const start = source.indexOf('/* REQ-804: in-bubble chrome')
+  expect(start).toBeGreaterThanOrEqual(0)
+  return source.slice(start)
+}
+
+function applyResolvedTheme(theme: 'light' | 'dark') {
+  document.documentElement.setAttribute('data-theme', theme)
+  if (theme === 'dark') {
+    document.documentElement.style.setProperty('--os-grok-code-inline', '#ff5667')
+    document.documentElement.style.setProperty('--os-grok-link', '#4194eb')
+    document.documentElement.style.setProperty('--color-primary', '#4a6fa5')
+    document.documentElement.style.setProperty('--color-error', '#7a4040')
+    document.documentElement.style.setProperty('--color-base-200', '#101010')
+    document.documentElement.style.setProperty('--color-base-300', '#242424')
+    document.documentElement.style.setProperty('--color-base-content', '#e6e6e6')
+  } else {
+    document.documentElement.style.setProperty('--os-grok-code-inline', '#c43d4e')
+    document.documentElement.style.setProperty('--os-grok-link', '#3d5a80')
+    document.documentElement.style.setProperty('--color-primary', '#3d5a80')
+    document.documentElement.style.setProperty('--color-error', '#7a4040')
+    document.documentElement.style.setProperty('--color-base-200', '#e8e8ea')
+    document.documentElement.style.setProperty('--color-base-300', '#d4d4d8')
+    document.documentElement.style.setProperty('--color-base-content', '#1a1a1a')
+  }
+}
+
+describe('REQ-804: chat markdown follows data-theme tokens', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-theme')
+    document.documentElement.removeAttribute('style')
+    document.getElementById('os-md-theme-contract')?.remove()
+  })
+
+  it('keeps #464 Grok tokens and adds light variants on the same names', () => {
+    expect(css).toContain('--os-grok-code-inline: #ff5667')
+    expect(css).toContain('--os-grok-link: #4194eb')
+    const lightBlock = css.match(/\[data-theme="light"\]\s*\{([^}]+)\}/)
+    expect(lightBlock?.[1]).toContain('--os-grok-code-inline: #c43d4e')
+    expect(lightBlock?.[1]).toContain('--os-grok-link: var(--color-primary)')
+  })
+
+  it('styles markdown chrome with DaisyUI / Grok variables, not bare #fff/#000', () => {
+    const mdCss = markdownCssContract(css)
+    expect(mdCss).toContain('.chat-md a')
+    expect(mdCss).toContain('.os-chat-md a')
+    expect(mdCss).toContain('var(--os-grok-link')
+    expect(mdCss).toContain('.chat-md code:not(pre code)')
+    expect(mdCss).toContain('var(--os-grok-code-inline')
+    expect(mdCss).toContain('.chat-md pre')
+    expect(mdCss).toContain('var(--color-base-300)')
+    expect(mdCss).toContain('.chat-md blockquote')
+    expect(mdCss).toContain('.chat-md table')
+    expect(mdCss).toContain('.chat-md th')
+    expect(mdCss).toContain('.chat-md hr')
+    expect(mdCss).not.toMatch(/#fff(?:fff)?\b/i)
+    expect(mdCss).not.toMatch(/#000(?:000)?\b/i)
+    expect(css).not.toMatch(/\.os-code-python\s*\{[^}]*#101218/)
+    expect(css).not.toMatch(/\.os-code-python\s*\{[^}]*#d6deeb/)
+  })
+
+  it('themes status, prior-history, suggestion, and support chrome with DaisyUI tokens', () => {
+    expect(css).toContain('.os-chat-status')
+    expect(css).toMatch(/\.os-chat-status[\s\S]*?var\(--color-base-content\)/)
+    expect(css).toContain('.os-suggestion-chip')
+    expect(css).toMatch(/\.os-suggestion-chip[\s\S]*?var\(--color-base-content\)/)
+    const chrome = chromeCssContract(css)
+    expect(chrome).toContain('.os-handoff-chip')
+    expect(chrome).toContain('.os-briefing-popover')
+    expect(chrome).toContain('.os-question-card')
+    expect(chrome).toContain('.os-question-choice')
+    expect(chrome).toContain('.os-attach-chip')
+    expect(chrome).toContain('.os-chat-gap')
+    expect(chrome).toContain('.os-chat-new')
+    expect(chrome).toContain('var(--color-base-content)')
+    expect(chrome).not.toMatch(/#fff(?:fff)?\b/i)
+    expect(chrome).not.toMatch(/#000(?:000)?\b/i)
+  })
+
+  it('renders themed markdown nodes and flips link/code tokens with data-theme', () => {
+    const style = document.createElement('style')
+    style.id = 'os-md-theme-contract'
+    style.textContent = markdownCssContract(css)
+    document.head.appendChild(style)
+
+    const { container, unmount } = render(<ChatBubbleBody text={SAMPLE_MD} streaming={false} />)
+    const root = screen.getByTestId('chat-md')
+    expect(root).toHaveClass('chat-md')
+    expect(root.querySelector('code:not(pre code)')).toBeTruthy()
+    expect(root.querySelector('a')).toBeTruthy()
+    expect(root.querySelector('blockquote')).toBeTruthy()
+    expect(root.querySelector('table')).toBeTruthy()
+    expect(root.querySelector('hr')).toBeTruthy()
+    expect(root.querySelector('pre.os-code-python')).toBeTruthy()
+
+    applyResolvedTheme('dark')
+    const darkLink = getComputedStyle(root.querySelector('a')!).color
+    const darkCode = getComputedStyle(root.querySelector('code:not(pre code)')!).color
+
+    applyResolvedTheme('light')
+    const lightLink = getComputedStyle(root.querySelector('a')!).color
+    const lightCode = getComputedStyle(root.querySelector('code:not(pre code)')!).color
+
+    expect(darkLink).not.toBe(lightLink)
+    expect(darkCode).not.toBe(lightCode)
+    expect(container.querySelector('[data-testid="chat-md"]')).toBeInTheDocument()
+    unmount()
+  })
+})

--- a/webui/frontend/src/index.css
+++ b/webui/frontend/src/index.css
@@ -108,6 +108,9 @@ html[data-theme="light"] #root {
 
 [data-theme="light"] {
   --os-chrome-sidebar: #ececee;
+  /* Same #464 token names — light-readable variants, not a second theme system */
+  --os-grok-code-inline: #c43d4e;
+  --os-grok-link: var(--color-primary);
 }
 
 /* REQ-101: Grok colour parity for dark chrome */
@@ -145,18 +148,90 @@ html:not([data-theme="light"]) .os-composer,
   background: var(--os-grok-composer, #262626);
 }
 
-html:not([data-theme="light"]) .chat-md code:not(pre code),
-[data-theme="dark"] .chat-md code:not(pre code),
-html:not([data-theme="light"]) .os-chat-md code:not(pre code),
-[data-theme="dark"] .os-chat-md code:not(pre code) {
-  color: var(--os-grok-code-inline, #ff5667);
+/* REQ-804: in-bubble markdown follows data-theme via DaisyUI / #464 tokens */
+.chat-md,
+.os-chat-md {
+  color: inherit;
 }
 
-html:not([data-theme="light"]) .chat-md a,
-[data-theme="dark"] .chat-md a,
-html:not([data-theme="light"]) .os-chat-md a,
-[data-theme="dark"] .os-chat-md a {
-  color: var(--os-grok-link, #4194eb);
+.chat-md a,
+.os-chat-md a {
+  color: var(--os-grok-link, var(--color-primary));
+}
+
+.chat-md code:not(pre code),
+.os-chat-md code:not(pre code) {
+  color: var(--os-grok-code-inline, var(--color-error));
+  background: color-mix(
+    in srgb,
+    var(--os-grok-code-inline, var(--color-error)) 16%,
+    var(--color-base-200)
+  );
+  padding: 0.08em 0.35em;
+  border-radius: 0.3rem;
+}
+
+.chat-md pre,
+.os-chat-md pre,
+.os-code,
+.os-code-python {
+  background: color-mix(in srgb, var(--color-base-300) 72%, var(--color-base-200));
+  color: var(--color-base-content);
+}
+
+.chat-md blockquote,
+.os-chat-md blockquote {
+  margin: 0.5rem 0;
+  padding: 0.35rem 0.75rem;
+  border-left: 3px solid color-mix(in srgb, var(--color-base-content) 28%, transparent);
+  background: color-mix(in srgb, var(--color-base-content) 5%, transparent);
+  color: color-mix(in srgb, var(--color-base-content) 82%, transparent);
+}
+
+.chat-md hr,
+.os-chat-md hr {
+  border: 0;
+  border-top: 1px solid color-mix(in srgb, var(--color-base-content) 16%, transparent);
+  margin: 0.75rem 0;
+}
+
+.chat-md table,
+.os-chat-md table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.5rem 0;
+}
+
+.chat-md th,
+.chat-md td,
+.os-chat-md th,
+.os-chat-md td {
+  border: 1px solid color-mix(in srgb, var(--color-base-content) 16%, transparent);
+  padding: 0.35rem 0.55rem;
+  text-align: left;
+}
+
+.chat-md th,
+.os-chat-md th {
+  background: color-mix(in srgb, var(--color-base-content) 7%, var(--color-base-200));
+  font-weight: 650;
+}
+
+.chat-md h1,
+.chat-md h2,
+.chat-md h3,
+.chat-md h4,
+.chat-md h5,
+.chat-md h6,
+.os-chat-md h1,
+.os-chat-md h2,
+.os-chat-md h3,
+.os-chat-md h4,
+.os-chat-md h5,
+.os-chat-md h6 {
+  color: inherit;
+  font-weight: 650;
+  margin: 0.65rem 0 0.35rem;
 }
 
 /* Large dashboard action cards — chrome panels, not rainbow buttons */
@@ -848,8 +923,6 @@ button.os-agent-row {
   max-height: min(36rem, 70vh);
   padding: 0.9rem 1rem;
   border-radius: 0.6rem;
-  background: #101218;
-  color: #d6deeb;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.78rem;
   line-height: 1.5;
@@ -858,11 +931,14 @@ button.os-agent-row {
 .os-code-python code {
   font-family: inherit;
 }
-.os-py-kw { color: #c792ea; }
-.os-py-str { color: #c3e88d; }
-.os-py-cmt { color: #697098; font-style: italic; }
-.os-py-num { color: #f78c6c; }
+.os-py-kw { color: #7eb8ff; font-weight: 650; }
+.os-py-str { color: #9ad4a0; }
+.os-py-cmt,
+.os-py-com { color: #8b93a7; font-style: italic; }
+.os-py-num { color: #e0b36a; }
 .os-py-fn { color: #82aaff; }
+.os-py-dec { color: #d7a1ff; }
+.os-py-bi { color: #7fd4d0; }
 
 .os-hidden-bots {
   margin: 0 0.5rem 0.15rem;
@@ -1187,11 +1263,12 @@ pre:focus-within .os-code-copy {
   left: 0;
   right: 0;
   height: 3.5rem;
-  background: linear-gradient(to bottom, transparent, rgba(20, 20, 20, 0.85));
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    color-mix(in srgb, var(--color-base-200) 92%, transparent)
+  );
   pointer-events: none;
-}
-html[data-theme="light"] .os-code--collapsible.os-code--collapsed::after {
-  background: linear-gradient(to bottom, transparent, rgba(240, 240, 240, 0.9));
 }
 .os-code--collapsible.os-code--collapsed .os-code-expand {
   opacity: 0;
@@ -1729,16 +1806,12 @@ html:not([data-theme="light"]) .os-composer__send,
 .os-code-python {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
-.os-py-kw { color: #7eb8ff; font-weight: 650; }
-.os-py-str { color: #9ad4a0; }
-.os-py-com { color: #8b93a7; font-style: italic; }
-.os-py-num { color: #e0b36a; }
-.os-py-dec { color: #d7a1ff; }
-.os-py-bi { color: #7fd4d0; }
 [data-theme="light"] .os-py-kw { color: #1d4f91; }
 [data-theme="light"] .os-py-str { color: #2d6a38; }
+[data-theme="light"] .os-py-cmt,
 [data-theme="light"] .os-py-com { color: #667085; }
 [data-theme="light"] .os-py-num { color: #9a5b10; }
+[data-theme="light"] .os-py-fn { color: #1d4f91; }
 [data-theme="light"] .os-py-dec { color: #7a3ea8; }
 [data-theme="light"] .os-py-bi { color: #0e6e6a; }
 
@@ -1757,4 +1830,113 @@ html:not([data-theme="light"]) .os-composer__send,
   text-align: left;
   font-weight: 550;
   line-height: 1.25;
+  color: var(--color-base-content);
+  background: color-mix(in srgb, var(--color-base-200) 80%, var(--color-base-100));
+  border-color: color-mix(in srgb, var(--color-base-content) 14%, transparent);
+}
+
+/* REQ-804: in-bubble chrome (pills / chips / support cards) uses DaisyUI tokens */
+.os-handoff-chip-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  margin: 0.35rem 0;
+}
+
+.os-handoff-chip,
+.os-question-choice {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--color-base-content) 16%, transparent);
+  background: color-mix(in srgb, var(--color-base-200) 80%, var(--color-base-100));
+  color: color-mix(in srgb, var(--color-base-content) 82%, transparent);
+  padding: 0.28rem 0.7rem;
+  font-size: 0.75rem;
+  line-height: 1.3;
+}
+
+.os-handoff-chip:hover,
+.os-question-choice:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-base-200) 55%, var(--color-base-300));
+  color: var(--color-base-content);
+}
+
+.os-handoff-avatars {
+  display: inline-flex;
+  align-items: center;
+}
+
+.os-handoff-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-base-content) 10%, var(--color-base-300));
+  color: var(--color-base-content);
+  font-size: 0.62rem;
+  font-weight: 700;
+}
+
+.os-briefing-popover,
+.os-question-card {
+  margin-top: 0.35rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--color-base-content) 12%, transparent);
+  background: var(--color-base-100);
+  color: var(--color-base-content);
+}
+
+.os-question-choices,
+.os-support-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.os-question-other-input {
+  background: var(--color-base-200);
+  color: var(--color-base-content);
+  border: 1px solid color-mix(in srgb, var(--color-base-content) 14%, transparent);
+}
+
+.os-attach-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.os-attach-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--color-base-content) 14%, transparent);
+  background: color-mix(in srgb, var(--color-base-200) 80%, var(--color-base-100));
+  color: var(--color-base-content);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+}
+
+.os-chat-gap,
+.os-chat-new {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin: 0.55rem 0;
+  color: color-mix(in srgb, var(--color-base-content) 48%, transparent);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+}
+
+.os-chat-new__rule {
+  flex: 1 1 2rem;
+  max-width: 4rem;
+  border-top: 1px solid color-mix(in srgb, var(--color-base-content) 14%, transparent);
 }

--- a/webui/frontend/src/lib/__tests__/markdown.test.ts
+++ b/webui/frontend/src/lib/__tests__/markdown.test.ts
@@ -34,4 +34,26 @@ describe('renderSafeMarkdown', () => {
     expect(view).toContain('language-python')
     expect(source).toContain('\n')
   })
+
+  it('renders tables, blockquotes, hr, and links for themed chat-md chrome', () => {
+    const view = renderSafeMarkdown(
+      [
+        '> quoted',
+        '',
+        '| Col | Val |',
+        '| --- | --- |',
+        '| a | 1 |',
+        '',
+        'See [docs](https://example.com/path)',
+        '',
+        '---',
+      ].join('\n'),
+    )
+    expect(view).toContain('<blockquote>')
+    expect(view).toContain('<table>')
+    expect(view).toContain('<th>')
+    expect(view).toContain('<td>')
+    expect(view).toContain('<hr>')
+    expect(view).toContain('href="https://example.com/path"')
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #804.

## Intent
When the user switches light / dark / system theme (#479), inline chat content — especially markdown (code blocks, tables, blockquotes, links, prose) and other in-bubble chrome — must follow the active DaisyUI theme. Nothing in the message stream should stay stuck on a fixed dark palette.

## What changed
- Chat markdown (`.chat-md` / `.os-chat-md`) now uses the existing #464 Grok tokens (`--os-grok-code-inline`, `--os-grok-link`) plus DaisyUI `--color-base-*` for fences, tables, hr, blockquotes, and headings.
- Light theme overrides those same token names (no second theme system): coral inline code `#c43d4e`, links `var(--color-primary)`.
- Python fences no longer hard-code `#101218` / `#d6deeb`. Syntax tokens keep dark defaults with explicit light variants, including the highlighter’s `os-py-cmt` class.
- Audited in-bubble chrome and added theme-token styles for status lines (already tokenised), prior-history gap/new markers, suggestion chips, support/handoff chips, briefing popover, question cards, and attach chips.

## Success
1. Toggle Settings (or navbar) theme light ↔ dark: markdown bubbles update (text, code fences, inline code, tables, hr, blockquote, links).
2. Status pills, prior-history markers, suggestion chips, and support cards follow the same tokens.
3. System theme still resolves via existing `theme.ts` (`data-theme` is never `system`).
4. Vitest + Python own-diff contracts lock markdown CSS tokens under `data-theme` / DaisyUI variables; rendered markdown includes table / blockquote / hr / code / link.
5. No secrets. GitHub-only.

## Remaining exceptions (not in-bubble chat markdown)
- Search palette category marks still use tinted hex + `#fff` (not chat chrome).
- Robot avatar SVG highlights stay `#fff` (illustration, not theme chrome).
- Dark Grok user-bubble text `#ffffff` / `#f2f2f2` remains REQ-101 dark-only chrome; light bubbles keep DaisyUI `text-base-content` / `text-neutral-content`.
- Composer send `#fff` on dark is existing chrome, not markdown.

## Constraints
- Builds on #479 theme + #464 chrome colours. No second theme system.
- GitHub-only. No `:8001`. Own-diff CI (Python contract + Vitest CSS/render coverage).

## Owner
Cursor. CoS: Open Swarm.

## Verification
- `npx vitest run` on `ChatMarkdownTheme`, `markdown`, `GrokChromeColours`, `ChatMessageBubble`, `AgentMessageBubble` — 35 passed.
- `uv run pytest tests/unit/test_req804_chat_markdown_theme.py` plus related theme/code-fence contracts — 15 passed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-010c23c1-e30b-41ca-96cd-e79a38762deb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-010c23c1-e30b-41ca-96cd-e79a38762deb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

