### PR TITLE
fix(remotes): stop sending API_AUTH_TOKEN and API_SERVER_KEY to remotes (#611)

### DIFF
--- a/src/swarm/blueprints/agent_router/blueprint_agent_router.py
+++ b/src/swarm/blueprints/agent_router/blueprint_agent_router.py
@@ -821,6 +821,7 @@ Remember to provide a clear, unified response to the user, even when multiple ag
             format_herdr_roster,
             herdr_list_agents,
             resolve_herdr_target,
+            resolve_remote_api_key,
         )
 
         agent_name = getattr(agent, "name", "Remote team")
@@ -835,7 +836,7 @@ Remember to provide a clear, unified response to the user, even when multiple ag
             framework = fid
             overlay = parent_spec_for_framework(fid, getattr(self, "_config", None))
             if overlay:
-                for key in ("base_url", "target", "model", "transport", "name"):
+                for key in ("base_url", "target", "model", "transport", "name", "api_key"):
                     if overlay.get(key):
                         spec[key] = overlay[key]
                 transport = spec.get("transport") or transport
@@ -896,9 +897,12 @@ Remember to provide a clear, unified response to the user, even when multiple ag
             or "default"
         )
         child_id = getattr(agent, "remote_id", None) or spec.get("remote_id") or ""
+        api_key = getattr(agent, "api_key", None) or spec.get("api_key") or None
         if not override and not child_id and (framework or "").lower() == "openmausbot" and base_url:
             try:
-                members = await asyncio.to_thread(discover_http_members, str(base_url), str(framework))
+                members = await asyncio.to_thread(
+                    discover_http_members, str(base_url), str(framework), api_key=api_key
+                )
                 pick = default_remote_member(str(framework), members)
                 if pick:
                     model = pick
@@ -946,8 +950,22 @@ Remember to provide a clear, unified response to the user, even when multiple ag
             for m in messages
             if m.get("content")
         ] or [{"role": "user", "content": user_content}]
+        chat_kwargs: dict[str, Any] = {"model": model}
+        resolved_key = (
+            getattr(agent, "api_key", None)
+            or spec.get("api_key")
+            or resolve_remote_api_key(framework)
+        )
+        if resolved_key:
+            chat_kwargs["api_key"] = resolved_key
         try:
