### PR TITLE
test: align REQ-132 remotes contract with cascading picker

### DIFF
--- a/tests/unit/test_req132_remotes_dropdown_scope.py
+++ b/tests/unit/test_req132_remotes_dropdown_scope.py
@@ -15,11 +15,13 @@ def test_chat_page_guards_remotes_dropdown():
     # Post-#749: remotes chrome is remote-only (agent or remote-backed team).
     assert "showRemotesControl = isRemoteAgent || isRemoteBackedTeam" in tsx
 
-    # Empty catalog shows Add remote; otherwise RemoteSelect; omitted when not remote.
+    # Empty catalog shows Add remote; otherwise the REQ-200 picker; omitted when not remote.
     assert "showEmptyRemoteChrome" in tsx
     assert "{showEmptyRemoteChrome ? (" in tsx
     assert "showRemotesControl ? (" in tsx
-    assert "<RemoteSelect" in tsx
+    assert "<RemoteSelect" not in tsx
+    assert "NavbarRoutingPicker" in tsx
+    assert 'seatKind="remote"' in tsx
     assert ") : null}" in tsx
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Python Tests on the #809 picker branch failed because `test_req132_remotes_dropdown_scope` still required `<RemoteSelect` in `ChatPage.tsx`. Remotes chrome is now the same cascading `NavbarRoutingPicker` (`seatKind="remote"`). The remote-only guard is unchanged.

Related: #809 / #676.

## Test plan

- `uv run pytest tests/unit/test_req132_remotes_dropdown_scope.py tests/unit/test_req200_navbar_cascade.py tests/unit/test_req133_cli_api_dropdowns_models.py tests/unit/test_req186_navbar_dropdown.py --no-cov`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e14fa85d-70f3-4551-937f-f1b5e07480ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e14fa85d-70f3-4551-937f-f1b5e07480ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

