### PR TITLE
test: isolate custom-blueprint fixture so empty-list matrix stays green

### DIFF
--- a/tests/api/test_blueprint_personas.py
+++ b/tests/api/test_blueprint_personas.py
@@ -1,5 +1,6 @@
 """GET /v1/blueprints/<id>/personas — declared roster (REQ-81). No live host."""
 
+import uuid
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,22 @@ FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "openai_agents_per
 @pytest.fixture
 def api_client():
     return APIClient()
+
+
+@pytest.fixture
+def isolated_custom_blueprint(tmp_path, monkeypatch):
+    """Isolate custom-blueprint create/teardown (unique tmp library + registry)."""
+    from swarm.views import api_views
+    from swarm.views import blueprint_library_views as lib
+
+    monkeypatch.setattr(lib, "get_user_config_dir_for_swarm", lambda: tmp_path)
+    api_views._custom_blueprints_registry.clear()
+    yield tmp_path
+    api_views._custom_blueprints_registry.clear()
+
+
+def _unique_blueprint_name(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
 
 
 def test_personas_urls_accept_trailing_slash():
@@ -33,23 +50,21 @@ def test_software_dev_personas_are_three_named_seats(api_client):
 
 
 @pytest.mark.django_db
-def test_custom_three_agent_fixture_via_api(api_client, tmp_path, monkeypatch):
-    from swarm.views import blueprint_library_views as lib
-
-    monkeypatch.setattr(lib, "get_user_config_dir_for_swarm", lambda: tmp_path)
-
+def test_custom_three_agent_fixture_via_api(api_client, isolated_custom_blueprint):
     code = (FIXTURES / "three_agents.py").read_text(encoding="utf-8")
+    name = _unique_blueprint_name("req81_triad")
     created = api_client.post(
         "/v1/blueprints/custom/",
         {
-            "name": "triad",
+            "name": name,
             "description": "REQ-81 fixture",
             "code": code,
         },
         format="json",
     )
     assert created.status_code == 201
-    resp = api_client.get("/v1/blueprints/triad/personas")
+    bp_id = created.json()["id"]
+    resp = api_client.get(f"/v1/blueprints/{bp_id}/personas")
     assert resp.status_code == 200
     data = resp.json()
     assert data["count"] == 3
@@ -57,26 +72,50 @@ def test_custom_three_agent_fixture_via_api(api_client, tmp_path, monkeypatch):
 
 
 @pytest.mark.django_db
-def test_garbage_custom_blueprint_is_one_generic(api_client, tmp_path, monkeypatch):
-    from swarm.views import blueprint_library_views as lib
-
-    monkeypatch.setattr(lib, "get_user_config_dir_for_swarm", lambda: tmp_path)
-
+def test_garbage_custom_blueprint_is_one_generic(api_client, isolated_custom_blueprint):
+    name = _unique_blueprint_name("req81_junk")
     created = api_client.post(
         "/v1/blueprints/custom/",
         {
-            "name": "junk",
+            "name": name,
             "code": (FIXTURES / "garbage.py").read_text(encoding="utf-8"),
         },
         format="json",
     )
     assert created.status_code == 201
-    resp = api_client.get("/v1/blueprints/junk/personas")
+    bp_id = created.json()["id"]
+    resp = api_client.get(f"/v1/blueprints/{bp_id}/personas")
     assert resp.status_code == 200
     data = resp.json()
     assert data["count"] == 1
     assert data["personas"] == []
     assert "FakeInvented" not in str(data)
+
+
+@pytest.mark.django_db
+def test_custom_fixture_teardown_leaves_empty_custom_list(api_client, isolated_custom_blueprint):
+    """#826: leftover create must not fill GET /v1/blueprints/custom/ when empty."""
+    from unittest.mock import patch
+
+    from swarm.views import api_views
+
+    created = api_client.post(
+        "/v1/blueprints/custom/",
+        {
+            "name": _unique_blueprint_name("req81_leak"),
+            "code": "# isolated",
+        },
+        format="json",
+    )
+    assert created.status_code == 201
+    api_views._custom_blueprints_registry.clear()
+    with patch(
+        "swarm.views.api_views.get_user_blueprint_library",
+        return_value={"installed": [], "custom": []},
+    ):
+        resp = api_client.get("/v1/blueprints/custom/")
+    assert resp.status_code == 200
+    assert resp.json() == {"object": "list", "data": []}
 
 
 @pytest.mark.django_db

--- a/tests/api/test_blueprint_personas.py
+++ b/tests/api/test_blueprint_personas.py
@@ -50,7 +50,8 @@ def test_software_dev_personas_are_three_named_seats(api_client):
 
 
 @pytest.mark.django_db
-def test_custom_three_agent_fixture_via_api(api_client, isolated_custom_blueprint):
+@pytest.mark.usefixtures("isolated_custom_blueprint")
+def test_custom_three_agent_fixture_via_api(api_client):
     code = (FIXTURES / "three_agents.py").read_text(encoding="utf-8")
     name = _unique_blueprint_name("req81_triad")
     created = api_client.post(
@@ -72,7 +73,8 @@ def test_custom_three_agent_fixture_via_api(api_client, isolated_custom_blueprin
 
 
 @pytest.mark.django_db
-def test_garbage_custom_blueprint_is_one_generic(api_client, isolated_custom_blueprint):
+@pytest.mark.usefixtures("isolated_custom_blueprint")
+def test_garbage_custom_blueprint_is_one_generic(api_client):
     name = _unique_blueprint_name("req81_junk")
     created = api_client.post(
         "/v1/blueprints/custom/",
@@ -93,7 +95,8 @@ def test_garbage_custom_blueprint_is_one_generic(api_client, isolated_custom_blu
 
 
 @pytest.mark.django_db
-def test_custom_fixture_teardown_leaves_empty_custom_list(api_client, isolated_custom_blueprint):
+@pytest.mark.usefixtures("isolated_custom_blueprint")
+def test_custom_fixture_teardown_leaves_empty_custom_list(api_client):
     """#826: leftover create must not fill GET /v1/blueprints/custom/ when empty."""
     from unittest.mock import patch
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,21 @@ def isolate_swarm_chat_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("SWARM_CHAT_DIR", str(tmp_path / "chats"))
 
 
+@pytest.fixture(autouse=True)
+def isolate_custom_blueprint_registry():
+    """Keep leftover custom-blueprint POSTs from poisoning empty-list / matrix tests.
+
+    CustomBlueprintsView writes a process-global `_custom_blueprints_registry`
+    fallback. A prior create (e.g. REQ-81 fixture) must not fill GET
+    `/v1/blueprints/custom/` when the library is empty.
+    """
+    from swarm.views import api_views
+
+    api_views._custom_blueprints_registry.clear()
+    yield
+    api_views._custom_blueprints_registry.clear()
+
+
 # --- Fixtures ---
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Stop leftover custom-blueprint fixtures from leaking into empty-list / matrix tests after team blueprint Edit work (#433 / #824).

`POST /v1/blueprints/custom/` writes a process-global `_custom_blueprints_registry` fallback. REQ-81 persona tests created `triad` / `junk` and left them there. Later `test_list_custom_blueprints_empty` mocks an empty library, then GET falls back to that leftover — matrix red.

## What changed

Test-only. No product UI / #824 code.

- Autouse teardown of `_custom_blueprints_registry` in `tests/conftest.py` so one create cannot poison another test.
- REQ-81 custom-blueprint POSTs use a unique name, tmp library, and explicit registry cleanup.
- Own-diff lock: create then empty-list GET is `{"object": "list", "data": []}`.

## Tests

Own-diff, GitHub-only, no live host, no `:8001`, no secrets.

**Before (leak order on main):** create `junk` then empty-list → `assert 1 == 0` (leftover garbage fixture).

**After:** 22 passed, including the same leak-order trio:

- `tests/api/test_blueprint_personas.py` (9)
- `TestCustomBlueprintsView` including `test_list_custom_blueprints_empty`
- empty-list cousins: library / teams / models
- `test_custom_fixture_teardown_leaves_empty_custom_list`

`ruff check tests/api/test_blueprint_personas.py` clean.

## Constraints

- Distinct from product Success of #433 / #824.
- Tiny CI hygiene only.

Fixes #826.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48aa5d45-6f1e-47b8-a747-504f432a2d94?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48aa5d45-6f1e-47b8-a747-504f432a2d94&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