-            text = await asyncio.to_thread(chat_remote, base_url, payload, model=model)
+            text = await asyncio.to_thread(
+                chat_remote,
+                base_url,
+                payload,
+                **chat_kwargs,
+            )
+
         except Exception as exc:
             yield {
                 "content": f"[{agent_name}] Remote team call failed: {exc}",

--- a/src/swarm/core/remote_teams.py
+++ b/src/swarm/core/remote_teams.py
@@ -142,6 +142,36 @@ def completions_url(base_url: str) -> str:
     return url + "/v1/chat/completions"
 
 
+def resolve_remote_api_key(
+    framework: str | None = None,
+    config: dict[str, Any] | None = None,
+) -> str | None:
+    """Resolve API key for a remote framework.
+
+    Checks per-remote config/env (remotes.<id>.api_key or <ID>_API_KEY),
+    falling back to REMOTE_TEAM_API_KEY. Never falls back to API_AUTH_TOKEN
+    or API_SERVER_KEY (REQ-171C-2 / C-H3).
+    """
+    if framework:
+        fid = normalize_framework(framework) or framework.strip().lower()
+        if isinstance(config, dict):
+            rt_block = config.get("remote_teams")
+            if isinstance(rt_block, dict):
+                fw_cfg = rt_block.get(framework) or rt_block.get(fid)
+                if isinstance(fw_cfg, dict) and fw_cfg.get("api_key"):
+                    return str(fw_cfg["api_key"]).strip()
+        try:
+            from swarm.core.remotes import load_remote
+
+            spec = load_remote(fid, config=config)
+            if spec.api_key:
+                return spec.api_key
+        except Exception:
+            pass
+    token = os.getenv("REMOTE_TEAM_API_KEY")
+    return token.strip() if token else None
+
+
 def chat_remote(
     base_url: str,
     messages: list[dict[str, Any]],
@@ -149,15 +179,17 @@ def chat_remote(
     model: str = "default",
     timeout: float = 60.0,
     api_key: str | None = None,
+    framework: str | None = None,
 ) -> str:
     """POST OpenAI-style chat completions to a remote agentic team."""
     endpoint = completions_url(base_url)
     payload = json.dumps({"model": model or "default", "messages": messages}).encode("utf-8")
     headers = {"Content-Type": "application/json", "Accept": "application/json"}
-    token = api_key or os.getenv("REMOTE_TEAM_API_KEY") or os.getenv("API_AUTH_TOKEN")
+    token = api_key or resolve_remote_api_key(framework)
     if token:
         headers["Authorization"] = f"Bearer {token}"
     req = urllib.request.Request(endpoint, data=payload, headers=headers, method="POST")
+
     opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
     try:
         with opener.open(req, timeout=timeout) as resp:
@@ -244,6 +276,8 @@ def listed_remote_specs(
             base["target"] = str(overlay["target"])[:64]
         if overlay.get("specialty"):
             base["specialty"] = str(overlay["specialty"])[:160]
+        if overlay.get("api_key"):
+            base["api_key"] = str(overlay["api_key"]).strip()
         specs[fid] = base
     for fid, spec in specs.items():
         _apply_runtime_overlay(fid, spec)
@@ -303,7 +337,7 @@ def _hermes_fleet_url() -> str:
 
 
 def _apply_runtime_overlay(fid: str, spec: dict[str, Any]) -> None:
-    """Fill empty base_url/target from env (and Hermes fleet), never invent TBD ports."""
+    """Fill empty base_url/target/api_key from env/remotes config, never invent TBD ports."""
     if not spec.get("base_url"):
         raw = _env_first(*(_ENV_URLS.get(fid) or ()))
         if raw:
@@ -325,6 +359,11 @@ def _apply_runtime_overlay(fid: str, spec: dict[str, Any]) -> None:
         target = _env_first(*(_ENV_TARGETS.get(fid) or ()))
         if target:
             spec["target"] = target[:64]
+    if not spec.get("api_key"):
+        api_key = resolve_remote_api_key(fid)
+        if api_key:
+            spec["api_key"] = api_key
+
 
 
 def persist_remote_overlay(spec: dict[str, Any]) -> None:
@@ -503,9 +542,15 @@ def _members_from_list(items: list[Any]) -> list[dict[str, str]]:
     return out
 
 
-def _http_get_json(url: str, *, timeout: float = _DISCOVERY_TIMEOUT_S) -> Any:
+def _http_get_json(
+    url: str,
+    *,
+    timeout: float = _DISCOVERY_TIMEOUT_S,
+    api_key: str | None = None,
+    framework: str | None = None,
+) -> Any:
     headers = {"Accept": "application/json"}
-    token = os.getenv("REMOTE_TEAM_API_KEY") or os.getenv("API_AUTH_TOKEN") or os.getenv("API_SERVER_KEY")
+    token = api_key or resolve_remote_api_key(framework)
     if token:
         headers["Authorization"] = f"Bearer {token}"
     req = urllib.request.Request(url, headers=headers, method="GET")
@@ -514,13 +559,19 @@ def _http_get_json(url: str, *, timeout: float = _DISCOVERY_TIMEOUT_S) -> Any:
         return json.loads(resp.read().decode("utf-8"))
 
 
-def discover_http_members(base_url: str, framework: str) -> list[dict[str, str]]:
+def discover_http_members(
+    base_url: str,
+    framework: str,
+    *,
+    api_key: str | None = None,
+) -> list[dict[str, str]]:
     """Live agents/models/bots from an HTTP remote. Empty on any failure."""
     try:
         origin = origin_from_base_url(base_url)
     except ValueError:
         return []
-    cache_key = f"{framework}|{origin}"
+    token = api_key or resolve_remote_api_key(framework)
+    cache_key = f"{framework}|{origin}|{token or ''}"
     now = time.time()
     hit = _DISCOVERY_CACHE.get(cache_key)
     if hit and now - hit[0] < _DISCOVERY_TTL_S:
@@ -530,7 +581,7 @@ def discover_http_members(base_url: str, framework: str) -> list[dict[str, str]]
     for path in paths:
         url = origin + path
         try:
-            body = _http_get_json(url)
+            body = _http_get_json(url, api_key=token, framework=framework)
         except Exception:
             continue
         members = parse_remote_catalog(body)
@@ -563,7 +614,16 @@ def expand_remote_members(parents: list[dict[str, Any]]) -> list[dict[str, Any]]
                     "description": str(row.get("cwd") or row.get("agent_status") or ""),
                 })
         elif parent.get("base_url"):
-            children = discover_http_members(str(parent["base_url"]), fid)
+            api_key = parent.get("api_key")
+            if api_key:
+                try:
+                    children = discover_http_members(str(parent["base_url"]), fid, api_key=api_key)
+                except TypeError:
+                    children = discover_http_members(str(parent["base_url"]), fid)
+            else:
+                children = discover_http_members(str(parent["base_url"]), fid)
+
+
         if not children:
             continue
         names = ", ".join(c["name"] for c in children[:6])

--- a/tests/core/test_remote_teams.py
+++ b/tests/core/test_remote_teams.py
@@ -279,3 +279,92 @@ def test_chat_remote_parses_openai_payload():
     with patch("swarm.core.remote_teams.urllib.request.build_opener", return_value=_Opener()):
         text = chat_remote("http://127.0.0.1:9/v1", [{"role": "user", "content": "hi"}])
     assert text == "hello from hermes"
+
+
+def test_remote_auth_never_leaks_api_auth_token_or_api_server_key(monkeypatch):
+    """REQ-171C-2 / C-H3: chat_remote / _http_get_json never leak API_AUTH_TOKEN or API_SERVER_KEY."""
+    from swarm.core.remote_teams import _http_get_json, chat_remote
+
+    monkeypatch.setenv("API_AUTH_TOKEN", "super-secret-local-token")
+    monkeypatch.setenv("API_SERVER_KEY", "super-secret-server-key")
+    monkeypatch.delenv("REMOTE_TEAM_API_KEY", raising=False)
+    monkeypatch.delenv("HERMES_API_KEY", raising=False)
+    monkeypatch.delenv("OMB_API_KEY", raising=False)
+
+    captured_reqs = []
+
+    class _Resp:
+        def read(self):
+            return b'{"choices": [{"message": {"content": "ok"}}]}'
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    class _Opener:
+        def open(self, req, timeout=0):
+            captured_reqs.append(req)
+            return _Resp()
+
+    with patch("swarm.core.remote_teams.urllib.request.build_opener", return_value=_Opener()):
+        chat_remote("http://127.0.0.1:9/v1", [{"role": "user", "content": "hi"}])
+        assert len(captured_reqs) == 1
+        assert not captured_reqs[0].has_header("Authorization")
+
+        captured_reqs.clear()
+        _http_get_json("http://127.0.0.1:9/v1/models")
+        assert len(captured_reqs) == 1
+        assert not captured_reqs[0].has_header("Authorization")
+
+
+def test_remote_auth_uses_per_remote_key_and_remote_team_api_key(monkeypatch):
+    """REQ-171C-2 / C-H3: chat_remote / _http_get_json use per-remote or REMOTE_TEAM_API_KEY only."""
+    from swarm.core.remote_teams import _http_get_json, chat_remote, discover_http_members
+
+    monkeypatch.delenv("API_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("API_SERVER_KEY", raising=False)
+    monkeypatch.delenv("REMOTE_TEAM_API_KEY", raising=False)
+    monkeypatch.setenv("HERMES_API_KEY", "hermes-secret-key")
+
+    captured_reqs = []
+
+    class _Resp:
+        def read(self):
+            return b'{"choices": [{"message": {"content": "ok"}}], "data": []}'
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    class _Opener:
+        def open(self, req, timeout=0):
+            captured_reqs.append(req)
+            return _Resp()
+
+    with patch("swarm.core.remote_teams.urllib.request.build_opener", return_value=_Opener()):
+        # 1. Per-remote key via framework resolution
+        chat_remote("http://127.0.0.1:9/v1", [{"role": "user", "content": "hi"}], framework="hermes")
+        assert captured_reqs[-1].get_header("Authorization") == "Bearer hermes-secret-key"
+
+        _http_get_json("http://127.0.0.1:9/v1/models", framework="hermes")
+        assert captured_reqs[-1].get_header("Authorization") == "Bearer hermes-secret-key"
+
+        discover_http_members("http://127.0.0.1:9/v1", "hermes")
+        assert captured_reqs[-1].get_header("Authorization") == "Bearer hermes-secret-key"
+
+        # 2. Explicit api_key parameter overrides framework/env
+        chat_remote("http://127.0.0.1:9/v1", [{"role": "user", "content": "hi"}], api_key="explicit-key")
+        assert captured_reqs[-1].get_header("Authorization") == "Bearer explicit-key"
+
+        _http_get_json("http://127.0.0.1:9/v1/models", api_key="explicit-json-key")
+        assert captured_reqs[-1].get_header("Authorization") == "Bearer explicit-json-key"
+
+        # 3. REMOTE_TEAM_API_KEY fallback when no per-remote key
+        monkeypatch.delenv("HERMES_API_KEY", raising=False)
+        monkeypatch.setenv("REMOTE_TEAM_API_KEY", "generic-team-key")
+        chat_remote("http://127.0.0.1:9/v1", [{"role": "user", "content": "hi"}])
+        assert captured_reqs[-1].get_header("Authorization") == "Bearer generic-team-key"
+
+        _http_get_json("http://127.0.0.1:9/v1/models")
+        assert captured_reqs[-1].get_header("Authorization") == "Bearer generic-team-key"
+


### PR DESCRIPTION
Resolves #611 (REQ-171C-2 / C-H3).

### Changes
- Updated `chat_remote` and `_http_get_json` in `src/swarm/core/remote_teams.py` to never fall back to `API_AUTH_TOKEN` or `API_SERVER_KEY`.
- Introduced `resolve_remote_api_key` helper to resolve credentials exclusively from per-remote configuration (`remotes.<id>.api_key`, `remote_teams.<id>.api_key`, or `<ID>_API_KEY`) or `REMOTE_TEAM_API_KEY`.
- Updated `discover_http_members` and `expand_remote_members` to pass per-remote credentials.
- Updated `src/swarm/blueprints/agent_router/blueprint_agent_router.py` to pass resolved API credentials for remote agents.
- Added tests in `tests/core/test_remote_teams.py` verifying `Authorization` headers are absent when unset and equal per-remote keys when configured.