### PR TITLE
Plugins: add remote OpenAPI as MCP via mcp-openapi-proxy

### DIFF
--- a/docs/examples/plugins-mcp.md
+++ b/docs/examples/plugins-mcp.md
@@ -1,4 +1,4 @@
-### Plugins — MCP local / remote servers (#502)
+### Plugins — MCP local / remote / OpenAPI servers (#502 / #750)
 
 Settings → **Plugins** (Manage servers from the rail Plugins popup) is the
 configuration overlay for attaching MCP tool servers. Chat stays mounted.
@@ -15,20 +15,77 @@ This page is the Manage / config path.
 - CLI path already mounts the same `mcpServers` through `cli_mcp` when the
   catalog CLI accepts `--mcp-config`.
 
-#### Local vs remote
+#### Add paths
 
-| Kind | Fields | Auth |
+| Add | Kind | What it stores |
 |---|---|---|
-| **Local** | `command`, `args`, optional `cwd`, optional env name | env values are `${VAR}` only |
-| **Remote** | `url` (http/s), optional header name + env | header values are `${VAR}` only |
+| **Add: Local MCP** | `local` | `command`, `args`, optional `cwd`, optional env name |
+| **Add: Remote MCP** | `remote` | `url` (http/s), optional header name + env |
+| **Add: OpenAPI (mcp-openapi-proxy)** | `local` or `remote` + `source=openapi` | see below |
 
 Never paste a token, key, or URL userinfo. Config ownership refuses plaintext.
+Auth values are `${VAR}` only.
+
+#### OpenAPI via mcp-openapi-proxy (#750)
+
+Uses [matthewhand/mcp-openapi-proxy](https://github.com/matthewhand/mcp-openapi-proxy)
+so OpenAPI operations become MCP tools. open-swarm does **not** vendor that
+repo and does **not** invent a second OpenAPI→MCP mapper.
+
+**v1 remote path (chosen):** the operator pastes the **running proxy MCP URL**
+(SSE / streamable-HTTP as that host already exposes). open-swarm does not
+launch an HTTP proxy for remote mode.
+
+**Local path:** swarm configures stdio `uvx mcp-openapi-proxy` and sets
+`OPENAPI_SPEC_URL` to the wizard spec (http(s) URL or `file://` path).
+
+| Field | Local | Remote |
+|---|---|---|
+| Display name | required | required |
+| OpenAPI spec source | URL or local file path (required) | optional display URL (http/s only) |
+| Proxy MCP URL | — | required (`url`) |
+| Auth | optional env name (`API_KEY` → `${API_KEY}`) | optional header + `${VAR}` |
+
+Install / run for local mode (do not commit secrets; names only):
+
+```bash
+uvx mcp-openapi-proxy
+# or
+pip install mcp-openapi-proxy
+```
+
+Upstream env names the proxy reads (values stay in the operator environment):
+
+- `OPENAPI_SPEC_URL` — spec URL or `file:///path/to/spec.json`
+- `API_KEY` — optional API auth for the spec host
+- `API_AUTH_TYPE` / `API_AUTH_HEADER` / `SERVER_URL_OVERRIDE` / `TOOL_WHITELIST`
+
+Saved shape (local):
+
+```json
+{
+  "petstore": {
+    "kind": "local",
+    "source": "openapi",
+    "command": "uvx",
+    "args": ["mcp-openapi-proxy"],
+    "openapi_spec_url": "https://example.invalid/openapi.json",
+    "env": {
+      "OPENAPI_SPEC_URL": "https://example.invalid/openapi.json",
+      "API_KEY": "${API_KEY}"
+    }
+  }
+}
+```
+
+Honest failures: bad spec URL, local file missing, `mcp-openapi-proxy` not
+installed, connect timeout. Disabled / removed servers drop their tools.
 
 #### Discover tools
 
 After **Save**, **Discover tools** connects (`list_tools`) and shows each tool
 name + short description. Failure is an error toast, not a silent empty list.
-CI uses fixture local + remote mocks — no live host, no `:8001`.
+CI uses fixture local + remote + OpenAPI mocks — no live host, no `:8001`.
 
 #### Runtime
 

--- a/docs/examples/plugins-popup.md
+++ b/docs/examples/plugins-popup.md
@@ -5,9 +5,10 @@ session picker) over the still-mounted chat. Each row is a discovered tool
 with a visible **On/Off** switch scoped to the **current conversation**.
 Enabled tools sort first; search keeps that order inside matches.
 
-**Manage servers** opens Settings → Plugins (#502 add/edit/remove + local/remote
-+ discover). Servers persist in `swarm_config.json` `mcpServers`. Auth is
-`${VAR}` only. See [plugins-mcp.md](./plugins-mcp.md).
+**Manage servers** opens Settings → Plugins (#502 / #750 add/edit/remove +
+Local MCP / Remote MCP / OpenAPI (mcp-openapi-proxy) + discover). Servers
+persist in `swarm_config.json` `mcpServers`. Auth is `${VAR}` only. See
+[plugins-mcp.md](./plugins-mcp.md).
 
 #### Discovery degrade
 

