### PR TITLE
Fix favourite and Alt+1–9 pins to honour team and remote ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - **REQ-81 team blueprint Edit + declared roster:** Team editor (rail Edit Profile / chat header) has **Edit blueprint…** and opens Settings → Blueprints with that team’s recipe selected. Chat stays mounted; the Teams drop-zone is not opened. A static (no-exec) parse of openai-agents `Agent(...)` / `make_agent` / `_make_agent` returns count + names. The rail row and team pane show that many faces (initials or avatars). Unknown / unparsable source is one generic face and no invented names. Distinct from the live working stack. Fixes #433.
 
 ### Fixed
+- **REQ-171B favourite / Alt+1–9 kind hrefs:** Pinning a team or remote opens `?team=` / `?remote=` instead of `?blueprint=team%3Ademo`. Herdr pins still go to `/teams/#herdr-members`. Tests pin each kind and assert href. Fixes #608.
 - **REQ-72 plugins chrome contracts after #805:** Source-string tests lock the Plugins search overlay (`PluginsPopup`, honest “No tools.” / Manage empty copy) instead of the retired “No plugins installed.” dialog. Unblocks Python Tests on main after #816.
 - **Inline chat markdown follows light/dark theme:** Code fences, inline code, tables, blockquotes, links, and other in-bubble chrome (status/history pills, suggestion chips, support cards) use DaisyUI / #464 Grok tokens instead of a stuck dark palette. Fixes #804.
 

--- a/webui/frontend/src/components/AgentPinGrid.tsx
+++ b/webui/frontend/src/components/AgentPinGrid.tsx
@@ -13,9 +13,12 @@ import {
   unpinAgent,
   type PinnedAgent,
 } from '../lib/pinnedAgents'
+import { chatHrefForRowId } from '../lib/agentNotifications'
+import { isHerdrAgent } from '../lib/railHotkeys'
 
