### PR TITLE
test: retarget REQ-72 plugins chrome contracts after #805

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **REQ-72 plugins chrome contracts after #805:** Source-string tests lock the Plugins search overlay (`PluginsPopup`, honest “No tools.” / Manage empty copy) instead of the retired “No plugins installed.” dialog. Unblocks Python Tests on main after #816.
 - **Inline chat markdown follows light/dark theme:** Code fences, inline code, tables, blockquotes, links, and other in-bubble chrome (status/history pills, suggestion chips, support cards) use DaisyUI / #464 Grok tokens instead of a stuck dark palette. Fixes #804.
 
 ### Added

--- a/tests/unit/test_req72_chrome_contracts.py
+++ b/tests/unit/test_req72_chrome_contracts.py
@@ -52,12 +52,14 @@ def test_chat_page_support_default_and_manage_teams():
     assert "Compact failed" in src
 
 
-def test_sidebar_team_hide_id_and_plugins_empty_copy():
-    """#342 team hide uses teamHideId; #322 Plugins dialog is empty; REQ-82 menu labels."""
+def test_sidebar_team_hide_id_and_plugins_popup():
+    """#342 team hide uses teamHideId; #805 Plugins mounts PluginsPopup; REQ-82 menu labels."""
     src = SIDEBAR.read_text(encoding="utf-8")
     menu = RAIL_MENU.read_text(encoding="utf-8")
     assert "teamHideId(team.id)" in src
-    assert "No plugins installed." in src
+    assert "<PluginsPopup" in src
+    assert "pluginsOpen" in src
+    assert "No plugins installed." not in src
     assert 'aria-label="Open agents sidebar"' not in src  # REQ-54: hamburger removed
     # Unpin / Delete / Edit live in the menu builder, not inline rail JSX.
     assert "id: 'unpin', label: 'Unpin'" in menu

--- a/tests/unit/test_req72_shipped_chrome.py
+++ b/tests/unit/test_req72_shipped_chrome.py
@@ -12,6 +12,7 @@ SPA_APP = REPO / "webui" / "frontend" / "src" / "App.tsx"
 SETTINGS_SHEET = REPO / "webui" / "frontend" / "src" / "components" / "SettingsSheet.tsx"
 REMOTES_LIB = REPO / "webui" / "frontend" / "src" / "lib" / "remotes.ts"
 SIDEBAR = REPO / "webui" / "frontend" / "src" / "components" / "AgentSidebar.tsx"
+PLUGINS_POPUP = REPO / "webui" / "frontend" / "src" / "components" / "PluginsPopup.tsx"
 SEARCH = REPO / "webui" / "frontend" / "src" / "components" / "SearchPalette.tsx"
 DJANGO_SETTINGS = REPO / "src" / "swarm" / "templates" / "settings_dashboard.html"
 DJANGO_SIDEBAR = REPO / "src" / "swarm" / "static" / "js" / "agent_sidebar.js"
@@ -44,11 +45,21 @@ def test_settings_remotes_are_opt_in_not_live_lan():
 
 
 def test_rail_plugins_overlay_is_empty_honest():
-    """#322: Plugins is an overlay with an empty-state, not a live LAN catalog."""
+    """#805: Plugins is a search overlay with honest empty copy, not a live LAN catalog."""
     sidebar = SIDEBAR.read_text(encoding="utf-8")
-    assert "No plugins installed." in sidebar
-    assert 'aria-labelledby="os-plugins-title"' in sidebar
+    popup = PLUGINS_POPUP.read_text(encoding="utf-8")
+    assert "<PluginsPopup" in sidebar
     assert "pluginsOpen" in sidebar
+    assert 'data-testid="os-plugins-overlay"' in popup
+    assert 'aria-label="Plugins"' in popup
+    assert "No tools." in popup
+    assert "Connect a server in Manage…" in popup
+    assert "Showing the shipped catalog until MCP servers are connected." in popup
+    assert "No plugins installed." not in sidebar
+    assert "No plugins installed." not in popup
+    assert 'aria-labelledby="os-plugins-title"' not in sidebar
+    assert 'aria-labelledby="os-plugins-title"' not in popup
+    assert ":8001" not in popup
 
 
 def test_search_palette_has_bots_and_actions_tabs():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Python Tests on `main` (3.10 / 3.11 / 3.12) failed after #816 because two REQ-72 source-string contracts still expected the retired rail dialog copy `No plugins installed.`

This retargets those contracts to the shipped #805 Plugins search overlay:

- Sidebar mounts `<PluginsPopup` / `pluginsOpen` (not the old empty dialog).
- Overlay locks honest empty copy (`No tools.`, `Connect a server in Manage…`) plus the fixture-catalog degrade line.
- Still forbids a live LAN catalog (`:8001`) and the old `os-plugins-title` labelled dialog.

REQ-132 `<RemoteSelect` was already aligned on `main` by #818.

## Test plan

- [x] `uv run pytest tests/unit/test_req72_chrome_contracts.py tests/unit/test_req72_shipped_chrome.py tests/unit/test_req132_remotes_dropdown_scope.py tests/core/test_chat_plugin_tools.py`
- [ ] Confirm Python Tests matrix is green on this branch

Related: #805 / #816

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22e93299-8977-40c2-9714-87c95e6282a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22e93299-8977-40c2-9714-87c95e6282a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