--- a/src/swarm/core/mcp_plugins.py
+++ b/src/swarm/core/mcp_plugins.py
@@ -1,4 +1,4 @@
-"""Plugins manage path (#502): swarm as an MCP *client*.
+"""Plugins manage path (#502 / #750): swarm as an MCP *client*.
 
 Server topology is global (``swarm_config.json`` ``mcpServers``). Tool On/Off
 is per-chat (#805 ``params.enabled_tools``). Distinct from
@@ -6,7 +6,10 @@ is per-chat (#805 ``params.enabled_tools``). Distinct from
 
 Local servers use stdio (command + args + env ``${VAR}``). Remote servers use
 a URL plus optional headers whose values are env placeholders — never plaintext
-secrets. Live ``list_tools`` is injectable so CI uses fixture mocks, not hosts.
+secrets. OpenAPI-backed servers (#750) launch or attach
+``mcp-openapi-proxy`` (https://github.com/matthewhand/mcp-openapi-proxy)
+so OpenAPI operations become MCP tools. Live ``list_tools`` is injectable so
+CI uses fixture mocks, not hosts.
 """
 
 from __future__ import annotations
@@ -17,6 +20,7 @@ import os
 import re
 from collections.abc import Callable, Iterable, Mapping
 from contextlib import suppress
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
@@ -33,8 +37,18 @@ logger = logging.getLogger(__name__)
 
 KIND_LOCAL = "local"
 KIND_REMOTE = "remote"
+SOURCE_GENERIC = "generic"
+SOURCE_OPENAPI = "openapi"
+OPENAPI_PROXY_COMMAND = "uvx"
+OPENAPI_PROXY_ARGS = ("mcp-openapi-proxy",)
+OPENAPI_SPEC_ENV = "OPENAPI_SPEC_URL"
+OPENAPI_PROXY_PACKAGE = "mcp-openapi-proxy"
+_OPENAPI_SOURCE_ALIASES = frozenset(
+    {"openapi", "mcp-openapi-proxy", "openapi-proxy", "openapi_proxy"}
+)
 _PLACEHOLDER_RE = re.compile(r"^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$")
 _SAFE_URL_SCHEMES = frozenset({"http", "https"})
+_FILE_SCHEMES = frozenset({"file"})
 
 ListToolsFn = Callable[[dict[str, Any]], list[dict[str, str]]]
 
@@ -100,11 +114,197 @@ def _kind_of(spec: Mapping[str, Any] | None) -> str:
     explicit = str(raw.get("kind") or raw.get("type") or raw.get("transport") or "").strip().lower()
     if explicit in {KIND_LOCAL, "stdio"}:
         return KIND_LOCAL
-    if explicit in {KIND_REMOTE, "http", "sse", "url"}:
+    if explicit in {KIND_REMOTE, "http", "sse", "url", "streamable-http", "streamable_http"}:
         return KIND_REMOTE
     if isinstance(raw.get("url"), str) and raw["url"].strip():
         return KIND_REMOTE
     return KIND_LOCAL
+
+
+def _args_mention_openapi_proxy(spec: Mapping[str, Any] | None) -> bool:
+    raw = spec or {}
+    haystack = " ".join(
+        [str(raw.get("command") or "")] + [str(item) for item in (raw.get("args") or [])]
+    )
+    return OPENAPI_PROXY_PACKAGE in haystack
+
+
+def _source_of(spec: Mapping[str, Any] | None) -> str:
+    raw = spec or {}
+    explicit = str(raw.get("source") or raw.get("adapter") or "").strip().lower()
+    if explicit in _OPENAPI_SOURCE_ALIASES:
+        return SOURCE_OPENAPI
+    if str(raw.get("openapi_spec_url") or raw.get("openapiSpecUrl") or raw.get("spec_url") or "").strip():
+        return SOURCE_OPENAPI
+    env = raw.get("env")
+    if isinstance(env, dict) and str(env.get(OPENAPI_SPEC_ENV) or "").strip():
+        return SOURCE_OPENAPI
+    if _args_mention_openapi_proxy(raw):
+        return SOURCE_OPENAPI
+    return SOURCE_GENERIC
+
+
+def _looks_like_local_path(value: str) -> bool:
+    trimmed = (value or "").strip()
+    if not trimmed:
+        return False
+    return trimmed.startswith(("/", "./", "../", "~/")) or (
+        len(trimmed) >= 2 and trimmed[1] == ":" and trimmed[0].isalpha()
+    )
+
+
+def _normalize_openapi_spec_source(value: Any, *, allow_file: bool) -> str:
+    """Accept http(s) spec URLs; local mode also accepts a file path / file://."""
+    trimmed = str(value or "").strip()
+    if not trimmed:
+        return ""
+    if trimmed.startswith("${") or looks_like_env_name(trimmed):
+        raise McpPluginError(
+            "OpenAPI spec source must be a URL or local file path, not an env name. "
+            f"The proxy reads {OPENAPI_SPEC_ENV} from the saved spec field.",
+            code="bad_payload",
+        )
+    if "://" not in trimmed and _looks_like_local_path(trimmed):
+        if not allow_file:
+            raise McpPluginError(
+                "Remote OpenAPI uses a running proxy MCP URL. "
+                "Local file specs are for Local (stdio mcp-openapi-proxy) only.",
+                code="bad_payload",
+            )
+        expanded = os.path.expanduser(trimmed)
+        path = Path(expanded).expanduser()
+        if path.exists() and path.is_file():
+            return path.resolve().as_uri()
+        if path.is_absolute() or trimmed.startswith(("/", "file:")):
+            return Path(expanded).absolute().as_uri()
+        return f"file://{expanded}"
+    parsed = urlparse(trimmed)
+    if parsed.scheme in _FILE_SCHEMES:
+        if not allow_file:
+            raise McpPluginError(
+                "Remote OpenAPI uses a running proxy MCP URL. "
+                "file:// specs are for Local (stdio mcp-openapi-proxy) only.",
+                code="bad_payload",
+            )
+        if parsed.username or parsed.password:
+            raise McpPluginError(
+                "Refusing credentials in the OpenAPI spec URL. Use a ${VAR} env for API_KEY.",
+                code="plaintext_secret",
+            )
+        return trimmed
+    if parsed.scheme in _SAFE_URL_SCHEMES and parsed.netloc:
+        if parsed.username or parsed.password:
+            raise McpPluginError(
+                "Refusing credentials in the OpenAPI spec URL. Use a ${VAR} env for API_KEY.",
+                code="plaintext_secret",
+            )
+        return trimmed
+    raise McpPluginError(
+        "OpenAPI spec source must be an http(s) URL"
+        + (" or a local file path." if allow_file else "."),
+        code="bad_payload",
+    )
+
+
+def _lift_openapi_spec_from_env(raw_env: Any) -> tuple[dict[str, Any], str]:
+    """Pull a literal OPENAPI_SPEC_URL out of env so it is not treated as a secret."""
+    if not isinstance(raw_env, dict):
+        return {}, ""
+    lifted = ""
+    rest: dict[str, Any] = {}
+    for raw_key, raw_val in raw_env.items():
+        key = str(raw_key).strip()
+        if (
+            key == OPENAPI_SPEC_ENV
+            and isinstance(raw_val, str)
+            and raw_val.strip()
+            and not is_placeholder(raw_val)
+            and not looks_like_env_name(raw_val)
+        ):
+            lifted = raw_val.strip()
+            continue
+        rest[key] = raw_val
+    return rest, lifted
+
+
+def _apply_openapi_defaults(entry: dict[str, Any], raw: Mapping[str, Any]) -> dict[str, Any]:
+    """Fill mcp-openapi-proxy command/env for the OpenAPI add path (#750)."""
+    kind = entry["kind"]
+    allow_file = kind == KIND_LOCAL
+    raw_spec = (
+        raw.get("openapi_spec_url")
+        or raw.get("openapiSpecUrl")
+        or raw.get("spec_url")
+        or raw.get("spec")
+        or ""
+    )
+    spec_url = _normalize_openapi_spec_source(raw_spec, allow_file=allow_file) if raw_spec else ""
+    if not spec_url:
+        existing = str(entry.get("openapi_spec_url") or "").strip()
+        spec_url = _normalize_openapi_spec_source(existing, allow_file=allow_file) if existing else ""
+    env = dict(entry.get("env") or {})
+    env_spec = env.pop(OPENAPI_SPEC_ENV, "")
+    if not spec_url and env_spec:
+        spec_url = _normalize_openapi_spec_source(env_spec, allow_file=allow_file)
+    if spec_url:
+        entry["openapi_spec_url"] = spec_url
+    entry["source"] = SOURCE_OPENAPI
+    if kind == KIND_REMOTE:
+        if not str(entry.get("url") or "").strip():
+            raise McpPluginError(
+                "Remote OpenAPI needs the running proxy MCP URL (http/s). "
+                "Use Local to launch mcp-openapi-proxy with OPENAPI_SPEC_URL.",
+                code="bad_payload",
+            )
+        return entry
+    if not spec_url:
+        raise McpPluginError(
+            "Local OpenAPI (mcp-openapi-proxy) needs an OpenAPI spec URL or file path.",
+            code="bad_payload",
+        )
+    command = str(raw.get("command") or entry.get("command") or OPENAPI_PROXY_COMMAND).strip()
+    args = _str_list(raw.get("args") if raw.get("args") not in (None, "") else entry.get("args"))
+    if not command:
+        command = OPENAPI_PROXY_COMMAND
+    if not args:
+        args = list(OPENAPI_PROXY_ARGS)
+    entry["command"] = command
+    entry["args"] = args
+    env[OPENAPI_SPEC_ENV] = spec_url
+    entry["env"] = env
+    return entry
+
+
+def _with_openapi_runtime_env(spec: Mapping[str, Any]) -> dict[str, Any]:
+    """Ensure the stdio child sees OPENAPI_SPEC_URL (name only in docs; value is the spec)."""
+    out = dict(spec)
+    if _source_of(out) != SOURCE_OPENAPI:
+        return out
+    spec_url = str(out.get("openapi_spec_url") or "").strip()
+    env = dict(out.get("env") or {}) if isinstance(out.get("env"), dict) else {}
+    if spec_url:
+        env.setdefault(OPENAPI_SPEC_ENV, spec_url)
+    if env:
+        out["env"] = env
+    return out
+
+
+def _openapi_discover_hint(exc: Exception, spec: Mapping[str, Any]) -> str:
+    text = str(exc) or exc.__class__.__name__
+    lowered = text.lower()
+    if _source_of(spec) != SOURCE_OPENAPI and not _args_mention_openapi_proxy(spec):
+        return f"Could not list tools from the MCP server: {text}"
+    if isinstance(exc, FileNotFoundError) or "no such file" in lowered or "not found" in lowered:
+        return (
+            "mcp-openapi-proxy is not installed. "
+            "Install with: uvx mcp-openapi-proxy (PyPI) or pip install mcp-openapi-proxy."
+        )
+    if "timeout" in lowered or "timed out" in lowered:
+        return (
+            "Connect timeout talking to mcp-openapi-proxy. "
+            f"Check {OPENAPI_SPEC_ENV} and that the proxy can fetch the spec."
+        )
+    return f"Could not list tools from mcp-openapi-proxy: {text}"
 
 
 def _validate_remote_url(url: str) -> str:
@@ -136,16 +336,21 @@ def normalize_plugin_spec(raw: Any, *, name: str = "") -> dict[str, Any]:
     display = str(raw.get("label") or raw.get("name") or name).strip()
     key = _slug(str(raw.get("id") or raw.get("name") or name))
     kind = _kind_of(raw)
+    source = _source_of(raw)
     enabled = raw.get("enabled")
     entry: dict[str, Any] = {
         "name": key,
         "label": display or key,
         "kind": kind,
+        "source": source,
         "enabled": not (enabled is False or enabled == "false"),
         "provides": _str_list(raw.get("provides")),
         "note": str(raw.get("note") or "").strip(),
     }
-    env = _placeholder_map(raw.get("env"), field="env")
+    raw_env, lifted_spec = _lift_openapi_spec_from_env(raw.get("env"))
+    env = _placeholder_map(raw_env, field="env")
+    if lifted_spec:
+        entry["openapi_spec_url"] = lifted_spec
     if env:
         entry["env"] = env
     headers = _placeholder_map(raw.get("headers"), field="headers")
@@ -171,11 +376,20 @@ def normalize_plugin_spec(raw: Any, *, name: str = "") -> dict[str, Any]:
             if not entry["provides"]:
                 entry["provides"] = [row["name"] for row in tools]
     if kind == KIND_REMOTE:
-        entry["url"] = _validate_remote_url(str(raw.get("url") or ""))
+        url_value = str(raw.get("url") or "")
+        if source == SOURCE_OPENAPI and not url_value.strip():
+            raise McpPluginError(
+                "Remote OpenAPI needs the running proxy MCP URL (http/s). "
+                "Use Local to launch mcp-openapi-proxy with OPENAPI_SPEC_URL.",
+                code="bad_payload",
+            )
+        entry["url"] = _validate_remote_url(url_value)
         transport = str(raw.get("type") or raw.get("transport") or "sse").strip() or "sse"
         entry["type"] = transport
     else:
         command = str(raw.get("command") or "").strip()
+        if source == SOURCE_OPENAPI and not command:
+            command = OPENAPI_PROXY_COMMAND
         if not command:
             raise McpPluginError("Local MCP servers need a command (stdio).", code="bad_payload")
         entry["command"] = command
@@ -183,6 +397,8 @@ def normalize_plugin_spec(raw: Any, *, name: str = "") -> dict[str, Any]:
         cwd = str(raw.get("cwd") or "").strip()
         if cwd:
             entry["cwd"] = cwd
+    if source == SOURCE_OPENAPI:
+        _apply_openapi_defaults(entry, raw)
     return entry
 
 
@@ -220,10 +436,12 @@ def public_server(name: str, spec: Mapping[str, Any] | None) -> dict[str, Any]:
         "name": name,
         "label": str(raw.get("label") or name),
         "kind": kind,
+        "source": _source_of(raw),
         "enabled": raw.get("enabled") is not False,
         "command": str(redacted.get("command") or ""),
         "args": list(redacted.get("args") or []),
         "url": str(redacted.get("url") or ""),
+        "openapi_spec_url": str(raw.get("openapi_spec_url") or ""),
         "type": str(redacted.get("type") or redacted.get("transport") or ""),
         "cwd": str(redacted.get("cwd") or ""),
         "env": redacted.get("env") if isinstance(redacted.get("env"), dict) else {},
@@ -305,11 +523,12 @@ def _tool_rows(tools: Iterable[Any]) -> list[dict[str, str]]:
 async def _discover_local(spec: Mapping[str, Any], *, timeout: int) -> list[dict[str, str]]:
     from swarm.extensions.mcp.mcp_client import MCPClient
 
+    live = _with_openapi_runtime_env(spec)
     client = MCPClient(
         {
-            "command": spec.get("command"),
-            "args": list(spec.get("args") or []),
-            "env": spec.get("env") or {},
+            "command": live.get("command"),
+            "args": list(live.get("args") or []),
+            "env": live.get("env") or {},
         },
         timeout=timeout,
         debug=False,
@@ -363,7 +582,7 @@ def list_tools_for_spec(
     if normalized.get("enabled") is False:
         raise McpPluginError("Server is disabled. Enable it before discovering tools.", code="disabled")
     if list_tools_fn is not None:
-        return _tool_rows(list_tools_fn(normalized))
+        return _tool_rows(list_tools_fn(_with_openapi_runtime_env(normalized)))
     missing = _missing_env(normalized)
     if missing:
         names = ", ".join(sorted(set(missing)))
@@ -371,7 +590,7 @@ def list_tools_for_spec(
             f"Secret env {names} is not set. Export the variable; do not paste the value.",
             code="secret_unset",
         )
-    live = _expand_placeholders(normalized)
+    live = _with_openapi_runtime_env(_expand_placeholders(normalized))
     try:
         return _tool_rows(_run_async(_discover_live(live, timeout=timeout)))
     except McpPluginError:
@@ -379,7 +598,7 @@ def list_tools_for_spec(
     except Exception as exc:
         logger.warning("MCP list_tools failed for %s", normalized.get("name") or normalized.get("kind"))
         raise McpPluginError(
-            f"Could not list tools from the MCP server: {exc}",
+            _openapi_discover_hint(exc, normalized),
             code="mcp_discover_failed",
             status=502,
         ) from exc
@@ -431,7 +650,7 @@ def _make_tool_caller(tool_name: str, spec: Mapping[str, Any]) -> Callable[..., 
     body = dict(spec)
 
     async def _call(**kwargs: Any) -> Any:
-        live = _expand_placeholders(body)
+        live = _with_openapi_runtime_env(_expand_placeholders(body))
         if _kind_of(live) == KIND_REMOTE:
             from mcp import ClientSession
             from mcp.client.sse import sse_client

--- a/src/swarm/views/mcp_plugins_api.py
+++ b/src/swarm/views/mcp_plugins_api.py
@@ -1,12 +1,13 @@
-"""REST surface for Plugins MCP manage (#502).
+"""REST surface for Plugins MCP manage (#502 / #750).
 
 GET    /v1/mcp-plugins/           redacted server list + discovered tools
-POST   /v1/mcp-plugins/           upsert one local/remote server
+POST   /v1/mcp-plugins/           upsert one local/remote/OpenAPI server
 DELETE /v1/mcp-plugins/<name>/    remove a server
 POST   /v1/mcp-plugins/discover/  connect and list_tools (honest error)
 
 Persists through ADR-002 ``mcpServers``. Secrets stay ``${VAR}``. Responses
 never include secret values. Distinct from ``ENABLE_MCP_SERVER`` / ``/mcp/``.
+OpenAPI servers use ``mcp-openapi-proxy`` (source=openapi).
 """
 
 from __future__ import annotations
@@ -65,15 +66,17 @@ class McpPluginsView(APIView):
 
     @extend_schema(
         operation_id="v1_mcp_plugins_post",
-        summary="Upsert one local or remote MCP plugin server",
+        summary="Upsert one local, remote, or OpenAPI MCP plugin server",
         request=inline_serializer(
             name="McpPluginUpsertRequest",
             fields={
                 "name": serializers.CharField(),
                 "kind": serializers.CharField(required=False),
+                "source": serializers.CharField(required=False, allow_blank=True),
                 "command": serializers.CharField(required=False, allow_blank=True),
                 "args": serializers.ListField(required=False, child=serializers.CharField()),
                 "url": serializers.CharField(required=False, allow_blank=True),
+                "openapi_spec_url": serializers.CharField(required=False, allow_blank=True),
                 "enabled": serializers.BooleanField(required=False),
                 "env": serializers.DictField(required=False),
                 "headers": serializers.DictField(required=False),
@@ -137,9 +140,11 @@ class McpPluginDiscoverView(APIView):
             fields={
                 "name": serializers.CharField(required=False, allow_blank=True),
                 "kind": serializers.CharField(required=False),
+                "source": serializers.CharField(required=False, allow_blank=True),
                 "command": serializers.CharField(required=False, allow_blank=True),
                 "args": serializers.ListField(required=False, child=serializers.CharField()),
                 "url": serializers.CharField(required=False, allow_blank=True),
+                "openapi_spec_url": serializers.CharField(required=False, allow_blank=True),
                 "env": serializers.DictField(required=False),
                 "headers": serializers.DictField(required=False),
             },
@@ -164,6 +169,7 @@ class McpPluginDiscoverView(APIView):
                 "object": "mcp_plugin_tools",
                 "name": spec.get("name") or name,
                 "kind": spec.get("kind"),
+                "source": spec.get("source"),
                 "tools": tools,
             }
         )

--- a/tests/core/test_mcp_plugins.py
+++ b/tests/core/test_mcp_plugins.py
@@ -8,6 +8,9 @@ import pytest
 
 from swarm.core.mcp_plugins import (
     McpPluginError,
+    OPENAPI_PROXY_ARGS,
+    OPENAPI_PROXY_COMMAND,
+    OPENAPI_SPEC_ENV,
     apply_plugin_mcp_runtime,
     attach_plugin_mcp_tools,
     enabled_mcp_servers,
@@ -16,6 +19,39 @@ from swarm.core.mcp_plugins import (
     plugin_catalog_ids,
     public_server,
 )
+
+MOCK_OPENAPI = {
+    "openapi": "3.0.0",
+    "info": {"title": "Pets", "version": "1.0.0"},
+    "paths": {
+        "/pets": {
+            "get": {
+                "operationId": "list_pets",
+                "summary": "List pets",
+            }
+        },
+        "/pets/{id}": {
+            "get": {
+                "operationId": "get_pet",
+                "summary": "Get a pet",
+            }
+        },
+    },
+}
+
+
+def _tools_from_mock_openapi(doc):
+    """Fixture mapper: OpenAPI operations → MCP tool rows (no live proxy)."""
+    rows = []
+    for path, methods in (doc.get("paths") or {}).items():
+        if not isinstance(methods, dict):
+            continue
+        for method, op in methods.items():
+            if not isinstance(op, dict):
+                continue
+            name = str(op.get("operationId") or f"{method}_{path.strip('/').replace('/', '_')}")
+            rows.append({"name": name, "description": str(op.get("summary") or "")})
+    return rows
 
 
 def _fn(name: str):
@@ -138,6 +174,192 @@ def test_disable_removes_tools_from_agent():
     names = [getattr(fn, "name", "") for fn in agent.functions]
     assert "web_fetch" not in names
     assert "chat" in names
+
+
+def test_normalize_openapi_local_defaults_proxy_and_spec_env():
+    spec = normalize_plugin_spec(
+        {
+            "name": "Pets",
+            "source": "openapi",
+            "kind": "local",
+            "openapi_spec_url": "https://example.invalid/openapi.json",
+            "env": {"API_KEY": "${API_KEY}"},
+        },
+        name="Pets",
+    )
+    assert spec["source"] == "openapi"
+    assert spec["kind"] == "local"
+    assert spec["command"] == OPENAPI_PROXY_COMMAND
+    assert spec["args"] == list(OPENAPI_PROXY_ARGS)
+    assert spec["openapi_spec_url"] == "https://example.invalid/openapi.json"
+    assert spec["env"][OPENAPI_SPEC_ENV] == "https://example.invalid/openapi.json"
+    assert spec["env"]["API_KEY"] == "${API_KEY}"
+
+
+def test_normalize_openapi_local_file_path(tmp_path):
+    spec_file = tmp_path / "pets.json"
+    spec_file.write_text("{}", encoding="utf-8")
+    spec = normalize_plugin_spec(
+        {
+            "name": "local-pets",
+            "source": "openapi",
+            "kind": "local",
+            "openapi_spec_url": str(spec_file),
+        },
+        name="local-pets",
+    )
+    assert spec["openapi_spec_url"].startswith("file://")
+    assert spec["env"][OPENAPI_SPEC_ENV].startswith("file://")
+
+
+def test_normalize_openapi_remote_needs_proxy_url():
+    remote = normalize_plugin_spec(
+        {
+            "name": "pets-remote",
+            "source": "openapi",
+            "kind": "remote",
+            "url": "https://example.invalid/mcp",
+            "openapi_spec_url": "https://example.invalid/openapi.json",
+        },
+        name="pets-remote",
+    )
+    assert remote["kind"] == "remote"
+    assert remote["source"] == "openapi"
+    assert remote["url"] == "https://example.invalid/mcp"
+    assert remote["openapi_spec_url"] == "https://example.invalid/openapi.json"
+
+    with pytest.raises(McpPluginError) as missing_url:
+        normalize_plugin_spec(
+            {
+                "name": "pets-remote",
+                "source": "openapi",
+                "kind": "remote",
+                "openapi_spec_url": "https://example.invalid/openapi.json",
+            },
+            name="pets-remote",
+        )
+    assert missing_url.value.code == "bad_payload"
+    assert "proxy MCP URL" in str(missing_url.value)
+
+
+def test_normalize_openapi_local_requires_spec():
+    with pytest.raises(McpPluginError) as exc:
+        normalize_plugin_spec(
+            {"name": "pets", "source": "openapi", "kind": "local"},
+            name="pets",
+        )
+    assert exc.value.code == "bad_payload"
+    assert "spec" in str(exc.value).lower()
+
+
+def test_normalize_openapi_refuses_spec_userinfo():
+    with pytest.raises(McpPluginError) as exc:
+        normalize_plugin_spec(
+            {
+                "name": "pets",
+                "source": "openapi",
+                "kind": "local",
+                "openapi_spec_url": "https://user:token@example.invalid/openapi.json",
+            },
+            name="pets",
+        )
+    assert exc.value.code == "plaintext_secret"
+
+
+def test_list_tools_openapi_mock_from_spec_operations():
+    expected = _tools_from_mock_openapi(MOCK_OPENAPI)
+
+    def openapi_fn(spec):
+        assert spec["source"] == "openapi"
+        assert spec["env"][OPENAPI_SPEC_ENV] == "https://example.invalid/openapi.json"
+        return expected
+
+    tools = list_tools_for_spec(
+        {
+            "name": "pets",
+            "source": "openapi",
+            "kind": "local",
+            "openapi_spec_url": "https://example.invalid/openapi.json",
+        },
+        list_tools_fn=openapi_fn,
+    )
+    assert tools == [
+        {"name": "list_pets", "description": "List pets"},
+        {"name": "get_pet", "description": "Get a pet"},
+    ]
+
+
+def test_disable_openapi_server_removes_tools():
+    config = {
+        "mcpServers": {
+            "pets": {
+                "source": "openapi",
+                "kind": "local",
+                "command": "uvx",
+                "args": ["mcp-openapi-proxy"],
+                "openapi_spec_url": "https://example.invalid/openapi.json",
+                "discovered_tools": _tools_from_mock_openapi(MOCK_OPENAPI),
+            },
+            "pets-off": {
+                "source": "openapi",
+                "kind": "local",
+                "command": "uvx",
+                "args": ["mcp-openapi-proxy"],
+                "enabled": False,
+                "discovered_tools": [{"name": "hidden_op", "description": "Hidden"}],
+            },
+        }
+    }
+    agent = SimpleNamespace(functions=[_fn("chat")], tools=[], mcp_servers=[])
+    blueprint = SimpleNamespace(agents={"worker": agent}, starting_agent=agent)
+    attach_plugin_mcp_tools(blueprint, config)
+    names = [getattr(fn, "name", "") for fn in agent.functions]
+    assert "list_pets" in names
+    assert "get_pet" in names
+    assert "hidden_op" not in names
+    assert "pets-off" not in enabled_mcp_servers(config)
+
+    apply_plugin_mcp_runtime(blueprint, config, [])
+    names = [getattr(fn, "name", "") for fn in agent.functions]
+    assert "list_pets" not in names
+    assert "chat" in names
+
+
+def test_public_server_exposes_openapi_source_without_secrets():
+    row = public_server(
+        "pets",
+        {
+            "source": "openapi",
+            "command": "uvx",
+            "args": ["mcp-openapi-proxy"],
+            "openapi_spec_url": "https://example.invalid/openapi.json",
+            "env": {"API_KEY": "${API_KEY}", "OPENAPI_SPEC_URL": "https://example.invalid/openapi.json"},
+            "discovered_tools": [{"name": "list_pets", "description": "List pets"}],
+        },
+    )
+    assert row["source"] == "openapi"
+    assert row["openapi_spec_url"] == "https://example.invalid/openapi.json"
+    assert row["tools"][0]["name"] == "list_pets"
+    assert "sk-" not in str(row)
+    assert row["env"]["API_KEY"] == "${API_KEY}"
+
+
+def test_openapi_discover_honest_missing_proxy(monkeypatch):
+    def boom(*_args, **_kwargs):
+        raise FileNotFoundError("uvx")
+
+    monkeypatch.setattr("swarm.core.mcp_plugins._run_async", boom)
+    with pytest.raises(McpPluginError) as exc:
+        list_tools_for_spec(
+            {
+                "name": "pets",
+                "source": "openapi",
+                "kind": "local",
+                "openapi_spec_url": "https://example.invalid/openapi.json",
+            }
+        )
+    assert exc.value.code == "mcp_discover_failed"
+    assert "not installed" in str(exc.value)
 
 
 def test_plugin_catalog_ids_include_discovered():

--- a/tests/core/test_mcp_plugins.py
+++ b/tests/core/test_mcp_plugins.py
@@ -345,10 +345,10 @@ def test_public_server_exposes_openapi_source_without_secrets():
 
 
 def test_openapi_discover_honest_missing_proxy(monkeypatch):
-    def boom(*_args, **_kwargs):
+    async def boom(*_args, **_kwargs):
         raise FileNotFoundError("uvx")
 
-    monkeypatch.setattr("swarm.core.mcp_plugins._run_async", boom)
+    monkeypatch.setattr("swarm.core.mcp_plugins._discover_live", boom)
     with pytest.raises(McpPluginError) as exc:
         list_tools_for_spec(
             {

--- a/tests/views/test_mcp_plugins_api.py
+++ b/tests/views/test_mcp_plugins_api.py
@@ -121,3 +121,80 @@ def test_discover_local_and_remote_mocks(api_client, tmp_path: Path):
         assert failed.status_code == 502
         assert failed.json()["code"] == "mcp_discover_failed"
         assert "refused" in failed.json()["error"]
+
+
+def test_upsert_and_discover_openapi_mock(api_client, tmp_path: Path):
+    path = tmp_path / "swarm_config.json"
+    path.write_text(json.dumps({"llm": {}, "mcpServers": {}}), encoding="utf-8")
+
+    def fake_list(spec):
+        assert spec.get("source") == "openapi"
+        assert spec.get("openapi_spec_url") == "https://example.invalid/openapi.json"
+        return [
+            {"name": "list_pets", "description": "List pets"},
+            {"name": "get_pet", "description": "Get a pet"},
+        ]
+
+    cfg = {"llm": {}, "mcpServers": {}}
+    with (
+        patch("swarm.core.remotes.load_raw_config", return_value=(cfg, path)),
+        patch("swarm.core.mcp_plugins.swarm_config", return_value=cfg),
+    ):
+        created = api_client.post(
+            "/v1/mcp-plugins/",
+            {
+                "name": "pets",
+                "source": "openapi",
+                "kind": "local",
+                "openapi_spec_url": "https://example.invalid/openapi.json",
+                "env": {"API_KEY": "${API_KEY}"},
+            },
+            format="json",
+        )
+        assert created.status_code == 200
+        pets = next(row for row in created.json()["servers"] if row["name"] == "pets")
+        assert pets["source"] == "openapi"
+        assert pets["command"] == "uvx"
+        assert pets["args"] == ["mcp-openapi-proxy"]
+        assert pets["openapi_spec_url"] == "https://example.invalid/openapi.json"
+        assert "sk-" not in json.dumps(created.json())
+
+        missing = api_client.post(
+            "/v1/mcp-plugins/",
+            {"name": "no-spec", "source": "openapi", "kind": "local"},
+            format="json",
+        )
+        assert missing.status_code == 400
+        assert missing.json()["code"] == "bad_payload"
+
+    cfg = {
+        "llm": {},
+        "mcpServers": {
+            "pets": {
+                "source": "openapi",
+                "kind": "local",
+                "command": "uvx",
+                "args": ["mcp-openapi-proxy"],
+                "openapi_spec_url": "https://example.invalid/openapi.json",
+            }
+        },
+    }
+    path.write_text(json.dumps(cfg), encoding="utf-8")
+    with (
+        patch("swarm.core.remotes.load_raw_config", return_value=(cfg, path)),
+        patch("swarm.core.mcp_plugins.swarm_config", return_value=cfg),
+        patch("swarm.core.mcp_plugins.list_tools_for_spec", side_effect=lambda spec, **_k: fake_list(spec)),
+    ):
+        discovered = api_client.post(
+            "/v1/mcp-plugins/discover/",
+            {
+                "name": "pets",
+                "source": "openapi",
+                "kind": "local",
+                "openapi_spec_url": "https://example.invalid/openapi.json",
+            },
+            format="json",
+        )
+        assert discovered.status_code == 200
+        assert [row["name"] for row in discovered.json()["tools"]] == ["list_pets", "get_pet"]
+        assert discovered.json()["source"] == "openapi"

--- a/webui/frontend/src/components/PluginsServersPane.tsx
+++ b/webui/frontend/src/components/PluginsServersPane.tsx
@@ -10,27 +10,37 @@ import {
 } from '../lib/api'
 import {
   MCP_SERVER_TEMPLATES,
+  OPENAPI_PROXY_ARGS,
+  OPENAPI_PROXY_COMMAND,
   asEnvPlaceholder,
   entryToUpsertBody,
   isEnvPlaceholder,
+  isOpenApiSource,
   newMcpServerId,
   saveConfiguredMcpServers,
   serversFromApi,
+  validateOpenApiWizard,
   type McpServerEntry,
   type McpServerKind,
+  type McpServerSource,
 } from '../lib/mcpServers'
 
 const QUERY_KEY = ['mcp-plugins']
 
-function emptyDraft(kind: McpServerKind = 'local'): McpServerEntry {
+function emptyDraft(
+  kind: McpServerKind = 'local',
+  source: McpServerSource = 'generic',
+): McpServerEntry {
   return {
     id: '',
     name: '',
     kind,
+    source,
     enabled: true,
-    command: '',
-    args: [],
+    command: source === 'openapi' && kind === 'local' ? OPENAPI_PROXY_COMMAND : '',
+    args: source === 'openapi' && kind === 'local' ? [...OPENAPI_PROXY_ARGS] : [],
     url: '',
+    openapi_spec_url: '',
     env: {},
     headers: {},
     provides: [],
@@ -56,10 +66,12 @@ export default function PluginsServersPane() {
   })
   const [editing, setEditing] = useState<McpServerEntry | null>(null)
   const [kind, setKind] = useState<McpServerKind>('local')
+  const [source, setSource] = useState<McpServerSource>('generic')
   const [name, setName] = useState('')
   const [command, setCommand] = useState('')
   const [argsText, setArgsText] = useState('')
   const [url, setUrl] = useState('')
+  const [specSource, setSpecSource] = useState('')
   const [envName, setEnvName] = useState('')
   const [headerName, setHeaderName] = useState('')
   const [headerEnv, setHeaderEnv] = useState('')
@@ -78,10 +90,12 @@ export default function PluginsServersPane() {
     setEditing(null)
     setOriginalId('')
     setKind('local')
+    setSource('generic')
     setName('')
     setCommand('')
     setArgsText('')
     setUrl('')
+    setSpecSource('')
     setEnvName('')
     setHeaderName('')
     setHeaderEnv('')
@@ -92,11 +106,13 @@ export default function PluginsServersPane() {
     setEditing(entry)
     setOriginalId(entry.id)
     setKind(entry.kind)
+    setSource(isOpenApiSource(entry) ? 'openapi' : 'generic')
     setName(entry.name)
     setCommand(entry.command || '')
     setArgsText((entry.args || []).join(' '))
     setUrl(entry.url || '')
-    const envKeys = Object.keys(entry.env || {})
+    setSpecSource(entry.openapi_spec_url || '')
+    const envKeys = Object.keys(entry.env || {}).filter((key) => key !== 'OPENAPI_SPEC_URL')
     setEnvName(envKeys[0] || '')
     const headerKeys = Object.keys(entry.headers || {})
     setHeaderName(headerKeys[0] || '')
@@ -106,12 +122,37 @@ export default function PluginsServersPane() {
     setNote(entry.note || '')
   }
 
+  const startAdd = (nextKind: McpServerKind, nextSource: McpServerSource) => {
+    const draft = emptyDraft(nextKind, nextSource)
+    fillForm(draft)
+    setKind(nextKind)
+    setSource(nextSource)
+    if (nextSource === 'openapi' && nextKind === 'local') {
+      setCommand(OPENAPI_PROXY_COMMAND)
+      setArgsText(OPENAPI_PROXY_ARGS.join(' '))
+    }
+  }
+
   const buildEntry = (): McpServerEntry | null => {
     const trimmed = name.trim()
     if (!trimmed) return null
     const id = originalId || newMcpServerId(trimmed)
+    let openapiSpec = ''
+    if (source === 'openapi') {
+      const check = validateOpenApiWizard({
+        name: trimmed,
+        kind,
+        specSource,
+        url,
+      })
+      if (!check.ok) {
+        toastError(check.error, check.detail)
+        return null
+      }
+      openapiSpec = check.specSource
+    }
     const env: Record<string, string> = {}
-    if (kind === 'local' && envName.trim()) {
+    if ((kind === 'local' || source === 'openapi') && envName.trim()) {
       const key = envName.trim()
       if (!isEnvPlaceholder(key) && !/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
         toastError('Invalid env name', 'Use an ENV_VAR name. Never paste a token.')
@@ -131,10 +172,24 @@ export default function PluginsServersPane() {
       id,
       name: trimmed,
       kind,
+      source,
       enabled: editing?.enabled !== false,
-      command: kind === 'local' ? command.trim() : '',
-      args: kind === 'local' ? parseArgs(argsText) : [],
+      command:
+        kind === 'local'
+          ? source === 'openapi'
+            ? command.trim() || OPENAPI_PROXY_COMMAND
+            : command.trim()
+          : '',
+      args:
+        kind === 'local'
+          ? source === 'openapi'
+            ? parseArgs(argsText).length > 0
+              ? parseArgs(argsText)
+              : [...OPENAPI_PROXY_ARGS]
+            : parseArgs(argsText)
+          : [],
       url: kind === 'remote' ? url.trim() : '',
+      openapi_spec_url: source === 'openapi' ? openapiSpec : '',
       env,
       headers,
       provides: editing?.provides || [],
@@ -190,9 +245,11 @@ export default function PluginsServersPane() {
       discoverMcpPluginTools({
         name: entry.id,
         kind: entry.kind,
+        source: entry.source,
         command: entry.command,
         args: entry.args,
         url: entry.url,
+        openapi_spec_url: entry.openapi_spec_url,
         env: entry.env,
         headers: entry.headers,
       }),
@@ -239,10 +296,10 @@ export default function PluginsServersPane() {
       <div>
         <h4 className="text-lg font-semibold">Plugins</h4>
         <p className="mt-1 text-sm text-base-content/70">
-          Define local (stdio command) or remote (URL) MCP servers for this
-          host. Per-chat tool On/Off lives in the rail Plugins popup. Auth is{' '}
-          <code>${'{VAR}'}</code> only — never paste a token. Distinct from
-          exposing swarm as an MCP server.
+          Define local (stdio command), remote (URL), or OpenAPI
+          (mcp-openapi-proxy) MCP servers for this host. Per-chat tool On/Off
+          lives in the rail Plugins popup. Auth is <code>${'{VAR}'}</code> only
+          — never paste a token. Distinct from exposing swarm as an MCP server.
         </p>
       </div>
 
@@ -266,10 +323,14 @@ export default function PluginsServersPane() {
                 <div className="min-w-0">
                   <p className="font-medium">{server.name}</p>
                   <p className="truncate text-xs text-base-content/55">
-                    {server.kind === 'remote'
-                      ? server.url || 'Remote URL not set'
-                      : [server.command, ...(server.args || [])].filter(Boolean).join(' ') ||
-                        'Local command not set'}
+                    {server.source === 'openapi'
+                      ? server.kind === 'remote'
+                        ? `OpenAPI proxy · ${server.url || 'MCP URL not set'}`
+                        : `OpenAPI · ${server.openapi_spec_url || 'spec not set'}`
+                      : server.kind === 'remote'
+                        ? server.url || 'Remote URL not set'
+                        : [server.command, ...(server.args || [])].filter(Boolean).join(' ') ||
+                          'Local command not set'}
                   </p>
                   {(server.tools.length > 0 || server.provides.length > 0) && (
                     <ul className="mt-1 space-y-0.5" aria-label={`${server.name} tools`}>
@@ -342,31 +403,76 @@ export default function PluginsServersPane() {
         </ul>
       )}
 
-      <div className="flex flex-wrap gap-2">
-        <button
-          type="button"
-          className="btn btn-sm btn-primary"
-          onClick={() => {
-            if (editing) resetForm()
-            else fillForm(emptyDraft(kind))
-          }}
-        >
-          <Plus className="h-4 w-4" aria-hidden="true" />
-          {editing ? 'Cancel' : 'Add server'}
-        </button>
+      <div className="flex flex-wrap gap-2" aria-label="Add MCP server">
+        {editing ? (
+          <button type="button" className="btn btn-sm" onClick={resetForm}>
+            Cancel
+          </button>
+        ) : (
+          <>
+            <button
+              type="button"
+              className="btn btn-sm btn-primary"
+              onClick={() => startAdd('local', 'generic')}
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Add: Local MCP
+            </button>
+            <button
+              type="button"
+              className="btn btn-sm"
+              onClick={() => startAdd('remote', 'generic')}
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Add: Remote MCP
+            </button>
+            <button
+              type="button"
+              className="btn btn-sm"
+              onClick={() => startAdd('local', 'openapi')}
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Add: OpenAPI (mcp-openapi-proxy)
+            </button>
+          </>
+        )}
       </div>
 
       {editing ? (
-        <form className="space-y-3 rounded-lg border border-base-300 p-3" onSubmit={handleSubmit}>
+        <form
+          className="space-y-3 rounded-lg border border-base-300 p-3"
+          onSubmit={handleSubmit}
+          data-mcp-source={source}
+        >
+          {source === 'openapi' ? (
+            <p className="text-sm text-base-content/70" data-testid="os-openapi-wizard-hint">
+              OpenAPI (mcp-openapi-proxy). Local launches{' '}
+              <code>uvx mcp-openapi-proxy</code> with <code>OPENAPI_SPEC_URL</code>.
+              Remote attaches to a running proxy MCP URL. Install:{' '}
+              <code>uvx mcp-openapi-proxy</code> or <code>pip install mcp-openapi-proxy</code>.
+              Use env names only — never paste a token.
+            </p>
+          ) : null}
           <Select
             label="Kind"
             name="mcp-kind"
             value={kind}
-            onChange={(event) => setKind(event.target.value as McpServerKind)}
+            onChange={(event) => {
+              const next = event.target.value as McpServerKind
+              setKind(next)
+              if (source === 'openapi' && next === 'local') {
+                setCommand((current) => current || OPENAPI_PROXY_COMMAND)
+                setArgsText((current) => current || OPENAPI_PROXY_ARGS.join(' '))
+              }
+            }}
             size="sm"
           >
-            <option value="local">Local command</option>
-            <option value="remote">Remote URL</option>
+            <option value="local">
+              {source === 'openapi' ? 'Local stdio proxy' : 'Local command'}
+            </option>
+            <option value="remote">
+              {source === 'openapi' ? 'Remote proxy MCP URL' : 'Remote URL'}
+            </option>
           </Select>
           <Input
             label="Name"
@@ -378,7 +484,27 @@ export default function PluginsServersPane() {
             autoComplete="off"
             spellCheck={false}
           />
-          {kind === 'local' ? (
+          {source === 'openapi' ? (
+            <Input
+              label={
+                kind === 'local'
+                  ? 'OpenAPI spec source (URL or file)'
+                  : 'OpenAPI spec URL (optional)'
+              }
+              name="mcp-openapi-spec"
+              value={specSource}
+              onChange={(event) => setSpecSource(event.target.value)}
+              size="sm"
+              placeholder={
+                kind === 'local'
+                  ? 'https://example.invalid/openapi.json'
+                  : 'https://example.invalid/openapi.json'
+              }
+              autoComplete="off"
+              spellCheck={false}
+            />
+          ) : null}
+          {kind === 'local' && source === 'generic' ? (
             <>
               <Input
                 label="Command"
@@ -411,10 +537,23 @@ export default function PluginsServersPane() {
                 spellCheck={false}
               />
             </>
-          ) : (
+          ) : null}
+          {kind === 'local' && source === 'openapi' ? (
+            <Input
+              label="API auth env name (optional)"
+              name="mcp-env"
+              value={envName}
+              onChange={(event) => setEnvName(event.target.value)}
+              size="sm"
+              placeholder="API_KEY"
+              autoComplete="off"
+              spellCheck={false}
+            />
+          ) : null}
+          {kind === 'remote' ? (
             <>
               <Input
-                label="URL"
+                label={source === 'openapi' ? 'Proxy MCP URL' : 'URL'}
                 name="mcp-url"
                 value={url}
                 onChange={(event) => setUrl(event.target.value)}
@@ -444,7 +583,7 @@ export default function PluginsServersPane() {
                 spellCheck={false}
               />
             </>
-          )}
+          ) : null}
           <Input
             label="Note"
             name="mcp-note"

--- a/webui/frontend/src/components/__tests__/PluginsServersPane.test.tsx
+++ b/webui/frontend/src/components/__tests__/PluginsServersPane.test.tsx
@@ -74,6 +74,8 @@ describe('PluginsServersPane', () => {
           command: body.command || '',
           args: body.args || [],
           url: body.url || '',
+          source: body.source || 'generic',
+          openapi_spec_url: body.openapi_spec_url || '',
           env: body.env || {},
           headers: body.headers || {},
           provides: body.provides || [],
@@ -98,8 +100,7 @@ describe('PluginsServersPane', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Discover tools' }))
     expect(await screen.findByText(/Found 1 tool/i)).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Add server' }))
-    fireEvent.change(screen.getByRole('combobox', { name: 'Kind' }), { target: { value: 'remote' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add: Remote MCP' }))
     fireEvent.change(screen.getByRole('textbox', { name: 'Name' }), { target: { value: 'proxy' } })
     fireEvent.change(screen.getByRole('textbox', { name: 'URL' }), {
       target: { value: 'https://example.invalid/mcp' },
@@ -167,5 +168,85 @@ describe('PluginsServersPane', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Discover tools' }))
     expect(await screen.findByText('Could not list tools')).toBeInTheDocument()
     expect(screen.getByText(/refused connect/i)).toBeInTheDocument()
+  })
+
+  it('adds OpenAPI (mcp-openapi-proxy), discovers mock tools, and disables them', async () => {
+    const servers: Record<string, unknown>[] = []
+    const fetchMock = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      const method = (init?.method || 'GET').toUpperCase()
+      const body = init?.body ? JSON.parse(String(init.body)) : {}
+      if (url.includes('/v1/mcp-plugins/discover')) {
+        expect(body.source).toBe('openapi')
+        expect(body.openapi_spec_url).toBe('https://example.invalid/openapi.json')
+        return jsonResponse({
+          object: 'mcp_plugin_tools',
+          name: body.name,
+          kind: 'local',
+          source: 'openapi',
+          tools: [
+            { name: 'list_pets', description: 'List pets' },
+            { name: 'get_pet', description: 'Get a pet' },
+          ],
+        })
+      }
+      if (url.includes('/v1/mcp-plugins/') && method === 'POST') {
+        expect(JSON.stringify(body)).not.toMatch(/sk-|api[_-]?key|bearer /i)
+        expect(body.source).toBe('openapi')
+        expect(body.command).toBe('uvx')
+        expect(body.args).toEqual(['mcp-openapi-proxy'])
+        const row = {
+          name: 'pets',
+          label: body.name,
+          kind: 'local',
+          source: 'openapi',
+          enabled: body.enabled !== false,
+          command: body.command,
+          args: body.args,
+          url: '',
+          openapi_spec_url: body.openapi_spec_url,
+          env: body.env || {},
+          headers: {},
+          provides: ['list_pets', 'get_pet'],
+          note: body.note || '',
+          tools: [],
+        }
+        const existing = servers.findIndex((item) => item.name === row.name)
+        if (existing >= 0) servers[existing] = { ...servers[existing], ...row }
+        else servers.push(row)
+        return jsonResponse({ object: 'mcp_plugins', scope: 'global_servers_per_chat_tools', servers })
+      }
+      return jsonResponse({ object: 'mcp_plugins', scope: 'global_servers_per_chat_tools', servers })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderPane()
+    fireEvent.click(await screen.findByRole('button', { name: 'Add: OpenAPI (mcp-openapi-proxy)' }))
+    expect(screen.getByTestId('os-openapi-wizard-hint')).toHaveTextContent(/mcp-openapi-proxy/)
+    fireEvent.change(screen.getByRole('textbox', { name: 'Name' }), { target: { value: 'Pets' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save server' }))
+    expect(await screen.findByText(/OpenAPI spec required/i)).toBeInTheDocument()
+
+    fireEvent.change(screen.getByRole('textbox', { name: /OpenAPI spec source/i }), {
+      target: { value: 'https://example.invalid/openapi.json' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save server' }))
+    expect((await screen.findAllByText('MCP server saved')).length).toBeGreaterThan(0)
+    expect(screen.getByRole('list', { name: 'Configured MCP servers' })).toHaveTextContent('Pets')
+    expect(screen.getByRole('list', { name: 'Configured MCP servers' })).toHaveTextContent(
+      'https://example.invalid/openapi.json',
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Discover tools' }))
+    expect(await screen.findByText(/Found 2 tools/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('switch', { name: /Pets enabled/i }))
+    await waitFor(() => {
+      const bodies = fetchMock.mock.calls
+        .map((call) => call[1]?.body)
+        .filter(Boolean)
+        .map((raw) => JSON.parse(String(raw)))
+      expect(bodies.some((body) => body.enabled === false && body.source === 'openapi')).toBe(true)
+    })
   })
 })

--- a/webui/frontend/src/lib/__tests__/chatPluginTools.test.ts
+++ b/webui/frontend/src/lib/__tests__/chatPluginTools.test.ts
@@ -137,6 +137,7 @@ describe('catalog degrade', () => {
         {
           name: 'fetch',
           kind: 'local',
+          source: 'generic',
           enabled: true,
           command: 'uvx',
           args: ['mcp-server-fetch'],

--- a/webui/frontend/src/lib/__tests__/mcpServers.test.ts
+++ b/webui/frontend/src/lib/__tests__/mcpServers.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   MCP_SERVERS_KEY,
+  entryToUpsertBody,
   loadConfiguredMcpServers,
   newMcpServerId,
+  normalizeOpenApiSpecSource,
   removeMcpServer,
   upsertMcpServer,
+  validateOpenApiWizard,
 } from '../mcpServers'
 
 describe('mcpServers document store', () => {
@@ -48,5 +51,70 @@ describe('mcpServers document store', () => {
     expect(saved[0].env).toEqual({ BRAVE_API_KEY: '${BRAVE_API_KEY}' })
     expect(JSON.stringify(saved)).not.toMatch(/sk-live/)
     expect(saved[0].tools[0].name).toBe('search_docs')
+  })
+
+  it('validates the OpenAPI wizard and keeps spec URLs out of secret fields', () => {
+    expect(
+      validateOpenApiWizard({
+        name: '',
+        kind: 'local',
+        specSource: 'https://example.invalid/openapi.json',
+        url: '',
+      }).ok,
+    ).toBe(false)
+    expect(
+      validateOpenApiWizard({
+        name: 'Pets',
+        kind: 'local',
+        specSource: '',
+        url: '',
+      }),
+    ).toMatchObject({ ok: false, error: 'OpenAPI spec required' })
+    expect(
+      validateOpenApiWizard({
+        name: 'Pets',
+        kind: 'remote',
+        specSource: 'https://example.invalid/openapi.json',
+        url: '',
+      }),
+    ).toMatchObject({ ok: false, error: 'Proxy MCP URL required' })
+    expect(
+      validateOpenApiWizard({
+        name: 'Pets',
+        kind: 'local',
+        specSource: 'https://user:token@example.invalid/openapi.json',
+        url: '',
+      }).ok,
+    ).toBe(false)
+    const localOk = validateOpenApiWizard({
+      name: 'Pets',
+      kind: 'local',
+      specSource: 'https://example.invalid/openapi.json',
+      url: '',
+    })
+    expect(localOk).toEqual({
+      ok: true,
+      specSource: 'https://example.invalid/openapi.json',
+      url: '',
+    })
+    expect(normalizeOpenApiSpecSource('/tmp/pets.json', 'local')).toBe('file:///tmp/pets.json')
+    const saved = upsertMcpServer({
+      id: 'pets',
+      name: 'Pets',
+      kind: 'local',
+      source: 'openapi',
+      enabled: true,
+      command: 'uvx',
+      args: ['mcp-openapi-proxy'],
+      openapi_spec_url: 'https://example.invalid/openapi.json',
+      env: { API_KEY: '${API_KEY}' },
+      provides: ['list_pets'],
+      tools: [{ name: 'list_pets', description: 'List pets' }],
+    })
+    const body = entryToUpsertBody(saved[0])
+    expect(body.source).toBe('openapi')
+    expect(body.openapi_spec_url).toBe('https://example.invalid/openapi.json')
+    expect(JSON.stringify(body)).not.toMatch(/sk-|token|password/i)
+    expect(body.env).toEqual({ API_KEY: '${API_KEY}' })
   })
 })

--- a/webui/frontend/src/lib/api.ts
+++ b/webui/frontend/src/lib/api.ts
@@ -1173,10 +1173,12 @@ export interface McpPluginServer {
   name: string
   label?: string
   kind: 'local' | 'remote'
+  source?: 'generic' | 'openapi'
   enabled: boolean
   command: string
   args: string[]
   url: string
+  openapi_spec_url?: string
   type?: string
   cwd?: string
   env: Record<string, string>
@@ -1196,6 +1198,7 @@ export interface McpPluginDiscoverPayload {
   object: 'mcp_plugin_tools'
   name: string
   kind: 'local' | 'remote'
+  source?: 'generic' | 'openapi'
   tools: McpPluginTool[]
 }
 

--- a/webui/frontend/src/lib/mcpServers.ts
+++ b/webui/frontend/src/lib/mcpServers.ts
@@ -1,17 +1,24 @@
 /**
- * MCP server entries for Settings → Plugins (#502 manage path).
+ * MCP server entries for Settings → Plugins (#502 / #750 manage path).
  *
  * Source of truth is ``swarm_config.json`` ``mcpServers`` via
  * ``/v1/mcp-plugins/``. localStorage is a write-through cache so the rail
  * Plugins popup can show configured tools when the API is mid-flight.
  *
  * Env / header values are ``${VAR}`` placeholders only — never keys or tokens.
+ * OpenAPI servers store the spec on ``openapi_spec_url`` (not a secret) and
+ * launch ``uvx mcp-openapi-proxy`` locally with ``OPENAPI_SPEC_URL``.
  */
 
 export const MCP_SERVERS_KEY = 'swarm_mcp_servers'
 export const MCP_SERVERS_EVENT = 'swarm:mcp-servers'
 
 export type McpServerKind = 'local' | 'remote'
+export type McpServerSource = 'generic' | 'openapi'
+
+export const OPENAPI_PROXY_COMMAND = 'uvx'
+export const OPENAPI_PROXY_ARGS = ['mcp-openapi-proxy'] as const
+export const OPENAPI_SPEC_ENV = 'OPENAPI_SPEC_URL'
 
 export interface McpDiscoveredTool {
   name: string
@@ -22,10 +29,12 @@ export interface McpServerEntry {
   id: string
   name: string
   kind: McpServerKind
+  source?: McpServerSource
   enabled: boolean
   command?: string
   args?: string[]
   url?: string
+  openapi_spec_url?: string
   cwd?: string
   env?: Record<string, string>
   headers?: Record<string, string>
@@ -39,6 +48,125 @@ const ENV_NAME_RE = /^[A-Z][A-Z0-9_]*$/
 
 function isKind(value: unknown): value is McpServerKind {
   return value === 'local' || value === 'remote'
+}
+
+function isSource(value: unknown): value is McpServerSource {
+  return value === 'generic' || value === 'openapi'
+}
+
+export function isOpenApiSource(entry: {
+  source?: string
+  openapi_spec_url?: string
+  args?: string[]
+  command?: string
+} | null | undefined): boolean {
+  if (!entry) return false
+  if (entry.source === 'openapi') return true
+  if (typeof entry.openapi_spec_url === 'string' && entry.openapi_spec_url.trim()) return true
+  const haystack = [entry.command, ...(entry.args || [])].filter(Boolean).join(' ')
+  return haystack.includes('mcp-openapi-proxy')
+}
+
+const LOCAL_PATH_RE = /^(?:\/|\.\/|\.\.\/|~\/|[A-Za-z]:[\\/])/
+
+function urlHasUserinfo(value: string): boolean {
+  try {
+    const parsed = new URL(value)
+    return Boolean(parsed.username || parsed.password)
+  } catch {
+    return /:\/\/[^/]*@/.test(value)
+  }
+}
+
+export function normalizeOpenApiSpecSource(raw: string, kind: McpServerKind): string {
+  const trimmed = raw.trim()
+  if (!trimmed) return ''
+  if (/^https?:\/\//i.test(trimmed)) return trimmed
+  if (/^file:\/\//i.test(trimmed)) return kind === 'local' ? trimmed : ''
+  if (kind === 'local' && LOCAL_PATH_RE.test(trimmed)) {
+    if (trimmed.startsWith('file:')) return trimmed
+    if (trimmed.startsWith('/')) return `file://${trimmed}`
+    return trimmed
+  }
+  return trimmed
+}
+
+export interface OpenApiWizardFields {
+  name: string
+  kind: McpServerKind
+  specSource: string
+  url: string
+}
+
+export interface OpenApiWizardOk {
+  ok: true
+  specSource: string
+  url: string
+}
+
+export interface OpenApiWizardErr {
+  ok: false
+  error: string
+  detail: string
+}
+
+/** Client-side #750 wizard checks. Server still refuses secrets / bad URLs. */
+export function validateOpenApiWizard(fields: OpenApiWizardFields): OpenApiWizardOk | OpenApiWizardErr {
+  const name = fields.name.trim()
+  if (!name) {
+    return { ok: false, error: 'Name required', detail: 'Give the OpenAPI MCP server a display name.' }
+  }
+  if (fields.kind === 'local') {
+    const specSource = normalizeOpenApiSpecSource(fields.specSource, 'local')
+    if (!specSource) {
+      return {
+        ok: false,
+        error: 'OpenAPI spec required',
+        detail: 'Local mcp-openapi-proxy needs an http(s) spec URL or a local file path.',
+      }
+    }
+    if (/^https?:\/\//i.test(specSource) && urlHasUserinfo(specSource)) {
+      return {
+        ok: false,
+        error: 'Refusing credentials in spec URL',
+        detail: 'Do not paste userinfo. Use ${API_KEY} if the API needs auth.',
+      }
+    }
+    return { ok: true, specSource, url: '' }
+  }
+  const url = fields.url.trim()
+  if (!url) {
+    return {
+      ok: false,
+      error: 'Proxy MCP URL required',
+      detail: 'Remote OpenAPI attaches to a running proxy MCP URL. Use Local to launch stdio.',
+    }
+  }
+  if (!/^https?:\/\//i.test(url)) {
+    return {
+      ok: false,
+      error: 'URL required',
+      detail: 'Remote MCP URL must be http(s) with a host. Do not paste secrets in the URL.',
+    }
+  }
+  if (urlHasUserinfo(url)) {
+    return {
+      ok: false,
+      error: 'Refusing credentials in URL',
+      detail: 'Use a ${VAR} header instead of userinfo.',
+    }
+  }
+  const specSource = fields.specSource.trim()
+    ? normalizeOpenApiSpecSource(fields.specSource, 'remote')
+    : ''
+  if (fields.specSource.trim() && !specSource) {
+    return {
+      ok: false,
+      error: 'OpenAPI spec must be http(s)',
+      detail: 'Remote mode stores an optional spec URL for display. File paths are local-only.',
+    }
+  }
+  return { ok: true, specSource, url }
 }
 
 export function isEnvPlaceholder(value: string): boolean {
@@ -98,6 +226,13 @@ function parseEntry(value: unknown): McpServerEntry | null {
     : typeof row.url === 'string' && row.url.trim()
       ? 'remote'
       : 'local'
+  const source = isSource(row.source)
+    ? row.source
+    : typeof row.openapi_spec_url === 'string' && row.openapi_spec_url.trim()
+      ? 'openapi'
+      : Array.isArray(row.args) && row.args.some((item) => String(item).includes('mcp-openapi-proxy'))
+        ? 'openapi'
+        : 'generic'
   if (!id || !name) return null
   const provides = Array.isArray(row.provides)
     ? row.provides.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
@@ -110,10 +245,12 @@ function parseEntry(value: unknown): McpServerEntry | null {
     id,
     name,
     kind,
+    source,
     enabled: row.enabled !== false && row.enabled !== 'false',
     command: typeof row.command === 'string' ? row.command : '',
     args,
     url: typeof row.url === 'string' ? row.url : '',
+    openapi_spec_url: typeof row.openapi_spec_url === 'string' ? row.openapi_spec_url : '',
     cwd: typeof row.cwd === 'string' ? row.cwd : '',
     env: parsePlaceholderMap(row.env),
     headers: parsePlaceholderMap(row.headers),
@@ -174,9 +311,13 @@ export function entryToUpsertBody(entry: McpServerEntry): Record<string, unknown
   const body: Record<string, unknown> = {
     name: parsed.name || parsed.id,
     kind: parsed.kind,
+    source: parsed.source || 'generic',
     enabled: parsed.enabled,
     provides: parsed.provides,
     note: parsed.note || '',
+  }
+  if (parsed.openapi_spec_url) {
+    body.openapi_spec_url = parsed.openapi_spec_url
   }
   if (parsed.kind === 'remote') {
     body.url = parsed.url || ''


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #750

Adds an **Add: OpenAPI (mcp-openapi-proxy)** path to Settings → Plugins alongside **Add: Local MCP** and **Add: Remote MCP**. OpenAPI operations become MCP tools by integrating [matthewhand/mcp-openapi-proxy](https://github.com/matthewhand/mcp-openapi-proxy) rather than a parallel mapper. The package is not vendored.

## v1 path (documented)

- **Local:** configure stdio `uvx mcp-openapi-proxy` and set `OPENAPI_SPEC_URL` from the wizard spec (http(s) URL or local `file://` path). Optional auth env name (`API_KEY` → `${API_KEY}`).
- **Remote:** operator pastes the **running proxy MCP URL** (same attach path as #502 remote). Optional spec URL is stored for display only. open-swarm does not launch an HTTP proxy.

## Wizard fields

- Display name
- Local vs remote (same #502 toggle)
- OpenAPI spec source (required for local; optional http(s) for remote)
- Proxy MCP URL (required for remote)
- Optional `${VAR}` auth

## Scope

Same as #502: servers are global (`swarm_config.json` `mcpServers`); tools are per-chat opt-in via the rail Plugins popup (`params.enabled_tools`). Distinct from `ENABLE_MCP_SERVER`.

## Honesty / secrets

Discover failures name missing proxy install, bad spec, or connect timeout. No secrets or personal dumps. Env/header values stay `${VAR}`. Spec URLs refuse userinfo.

## Tests

- Mock OpenAPI operations → mock MCP tool list
- Wizard validation (missing spec / missing proxy URL / userinfo)
- Disable / per-chat allowlist removes tools
- No live LAN hosts

Install for local mode: `uvx mcp-openapi-proxy` or `pip install mcp-openapi-proxy`.

## Docs

See `docs/examples/plugins-mcp.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d6d5113-e63c-4521-bc17-fdce5f2b27ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d6d5113-e63c-4521-bc17-fdce5f2b27ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

