### PR TITLE
REQ-135: kind-clear demo names and team personas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **REQ-135 showoff demo names:** Two naming modes — Mode A kind-clear (`Grok CLI`, `LiteLLM API`, `Hermes Remote`, `OpenMousBot Remote`) vs Mode B personas (`Chief of Staff`, `BA`, `Engineer`, `Tester`, `Skeptic`). Demo seed/fixture is additive and labeled Demo. Member `name` survives roster normalize + `/v1/team-rosters/`. SoT: `docs/SHOWOFF_DEMO_AGENTS.md`. `scripts/seed_demo_agents.py --reset`. Fixes #526.
+
+### Added
 - **REQ-100 Herdr SSH-shaped remotes:** Local Herdr talks to Herdr on this host (no SSH). Remote Herdr captures SSH host / user / identity-env (path name only) / agent — then health, list, send, and interrogate go over SSH to that Herdr host and its CLIs. Distinct from HTTP remotes (OpenMousBot / Hermes / Rakazo). Settings + Support skill copy say so. Tests stub SSH; missing SSH config is a clear error. Fixes #463.
 - **REQ-107 optional Chief of Staff on the team designer:** After adding members, pick one API or CLI roster seat as CoS (or none). A generic starter brief plus helper examples tell that CoS how to use the rest of the roster. Saved on the team (`team_rosters.json` / `/v1/team-rosters/`); runtime injects the brief for that team's CoS only. Same agent on two teams keeps two briefs. Remotes stay off the picker until they can receive a system/developer message. Fixes #475.
 - **REQ-75 blueprint roles / workflows:** A Python blueprint may declare `metadata.role` (`gate` / `skeptic` / `cos` / `engineer` / `support` / `none`) and an optional `metadata.workflow` hint (`handoff` / `as_tool`). Creating or re-picking that recipe assigns the default role; the agent-editor Role control wins once the operator overrides it. Catalog / picker show the role as a badge (chrome stays badge-only). `engineer` is a canonical role. Pickers hide leftover webui kinds (no second webui kind; #419 already retired `django_chat`). Fixes #420.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The differentiator is a **programmatic graph** — not “let chat figure it out
 
 **Limit (up front):** that graph runs **inside Blueprint seats** (today’s leftover `api` bucket). We **cannot inject** openai-agents into **CLI** or **Remote** harnesses — those **stay native** sessions. Cross-kind teams still work: a Blueprint coordinator can sit with a Grok CLI and a Hermes Remote.
 
-Mermaid, kind bases, and the `:8001` seed live on [docs/DEVELOPER.md](docs/DEVELOPER.md). Worked configs: [docs/examples/openai-agents-handoff-graphs/](docs/examples/openai-agents-handoff-graphs/README.md) (REQ-156 / #564). Kind-base ADR: [ADR-005](docs/adr/005-kind-bases.md) (REQ-159 / #570).
+Mermaid, kind bases, and the `:8001` seed live on [docs/DEVELOPER.md](docs/DEVELOPER.md). Worked configs: [docs/examples/openai-agents-handoff-graphs/](docs/examples/openai-agents-handoff-graphs/README.md) (REQ-156 / #564). Demo roster names (Mode A kind-clear vs Mode B personas): [docs/SHOWOFF_DEMO_AGENTS.md](docs/SHOWOFF_DEMO_AGENTS.md) (REQ-135 / #526). Kind-base ADR: [ADR-005](docs/adr/005-kind-bases.md) (REQ-159 / #570).
 
 ---
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -57,6 +57,8 @@ Worked configs, Mode A/B demo names, tests that lock the edges, and
 `:8001` seed steps (no secrets):
 [docs/examples/openai-agents-handoff-graphs/](./examples/openai-agents-handoff-graphs/README.md)
 (REQ-156 / [#564](https://github.com/matthewhand/open-swarm/issues/564)).
+Showoff naming SoT: [SHOWOFF_DEMO_AGENTS.md](./SHOWOFF_DEMO_AGENTS.md)
+(REQ-135 / [#526](https://github.com/matthewhand/open-swarm/issues/526)).
 
 ---
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -67,7 +67,7 @@ This is **not** the Django `/teams/` + `/v1/teams/` JSON registry.
 ## Team roster (composition) / Chief of Staff
 
 A **team roster** (`team_rosters.json`, `/v1/team-rosters/`) is a composition
-of members `{id, kind: api\|cli\|remote\|team\|herdr, role, source}`. This is
+of members `{id, name, kind: api\|cli\|remote\|team\|herdr, role, source}`. This is
 **not** the `/v1/teams` alias. `kind=team` + `team_id` nests a child roster.
 A roster may optionally name one **API or CLI** member as Chief of Staff and
 store team-scoped how-to-use-the-roster instructions. The same agent id may

--- a/docs/SHOWOFF_DEMO_AGENTS.md
+++ b/docs/SHOWOFF_DEMO_AGENTS.md
@@ -1,0 +1,119 @@
+# Showoff demo agents — two naming modes (REQ-135)
+
+Issue SoT: [REQ-135 #526](https://github.com/matthewhand/open-swarm/issues/526).
+
+**Intent:** Demo roster names make the story obvious at a glance — what
+**kind** something is for harness demos; what **role** it plays for team
+demos.
+
+Seed is **additive** and labeled **Demo**. It does not rename day-to-day
+agents. No secrets: URLs and keys stay placeholders / env. GitHub-only
+until an engineer seeds a live box.
+
+Announce GIF [#529](https://github.com/matthewhand/open-swarm/issues/529)
+and near-release media [#456](https://github.com/matthewhand/open-swarm/issues/456)
+should prefer **Mode A** names on harness rows.
+
+---
+
+## Mode A — mixture of types (kind + backend)
+
+Use when the demo is “CLI vs API vs remote.” Names encode **kind + backend**.
+Label **OpenMousBot**, never OMB. Same pattern for Rakazo / Herdr remotes
+when those seats are shown.
+
+| Id | Display name | Kind | Source (no secrets) |
+|----|--------------|------|---------------------|
+| `grok-cli` | Grok CLI | `cli` | `cli:grok` |
+| `antigravity-cli` | Antigravity CLI | `cli` | `cli:agy` |
+| `litellm-api` | LiteLLM API | `api` | `blueprint:sdlc_handoff` |
+| `hermes-remote` | Hermes Remote | `remote` | `placeholder:remote:hermes` |
+| `openmousbot-remote` | OpenMousBot Remote | `remote` | `placeholder:remote:omb` |
+
+Roster: [`docs/examples/openai-agents-handoff-graphs/demo-harness-kinds.json`](./examples/openai-agents-handoff-graphs/demo-harness-kinds.json)
+(`Demo Harness Kinds`).
+
+Do **not** put role names (`Engineer`, `QA`) on this roster. A harness row
+named Engineer hides the type story.
+
+---
+
+## Mode B — teams / blueprints (role / persona)
+
+Use when the demo is a team or blueprint workflow. Names are **roles**,
+not kinds. Default seed is the practical set. Funny names are an
+alternate only — do not ship both in one roster.
+
+| Id | Default (practical) | Alternate (funny) |
+|----|---------------------|-------------------|
+| `cos` | Chief of Staff | Ringmaster |
+| `ba` | BA | Requirements Nag |
+| `engineer` | Engineer | Code Monkey |
+| `tester` | Tester | QA Hawk |
+| `skeptic` | Skeptic | Professional Doubter |
+
+Rosters:
+
+- [`demo-sdlc-pipeline.json`](./examples/openai-agents-handoff-graphs/demo-sdlc-pipeline.json) — CoS + BA → Engineer → Tester
+- [`demo-sdlc-skeptic-loop.json`](./examples/openai-agents-handoff-graphs/demo-sdlc-skeptic-loop.json) — same plus Skeptic punt-back
+
+CoS is selected via `chief_of_staff_id` (team designer, REQ-107 / #475).
+The brief is team-scoped and contains no secrets.
+
+Do **not** name a Mode B seat `LiteLLM API` — that confuses the team story.
+
+---
+
+## Intentional mix
+
+[`demo-bridge.json`](./examples/openai-agents-handoff-graphs/demo-bridge.json)
+is the one roster that **mixes on purpose**: Chief of Staff (persona)
+coordinates **Grok CLI** and **Hermes Remote** (kind-clear). That is the
+announce-bridge beat, not a Mode A or Mode B roster.
+
+---
+
+## Seed / reset demo agents
+
+Fixture JSON (rail first-load, labeled Demo):
+
+- [`webui/frontend/public/team_rosters.json`](../webui/frontend/public/team_rosters.json)
+- [`src/swarm/static/team_rosters.json`](../src/swarm/static/team_rosters.json)
+
+The empty-state stub `demo-team` (Codey / Stewie) stays so existing
+sidepane tests keep a generic team. It is **not** a Mode A/B showoff roster.
+
+Reset / upsert only `demo-*` ids (never day-to-day rosters):
+
+```bash
+# See what would be written (no disk write)
+uv run python scripts/seed_demo_agents.py --dry-run
+
+# Additive upsert
+uv run python scripts/seed_demo_agents.py
+
+# Replace existing demo-* ids only
+uv run python scripts/seed_demo_agents.py --reset
+```
+
+`scripts/seed_req156_demo.py` is the same path (`--overwrite` = `--reset`).
+Do not run this against a live `:8001` / FF box from CI. Engineer seeds
+after merge. Placeholders only — no hostnames, tokens, or LAN dumps.
+
+---
+
+## Where names must appear
+
+After seed (or from the fixture JSON):
+
+- **Rail** — team rows `Demo Harness Kinds`, `Demo SDLC Pipeline`,
+  `Demo SDLC Skeptic Loop`, `Demo Bridge`. CoS rail injection uses the
+  member display name (`Chief of Staff`) when that seat is not already
+  a catalog agent.
+- **Favourites** — pinning a Demo team keeps that team title.
+- **Chat header** — team title plus the unlabeled member dropdown
+  (`Grok CLI (cli/default)`, `BA (api/default)`, …).
+
+Member `name` is part of the roster contract and survives
+`normalize_member` / `GET /v1/team-rosters/`. Missing name falls back to
+`id` (never invents a secret).

--- a/docs/TEAM_ROSTERS.md
+++ b/docs/TEAM_ROSTERS.md
@@ -10,7 +10,7 @@ This is **not** the Django `/teams/` LLM-profile alias admin.
 | Store / surface | What it is | Schema |
 |---|---|---|
 | **Live aliases** — `teams.json`, `/v1/teams/`, Django `/teams/` (Launcher, Admin, Swarm Creator) | Named **LLM-profile alias** (`id` / `description` / `llm_profile`) exposed as a model id via `DynamicTeamBlueprint` | Unchanged. Do not overwrite. |
-| **Intended composition** — `team_rosters.json`, `/v1/team-rosters/`, SPA `+` overlay | Roster of members (`api` from a blueprint, `cli`, or `remote` harness) plus per-team wire toggles | `members[{id, kind, role, source}]` + `wires{handoff, as_tool}` |
+| **Intended composition** — `team_rosters.json`, `/v1/team-rosters/`, SPA `+` overlay | Roster of members (`api` from a blueprint, `cli`, or `remote` harness) plus per-team wire toggles | `members[{id, name, kind, role, source}]` + `wires{handoff, as_tool}` |
 
 Django `/teams/` remains aliases. The SPA does **not** add a top-nav Teams tab
 or restore Home/Chat chrome. Entry is the chat-header **Compose team** `+`
@@ -27,9 +27,9 @@ control (DaisyUI `modal-end` Settings sheet is not in this tree).
     "id": "research-squad",
     "name": "Research Squad",
     "members": [
-      {"id": "jeeves", "kind": "api", "role": "default", "source": "blueprint:jeeves"},
-      {"id": "grok", "kind": "cli", "role": "skeptic", "source": "cli:grok"},
-      {"id": "acp", "kind": "remote", "role": "support", "source": "placeholder:remote:acp"}
+      {"id": "jeeves", "name": "Jeeves", "kind": "api", "role": "default", "source": "blueprint:jeeves"},
+      {"id": "grok", "name": "Grok CLI", "kind": "cli", "role": "skeptic", "source": "cli:grok"},
+      {"id": "acp", "name": "ACP Remote", "kind": "remote", "role": "support", "source": "placeholder:remote:acp"}
     ],
     "wires": {"handoff": true, "as_tool": true},
     "chief_of_staff_id": "jeeves",
@@ -39,6 +39,9 @@ control (DaisyUI `modal-end` Settings sheet is not in this tree).
 ```
 
 - `kind`: `api` | `cli` | `remote`
+- `name`: optional display label (rail / favourites / chat header). Missing
+  name falls back to `id`. Showoff Mode A vs Mode B:
+  [SHOWOFF_DEMO_AGENTS.md](./SHOWOFF_DEMO_AGENTS.md) (REQ-135).
 - `role`: `support` | `gate` | `skeptic` | `default` | `chief_of_staff`
 - `chief_of_staff_id`: optional member id already on the roster (API or CLI).
   Empty / omitted = no CoS. Never auto-picked.

--- a/docs/examples/openai-agents-handoff-graphs/README.md
+++ b/docs/examples/openai-agents-handoff-graphs/README.md
@@ -24,9 +24,10 @@ do not talk to **remote harnesses** (Hermes, OpenMousBot as remote, …).
 Open Swarm is a Grok-agnostic Grok-Bot-like UI **and** a bridge — task one
 place, coordinate across CLI, API, remotes, and local blueprints.
 
-Demo names follow [REQ-135 #526](https://github.com/matthewhand/open-swarm/issues/526):
-Mode A encodes **kind + backend**; Mode B uses **role/persona**. Do not mix
-those modes in one roster without intent.
+Demo names follow [REQ-135 #526](https://github.com/matthewhand/open-swarm/issues/526)
+([SHOWOFF_DEMO_AGENTS.md](../../SHOWOFF_DEMO_AGENTS.md)): Mode A encodes
+**kind + backend**; Mode B uses **role/persona**. Do not mix those modes in
+one roster without intent.
 
 ---
 
@@ -179,13 +180,13 @@ Default dest is XDG `…/swarm/team_rosters.json`. Override with
 
 ```bash
 # See what would be added (no write)
-uv run python scripts/seed_req156_demo.py --dry-run
+uv run python scripts/seed_demo_agents.py --dry-run
 
 # Additive upsert of demo-* rosters only
-uv run python scripts/seed_req156_demo.py
+uv run python scripts/seed_demo_agents.py
 
 # If a previous Demo seed exists and you want to replace those four ids only
-uv run python scripts/seed_req156_demo.py --overwrite
+uv run python scripts/seed_demo_agents.py --reset
 ```
 
 REST equivalent (preview listen URL; no personal hostname in this doc):

--- a/docs/examples/openai-agents-handoff-graphs/demo-bridge.json
+++ b/docs/examples/openai-agents-handoff-graphs/demo-bridge.json
@@ -1,25 +1,31 @@
 {
   "id": "demo-bridge",
   "name": "Demo Bridge",
+  "description": "Intentional mix (REQ-135) — CoS persona plus kind-clear harness seats. Demo only.",
   "members": [
     {
       "id": "cos",
+      "name": "Chief of Staff",
       "kind": "api",
       "role": "chief_of_staff",
       "source": "blueprint:sdlc_handoff"
     },
     {
       "id": "grok-cli",
+      "name": "Grok CLI",
       "kind": "cli",
       "role": "default",
       "source": "cli:grok"
     },
     {
       "id": "hermes-remote",
+      "name": "Hermes Remote",
       "kind": "remote",
       "role": "default",
       "source": "placeholder:remote:hermes"
     }
   ],
-  "wires": {"handoff": true, "as_tool": true}
+  "wires": {"handoff": true, "as_tool": true},
+  "chief_of_staff_id": "cos",
+  "chief_of_staff_instructions": "Coordinate this Demo Bridge. Hand the user task to Grok CLI or Hermes Remote by kind. Do not pretend CLI or remote seats run the openai-agents graph. Report back."
 }

--- a/docs/examples/openai-agents-handoff-graphs/demo-harness-kinds.json
+++ b/docs/examples/openai-agents-handoff-graphs/demo-harness-kinds.json
@@ -1,33 +1,39 @@
 {
   "id": "demo-harness-kinds",
   "name": "Demo Harness Kinds",
+  "description": "Mode A (REQ-135) — kind-clear names. Demo only. Placeholders / env for URLs and keys.",
   "members": [
     {
       "id": "grok-cli",
+      "name": "Grok CLI",
       "kind": "cli",
       "role": "default",
       "source": "cli:grok"
     },
     {
       "id": "antigravity-cli",
+      "name": "Antigravity CLI",
       "kind": "cli",
       "role": "default",
       "source": "cli:agy"
     },
     {
       "id": "litellm-api",
+      "name": "LiteLLM API",
       "kind": "api",
       "role": "default",
       "source": "blueprint:sdlc_handoff"
     },
     {
       "id": "hermes-remote",
+      "name": "Hermes Remote",
       "kind": "remote",
       "role": "default",
       "source": "placeholder:remote:hermes"
     },
     {
       "id": "openmousbot-remote",
+      "name": "OpenMousBot Remote",
       "kind": "remote",
       "role": "default",
       "source": "placeholder:remote:omb"

--- a/docs/examples/openai-agents-handoff-graphs/demo-sdlc-pipeline.json
+++ b/docs/examples/openai-agents-handoff-graphs/demo-sdlc-pipeline.json
@@ -1,10 +1,38 @@
 {
   "id": "demo-sdlc-pipeline",
   "name": "Demo SDLC Pipeline",
+  "description": "Mode B (REQ-135) — practical personas. Demo only. Alternate funny names live in docs/SHOWOFF_DEMO_AGENTS.md.",
   "members": [
-    {"id": "ba", "kind": "api", "role": "default", "source": "blueprint:sdlc_handoff"},
-    {"id": "engineer", "kind": "api", "role": "default", "source": "blueprint:sdlc_handoff"},
-    {"id": "tester", "kind": "api", "role": "default", "source": "blueprint:sdlc_handoff"}
+    {
+      "id": "cos",
+      "name": "Chief of Staff",
+      "kind": "api",
+      "role": "chief_of_staff",
+      "source": "blueprint:sdlc_handoff"
+    },
+    {
+      "id": "ba",
+      "name": "BA",
+      "kind": "api",
+      "role": "default",
+      "source": "blueprint:sdlc_handoff"
+    },
+    {
+      "id": "engineer",
+      "name": "Engineer",
+      "kind": "api",
+      "role": "default",
+      "source": "blueprint:sdlc_handoff"
+    },
+    {
+      "id": "tester",
+      "name": "Tester",
+      "kind": "api",
+      "role": "default",
+      "source": "blueprint:sdlc_handoff"
+    }
   ],
-  "wires": {"handoff": true, "as_tool": false}
+  "wires": {"handoff": true, "as_tool": false},
+  "chief_of_staff_id": "cos",
+  "chief_of_staff_instructions": "Coordinate this SDLC roster. Forced handoff is BA → Engineer → Tester. Do not skip seats. Report back."
 }

--- a/docs/examples/openai-agents-handoff-graphs/demo-sdlc-skeptic-loop.json
+++ b/docs/examples/openai-agents-handoff-graphs/demo-sdlc-skeptic-loop.json
@@ -1,11 +1,45 @@
 {
   "id": "demo-sdlc-skeptic-loop",
   "name": "Demo SDLC Skeptic Loop",
+  "description": "Mode B (REQ-135) — practical personas including Skeptic. Demo only.",
   "members": [
-    {"id": "ba", "kind": "api", "role": "default", "source": "blueprint:sdlc_handoff"},
-    {"id": "engineer", "kind": "api", "role": "default", "source": "blueprint:sdlc_handoff"},
-    {"id": "tester", "kind": "api", "role": "default", "source": "blueprint:sdlc_handoff"},
-    {"id": "skeptic", "kind": "api", "role": "skeptic", "source": "blueprint:sdlc_handoff"}
+    {
+      "id": "cos",
+      "name": "Chief of Staff",
+      "kind": "api",
+      "role": "chief_of_staff",
+      "source": "blueprint:sdlc_handoff"
+    },
+    {
+      "id": "ba",
+      "name": "BA",
+      "kind": "api",
+      "role": "default",
+      "source": "blueprint:sdlc_handoff"
+    },
+    {
+      "id": "engineer",
+      "name": "Engineer",
+      "kind": "api",
+      "role": "default",
+      "source": "blueprint:sdlc_handoff"
+    },
+    {
+      "id": "tester",
+      "name": "Tester",
+      "kind": "api",
+      "role": "default",
+      "source": "blueprint:sdlc_handoff"
+    },
+    {
+      "id": "skeptic",
+      "name": "Skeptic",
+      "kind": "api",
+      "role": "skeptic",
+      "source": "blueprint:sdlc_handoff"
+    }
   ],
-  "wires": {"handoff": true, "as_tool": false}
+  "wires": {"handoff": true, "as_tool": false},
+  "chief_of_staff_id": "cos",
+  "chief_of_staff_instructions": "Coordinate this SDLC skeptic loop. Forced handoff is BA → Engineer → Tester → Skeptic; Skeptic may punt back to Engineer. Do not skip seats. Report back."
 }

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -38,6 +38,7 @@ Oracle from anything in this tree.
 | [REQ-114](./REQ-114.md) | [Rail right-click — Terminate running CLI process](https://github.com/matthewhand/open-swarm/issues/495) |
 | [REQ-106](./REQ-106.md) | [Bee brand mark — SVG favicon + multi-size app icons (colour + mono)](https://github.com/matthewhand/open-swarm/issues/470); surface split [minimal / geometric / cyber-swarm](https://github.com/matthewhand/open-swarm/issues/768) |
 | [REQ-107](./REQ-107.md) | [Team designer — optional Chief of Staff + how-to-use-the-team instructions](https://github.com/matthewhand/open-swarm/issues/475) |
+| [REQ-135](./REQ-135.md) | [Showoff demo agents — kind-clear names + team personas](https://github.com/matthewhand/open-swarm/issues/526) |
 | [REQ-189](./REQ-189.md) | [Look-only — OMB+Rakazo local computer control → open-swarm adaptation](https://github.com/matthewhand/open-swarm/issues/645) |
 | [REQ-156](./REQ-156.md) | [README — why openai-agents + 3 harness types + workflow diagrams](https://github.com/matthewhand/open-swarm/issues/564) |
 | [REQ-159](./REQ-159.md) | [Three kind bases (API/CLI/remote) — Support builds from these](https://github.com/matthewhand/open-swarm/issues/570) |

--- a/docs/requirements/REQ-135.md
+++ b/docs/requirements/REQ-135.md
@@ -1,0 +1,3 @@
+# REQ-135 — Showoff demo agents — kind-clear names + team personas
+
+https://github.com/matthewhand/open-swarm/issues/526

--- a/scripts/seed_demo_agents.py
+++ b/scripts/seed_demo_agents.py
@@ -10,7 +10,7 @@ SCRIPTS = Path(__file__).resolve().parent
 if str(SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SCRIPTS))
 
-from seed_req156_demo import main  # noqa: E402
+from seed_req156_demo import main  # noqa: E402,I001
 
 
 if __name__ == "__main__":

--- a/scripts/seed_demo_agents.py
+++ b/scripts/seed_demo_agents.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Reset / seed labeled Demo agents (REQ-135). Same path as seed_req156_demo.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from seed_req156_demo import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/seed_req156_demo.py
+++ b/scripts/seed_req156_demo.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
-"""Additive Demo roster seed for REQ-156 (no secrets).
+"""Additive Demo roster seed for REQ-156 / REQ-135 (no secrets).
 
 Writes labeled ``demo-*`` team rosters into ``team_rosters.json``. Does not
-touch ``teams.json``, ``.env``, or Matthew's day-to-day agents.
+touch ``teams.json``, ``.env``, or day-to-day agents.
 
 Usage (engineer on ubuntu-gtx / preview after merge)::
 
-    uv run python scripts/seed_req156_demo.py --dry-run
-    uv run python scripts/seed_req156_demo.py
-    uv run python scripts/seed_req156_demo.py --config-dir /path/to/swarm --overwrite
+    uv run python scripts/seed_demo_agents.py --dry-run
+    uv run python scripts/seed_demo_agents.py
+    uv run python scripts/seed_demo_agents.py --config-dir /path/to/swarm --reset
 
-See docs/examples/openai-agents-handoff-graphs/README.md (:8001 seed).
+See docs/SHOWOFF_DEMO_AGENTS.md and
+docs/examples/openai-agents-handoff-graphs/README.md (:8001 seed).
 """
 
 from __future__ import annotations
@@ -46,8 +47,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--overwrite",
+        "--reset",
         action="store_true",
-        help="Replace existing demo-* ids. Never deletes non-demo rosters.",
+        dest="overwrite",
+        help="Replace existing demo-* ids (reset demo agents). Never deletes non-demo rosters.",
     )
     args = parser.parse_args(argv)
     dest = _dest(args.config_dir)

--- a/src/swarm/core/handoff_graph.py
+++ b/src/swarm/core/handoff_graph.py
@@ -33,6 +33,31 @@ DEMO_ROSTER_IDS = (
     "demo-harness-kinds",
 )
 
+# REQ-135 showoff names. Mode A = kind + backend. Mode B = role/persona.
+# Do not mix modes in one roster without intent (demo-bridge is the mix).
+MODE_A_MEMBER_NAMES = {
+    "grok-cli": "Grok CLI",
+    "antigravity-cli": "Antigravity CLI",
+    "litellm-api": "LiteLLM API",
+    "hermes-remote": "Hermes Remote",
+    "openmousbot-remote": "OpenMousBot Remote",
+}
+MODE_B_MEMBER_NAMES = {
+    "cos": "Chief of Staff",
+    "ba": "BA",
+    "engineer": "Engineer",
+    "tester": "Tester",
+    "skeptic": "Skeptic",
+}
+# Documented alternate only — not the default seed.
+MODE_B_FUNNY_NAMES = {
+    "cos": "Ringmaster",
+    "ba": "Requirements Nag",
+    "engineer": "Code Monkey",
+    "tester": "QA Hawk",
+    "skeptic": "Professional Doubter",
+}
+
 
 def repo_root() -> Path:
     """Walk up from this file to the checkout that holds the example pack."""
@@ -369,6 +394,9 @@ def seed_demo_rosters(
 
 __all__ = [
     "DEMO_ROSTER_IDS",
+    "MODE_A_MEMBER_NAMES",
+    "MODE_B_FUNNY_NAMES",
+    "MODE_B_MEMBER_NAMES",
     "HandoffEdge",
     "HandoffGraph",
     "HandoffNode",

--- a/src/swarm/core/team_rosters.py
+++ b/src/swarm/core/team_rosters.py
@@ -5,7 +5,7 @@ plus per-team openai-agents wire toggles (handoff / as_tool).
 
 Member shape (``team_rosters`` / ``agent_team`` members)::
 
-    {id, kind: api|cli|remote|team|herdr, role, source}
+    {id, name, kind: api|cli|remote|team|herdr, role, source}
 
 ``kind=team`` also carries ``team_id`` (the nested roster). Parent talks to
 that child team as **one member** (send-to-all on the child), not every
@@ -88,7 +88,10 @@ def normalize_member(raw: Any) -> dict[str, str]:
         team_id = ""
 
     source = str(raw.get("source") or "").strip() or _default_source(member_id, kind, team_id or None)
-    member = {"id": member_id, "kind": kind, "role": role, "source": source}
+    name = str(raw.get("name") or "").strip() or member_id
+    if len(name) > 80:
+        raise ValueError("Member name too long (max 80).")
+    member = {"id": member_id, "name": name, "kind": kind, "role": role, "source": source}
     if team_id:
         member["team_id"] = team_id
     return member

--- a/src/swarm/static/team_rosters.json
+++ b/src/swarm/static/team_rosters.json
@@ -5,7 +5,7 @@
       "id": "demo-team",
       "object": "team_roster",
       "name": "Demo Team",
-      "description": "Example multi-agent roster",
+      "description": "Empty-state stub (not a Mode A/B showoff roster). See docs/SHOWOFF_DEMO_AGENTS.md.",
       "members": [
         {
           "id": "codey",
@@ -20,6 +20,167 @@
           "role": "ops"
         }
       ]
+    },
+    {
+      "id": "demo-harness-kinds",
+      "object": "team_roster",
+      "name": "Demo Harness Kinds",
+      "description": "Mode A (REQ-135) — kind-clear names. Demo only. Placeholders / env for URLs and keys.",
+      "members": [
+        {
+          "id": "grok-cli",
+          "name": "Grok CLI",
+          "kind": "cli",
+          "role": "default",
+          "source": "cli:grok"
+        },
+        {
+          "id": "antigravity-cli",
+          "name": "Antigravity CLI",
+          "kind": "cli",
+          "role": "default",
+          "source": "cli:agy"
+        },
+        {
+          "id": "litellm-api",
+          "name": "LiteLLM API",
+          "kind": "api",
+          "role": "default",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "hermes-remote",
+          "name": "Hermes Remote",
+          "kind": "remote",
+          "role": "default",
+          "source": "placeholder:remote:hermes"
+        },
+        {
+          "id": "openmousbot-remote",
+          "name": "OpenMousBot Remote",
+          "kind": "remote",
+          "role": "default",
+          "source": "placeholder:remote:omb"
+        }
+      ],
+      "wires": {"handoff": true, "as_tool": true}
+    },
+    {
+      "id": "demo-sdlc-pipeline",
+      "object": "team_roster",
+      "name": "Demo SDLC Pipeline",
+      "description": "Mode B (REQ-135) — practical personas. Demo only.",
+      "members": [
+        {
+          "id": "cos",
+          "name": "Chief of Staff",
+          "kind": "api",
+          "role": "chief_of_staff",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "ba",
+          "name": "BA",
+          "kind": "api",
+          "role": "default",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "engineer",
+          "name": "Engineer",
+          "kind": "api",
+          "role": "default",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "tester",
+          "name": "Tester",
+          "kind": "api",
+          "role": "default",
+          "source": "blueprint:sdlc_handoff"
+        }
+      ],
+      "wires": {"handoff": true, "as_tool": false},
+      "chief_of_staff_id": "cos",
+      "chief_of_staff_instructions": "Coordinate this SDLC roster. Forced handoff is BA → Engineer → Tester. Do not skip seats. Report back."
+    },
+    {
+      "id": "demo-sdlc-skeptic-loop",
+      "object": "team_roster",
+      "name": "Demo SDLC Skeptic Loop",
+      "description": "Mode B (REQ-135) — practical personas including Skeptic. Demo only.",
+      "members": [
+        {
+          "id": "cos",
+          "name": "Chief of Staff",
+          "kind": "api",
+          "role": "chief_of_staff",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "ba",
+          "name": "BA",
+          "kind": "api",
+          "role": "default",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "engineer",
+          "name": "Engineer",
+          "kind": "api",
+          "role": "default",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "tester",
+          "name": "Tester",
+          "kind": "api",
+          "role": "default",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "skeptic",
+          "name": "Skeptic",
+          "kind": "api",
+          "role": "skeptic",
+          "source": "blueprint:sdlc_handoff"
+        }
+      ],
+      "wires": {"handoff": true, "as_tool": false},
+      "chief_of_staff_id": "cos",
+      "chief_of_staff_instructions": "Coordinate this SDLC skeptic loop. Forced handoff is BA → Engineer → Tester → Skeptic; Skeptic may punt back to Engineer. Do not skip seats. Report back."
+    },
+    {
+      "id": "demo-bridge",
+      "object": "team_roster",
+      "name": "Demo Bridge",
+      "description": "Intentional mix (REQ-135) — CoS persona plus kind-clear harness seats. Demo only.",
+      "members": [
+        {
+          "id": "cos",
+          "name": "Chief of Staff",
+          "kind": "api",
+          "role": "chief_of_staff",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "grok-cli",
+          "name": "Grok CLI",
+          "kind": "cli",
+          "role": "default",
+          "source": "cli:grok"
+        },
+        {
+          "id": "hermes-remote",
+          "name": "Hermes Remote",
+          "kind": "remote",
+          "role": "default",
+          "source": "placeholder:remote:hermes"
+        }
+      ],
+      "wires": {"handoff": true, "as_tool": true},
+      "chief_of_staff_id": "cos",
+      "chief_of_staff_instructions": "Coordinate this Demo Bridge. Hand the user task to Grok CLI or Hermes Remote by kind. Do not pretend CLI or remote seats run the openai-agents graph. Report back."
     }
   ]
 }

--- a/src/swarm/views/team_rosters_api.py
+++ b/src/swarm/views/team_rosters_api.py
@@ -7,7 +7,7 @@ LLM-profile alias registry at ``teams.json`` / ``/v1/teams/`` / Django
 
 Member shape::
 
-    {id, kind: api|cli|remote|team|herdr, role, source}
+    {id, name, kind: api|cli|remote|team|herdr, role, source}
 
 ``kind=team`` also stores ``team_id``. Isolation / CoS consult tools live in
 ``swarm.core.team_isolation`` and ``swarm.core.team_consult``.

--- a/tests/core/test_handoff_graph.py
+++ b/tests/core/test_handoff_graph.py
@@ -8,6 +8,9 @@ import pytest
 
 from swarm.core.handoff_graph import (
     DEMO_ROSTER_IDS,
+    MODE_A_MEMBER_NAMES,
+    MODE_B_FUNNY_NAMES,
+    MODE_B_MEMBER_NAMES,
     PIPELINE_GRAPH_ID,
     SKEPTIC_LOOP_GRAPH_ID,
     assert_edges_match,
@@ -126,13 +129,24 @@ def test_demo_rosters_normalize_and_span_kinds():
     assert set(rosters) == set(DEMO_ROSTER_IDS)
 
     pipeline = rosters["demo-sdlc-pipeline"]
-    assert [m["id"] for m in pipeline["members"]] == ["ba", "engineer", "tester"]
+    assert [m["id"] for m in pipeline["members"]] == ["cos", "ba", "engineer", "tester"]
     assert all(m["kind"] == "api" for m in pipeline["members"])
     assert pipeline["wires"]["handoff"] is True
+    assert pipeline["chief_of_staff_id"] == "cos"
+    names = {m["id"]: m["name"] for m in pipeline["members"]}
+    assert names["ba"] == MODE_B_MEMBER_NAMES["ba"]
+    assert names["engineer"] == MODE_B_MEMBER_NAMES["engineer"]
+    assert names["tester"] == MODE_B_MEMBER_NAMES["tester"]
+    assert names["cos"] == MODE_B_MEMBER_NAMES["cos"]
+    assert "LiteLLM API" not in names.values()
 
     loop = rosters["demo-sdlc-skeptic-loop"]
     roles = {m["id"]: m["role"] for m in loop["members"]}
     assert roles["skeptic"] == "skeptic"
+    assert loop["chief_of_staff_id"] == "cos"
+    loop_names = {m["id"]: m["name"] for m in loop["members"]}
+    assert loop_names["skeptic"] == MODE_B_MEMBER_NAMES["skeptic"]
+    assert loop_names["cos"] == MODE_B_MEMBER_NAMES["cos"]
 
     bridge = rosters["demo-bridge"]
     kinds = {m["id"]: m["kind"] for m in bridge["members"]}
@@ -142,6 +156,11 @@ def test_demo_rosters_normalize_and_span_kinds():
         "hermes-remote": "remote",
     }
     assert any(m["role"] == "chief_of_staff" for m in bridge["members"])
+    assert bridge["chief_of_staff_id"] == "cos"
+    bridge_names = {m["id"]: m["name"] for m in bridge["members"]}
+    assert bridge_names["cos"] == MODE_B_MEMBER_NAMES["cos"]
+    assert bridge_names["grok-cli"] == MODE_A_MEMBER_NAMES["grok-cli"]
+    assert bridge_names["hermes-remote"] == MODE_A_MEMBER_NAMES["hermes-remote"]
 
     kinds_roster = rosters["demo-harness-kinds"]
     labels = {m["id"]: m["kind"] for m in kinds_roster["members"]}
@@ -150,6 +169,23 @@ def test_demo_rosters_normalize_and_span_kinds():
     assert labels["litellm-api"] == "api"
     assert labels["hermes-remote"] == "remote"
     assert labels["openmousbot-remote"] == "remote"
+    kind_names = {m["id"]: m["name"] for m in kinds_roster["members"]}
+    assert kind_names == MODE_A_MEMBER_NAMES
+    assert "OMB" not in kind_names.values()
+    assert "OpenMousBot Remote" in kind_names.values()
+    assert kinds_roster.get("chief_of_staff_id") in (None, "")
+
+
+def test_mode_b_funny_names_are_documented_alternates_not_seeded():
+    seeded = {
+        m["name"]
+        for roster in load_demo_rosters()
+        for m in roster["members"]
+        if m.get("id") in MODE_B_FUNNY_NAMES
+    }
+    assert MODE_B_MEMBER_NAMES["engineer"] in seeded
+    assert MODE_B_FUNNY_NAMES["engineer"] not in seeded
+    assert MODE_B_FUNNY_NAMES["ba"] not in seeded
 
 
 def test_example_json_has_no_secret_literals():
@@ -218,3 +254,35 @@ def test_seed_script_cli_dry_run(tmp_path):
     assert "demo-bridge" in proc.stdout
     assert "dry-run" in proc.stdout
     assert not (dest / "team_rosters.json").exists()
+
+
+def test_seed_demo_agents_script_reset_alias(tmp_path):
+    import subprocess
+    import sys
+
+    from swarm.core.handoff_graph import repo_root
+
+    dest = tmp_path / "cfg"
+    dest.mkdir()
+    dest.joinpath("team_rosters.json").write_text(
+        json.dumps({"demo-bridge": {"id": "demo-bridge", "name": "CUSTOM", "members": []}}),
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/seed_demo_agents.py",
+            "--config-dir",
+            str(dest),
+            "--reset",
+        ],
+        cwd=repo_root(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    written = json.loads((dest / "team_rosters.json").read_text(encoding="utf-8"))
+    assert written["demo-bridge"]["name"] == "Demo Bridge"
+    names = {m["id"]: m["name"] for m in written["demo-harness-kinds"]["members"]}
+    assert names["openmousbot-remote"] == "OpenMousBot Remote"

--- a/tests/core/test_team_rosters.py
+++ b/tests/core/test_team_rosters.py
@@ -41,7 +41,31 @@ def test_role_cos_persists_on_member():
     member = normalize_member({"id": "pat", "kind": "api", "role": "cos"})
     assert member["role"] == "chief_of_staff"
     assert member["kind"] == "api"
-    assert set(member) >= {"id", "kind", "role", "source"}
+    assert member["name"] == "pat"
+    assert set(member) >= {"id", "name", "kind", "role", "source"}
+
+
+def test_member_display_name_is_preserved():
+    member = normalize_member(
+        {"id": "grok-cli", "name": "Grok CLI", "kind": "cli", "role": "default"}
+    )
+    assert member["name"] == "Grok CLI"
+    stored = upsert_roster(
+        {
+            "id": "demo-harness-kinds",
+            "name": "Demo Harness Kinds",
+            "members": [
+                {
+                    "id": "openmousbot-remote",
+                    "name": "OpenMousBot Remote",
+                    "kind": "remote",
+                    "role": "default",
+                }
+            ],
+        }
+    )
+    assert stored["members"][0]["name"] == "OpenMousBot Remote"
+    assert stored["members"][0]["name"] != "OMB"
 
 
 def test_role_engineer_persists_on_member():

--- a/tests/views/test_team_rosters_api.py
+++ b/tests/views/test_team_rosters_api.py
@@ -198,3 +198,31 @@ def test_create_roster_with_remote_members(api_client):
     listed = api_client.get("/v1/team-rosters/")
     assert listed.status_code == 200
     assert listed.json()["data"][0]["id"] == "harness"
+
+
+def test_create_showoff_roster_keeps_kind_clear_names(api_client):
+    response = api_client.post(
+        "/v1/team-rosters/",
+        {
+            "name": "Demo Harness Kinds",
+            "members": [
+                {"id": "grok-cli", "name": "Grok CLI", "kind": "cli", "role": "default"},
+                {
+                    "id": "openmousbot-remote",
+                    "name": "OpenMousBot Remote",
+                    "kind": "remote",
+                    "role": "default",
+                },
+            ],
+        },
+        format="json",
+    )
+    assert response.status_code == 201
+    names = {m["id"]: m["name"] for m in response.json()["members"]}
+    assert names["grok-cli"] == "Grok CLI"
+    assert names["openmousbot-remote"] == "OpenMousBot Remote"
+    loaded = api_client.get("/v1/team-rosters/demo-harness-kinds/")
+    assert loaded.status_code == 200
+    again = {m["id"]: m["name"] for m in loaded.json()["members"]}
+    assert again == names
+    assert "OMB" not in again.values()

--- a/tests/views/test_web_views.py
+++ b/tests/views/test_web_views.py
@@ -474,6 +474,17 @@ class TestTeamRostersJson:
         assert first.get("id")
         assert "members" in first
         assert "llm_profile" not in first
+        by_id = {row["id"]: row for row in data["data"]}
+        harness = by_id["demo-harness-kinds"]
+        names = {m["id"]: m["name"] for m in harness["members"]}
+        assert names["grok-cli"] == "Grok CLI"
+        assert names["openmousbot-remote"] == "OpenMousBot Remote"
+        assert "OMB" not in names.values()
+        pipeline = by_id["demo-sdlc-pipeline"]
+        persona = {m["id"]: m["name"] for m in pipeline["members"]}
+        assert persona["engineer"] == "Engineer"
+        assert persona["cos"] == "Chief of Staff"
+        assert pipeline["chief_of_staff_id"] == "cos"
 
     def test_v1_team_rosters_is_composition_list(self, client):
         """REQ-28 composition API. Static sidepane file stays /team_rosters.json."""

--- a/webui/frontend/public/team_rosters.json
+++ b/webui/frontend/public/team_rosters.json
@@ -5,7 +5,7 @@
       "id": "demo-team",
       "object": "team_roster",
       "name": "Demo Team",
-      "description": "Example multi-agent roster",
+      "description": "Empty-state stub (not a Mode A/B showoff roster). See docs/SHOWOFF_DEMO_AGENTS.md.",
       "members": [
         {
           "id": "codey",
@@ -20,6 +20,167 @@
           "role": "ops"
         }
       ]
+    },
+    {
+      "id": "demo-harness-kinds",
+      "object": "team_roster",
+      "name": "Demo Harness Kinds",
+      "description": "Mode A (REQ-135) — kind-clear names. Demo only. Placeholders / env for URLs and keys.",
+      "members": [
+        {
+          "id": "grok-cli",
+          "name": "Grok CLI",
+          "kind": "cli",
+          "role": "default",
+          "source": "cli:grok"
+        },
+        {
+          "id": "antigravity-cli",
+          "name": "Antigravity CLI",
+          "kind": "cli",
+          "role": "default",
+          "source": "cli:agy"
+        },
+        {
+          "id": "litellm-api",
+          "name": "LiteLLM API",
+          "kind": "api",
+          "role": "default",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "hermes-remote",
+          "name": "Hermes Remote",
+          "kind": "remote",
+          "role": "default",
+          "source": "placeholder:remote:hermes"
+        },
+        {
+          "id": "openmousbot-remote",
+          "name": "OpenMousBot Remote",
+          "kind": "remote",
+          "role": "default",
+          "source": "placeholder:remote:omb"
+        }
+      ],
+      "wires": {"handoff": true, "as_tool": true}
+    },
+    {
+      "id": "demo-sdlc-pipeline",
+      "object": "team_roster",
+      "name": "Demo SDLC Pipeline",
+      "description": "Mode B (REQ-135) — practical personas. Demo only.",
+      "members": [
+        {
+          "id": "cos",
+          "name": "Chief of Staff",
+          "kind": "api",
+          "role": "chief_of_staff",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "ba",
+          "name": "BA",
+          "kind": "api",
+          "role": "default",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "engineer",
+          "name": "Engineer",
+          "kind": "api",
+          "role": "default",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "tester",
+          "name": "Tester",
+          "kind": "api",
+          "role": "default",
+          "source": "blueprint:sdlc_handoff"
+        }
+      ],
+      "wires": {"handoff": true, "as_tool": false},
+      "chief_of_staff_id": "cos",
+      "chief_of_staff_instructions": "Coordinate this SDLC roster. Forced handoff is BA → Engineer → Tester. Do not skip seats. Report back."
+    },
+    {
+      "id": "demo-sdlc-skeptic-loop",
+      "object": "team_roster",
+      "name": "Demo SDLC Skeptic Loop",
+      "description": "Mode B (REQ-135) — practical personas including Skeptic. Demo only.",
+      "members": [
+        {
+          "id": "cos",
+          "name": "Chief of Staff",
+          "kind": "api",
+          "role": "chief_of_staff",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "ba",
+          "name": "BA",
+          "kind": "api",
+          "role": "default",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "engineer",
+          "name": "Engineer",
+          "kind": "api",
+          "role": "default",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "tester",
+          "name": "Tester",
+          "kind": "api",
+          "role": "default",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "skeptic",
+          "name": "Skeptic",
+          "kind": "api",
+          "role": "skeptic",
+          "source": "blueprint:sdlc_handoff"
+        }
+      ],
+      "wires": {"handoff": true, "as_tool": false},
+      "chief_of_staff_id": "cos",
+      "chief_of_staff_instructions": "Coordinate this SDLC skeptic loop. Forced handoff is BA → Engineer → Tester → Skeptic; Skeptic may punt back to Engineer. Do not skip seats. Report back."
+    },
+    {
+      "id": "demo-bridge",
+      "object": "team_roster",
+      "name": "Demo Bridge",
+      "description": "Intentional mix (REQ-135) — CoS persona plus kind-clear harness seats. Demo only.",
+      "members": [
+        {
+          "id": "cos",
+          "name": "Chief of Staff",
+          "kind": "api",
+          "role": "chief_of_staff",
+          "source": "blueprint:sdlc_handoff"
+        },
+        {
+          "id": "grok-cli",
+          "name": "Grok CLI",
+          "kind": "cli",
+          "role": "default",
+          "source": "cli:grok"
+        },
+        {
+          "id": "hermes-remote",
+          "name": "Hermes Remote",
+          "kind": "remote",
+          "role": "default",
+          "source": "placeholder:remote:hermes"
+        }
+      ],
+      "wires": {"handoff": true, "as_tool": true},
+      "chief_of_staff_id": "cos",
+      "chief_of_staff_instructions": "Coordinate this Demo Bridge. Hand the user task to Grok CLI or Hermes Remote by kind. Do not pretend CLI or remote seats run the openai-agents graph. Report back."
     }
   ]
 }

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -626,7 +626,9 @@ export default function AgentSidebar({
         fromRosters.push({
           id: member.id,
           object: 'blueprint',
-          name: member.id === 'cos' ? 'Chief of Staff' : member.id,
+          name:
+            (member.name && member.name.trim()) ||
+            (member.id === 'cos' ? 'Chief of Staff' : member.id),
           description: 'Talks to any available team.',
           abbreviation: 'CoS',
           required_mcp_servers: [],

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -1271,6 +1271,48 @@ describe('AgentSidebar teams', () => {
     expect(within(list).getByRole('link', { name: /Stewie/ })).toBeInTheDocument()
   })
 
+  it('lists Demo Harness Kinds with Mode A names on the rail team row', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('team_rosters') || url.includes('team-rosters')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'list',
+              data: [
+                {
+                  id: 'demo-harness-kinds',
+                  object: 'team_roster',
+                  name: 'Demo Harness Kinds',
+                  members: [
+                    { id: 'grok-cli', name: 'Grok CLI', kind: 'cli', role: 'default' },
+                    { id: 'litellm-api', name: 'LiteLLM API', kind: 'api', role: 'default' },
+                  ],
+                },
+              ],
+            }),
+          } as Response
+        }
+        if (url.includes('/v1/herdr-agents')) {
+          return { ok: true, status: 200, json: async () => ({ object: 'list', data: [] }) } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ object: 'list', data: blueprints }),
+        } as Response
+      }),
+    )
+    renderSidebar()
+    const list = await screen.findByRole('navigation', { name: 'Agent list' })
+    const team = await within(list).findByRole('link', { name: /Demo Harness Kinds \(team\)/ })
+    expect(team).toHaveAttribute('href', '/chat?team=demo-harness-kinds')
+    expect(within(team).getByText('Team')).toBeInTheDocument()
+  })
+
   it('shows three declared persona faces on a team row (REQ-81)', async () => {
     vi.stubGlobal(
       'fetch',

--- a/webui/frontend/src/lib/__tests__/teamRoster.test.ts
+++ b/webui/frontend/src/lib/__tests__/teamRoster.test.ts
@@ -9,6 +9,7 @@ import {
   isCosEligibleMember,
   nestRosters,
   parseDragAgent,
+  parseRosterMember,
   parseTeamRoster,
   parseTeamRosterList,
   restoreCosId,
@@ -33,6 +34,9 @@ describe('teamRoster (REQ-28)', () => {
       ['omb', 'remote'],
       ['rakazo', 'remote'],
     ])
+    expect(parseRosterMember({ id: 'grok-cli', name: 'Grok CLI', kind: 'cli', role: 'default', source: 'cli:grok' })).toMatchObject(
+      { id: 'grok-cli', name: 'Grok CLI', kind: 'cli' },
+    )
     expect(parseTeamRoster({ id: 'alias', object: 'team', llm_profile: 'gpt' })).toBeNull()
   })
 

--- a/webui/frontend/src/lib/__tests__/teamRosters.test.ts
+++ b/webui/frontend/src/lib/__tests__/teamRosters.test.ts
@@ -119,6 +119,62 @@ describe('labels and ids', () => {
     expect(memberOptionLabel({ id: 'rakazo', name: 'Rakazo', kind: 'remote', role: 'default' })).toBe(
       'Rakazo (remote/default)',
     )
+    expect(
+      memberOptionLabel({
+        id: 'openmousbot-remote',
+        name: 'OpenMousBot Remote',
+        kind: 'remote',
+        role: 'default',
+      }),
+    ).toBe('OpenMousBot Remote (remote/default)')
+    expect(
+      memberOptionLabel({
+        id: 'openmousbot-remote',
+        name: 'OpenMousBot Remote',
+        kind: 'remote',
+        role: 'default',
+      }),
+    ).not.toMatch(/\bOMB\b/)
+  })
+
+  it('keeps Mode A kind-clear names from the showoff fixture', () => {
+    const parsed = parseTeamRosters({
+      object: 'list',
+      data: [
+        {
+          id: 'demo-harness-kinds',
+          object: 'team_roster',
+          name: 'Demo Harness Kinds',
+          members: [
+            { id: 'grok-cli', name: 'Grok CLI', kind: 'cli', role: 'default' },
+            { id: 'litellm-api', name: 'LiteLLM API', kind: 'api', role: 'default' },
+            { id: 'hermes-remote', name: 'Hermes Remote', kind: 'remote', role: 'default' },
+          ],
+        },
+      ],
+    })
+    expect(parsed[0].members.map((m) => m.name)).toEqual(['Grok CLI', 'LiteLLM API', 'Hermes Remote'])
+    expect(memberOptionLabel(parsed[0].members[0])).toBe('Grok CLI (cli/default)')
+  })
+
+  it('keeps Mode B persona names and does not mix kind labels', () => {
+    const parsed = parseTeamRosters({
+      object: 'list',
+      data: [
+        {
+          id: 'demo-sdlc-pipeline',
+          object: 'team_roster',
+          name: 'Demo SDLC Pipeline',
+          members: [
+            { id: 'cos', name: 'Chief of Staff', kind: 'api', role: 'chief_of_staff' },
+            { id: 'ba', name: 'BA', kind: 'api', role: 'default' },
+            { id: 'engineer', name: 'Engineer', kind: 'api', role: 'default' },
+          ],
+        },
+      ],
+    })
+    expect(parsed[0].members.map((m) => m.name)).toEqual(['Chief of Staff', 'BA', 'Engineer'])
+    expect(parsed[0].members.map((m) => m.name).join(' ')).not.toMatch(/LiteLLM API|Grok CLI/)
   })
 
   it('namespaces hide ids so a team cannot collide with an agent slug', () => {

--- a/webui/frontend/src/lib/api.ts
+++ b/webui/frontend/src/lib/api.ts
@@ -417,6 +417,7 @@ export interface TeamRosterRecord {
   name: string
   members: Array<{
     id: string
+    name?: string
     kind: string
     role: string
     source: string

--- a/webui/frontend/src/lib/teamRoster.ts
+++ b/webui/frontend/src/lib/teamRoster.ts
@@ -5,6 +5,7 @@ export type MemberKind = (typeof MEMBER_KINDS)[number]
 
 export interface TeamRosterMember {
   id: string
+  name?: string
   kind: MemberKind
   role: string
   source: string
@@ -99,8 +100,10 @@ export function parseRosterMember(raw: unknown): TeamRosterMember | null {
   const kind = String(row.kind || '').trim().toLowerCase()
   if (!id || !isMemberKind(kind)) return null
   const teamId = String(row.team_id || '').trim()
+  const name = typeof row.name === 'string' && row.name.trim() ? row.name.trim() : id
   const member: TeamRosterMember = {
     id,
+    name,
     kind,
     role: String(row.role || 'default'),
     source: String(row.source || ''),
@@ -212,6 +215,7 @@ export function addMember(members: TeamRosterMember[], agent: TeamAgent): TeamRo
     ...members,
     {
       id: agent.id,
+      name: agent.name || agent.id,
       kind: agent.kind,
       role: 'default',
       source: agent.source,

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -2108,6 +2108,56 @@ describe('ChatPage team member dropdown', () => {
     expect(screen.getByRole('heading', { name: 'Demo Team' })).toBeInTheDocument()
   })
 
+  it('shows Mode A kind-clear names in the team chat header dropdown', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (input: RequestInfo) => {
+        const url = String(input)
+        if (url.includes('team_rosters') || url.includes('team-rosters')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              object: 'list',
+              data: [
+                {
+                  id: 'demo-harness-kinds',
+                  object: 'team_roster',
+                  name: 'Demo Harness Kinds',
+                  members: [
+                    { id: 'grok-cli', name: 'Grok CLI', kind: 'cli', role: 'default' },
+                    { id: 'litellm-api', name: 'LiteLLM API', kind: 'api', role: 'default' },
+                    { id: 'openmousbot-remote', name: 'OpenMousBot Remote', kind: 'remote', role: 'default' },
+                  ],
+                },
+              ],
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: [] }),
+        } as Response
+      }),
+    )
+    renderChat('/chat?team=demo-harness-kinds')
+    await act(async () => {
+      MockWebSocket.instances[0]?.open()
+    })
+    expect(await screen.findByRole('heading', { name: 'Demo Harness Kinds' })).toBeInTheDocument()
+    const select = await screen.findByRole('combobox', { name: 'Team members' })
+    const options = within(select).getAllByRole('option').map((opt) => opt.textContent)
+    expect(options).toEqual([
+      'All members',
+      'Grok CLI (cli/default)',
+      'LiteLLM API (api/default)',
+      'OpenMousBot Remote (remote/default)',
+      'Manage Team',
+    ])
+    expect(options.join(' ')).not.toMatch(/\bOMB\b/)
+  })
+
   it('sends params {team, target} for all-members and a chosen member', async () => {
     renderChat('/chat?team=demo-team')
     await act(async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #526

Demo roster names now make the showoff story obvious at a glance.

**Mode A (mixture of types):** `Demo Harness Kinds` uses kind + backend names — `Grok CLI`, `Antigravity CLI`, `LiteLLM API`, `Hermes Remote`, `OpenMousBot Remote` (never OMB). Placeholders / env only; no secrets.

**Mode B (teams / blueprints):** `Demo SDLC Pipeline` and `Demo SDLC Skeptic Loop` use practical personas — Chief of Staff, BA, Engineer, Tester, Skeptic. Funny alternates (Requirements Nag, Code Monkey, …) stay in the doc, not the default seed. CoS is selected via `chief_of_staff_id` (team designer).

**Intentional mix:** `Demo Bridge` is the one roster that mixes on purpose (CoS + Grok CLI + Hermes Remote).

## What changed
- Member `name` is part of the roster contract and survives `normalize_member` / `GET /v1/team-rosters/`, so rail, favourites, and the chat-header member dropdown show the seeded labels.
- Additive `demo-*` seed + shipped fixture JSON. Does not rename day-to-day agents. Reset path: `scripts/seed_demo_agents.py --reset`.
- SoT note: `docs/SHOWOFF_DEMO_AGENTS.md` (Issue remains SoT). README / developer / REQ-156 pack point at it.

## Tests
- Python (32 passed): demo roster names, OpenMousBot not OMB, seed `--reset`, no secret literals, `/team_rosters.json` fixture, API name round-trip.
- Frontend (new cases passed): Mode A/B parse, chat header dropdown (`Grok CLI` / `LiteLLM API` / `OpenMousBot Remote`), rail team title `Demo Harness Kinds`.

GitHub-only. No live `:8001` / FF deploy. No secrets or personal dumps.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-330e802c-2995-497e-833d-58c8bc12e2f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-330e802c-2995-497e-833d-58c8bc12e2f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

