### PR TITLE
Default local Postgres in Compose; cloud via DATABASE_URL; Neon test-only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,7 +118,7 @@ PORT="8000"
 # free-tier typically burns quota by ~day 17. See docs/DATABASE.md and
 # docs/RUNBOOK_NEON_QUOTA_CRASH_LOOP.md.
 #
-# Placeholders only. Never commit a real password or a neon.tech hostname here.
+# Placeholders only. Never commit a real password or a Neon hostname here.
 
 # Single supported override (compose default is postgres://swarm:swarm@postgres:5432/swarm):
 # DATABASE_URL="postgres://USER:PASSWORD@HOST:5432/DBNAME"

--- a/.env.example
+++ b/.env.example
@@ -96,7 +96,7 @@ PORT="8000"
 # Set 0 to disable auto-archive. Empty trash is always a manual Settings action.
 # SWARM_CHAT_DIR="/path/to/chats"
 # SWARM_CHAT_MAX_AGE_DAYS="90"
-# Composer file attach bytes (REQ-38). Metadata is Django sqlite.
+# Composer file attach bytes (REQ-38). Metadata is Django ChatAttachment.
 # SWARM_ATTACHMENTS_DIR="/path/to/attachments"
 
 # REQ-45: where *this app* is running (SPA runtime banner). Missing = unknown
@@ -110,20 +110,34 @@ PORT="8000"
 
 
 # =============================================================================
-# Database Configuration
+# Database Configuration (REQ-123 / #508)
 # =============================================================================
+# Durable happy path: local Postgres in `docker compose up` (service `postgres`).
+# Cloud / any Postgres: set DATABASE_URL (wins) or POSTGRES_HOST + POSTGRES_*.
+# Neon is test/CI/experiments only — never the implied default. Always-on Neon
+# free-tier typically burns quota by ~day 17. See docs/DATABASE.md and
+# docs/RUNBOOK_NEON_QUOTA_CRASH_LOOP.md.
+#
+# Placeholders only. Never commit a real password or a neon.tech hostname here.
 
-DJANGO_DATABASE="sqlite"
-# Path used by the Django app (defaults to /tmp/db.sqlite3 if unset):
-# DJANGO_DB_NAME="/path/to/db.sqlite3"
-# Path used by SQLite-backed blueprints:
-SQLITE_DB_PATH="/path/to/db.sqlite3"
-# For PostgreSQL, uncomment and configure:
+# Single supported override (compose default is postgres://swarm:swarm@postgres:5432/swarm):
+# DATABASE_URL="postgres://USER:PASSWORD@HOST:5432/DBNAME"
+
+# Alternative to DATABASE_URL when you prefer discrete knobs:
 # POSTGRES_DB="swarm"
-# POSTGRES_USER="postgres"
+# POSTGRES_USER="swarm"
 # POSTGRES_PASSWORD="your-postgres-password"
 # POSTGRES_HOST="localhost"
 # POSTGRES_PORT="5432"
+
+# SQLite is secondary: pytest, desktop (ADR-003), and tiny native demos.
+# Unset DATABASE_URL / POSTGRES_HOST to use it. Compose does not default here.
+# DJANGO_DATABASE="sqlite"
+# DJANGO_DB_NAME="/path/to/db.sqlite3"
+# SQLITE_DB_PATH="/path/to/db.sqlite3"
+
+# Emergency: skip the startup Postgres health check (not recommended).
+# SWARM_SKIP_DB_HEALTH="1"
 
 # Redis (optional; used when configured)
 # REDIS_HOST="localhost"

--- a/.github/workflows/python-pytest.yml
+++ b/.github/workflows/python-pytest.yml
@@ -66,3 +66,39 @@ jobs:
         run: uv run pytest
         env:
           DJANGO_ALLOW_ASYNC_UNSAFE: "true"
+        # REQ-123: pytest stays on SQLite (no live Neon). See docs/DATABASE.md.
+
+  # REQ-123 / #508: migrate smoke against a local Postgres service — not Neon.
+  postgres-migrate:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: swarm
+          POSTGRES_PASSWORD: swarm
+          POSTGRES_DB: swarm
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U swarm -d swarm"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Migrate against local Postgres
+        run: uv run python manage.py migrate --noinput
+        env:
+          DJANGO_DEBUG: "true"
+          DATABASE_URL: postgres://swarm:swarm@localhost:5432/swarm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **REQ-123 local Compose Postgres:** `docker compose` starts official Postgres 16 (volume + healthcheck) and wires `swarm` to it via `DATABASE_URL`. Cloud operators override `DATABASE_URL` / `POSTGRES_*`. Neon is documented as test/CI/experiments only (free-tier ~day 17). Unreachable / quota Postgres **exits 78** with a clear redacted message. pytest stays on SQLite; CI adds a local Postgres `migrate` smoke job. Docs: `docs/DATABASE.md`. Fixes #508.
+
 ### Added
 - **REQ-80 computer-icon Routines pane:** Expanding the Chat tools Monitor icon opens a right pane over mounted Chat: placeholder `{Agent}'s screen` thumbnail, then **Routines** with **+**. A routine is a named, disableable GitHub PR-merge prompt with Test run, Delete, and relative-time history. API `/v1/agents/<id>/routines/` plus fake-merge delivery at `/v1/routines/github-merge/` (no live GitHub, no secrets, no `:8001`). Fixes #432.
 - **REQ-77 mic STT + read-aloud TTS:** Composer microphone uses the browser/OS speech recognizer by default and inserts the transcript into the composer (does not auto-send). Assistant messages get a Read aloud control that uses `speechSynthesis`. Settings → Speech can opt each of STT and TTS into a custom OpenAI-compatible endpoint (`/v1/audio/transcriptions`, `/v1/audio/speech`): base URL, model id, api-key env name only. System stays the source even if a custom URL is stored. Empty custom URL never guesses a host. Missing/DOWN is an honest info line. `GET/PATCH /v1/speech/`, `POST /v1/speech/transcribe/`, `POST /v1/speech/speak/`. Tests stub system APIs and HTTP — no live paid calls, no `:8001`, no secrets. Fixes #422.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -288,7 +288,7 @@ environment / `.env`, never in `swarm_config.json` (reference them with
 | `SWARM_RESPONSES_SYNC_TIMEOUT` | Default seconds a `/v1/responses` request waits inline before auto-escalating to a queued handle (per-request override: `max_wait_seconds`). Unset = fully-blocking sync. | unset |
 | `SWARM_RESPONSES_MAX_AGE_DAYS` | Optional retention for `swarm.core.responses_store.prune_expired()` (terminal records only; skips `queued`/`in_progress`). **Not applied automatically** — call the helper or cron it. Unset / ≤0 = prune no-op when age omitted. | unset |
 | `SWARM_CHAT_DIR` | Per-agent SPA chat JSON store (`active/<user>/<agent>.json` + `trash/`). Used to restore Chat after reload / agent switch. Retention UI is Settings-only. | `$SWARM_USER_DATA_DIR/chats` (platformdirs if unset) |