-function chatHref(id: string): string {
-  return `/chat?blueprint=${encodeURIComponent(id)}`
+function pinHref(id: string): string {
+  if (isHerdrAgent({ id })) return '/teams/#herdr-members'
+  return chatHrefForRowId(id)
 }
 
 export default function AgentPinGrid() {
@@ -92,7 +95,7 @@ export default function AgentPinGrid() {
         return (
           <div key={pin.id} className={`os-agent-tile ${active ? 'is-active' : ''}`}>
             <Link
-              to={chatHref(pin.id)}
+              to={pinHref(pin.id)}
               className="os-agent-tile__link"
               aria-current={active ? 'page' : undefined}
             >

--- a/webui/frontend/src/components/__tests__/AgentPinGrid.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentPinGrid.test.tsx
@@ -138,6 +138,32 @@ describe('AgentPinGrid drag-to-pin', () => {
     ])
   })
 
+  it('REQ-171B: pins of each kind use kind-aware hrefs', async () => {
+    localStorage.setItem(
+      PINNED_AGENTS_STORAGE_KEY,
+      JSON.stringify([
+        { id: 'codey', name: 'Codey' },
+        { id: 'team:demo', name: 'Demo' },
+        { id: 'remote:omb', name: 'OpenMousBot' },
+        { id: 'herdr:w3:p1', name: 'w3:p1' },
+      ]),
+    )
+    renderChrome()
+
+    const grid = screen.getByTestId('agent-pin-grid')
+    const codey = await within(grid).findByRole('link', { name: /Codey/ })
+    const team = within(grid).getByRole('link', { name: /Demo/ })
+    const remote = within(grid).getByRole('link', { name: /OpenMousBot/ })
+    const herdr = within(grid).getByRole('link', { name: /w3:p1/ })
+
+    expect(codey).toHaveAttribute('href', '/chat?blueprint=codey')
+    expect(team).toHaveAttribute('href', '/chat?team=demo')
+    expect(team.getAttribute('href')).not.toMatch(/blueprint=/)
+    expect(remote).toHaveAttribute('href', '/chat?remote=omb')
+    expect(remote.getAttribute('href')).not.toMatch(/blueprint=/)
+    expect(herdr).toHaveAttribute('href', '/teams/#herdr-members')
+  })
+
   it('restores tiles from localStorage and lets the user remove one', async () => {
     localStorage.setItem(
       PINNED_AGENTS_STORAGE_KEY,

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -1596,6 +1596,155 @@ describe('AgentSidebar favourites grid (REQ-94)', () => {
   })
 })
 
+describe('AgentSidebar favourite kind hrefs (REQ-171B #608)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    rememberEmptyFavourites()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('/v1/preferences')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'user_preferences',
+              empty: true,
+              favourites: [],
+              hidden_agents: [],
+            }),
+          } as Response
+        }
+        if (url.includes('team_rosters') || url.includes('team-rosters')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'list',
+              data: [
+                {
+                  id: 'demo',
+                  object: 'team_roster',
+                  name: 'Demo',
+                  description: 'Example roster',
+                  members: [{ id: 'codey', name: 'Codey', kind: 'agent', role: 'coder' }],
+                },
+              ],
+            }),
+          } as Response
+        }
+        if (url.includes('/v1/remotes') || url.includes('remotes_catalog')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'list',
+              data: [
+                {
+                  id: 'omb',
+                  title: 'OpenMousBot',
+                  configured: true,
+                  agents: [],
+                },
+              ],
+            }),
+          } as Response
+        }
+        if (url.includes('/v1/herdr-agents')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'list',
+              data: [
+                {
+                  id: 1,
+                  object: 'herdr.agent',
+                  kind: 'herdr',
+                  name: 'w3:p1',
+                  remote: '',
+                  created_at: '2026-09-03T00:00:00Z',
+                  updated_at: '2026-09-03T00:00:00Z',
+                },
+              ],
+            }),
+          } as Response
+        }
+        if (url.includes('/v1/cli-agents')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              clis: [],
+              native_consensus: {},
+              catalog: {},
+              rail: [],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ object: 'list', data: blueprints }),
+        } as Response
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    localStorage.clear()
+  })
+
+  it('pins blueprint / team / remote / herdr and uses kind-aware hrefs', async () => {
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const codey = await within(list).findByRole('link', { name: /Codey/ })
+    const team = await within(list).findByRole('link', { name: /Demo \(team\)/ })
+    const remote = await within(list).findByRole('link', { name: /OpenMousBot \(remote\)/ })
+    const herdr = await within(list).findByRole('link', { name: /w3:p1/ })
+    const grid = screen.getByTestId('agent-fav-grid')
+
+    fireEvent.contextMenu(codey)
+    fireEvent.click(await screen.findByRole('menuitem', { name: /^Pin$/i }))
+    fireEvent.contextMenu(team)
+    fireEvent.click(await screen.findByRole('menuitem', { name: /^Pin$/i }))
+    fireEvent.contextMenu(remote)
+    fireEvent.click(await screen.findByRole('menuitem', { name: /^Pin$/i }))
+    fireEvent.contextMenu(herdr)
+    fireEvent.click(await screen.findByRole('menuitem', { name: /^Pin$/i }))
+
+    const codeyTile = await within(grid).findByRole('link', { name: 'Codey' })
+    const teamTile = within(grid).getByRole('link', { name: 'Demo' })
+    const remoteTile = within(grid).getByRole('link', { name: 'OpenMousBot' })
+    const herdrTile = within(grid).getByRole('link', { name: 'w3:p1' })
+
+    expect(codeyTile).toHaveAttribute('href', '/chat?blueprint=codey')
+    expect(teamTile).toHaveAttribute('href', '/chat?team=demo')
+    expect(teamTile.getAttribute('href')).not.toMatch(/blueprint=/)
+    expect(remoteTile).toHaveAttribute('href', '/chat?remote=omb')
+    expect(remoteTile.getAttribute('href')).not.toMatch(/blueprint=/)
+    expect(herdrTile).toHaveAttribute('href', '/teams/#herdr-members')
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '2', altKey: true, bubbles: true, cancelable: true }),
+      )
+    })
+    expect(screen.getByTestId('os-test-search')).toHaveTextContent('team=demo')
+    expect(screen.getByTestId('os-test-search')).not.toHaveTextContent('blueprint=')
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '3', altKey: true, bubbles: true, cancelable: true }),
+      )
+    })
+    expect(screen.getByTestId('os-test-search')).toHaveTextContent('remote=omb')
+    expect(screen.getByTestId('os-test-search')).not.toHaveTextContent('blueprint=')
+  })
+})
+
 describe('AgentSidebar Django prefs (REQ-144)', () => {
   afterEach(() => {
     vi.unstubAllGlobals()

--- a/webui/frontend/src/lib/__tests__/agentChat.test.ts
+++ b/webui/frontend/src/lib/__tests__/agentChat.test.ts
@@ -47,6 +47,14 @@ describe('conversationIdForAgent', () => {
     expect(conversationIdForAgent('codey')).toBe('sess-notes')
     expect(agentChatHref('codey')).toBe('/chat?blueprint=codey&session=sess-notes')
     expect(agentChatHref('stewie')).toBe('/chat?blueprint=stewie')
+    expect(agentChatHref('team:demo')).toBe('/chat?team=demo')
+    expect(agentChatHref('remote:omb')).toBe('/chat?remote=omb')
+    setConversationIdForAgent('team:demo', 'sess-team')
+    expect(agentChatHref('team:demo')).toBe('/chat?team=demo&session=sess-team')
+    expect(agentChatHref('team:demo')).not.toMatch(/blueprint=/)
+    setConversationIdForAgent('remote:omb', 'sess-remote')
+    expect(agentChatHref('remote:omb')).toBe('/chat?remote=omb&session=sess-remote')
+    expect(agentChatHref('remote:omb')).not.toMatch(/blueprint=/)
   })
 
   it('keeps the selected id after the module-level helpers are called again (unmount)', () => {

--- a/webui/frontend/src/lib/__tests__/railHotkeys.test.ts
+++ b/webui/frontend/src/lib/__tests__/railHotkeys.test.ts
@@ -79,6 +79,43 @@ describe('computeRailHotkeyTargets (REQ-172)', () => {
     expect(targets.some((t) => t.kind !== 'pin')).toBe(false)
   })
 
+  it('REQ-171B: pins of each kind use kind-aware hrefs (not always ?blueprint=)', () => {
+    const targets = computeRailHotkeyTargets({
+      visiblePins: [
+        { id: 'codey', name: 'Codey' },
+        { id: 'team:demo', name: 'Demo' },
+        { id: 'remote:omb', name: 'OpenMousBot' },
+        { id: 'herdr:w3:p1', name: 'w3:p1', kind: 'herdr' },
+      ],
+      orderedRows: [],
+    })
+
+    expect(targets).toHaveLength(4)
+    expect(targets[0]).toMatchObject({
+      id: 'codey',
+      kind: 'pin',
+      href: '/chat?blueprint=codey',
+    })
+    expect(targets[1]).toMatchObject({
+      id: 'team:demo',
+      kind: 'pin',
+      href: '/chat?team=demo',
+    })
+    expect(targets[1].href).not.toMatch(/blueprint=/)
+    expect(targets[2]).toMatchObject({
+      id: 'remote:omb',
+      kind: 'pin',
+      href: '/chat?remote=omb',
+    })
+    expect(targets[2].href).not.toMatch(/blueprint=/)
+    expect(targets[3]).toMatchObject({
+      id: 'herdr:w3:p1',
+      kind: 'pin',
+      href: '/teams/#herdr-members',
+      isHerdr: true,
+    })
+  })
+
   it('handles fewer than 9 total items gracefully', () => {
     const pins = [{ id: 'pin-1', name: 'Pin 1' }]
     const rows: RailRow[] = [

--- a/webui/frontend/src/lib/agentChat.ts
+++ b/webui/frontend/src/lib/agentChat.ts
@@ -1,5 +1,6 @@
 import { apiGet, apiPatch, apiPost, ensureCsrfCookie } from './api'
 import { classifyAgentKind, type AgentKind } from './agentKind'
+import { chatHrefForRowId } from './agentNotifications'
 import {
   isConversationSummary,
   type ConversationSummary,
@@ -70,13 +71,9 @@ export function peekConversationIdForAgent(agentId: string): string | null {
 export function agentChatHref(agentId: string): string {
   const agent = agentIdFromBlueprint(agentId)
   const session = peekConversationIdForAgent(agent)
-  if (session) {
-    const params = new URLSearchParams()
-    params.set('blueprint', agent)
-    params.set('session', session)
-    return `/chat?${params.toString()}`
-  }
-  return `/chat?blueprint=${encodeURIComponent(agent)}`
+  const base = chatHrefForRowId(agent)
+  if (!session) return base
+  return `${base}&session=${encodeURIComponent(session)}`
 }
 
 function tasksKey(agentId: string): string {

--- a/webui/frontend/src/lib/railHotkeys.ts
+++ b/webui/frontend/src/lib/railHotkeys.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Team, RemoteConnection } from './api'
+import { chatHrefForRowId } from './agentNotifications'
 
 export function isHerdrAgent(agent?: { id?: string; kind?: string } | null): boolean {
   if (!agent) return false
@@ -43,7 +44,7 @@ export function computeRailHotkeyTargets({
       kind: 'pin',
       name: pin.name || pin.id,
       isHerdr: herdr,
-      href: herdr ? '/teams/#herdr-members' : `/chat?blueprint=${encodeURIComponent(pin.id)}`,
+      href: herdr ? '/teams/#herdr-members' : chatHrefForRowId(pin.id),
     })
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Favourite tiles and Alt+1–9 treated every pin as a blueprint id, so pinning a team or remote opened `?blueprint=team%3Ademo` instead of the real chat URL.

**What changed**
- Favourite Link / Alt+1–9 now use kind-aware hrefs: `?blueprint=` / `?team=` / `?remote=`.
- Herdr pins still go to `/teams/#herdr-members`.
- Tests pin each kind and assert href (rail hotkeys, pin grid, sidebar + Alt+N).

Fixes #608

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55880fc6-b86a-4b26-aa7c-ea7bb6632920?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55880fc6-b86a-4b26-aa7c-ea7bb6632920&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