-| `SWARM_ATTACHMENTS_DIR` | Composer file-attach bytes (REQ-38). Metadata is Django sqlite `ChatAttachment`; paths are `{user_key}/{uuid}` only. | `$SWARM_USER_DATA_DIR/attachments` |
+| `SWARM_ATTACHMENTS_DIR` | Composer file-attach bytes (REQ-38). Metadata is Django `ChatAttachment`; paths are `{user_key}/{uuid}` only. | `$SWARM_USER_DATA_DIR/attachments` |
 | `SWARM_CHAT_MAX_AGE_DAYS` | Auto-**move to trash** (never hard-delete) inactive agent chats older than this many days when Settings loads. `0` disables. Empty trash is a manual Settings action. | `90` |
 | `SWARM_RUNTIME_MODE` | Where **this app** is running (SPA runtime banner). `bare-metal` (dedicated harness, no container), `sandbox-home` (compose with `$HOME` / `SWARM_SANDBOX_ROOT` mapped), `sandbox-isolated` (compose without that tree). Missing / unrecognized → **unknown** (never fake a green sandbox). This is **not** the browser-control or computer-control provider ([ADR-007](docs/adr/007-local-computer-control.md)). Compose: `docker-compose.yml` defaults `sandbox-home`; `docker-compose.dev.yml` also defaults sandbox-home. | unset → unknown |
 | `SWARM_CHROME_CDP` | Optional Chrome DevTools URL for Playwright **attach** (`Browser (this machine)`). Launch is used when unset. | unset |
@@ -320,6 +320,25 @@ environment / `.env`, never in `swarm_config.json` (reference them with
 | `SWARM_ENFORCE_SINGLE_WORKER` | When true (default), refuse `SWARM_UVICORN_WORKERS` &gt; 1 at app startup. | `true` |
 | `SWARM_ALLOW_USER_BLUEPRINT_DISCOVERY` | When true, scan user blueprint dirs (exec_module). Default off so creator saves are write-only. | `false` |
 | `SWARM_USER_BLUEPRINT_SANDBOX` | AST safety gate before `exec_module` for user/community blueprint roots (and creator save validation). Set `false` only to opt out. | `true` |
+
+### Database (REQ-123 / #508)
+
+Durable default is **local Postgres in docker compose**. Cloud operators
+point at any Postgres with `DATABASE_URL`. **Neon is test/CI/experiments
+only** (free-tier always-on ~day 17). Short guide:
+[docs/DATABASE.md](docs/DATABASE.md).
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `DATABASE_URL` | Wins. Postgres DSN (`postgres://` / `postgresql://`). Compose sets `postgres://swarm:swarm@postgres:5432/swarm` (local placeholder, not a secret). | compose: local `postgres` service; else unset → SQLite |
+| `POSTGRES_HOST` / `POSTGRES_PORT` / `POSTGRES_DB` / `POSTGRES_USER` / `POSTGRES_PASSWORD` | Discrete knobs when `DATABASE_URL` is empty. | compose: `postgres` / `5432` / `swarm` / `swarm` / `swarm` |
+| `DJANGO_DATABASE` | If `postgres` / `postgresql` without URL/host, startup **fails fast** (exit 78). `sqlite` is documentary. | unset |
+| `DJANGO_DB_NAME` / `SQLITE_DB_PATH` | SQLite file when Postgres is not configured (pytest, desktop, tiny native demos). | `/tmp/db.sqlite3` |
+| `SWARM_SKIP_DB_HEALTH` | Skip the startup Postgres connect check. Emergency only. | unset (check on) |
+
+Unreachable Postgres or a Neon quota/compute error **exits 78** with a
+clear, redacted message — see
+[docs/RUNBOOK_NEON_QUOTA_CRASH_LOOP.md](docs/RUNBOOK_NEON_QUOTA_CRASH_LOOP.md).
 
 ### Feature flags
 
@@ -376,8 +395,9 @@ Model/provider keys and service endpoints — `OPENAI_API_KEY`, `OPENAI_BASE_URL
 
 ## 10. Herdr members (REQ-21)
 
-Persisted Herdr connections (`kind=herdr`) live in the Django SQLite database
-(default; do **not** set `DATABASE_URL` / Neon for this). Empty `remote` means
+Persisted Herdr connections (`kind=herdr`) live in the Django database
+(Compose Postgres, or SQLite when `DATABASE_URL` is unset). Do **not**
+point this feature at Neon. Empty `remote` means
 localhost — `herdr` with no `--remote` (unix sockets under `~/.config/herdr/`).
 When `remote` is set, every call is `herdr --remote <value> …`.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -222,7 +222,7 @@ Open Swarm combines a command-line interface (`swarm-cli`) for local management 
 ## Docker Deployment Details
 
 *   **`Dockerfile`:** Builds the API service image. Installs dependencies via `pip install .`. Runs migrations and starts Django server via `CMD`.
-*   **`docker-compose.yml`:** Defines the `swarm` service. Builds `open-swarm:local`, publishes `:8000`, and bind-mounts XDG config (`${HOME}/.config/swarm`) plus writable state (`${HOME}/.local/share/swarm`).
+*   **`docker-compose.yml`:** Defines `postgres` (official Postgres 16, named volume, healthcheck) and `swarm`. Builds `open-swarm:local`, publishes `:8000`, wires `DATABASE_URL` to the local Postgres service, and bind-mounts XDG config (`${HOME}/.config/swarm`) plus writable state (`${HOME}/.local/share/swarm`). Cloud operators override `DATABASE_URL`. Neon is not a default. See [docs/DATABASE.md](docs/DATABASE.md).
 *   **`docker-compose.override.example.yml`:** Example override for user customization (additional volumes, local build, env vars); copy to `docker-compose.override.yml` locally.
 
 ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ FROM python:3.11-slim
 ARG PORT=8000
 ENV PORT=${PORT}
 
-# Install system-level build dependencies, including sqlite3
+# Build deps plus sqlite3 (native/pytest/tiny-demo fallback only; compose
+# durable default is Postgres — REQ-123 / #508).
 RUN apt-get update && apt-get install -y \
     git \
     gcc \
@@ -53,25 +54,31 @@ CMD if [ -n "$SWAPFILE_PATH" ]; then \
       mkswap "$SWAPFILE_PATH" && \
       swapon "$SWAPFILE_PATH"; \
     fi && \
-    : "${DJANGO_DB_NAME:=${SQLITE_DB_PATH:-/app/db.sqlite3}}" && \
-    export DJANGO_DB_NAME SQLITE_DB_PATH="${DJANGO_DB_NAME}" && \
-    mkdir -p "$(dirname "$DJANGO_DB_NAME")" && \
-    if [ "$FACTORY_RESET_DATABASE" = "True" ]; then \
-      echo "FACTORY_RESET_DATABASE is True; deleting database file if it exists" && \
-      rm -f "$DJANGO_DB_NAME"; \
-    fi && \
-    if [ -f "$DJANGO_DB_NAME" ]; then \
-      TABLE_COUNT=$(sqlite3 "$DJANGO_DB_NAME" "SELECT count(*) FROM sqlite_master WHERE type='table';") && \
-      if [ "$TABLE_COUNT" -gt 0 ]; then \
-        echo "Database exists with tables; applying migrations with --fake-initial if needed" && \
-        python manage.py migrate --fake-initial; \
+    python -c "from swarm.core.database_config import check_database_or_exit; check_database_or_exit()" && \
+    if [ -n "${DATABASE_URL}" ] || [ -n "${POSTGRES_HOST}" ]; then \
+      echo "Postgres configured (DATABASE_URL / POSTGRES_*); applying migrations" && \
+      python manage.py migrate --fake-initial; \
+    else \
+      : "${DJANGO_DB_NAME:=${SQLITE_DB_PATH:-/app/db.sqlite3}}" && \
+      export DJANGO_DB_NAME SQLITE_DB_PATH="${DJANGO_DB_NAME}" && \
+      mkdir -p "$(dirname "$DJANGO_DB_NAME")" && \
+      if [ "$FACTORY_RESET_DATABASE" = "True" ]; then \
+        echo "FACTORY_RESET_DATABASE is True; deleting database file if it exists" && \
+        rm -f "$DJANGO_DB_NAME"; \
+      fi && \
+      if [ -f "$DJANGO_DB_NAME" ]; then \
+        TABLE_COUNT=$(sqlite3 "$DJANGO_DB_NAME" "SELECT count(*) FROM sqlite_master WHERE type='table';") && \
+        if [ "$TABLE_COUNT" -gt 0 ]; then \
+          echo "Database exists with tables; applying migrations with --fake-initial if needed" && \
+          python manage.py migrate --fake-initial; \
+        else \
+          echo "Database exists but is empty; applying migrations normally" && \
+          python manage.py migrate; \
+        fi; \
       else \
-        echo "Database exists but is empty; applying migrations normally" && \
+        echo "No database found; creating and applying migrations" && \
         python manage.py migrate; \
       fi; \
-    else \
-      echo "No database found; creating and applying migrations" && \
-      python manage.py migrate; \
     fi && \
     echo "--- Starting Open Swarm ASGI (uvicorn) ---" && \
     exec uvicorn swarm.asgi:application --host 0.0.0.0 --port "$PORT" --workers "${SWARM_UVICORN_WORKERS:-1}"

--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -225,11 +225,20 @@ Open Swarm as a harness **for** other harnesses. Not a Grok-Bot chrome claim; no
 | Feature | Status | Evidence |
 |---|---|---|
 | `herdr` CLI wrapper | ✅ | `src/swarm/herdr/client.py` — workspace/agent list, agent read, `agent prompt TARGET TEXT` (one argv), wait-until idle\|working\|blocked\|done. Empty remote omits `--remote`. Tests mock the binary: `tests/herdr/test_herdr_client.py` (includes spaces in TEXT + proven `w3:p1` / `HERDR_PING_OK` → `agent_prompted`) |
-| Persisted members `kind=herdr` | ✅ | `HerdrAgent` model + migration `0012`; DRF `/v1/herdr-agents/` list/add/remove; discover from live `agent list` / `workspace list`. Settings + Teams + Django admin + SPA sidepane. SQLite default (no DATABASE_URL / Neon) |
+| Persisted members `kind=herdr` | ✅ | `HerdrAgent` model + migration `0012`; DRF `/v1/herdr-agents/` list/add/remove; discover from live `agent list` / `workspace list`. Settings + Teams + Django admin + SPA sidepane. Django DB (Compose Postgres or SQLite); no Neon |
 | Honesty | ✅ | [docs/HERDR.md](./docs/HERDR.md) — not Hermes/OMB/Rakazo; same-host default; `--remote` for other machines; blocked reject / `--wait` may finish an in-flight turn; CI must mock `herdr` |
 | Remotes kind + CLI `--remote` (REQ-64) | ✅ | `remotes.herdr` persist; Settings + Add; `HerdrClient.from_remote_config()`; stub HTTP health/list in `tests/core/test_herdr_remote.py` |
 
-## 14. Desktop package (REQ-151) — 📋 planned
+## 14. Durable database (REQ-123) — ✅
+
+| Feature | Status | Evidence |
+|---|---|---|
+| Compose local Postgres | ✅ | `docker-compose.yml` `postgres` service (official `postgres:16`, `swarm_pgdata`, healthcheck). `swarm` `depends_on` healthy + `DATABASE_URL=postgres://swarm:swarm@postgres:5432/swarm`. Neon is not a default hostname. |
+| Cloud override | ✅ | `DATABASE_URL` wins; `POSTGRES_*` when URL empty. [docs/DATABASE.md](docs/DATABASE.md), `.env.example`. |
+| Fail-fast | ✅ | `swarm.core.database_config.check_database_or_exit` → exit 78; compose `restart: on-failure:5`. |
+| CI | ✅ | pytest remains SQLite; `postgres-migrate` job uses Actions Postgres. No live Neon. Fixes #508. |
+
+## 15. Desktop package (REQ-151) — 📋 planned
 
 | Feature | Status | Evidence |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -53,9 +53,12 @@ uv sync --all-extras
 cp .env.example .env          # set OPENAI_API_KEY, API_AUTH_TOKEN, DJANGO_SECRET_KEY
 cp swarm_config.example.json swarm_config.json   # optional local SoT; secrets stay ${VAR} in .env
 make frontend                 # builds webui/frontend/dist/
-docker compose up --build
+docker compose up --build     # API + local Postgres (not Neon / not SQLite)
 # open http://localhost:8000
 ```
+
+Compose’s durable DB is the `postgres` service. Set `DATABASE_URL` for any
+cloud Postgres. Neon is test/CI only — [docs/DATABASE.md](docs/DATABASE.md).
 
 Without `dist/`, `/` falls back to Django templates. Rebuild after SPA pulls. Auth: [docs/AUTH.md](docs/AUTH.md) (websocket needs a session cookie; bearer does not auth WS).
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -32,8 +32,9 @@ services:
       - "8002:8000"
     # Image CMD is migrate-then-uvicorn without --reload. Override so saves under
     # the bind-mount restart the ASGI app. --reload requires a single process.
-    # Port 8000 is the in-container listen port (host maps 8002:8000); DB paths
-    # come from the merged environment, same as the production service.
+    # Port 8000 is the in-container listen port (host maps 8002:8000). The
+    # merged environment still points at the base-file `postgres` service
+    # (DATABASE_URL / POSTGRES_*). SQLite is not the compose happy path.
     command:
       - /bin/sh
       - -c

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,29 @@
 #   # For local open API only: SWARM_ALLOW_NO_AUTH=true  (NOT the default)
 #   docker compose up --build
 #   # …then add docker-compose.override.yml for host CLIs if needed.
+#
+# Durable DB (REQ-123 / #508): local Postgres in this stack is the happy path.
+# Cloud operators set DATABASE_URL (or POSTGRES_*) to any Postgres. Neon is
+# test/CI/experiments only — never a default hostname. Native pytest / desktop
+# still use SQLite when DATABASE_URL is unset. See docs/DATABASE.md.
 
 services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: "${POSTGRES_DB:-swarm}"
+      POSTGRES_USER: "${POSTGRES_USER:-swarm}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-swarm}"
+    volumes:
+      - swarm_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$$POSTGRES_USER\" -d \"$$POSTGRES_DB\""]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    restart: unless-stopped
+
   swarm:
     build:
       context: .
@@ -70,10 +91,16 @@ services:
       DJANGO_SECRET_KEY: "${DJANGO_SECRET_KEY:-}"
       DJANGO_ALLOWED_HOSTS: "${DJANGO_ALLOWED_HOSTS:-localhost,127.0.0.1}"
       API_AUTH_TOKEN: "${API_AUTH_TOKEN:-}"
-      # Durable Django DB + async /v1/responses store on the mounted volume.
-      # DJANGO_DB_NAME is what settings.py reads; SQLITE_DB_PATH is accepted as alias.
-      DJANGO_DB_NAME: "${HOME}/.local/share/swarm/db.sqlite3"
-      SQLITE_DB_PATH: "${HOME}/.local/share/swarm/db.sqlite3"
+      # Durable Django DB: local Compose Postgres by default. Override with
+      # DATABASE_URL for any cloud Postgres. Compose-internal user/password
+      # "swarm"/"swarm" is a local placeholder — not a production secret.
+      POSTGRES_HOST: "${POSTGRES_HOST:-postgres}"
+      POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
+      POSTGRES_DB: "${POSTGRES_DB:-swarm}"
+      POSTGRES_USER: "${POSTGRES_USER:-swarm}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-swarm}"
+      DATABASE_URL: "${DATABASE_URL:-postgres://swarm:swarm@postgres:5432/swarm}"
+      # Async /v1/responses store on the mounted volume (not the Django DB).
       SWARM_RESPONSES_DIR: "${HOME}/.local/share/swarm/responses"
       # Async /v1/responses cancel + inflight limits are process-local until a
       # shared queue exists. Keep a single uvicorn worker (see Dockerfile CMD).
@@ -87,8 +114,11 @@ services:
     volumes:
       # Your swarm config (llm profiles + any cli_agents) — read-only.
       - "${HOME}/.config/swarm:${HOME}/.config/swarm:ro"
-      # Writable state: SQLite DB + async /v1/responses task store.
+      # Writable state: async /v1/responses task store (Django DB is Postgres).
       - "${HOME}/.local/share/swarm:${HOME}/.local/share/swarm"
+    depends_on:
+      postgres:
+        condition: service_healthy
     healthcheck:
       test:
         [
@@ -101,4 +131,10 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
-    restart: unless-stopped
+    # Cap retries so an unreachable / quota-exhausted DATABASE_URL (e.g. Neon
+    # free-tier) fails fast with a clear log instead of crash-looping silently.
+    # systemd units also use RestartPreventExitStatus=78 — see the Neon runbook.
+    restart: "on-failure:5"
+
+volumes:
+  swarm_pgdata:

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -1,0 +1,87 @@
+# Database: local Compose Postgres, cloud via DATABASE_URL, Neon test-only
+
+REQ-123 / [#508](https://github.com/matthewhand/open-swarm/issues/508).
+
+## Happy path (durable / “real” deploys)
+
+`docker compose up` starts an official **Postgres 16** service (`postgres`)
+with a named volume and a healthcheck. The `swarm` service waits until
+Postgres is healthy, then uses:
+
+```text
+DATABASE_URL=postgres://swarm:swarm@postgres:5432/swarm
+```
+
+That user/password is a **compose-internal placeholder**, not a production
+secret. Change `POSTGRES_PASSWORD` (and matching `DATABASE_URL`) if the
+port is ever published. Port **5432 is not published** to the host by
+default.
+
+Native systemd / desktop / `pytest` are unchanged: **SQLite** when
+`DATABASE_URL` and `POSTGRES_HOST` are unset (desktop must still set a
+profile path — see [ADR-003](./adr/003-desktop-packaging.md)). SQLite is
+the tiny-demo / CI unit-test path, not the compose happy path.
+
+## Cloud / any Postgres
+
+Set one override:
+
+| Knob | Role |
+|---|---|
+| `DATABASE_URL` | Wins. Any `postgres://` / `postgresql://` DSN (RDS, Cloud SQL, self-hosted, …). |
+| `POSTGRES_HOST` + `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` / `POSTGRES_PORT` | Used when `DATABASE_URL` is empty. |
+
+Copy [`.env.example`](../.env.example) — placeholders only. No hostname is
+hard-coded in `src/swarm/settings.py`.
+
+Oracle native deploy ([ORACLE_DEPLOY.md](./ORACLE_DEPLOY.md)) stays on the
+unit’s `DJANGO_DB_NAME` SQLite path unless **you** set `DATABASE_URL`. This
+change does **not** point oracle or Fly at Neon.
+
+## Neon (test / CI / experiments only)
+
+Do **not** use Neon as the implied default for compose, oracle, or Fly.
+
+- Free-tier always-on typically exhausts compute around **day 17**.
+- Quota exhaustion used to crash-loop systemd (`Restart=always`) — see
+  [RUNBOOK_NEON_QUOTA_CRASH_LOOP.md](./RUNBOOK_NEON_QUOTA_CRASH_LOOP.md).
+- Optional for CI experiments. Default GitHub `pytest` does **not** require
+  live Neon (or any cloud Postgres).
+
+## Fail-fast
+
+If Postgres is selected (`DATABASE_URL`, `POSTGRES_HOST`, or
+`DJANGO_DATABASE=postgres`) and the server is unreachable, misconfigured,
+or returns a quota/compute error, the process **exits 78** (`EX_CONFIG`)
+with a redacted, operator-facing message. systemd units already set
+`RestartPreventExitStatus=78`. Compose caps `swarm` at `restart: on-failure:5`
+so a bad cloud URL does not loop silently.
+
+Escape hatch (emergency only): `SWARM_SKIP_DB_HEALTH=1`.
+
+## Migrations
+
+```bash
+# Compose (local Postgres)
+docker compose up --build
+docker compose exec swarm python manage.py migrate
+
+# Any DATABASE_URL Postgres (cloud or laptop)
+DATABASE_URL=postgres://USER:PASSWORD@HOST:5432/DBNAME \
+  uv run python src/manage.py migrate
+```
+
+## CI policy
+
+| Job | Database |
+|---|---|
+| `python-pytest.yml` → `test` (pytest matrix) | **SQLite** (existing policy; no live Neon) |
+| `python-pytest.yml` → `postgres-migrate` | GitHub Actions **local Postgres service** + `DATABASE_URL` (migrate smoke) |
+
+Do not add a Neon hostname or secret to CI.
+
+## Related
+
+- [CONFIGURATION.md](../CONFIGURATION.md) — env table
+- [ADR-002](./adr/002-config-ownership.md) — config ownership (DB location)
+- [`.env.example`](../.env.example) — copy-paste knobs

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -71,7 +71,7 @@ Worked configs, Mode A/B demo names, tests that lock the edges, and
 ├── webui/frontend/            # React SPA (rail + chat). dist/ is gitignored
 ├── tests/                     # pytest (keyless via SWARM_TEST_MODE)
 ├── docs/                      # Guides, ADRs, proofs
-├── docker-compose.yml         # API + baked SPA
+├── docker-compose.yml         # API + baked SPA + local Postgres (REQ-123)
 └── pyproject.toml             # Package metadata (open-swarm 0.5.4)
 ```
 

--- a/docs/ORACLE_DEPLOY.md
+++ b/docs/ORACLE_DEPLOY.md
@@ -92,6 +92,12 @@ After the proxy reloads the spec, the generated tools expose `params`, `name`,
 etc. (every write endpoint's body is documented).
 
 ## Notes
+- **Database:** this unit defaults to **SQLite** via `DJANGO_DB_NAME` (see
+  `deploy/oracle/open-swarm-oracle.service`). That is intentional and is
+  **not** Neon. To use any Postgres, set `DATABASE_URL` (or `POSTGRES_*`)
+  on the unit — compose’s happy path is local Postgres
+  ([DATABASE.md](./DATABASE.md)). Do **not** point oracle or Fly at Neon
+  as the primary path (test/CI only; free-tier ~day 17).
 - Keep `DJANGO_DEBUG=true` only if you accept verbose error pages on the LAN side;
   for stricter prod, set `DJANGO_DEBUG=false` and also set `DJANGO_SECRET_KEY` +
   `DJANGO_ALLOWED_HOSTS` (the server refuses to boot without them in prod), and

--- a/docs/RUNBOOK_NEON_QUOTA_CRASH_LOOP.md
+++ b/docs/RUNBOOK_NEON_QUOTA_CRASH_LOOP.md
@@ -1,5 +1,11 @@
 # Runbook: Crash-Loop on Neon Postgres Quota Exhaustion
 
+**Neon is test/CI/experiments only.** Do not use it as the implied default
+for compose, oracle, or Fly. Durable default is **local Postgres in
+`docker compose`**; cloud operators set `DATABASE_URL` to any reachable
+Postgres. Always-on Neon free-tier typically burns compute by **~day 17**.
+See [DATABASE.md](./DATABASE.md) (REQ-123 / #508).
+
 ## Incident summary
 
 - **Service**: `open-swarm-oracle.service` (systemd *user* unit; see
@@ -65,11 +71,13 @@ The database backend is fixed in the unit's environment instead.
 
 Edit `~/.config/systemd/user/open-swarm-oracle.service`:
 
-- **SQLite (default, recommended here)**: remove any
+- **SQLite (oracle unit default)**: remove any
   `Environment=DATABASE_URL=...` line and keep
   `Environment=DJANGO_DB_NAME=/home/YOURUSER/.local/share/swarm/db.sqlite3`.
+- **Compose / durable deploys**: use the local `postgres` service — do not
+  resume Neon for this host.
 - **Other Postgres**: set `DATABASE_URL` to an instance that is not
-  quota-limited.
+  quota-limited (any cloud or self-hosted Postgres — not Neon-as-default).
 
 ### 4. Add the restart exemption
 

--- a/docs/adr/002-config-ownership.md
+++ b/docs/adr/002-config-ownership.md
@@ -197,10 +197,13 @@ Django Settings HTML is an inspector, not a writer.
 It is **not** live `mcpServers` in `swarm_config.json`. Do not treat it as a
 second MCP SoT.
 
-**DB location:** `src/swarm/settings.py` — `DATABASE_URL` → Postgres; else
-`DJANGO_DB_NAME` / `SQLITE_DB_PATH` (compose: `~/.local/share/swarm/db.sqlite3`).
-Default without env is `/tmp/db.sqlite3` (ephemeral). #508 is the Postgres
-happy-path; this ADR does not move topology into SQL.
+**DB location:** `src/swarm/settings.py` via `swarm.core.database_config` —
+`DATABASE_URL` (or `POSTGRES_HOST` + `POSTGRES_*`) → Postgres; else
+`DJANGO_DB_NAME` / `SQLITE_DB_PATH`. Compose happy path is the local
+`postgres` service (`postgres://swarm:swarm@postgres:5432/swarm`). Native
+pytest / desktop without those env vars still use SQLite (`/tmp/db.sqlite3`
+unless a path is set). Neon is test-only — see [DATABASE.md](../DATABASE.md)
+and #508. This ADR does not move topology into SQL.
 
 **Per-user UI prefs today:** **not** Django. SPA uses `localStorage`
 (`webui/frontend/src/lib/pinnedAgents.ts`, `hiddenAgents.ts`, `theme.ts`,

--- a/src/swarm/apps.py
+++ b/src/swarm/apps.py
@@ -72,6 +72,7 @@ class SwarmConfig(AppConfig):
             logger.warning("Test-mode guard check failed: %s", e)
 
         self._warn_if_api_auth_disabled()
+        self._check_database()
 
         # Resume async /v1/responses tasks left in-flight by a restart — server
         # processes only (not migrate/test), guarded against the runserver
@@ -80,6 +81,17 @@ class SwarmConfig(AppConfig):
         self._maybe_resume_async_tasks()
 
         logger.info("Swarm app initialization checks completed.")
+
+    @staticmethod
+    def _check_database() -> None:
+        """Fail fast (exit 78) when Postgres is configured but unusable.
+
+        Skipped under pytest and when SWARM_SKIP_DB_HEALTH is set. SQLite is
+        a no-op. See swarm.core.database_config and docs/DATABASE.md.
+        """
+        from swarm.core.database_config import check_database_or_exit
+
+        check_database_or_exit()
 
     @staticmethod
     def _warn_if_api_auth_disabled() -> None:

--- a/src/swarm/core/database_config.py
+++ b/src/swarm/core/database_config.py
@@ -1,0 +1,240 @@
+"""Django database target resolution and Postgres fail-fast (REQ-123 / #508).
+
+Happy path for durable deploys is **local Postgres in docker compose**.
+Cloud operators override with ``DATABASE_URL`` (or ``POSTGRES_*``) pointing
+at any Postgres. Neon is test/CI/experiments only — never a default host.
+
+Native pytest, desktop, and tiny demos still fall back to SQLite when
+neither ``DATABASE_URL`` nor ``POSTGRES_HOST`` is set.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from typing import Callable, Mapping, TextIO
+from urllib.parse import quote, urlparse, urlunparse
+
+# sysexits.h EX_CONFIG — systemd RestartPreventExitStatus=78 (Neon runbook).
+EX_CONFIG = 78
+
+_QUOTA_MARKERS = (
+    "quota",
+    "exceeded your compute",
+    "compute time",
+    "compute units",
+    "disabled",
+    "cannot connect to compute",
+    "endpoint has been disabled",
+)
+
+_POSTGRES_ENGINES = frozenset({"postgres", "postgresql", "postgresql_psycopg2"})
+
+DEFAULT_SQLITE_NAME = "/tmp/db.sqlite3"
+DEFAULT_SQLITE_TEST_NAME = "/tmp/test_db.sqlite3"
+
+
+def _env_get(env: Mapping[str, str], key: str) -> str:
+    return (env.get(key) or "").strip()
+
+
+def postgres_selected_without_target(env: Mapping[str, str]) -> bool:
+    """``DJANGO_DATABASE=postgres`` but no URL/host — misconfigured."""
+    engine = _env_get(env, "DJANGO_DATABASE").lower()
+    if engine not in _POSTGRES_ENGINES:
+        return False
+    return not _env_get(env, "DATABASE_URL") and not _env_get(env, "POSTGRES_HOST")
+
+
+def resolve_database_url(env: Mapping[str, str] | None = None) -> str | None:
+    """Return a Postgres URL when configured, else None (SQLite fallback).
+
+    Precedence: non-empty ``DATABASE_URL``, then ``POSTGRES_HOST`` (+
+    ``POSTGRES_*`` parts). ``DJANGO_DATABASE=postgres`` without a host/URL
+    is not a URL — callers should treat it as a config error.
+    """
+    env = os.environ if env is None else env
+    explicit = _env_get(env, "DATABASE_URL")
+    if explicit:
+        return explicit
+    host = _env_get(env, "POSTGRES_HOST")
+    if not host:
+        return None
+    user = _env_get(env, "POSTGRES_USER") or "postgres"
+    password = env.get("POSTGRES_PASSWORD") or ""
+    port = _env_get(env, "POSTGRES_PORT") or "5432"
+    dbname = _env_get(env, "POSTGRES_DB") or "swarm"
+    netloc = f"{quote(user, safe='')}:{quote(password, safe='')}@{host}:{port}"
+    return urlunparse(("postgres", netloc, f"/{dbname}", "", "", ""))
+
+
+def sqlite_name(env: Mapping[str, str] | None = None) -> str:
+    env = os.environ if env is None else env
+    return (
+        _env_get(env, "DJANGO_DB_NAME")
+        or _env_get(env, "SQLITE_DB_PATH")
+        or DEFAULT_SQLITE_NAME
+    )
+
+
+def django_databases(env: Mapping[str, str] | None = None) -> dict:
+    """Build the Django ``DATABASES`` dict from env (no Neon hostname default)."""
+    env = os.environ if env is None else env
+    url = resolve_database_url(env)
+    if url:
+        import dj_database_url
+
+        return {
+            "default": dj_database_url.parse(
+                url, conn_max_age=600, conn_health_checks=True
+            ),
+        }
+    test_name = _env_get(env, "DJANGO_TEST_DB_NAME") or DEFAULT_SQLITE_TEST_NAME
+    return {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": sqlite_name(env),
+            "TEST": {
+                "NAME": test_name,
+                "OPTIONS": {
+                    "timeout": 20,
+                    "init_command": "PRAGMA journal_mode=WAL;",
+                },
+            },
+        }
+    }
+
+
+def is_postgres_configured(env: Mapping[str, str] | None = None) -> bool:
+    env = os.environ if env is None else env
+    return bool(resolve_database_url(env)) or postgres_selected_without_target(env)
+
+
+def redact_database_url(url: str) -> str:
+    """Mask userinfo in a database URL for logs."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return "<unparseable DATABASE_URL>"
+    if parsed.password is None and parsed.username is None:
+        return url
+    host = parsed.hostname or ""
+    port = f":{parsed.port}" if parsed.port else ""
+    user = parsed.username or ""
+    netloc = f"{user}:***@{host}{port}" if user else f"***@{host}{port}"
+    return urlunparse(
+        (parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment)
+    )
+
+
+def classify_postgres_error(exc: BaseException) -> str:
+    """Return ``quota`` or ``unreachable`` from a connection failure."""
+    blob = f"{type(exc).__name__}: {exc}".lower()
+    if any(marker in blob for marker in _QUOTA_MARKERS):
+        return "quota"
+    return "unreachable"
+
+
+def format_fail_fast_message(
+    *,
+    kind: str,
+    detail: str,
+    url: str | None = None,
+) -> str:
+    """Operator-facing message; no secrets. Aligns with the Neon quota runbook."""
+    redacted = redact_database_url(url) if url else "(no DATABASE_URL / POSTGRES_HOST)"
+    if kind == "missing-target":
+        headline = (
+            "ERROR: DJANGO_DATABASE selects Postgres, but neither DATABASE_URL "
+            "nor POSTGRES_HOST is set."
+        )
+    elif kind == "quota":
+        headline = (
+            "ERROR: Postgres is configured but the server rejected the connection "
+            "(quota / compute exhausted — common on always-on Neon free tier)."
+        )
+    else:
+        headline = (
+            "ERROR: Postgres is configured (DATABASE_URL / POSTGRES_*) "
+            "but is unreachable."
+        )
+    return (
+        f"{headline}\n"
+        f"  Target: {redacted}\n"
+        f"  Detail: {detail}\n"
+        "\n"
+        "  Durable default is local Postgres in docker compose "
+        "(`docker compose up` starts the `postgres` service).\n"
+        "  Cloud operators: set DATABASE_URL to any reachable Postgres.\n"
+        "  Neon is test/CI/experiments only — never the implied default.\n"
+        "  Neon free-tier always-on typically burns the quota by ~day 17.\n"
+        "  See docs/DATABASE.md and docs/RUNBOOK_NEON_QUOTA_CRASH_LOOP.md.\n"
+        "\n"
+        f"Exiting with code {EX_CONFIG} (EX_CONFIG) so systemd can stop "
+        "crash-looping (RestartPreventExitStatus=78).\n"
+    )
+
+
+def _connect_postgres(url: str) -> None:
+    import psycopg2
+
+    dsn = url
+    if dsn.startswith("postgres://"):
+        dsn = "postgresql://" + dsn[len("postgres://") :]
+    conn = psycopg2.connect(dsn, connect_timeout=5)
+    conn.close()
+
+
+def should_skip_db_health(env: Mapping[str, str] | None = None) -> bool:
+    env = os.environ if env is None else env
+    if _env_get(env, "SWARM_SKIP_DB_HEALTH") in {"1", "true", "yes"}:
+        return True
+    if "pytest" in sys.modules or "PYTEST_VERSION" in env:
+        return True
+    return False
+
+
+def check_database_or_exit(
+    env: Mapping[str, str] | None = None,
+    *,
+    connect: Callable[[str], None] | None = None,
+    stream: TextIO | None = None,
+    exit_fn: Callable[[int], None] | None = None,
+    skip_pytest: bool = True,
+) -> None:
+    """If Postgres is configured, connect or exit 78 with a clear message.
+
+    SQLite (no URL/host) is a no-op. Pytest is skipped unless ``skip_pytest``
+    is false (unit tests inject ``connect``).
+    """
+    env = os.environ if env is None else env
+    stream = sys.stderr if stream is None else stream
+    exit_fn = sys.exit if exit_fn is None else exit_fn
+    if skip_pytest and should_skip_db_health(env):
+        return
+    if postgres_selected_without_target(env):
+        stream.write(
+            format_fail_fast_message(
+                kind="missing-target",
+                detail="Set DATABASE_URL or POSTGRES_HOST.",
+            )
+        )
+        stream.flush()
+        exit_fn(EX_CONFIG)
+        return
+    url = resolve_database_url(env)
+    if not url:
+        return
+    connect_fn = connect or _connect_postgres
+    try:
+        connect_fn(url)
+    except Exception as exc:
+        kind = classify_postgres_error(exc)
+        stream.write(
+            format_fail_fast_message(
+                kind=kind,
+                detail=f"{type(exc).__name__}: {exc}",
+                url=url,
+            )
+        )
+        stream.flush()
+        exit_fn(EX_CONFIG)

--- a/src/swarm/settings.py
+++ b/src/swarm/settings.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent.parent # Points to src/
 
+from swarm.core.database_config import django_databases
 from swarm.utils.env_utils import *
 from swarm.utils.dotenv_load import load_swarm_dotenv
 
@@ -183,38 +184,11 @@ TEMPLATES = [
 WSGI_APPLICATION = 'swarm.wsgi.application'
 ASGI_APPLICATION = 'swarm.asgi.application'
 
-# Database — use Postgres (or any Django-supported backend) when DATABASE_URL is
-# set, e.g. DATABASE_URL=postgres://user:pass@host:5432/dbname. Otherwise fall
-# back to the zero-config SQLite default used for local/dev/tests.
-DATABASE_URL = os.environ.get('DATABASE_URL')
-if DATABASE_URL:
-    import dj_database_url
-    DATABASES = {
-        'default': dj_database_url.parse(
-            DATABASE_URL, conn_max_age=600, conn_health_checks=True
-        ),
-    }
-else:
-    # Prefer DJANGO_DB_NAME; accept SQLITE_DB_PATH as alias (compose historically
-    # set the latter while Django only read the former).
-    _sqlite_name = (
-        os.environ.get('DJANGO_DB_NAME')
-        or os.environ.get('SQLITE_DB_PATH')
-        or '/tmp/db.sqlite3'
-    )
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': _sqlite_name,
-            'TEST': {
-                'NAME': os.environ.get('DJANGO_TEST_DB_NAME', '/tmp/test_db.sqlite3'),
-                'OPTIONS': {
-                    'timeout': 20,
-                    'init_command': "PRAGMA journal_mode=WAL;",
-                },
-            },
-        }
-    }
+# Database — REQ-123 / #508. DATABASE_URL (or POSTGRES_HOST + POSTGRES_*)
+# selects Postgres. Otherwise SQLite for pytest / desktop / tiny native demos.
+# Compose wires local Postgres; no Neon hostname is a default.
+DATABASE_URL = (os.environ.get("DATABASE_URL") or "").strip() or None
+DATABASES = django_databases(os.environ)
 
 AUTH_PASSWORD_VALIDATORS = [
     {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',},

--- a/tests/unit/test_plan_a_prod_gates.py
+++ b/tests/unit/test_plan_a_prod_gates.py
@@ -283,7 +283,8 @@ class TestComposeAuthDefault:
         # Must not hard-set SWARM_ALLOW_NO_AUTH: "true" as the default prod path
         assert 'SWARM_ALLOW_NO_AUTH: "true"' not in text
         assert "healthcheck:" in text
-        assert "DJANGO_DB_NAME" in text
+        assert "DATABASE_URL" in text
+        assert "postgres:" in text
         assert "/health" in text
 
     def test_dockerfile_uses_uvicorn(self):

--- a/tests/unit/test_req123_postgres_compose.py
+++ b/tests/unit/test_req123_postgres_compose.py
@@ -1,0 +1,268 @@
+"""REQ-123 / #508: Compose local Postgres; DATABASE_URL override; Neon test-only."""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+
+import yaml
+
+from swarm.core.database_config import (
+    EX_CONFIG,
+    check_database_or_exit,
+    classify_postgres_error,
+    django_databases,
+    format_fail_fast_message,
+    postgres_selected_without_target,
+    redact_database_url,
+    resolve_database_url,
+    sqlite_name,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+COMPOSE = REPO / "docker-compose.yml"
+ENV_EXAMPLE = REPO / ".env.example"
+DATABASE_MD = REPO / "docs" / "DATABASE.md"
+NEON_RUNBOOK = REPO / "docs" / "RUNBOOK_NEON_QUOTA_CRASH_LOOP.md"
+ORACLE_DOCS = REPO / "docs" / "ORACLE_DEPLOY.md"
+ORACLE_UNIT = REPO / "deploy" / "oracle" / "open-swarm-oracle.service"
+DOCKERFILE = REPO / "Dockerfile"
+PYTEST_WORKFLOW = REPO / ".github" / "workflows" / "python-pytest.yml"
+SETTINGS = REPO / "src" / "swarm" / "settings.py"
+HELPER = REPO / "src" / "swarm" / "core" / "database_config.py"
+
+
+def _compose() -> dict:
+    return yaml.safe_load(COMPOSE.read_text(encoding="utf-8"))
+
+
+def test_compose_postgres_is_default_happy_path():
+    data = _compose()
+    pg = data["services"]["postgres"]
+    swarm = data["services"]["swarm"]
+    assert pg["image"].startswith("postgres:")
+    assert "swarm_pgdata" in str(pg["volumes"])
+    assert pg.get("healthcheck", {}).get("test")
+    assert "neon" not in pg["image"].lower()
+    env = swarm["environment"]
+    url = env["DATABASE_URL"]
+    assert "postgres@postgres:5432" in url or "@postgres:5432" in url
+    assert "neon.tech" not in url.lower()
+    assert env["POSTGRES_HOST"] == "${POSTGRES_HOST:-postgres}"
+    assert swarm["depends_on"]["postgres"]["condition"] == "service_healthy"
+    assert "swarm_pgdata" in data["volumes"]
+    # 5432 must not be published on the host by default.
+    assert "ports" not in pg
+    text = COMPOSE.read_text(encoding="utf-8")
+    assert "neon.tech" not in text.lower()
+    assert "REQ-123" in text or "#508" in text
+
+
+def test_compose_does_not_default_sqlite_file():
+    text = COMPOSE.read_text(encoding="utf-8")
+    assert "db.sqlite3" not in text
+    assert "DJANGO_DB_NAME" not in text
+
+
+def test_compose_caps_swarm_restarts():
+    swarm = _compose()["services"]["swarm"]
+    assert str(swarm["restart"]).startswith("on-failure")
+
+
+def test_env_example_documents_override_and_neon_warning():
+    text = ENV_EXAMPLE.read_text(encoding="utf-8")
+    assert "DATABASE_URL=" in text
+    assert "POSTGRES_HOST" in text
+    assert "test/CI" in text or "test-only" in text.lower() or "experiments only" in text
+    assert "day 17" in text
+    assert "neon.tech" not in text
+    assert "your-postgres-password" in text
+    assert "SWARM_SKIP_DB_HEALTH" in text
+
+
+def test_short_docs_and_runbook_keep_neon_optional():
+    db = DATABASE_MD.read_text(encoding="utf-8")
+    runbook = NEON_RUNBOOK.read_text(encoding="utf-8")
+    oracle = ORACLE_DOCS.read_text(encoding="utf-8")
+    assert "docker compose" in db.lower()
+    assert "DATABASE_URL" in db
+    assert "test/CI" in db or "test-only" in db.lower() or "experiments only" in db
+    assert "day 17" in db
+    assert "pytest" in db.lower()
+    assert "SQLite" in db
+    assert "neon.tech" not in db
+    assert "test/CI/experiments only" in runbook or "test/CI/experiments only" in db
+    assert "local Postgres" in runbook
+    assert "Do **not** point oracle or Fly at Neon" in oracle
+    assert "DJANGO_DB_NAME" in oracle
+
+
+def test_oracle_unit_stays_sqlite_not_neon():
+    text = ORACLE_UNIT.read_text(encoding="utf-8")
+    assert "DJANGO_DB_NAME=" in text
+    assert "db.sqlite3" in text
+    assert "neon.tech" not in text.lower()
+    assert "RestartPreventExitStatus=78" in text
+
+
+def test_dockerfile_fail_fast_and_postgres_migrate_branch():
+    text = DOCKERFILE.read_text(encoding="utf-8")
+    assert "check_database_or_exit" in text
+    assert "DATABASE_URL" in text
+    assert "POSTGRES_HOST" in text
+    assert "neon.tech" not in text.lower()
+
+
+def test_ci_policy_sqlite_pytest_and_local_postgres_migrate():
+    text = PYTEST_WORKFLOW.read_text(encoding="utf-8")
+    assert "postgres-migrate" in text
+    assert "postgres:16" in text
+    assert "DATABASE_URL: postgres://swarm:swarm@localhost:5432/swarm" in text
+    assert "neon.tech" not in text.lower()
+    assert "pytest stays on SQLite" in text or "SQLite" in text
+
+
+def test_settings_and_helper_have_no_neon_default_host():
+    for path in (SETTINGS, HELPER):
+        blob = path.read_text(encoding="utf-8").lower()
+        assert "neon.tech" not in blob
+        assert "neon.tech" not in blob.replace(" ", "")
+
+
+def test_resolve_database_url_precedence():
+    assert resolve_database_url({}) is None
+    assert resolve_database_url({"DJANGO_DATABASE": "sqlite"}) is None
+    url = resolve_database_url({"DATABASE_URL": "postgres://a:b@h:5432/db"})
+    assert url == "postgres://a:b@h:5432/db"
+    built = resolve_database_url(
+        {
+            "POSTGRES_HOST": "db",
+            "POSTGRES_USER": "u",
+            "POSTGRES_PASSWORD": "p@ss/word",
+            "POSTGRES_DB": "swarm",
+            "POSTGRES_PORT": "5433",
+        }
+    )
+    assert built is not None
+    assert "p%40ss%2Fword" in built
+    assert "@db:5433/swarm" in built
+    # DATABASE_URL wins over POSTGRES_*.
+    assert (
+        resolve_database_url(
+            {
+                "DATABASE_URL": "postgres://x:y@cloud:5432/prod",
+                "POSTGRES_HOST": "ignored",
+            }
+        )
+        == "postgres://x:y@cloud:5432/prod"
+    )
+
+
+def test_django_databases_sqlite_and_postgres():
+    sqlite = django_databases({})
+    assert sqlite["default"]["ENGINE"] == "django.db.backends.sqlite3"
+    assert sqlite["default"]["NAME"] == "/tmp/db.sqlite3"
+    named = django_databases({"DJANGO_DB_NAME": "/var/data/app.sqlite3"})
+    assert named["default"]["NAME"] == "/var/data/app.sqlite3"
+    assert sqlite_name({"SQLITE_DB_PATH": "/tmp/alt.sqlite3"}) == "/tmp/alt.sqlite3"
+    pg = django_databases({"DATABASE_URL": "postgres://u:p@h:5432/db"})
+    assert "postgres" in pg["default"]["ENGINE"]
+    assert pg["default"]["NAME"] == "db"
+    assert pg["default"]["HOST"] == "h"
+
+
+def test_postgres_selected_without_target_is_config_error():
+    assert postgres_selected_without_target({"DJANGO_DATABASE": "postgres"})
+    assert not postgres_selected_without_target(
+        {"DJANGO_DATABASE": "postgres", "POSTGRES_HOST": "db"}
+    )
+
+
+def test_redact_and_quota_classification():
+    assert (
+        redact_database_url("postgres://user:supersecret@db:5432/app")
+        == "postgres://user:***@db:5432/app"
+    )
+    assert classify_postgres_error(RuntimeError("connection refused")) == "unreachable"
+    assert (
+        classify_postgres_error(RuntimeError("Your project has exceeded the compute time quota"))
+        == "quota"
+    )
+
+
+def test_fail_fast_unreachable_exits_78():
+    buf = StringIO()
+    codes: list[int] = []
+
+    def boom(_url: str) -> None:
+        raise ConnectionError("connection refused")
+
+    check_database_or_exit(
+        {"DATABASE_URL": "postgres://user:supersecret@db:5432/app"},
+        connect=boom,
+        stream=buf,
+        exit_fn=codes.append,
+        skip_pytest=False,
+    )
+    assert codes == [EX_CONFIG]
+    msg = buf.getvalue()
+    assert "unreachable" in msg.lower() or "ERROR: Postgres is configured" in msg
+    assert "supersecret" not in msg
+    assert "user:***" in msg
+    assert "day 17" in msg
+    assert str(EX_CONFIG) in msg
+
+
+def test_fail_fast_quota_message():
+    buf = StringIO()
+    codes: list[int] = []
+
+    def boom(_url: str) -> None:
+        raise RuntimeError("compute time quota exceeded")
+
+    check_database_or_exit(
+        {"DATABASE_URL": "postgres://n:pw@ep-foo.us-east-2.aws.neon.tech/neondb"},
+        connect=boom,
+        stream=buf,
+        exit_fn=codes.append,
+        skip_pytest=False,
+    )
+    assert codes == [EX_CONFIG]
+    msg = buf.getvalue()
+    assert "quota" in msg.lower()
+    assert "pw" not in msg
+    assert "test/CI" in msg or "experiments only" in msg
+
+
+def test_fail_fast_missing_target():
+    buf = StringIO()
+    codes: list[int] = []
+    check_database_or_exit(
+        {"DJANGO_DATABASE": "postgres"},
+        stream=buf,
+        exit_fn=codes.append,
+        skip_pytest=False,
+    )
+    assert codes == [EX_CONFIG]
+    assert "POSTGRES_HOST" in buf.getvalue()
+
+
+def test_fail_fast_skips_sqlite():
+    buf = StringIO()
+    codes: list[int] = []
+    check_database_or_exit(
+        {},
+        connect=lambda _url: (_ for _ in ()).throw(RuntimeError("should not connect")),
+        stream=buf,
+        exit_fn=codes.append,
+        skip_pytest=False,
+    )
+    assert codes == []
+    assert buf.getvalue() == ""
+
+
+def test_fail_fast_message_contains_runbook_pointer():
+    msg = format_fail_fast_message(kind="unreachable", detail="x", url="postgres://u:p@h/db")
+    assert "RUNBOOK_NEON_QUOTA_CRASH_LOOP.md" in msg
+    assert "DATABASE.md" in msg
+    assert "p" not in msg.split("Target:", 1)[1].split("\n", 1)[0] or "***" in msg

--- a/tests/unit/test_req123_postgres_compose.py
+++ b/tests/unit/test_req123_postgres_compose.py
@@ -75,7 +75,11 @@ def test_env_example_documents_override_and_neon_warning():
     assert "POSTGRES_HOST" in text
     assert "test/CI" in text or "test-only" in text.lower() or "experiments only" in text
     assert "day 17" in text
-    assert "neon.tech" not in text
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or not stripped:
+            continue
+        assert "neon.tech" not in stripped.lower()
     assert "your-postgres-password" in text
     assert "SWARM_SKIP_DB_HEALTH" in text
 

--- a/tests/unit/test_req21_herdr.py
+++ b/tests/unit/test_req21_herdr.py
@@ -55,6 +55,10 @@ def test_sidepane_and_teams_can_pick_herdr_members():
 
 def test_sqlite_default_unchanged_no_neon_url():
     src = SETTINGS_PY.read_text(encoding="utf-8")
-    assert "django.db.backends.sqlite3" in src
-    # Feature must not hard-code Neon / DATABASE_URL.
+    helper = (REPO / "src" / "swarm" / "core" / "database_config.py").read_text(
+        encoding="utf-8"
+    )
+    assert "django.db.backends.sqlite3" in src or "django.db.backends.sqlite3" in helper
+    # Feature must not hard-code Neon as a default host.
     assert "neon.tech" not in src.lower()
+    assert "neon.tech" not in helper.lower()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements REQ-123: durable default DB is local Postgres in the docker compose stack. Cloud operators point at any Postgres with `DATABASE_URL` (or `POSTGRES_*`). Neon is test/CI/experiments only — never the implied default.

## What changed
- `docker-compose.yml` adds an official `postgres:16` service (named volume, healthcheck). `swarm` waits for healthy Postgres and uses `DATABASE_URL=postgres://swarm:swarm@postgres:5432/swarm` (compose-internal placeholder, port 5432 not published).
- Single override: `DATABASE_URL` wins; `POSTGRES_*` when the URL is empty. Documented in `.env.example`, `docs/DATABASE.md`, and `CONFIGURATION.md`.
- Fail-fast: if Postgres is configured but unreachable / quota-exhausted / missing host, exit **78** (`EX_CONFIG`) with a redacted operator message. Compose caps `swarm` at `restart: on-failure:5`. systemd already has `RestartPreventExitStatus=78`.
- SQLite remains the secondary path for pytest, desktop (ADR-003), and tiny native demos when `DATABASE_URL` / `POSTGRES_HOST` are unset.
- CI: pytest stays on SQLite (existing policy). New `postgres-migrate` job runs `manage.py migrate` against a GitHub Actions Postgres service — no live Neon.
- Oracle / Fly are **not** pointed at Neon. Oracle unit stays on `DJANGO_DB_NAME` SQLite unless an operator sets `DATABASE_URL`.

## Tests / docs
- `tests/unit/test_req123_postgres_compose.py` locks compose wiring, no `neon.tech` defaults, URL precedence, fail-fast 78, and CI policy.
- Short docs: `docs/DATABASE.md`. Neon runbook and oracle deploy docs updated for honesty.

Fixes #508

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2e8acd0-5ffa-46b5-a012-771fa7a39996?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2e8acd0-5ffa-46b5-a012-771fa7a39996&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

