### PR TITLE
fix(chat): LLM-summarise compact instead of concatenating turns

### DIFF
--- a/src/swarm/core/chat_compact.py
+++ b/src/swarm/core/chat_compact.py
@@ -1,17 +1,38 @@
-"""Nested conversation compact / summaries (REQ-37).
+"""Nested conversation compact / summaries (REQ-37 / #672).
 
 Raw transcripts stay on disk (JSON) and in ``ChatMessage``. Django/sqlite
 stores summary rows. Serving model context walks the summary tree — later
 compacts may summarise a mix of raw turns and earlier summaries.
+
+Compact **body** is an LLM-written digest (agent profile or Settings default),
+not a concatenated transcript dump. Auto-threshold (#444) should call
+:func:`compact_backlog` so it gets the same summariser when wired.
 """
 
 from __future__ import annotations
 
-from typing import Any, Iterable
+import logging
+import os
+import re
+from typing import Any, Callable, Iterable
 
 from swarm.core.speaker_identity import apply_speaker_identity
 from swarm.core.transcript_roles import is_ui_only_item, messages_for_model
 from swarm.models import ChatConversation, ChatMessage, ConversationSummary
+
+logger = logging.getLogger(__name__)
+
+COMPACT_SYSTEM = (
+    "Write a concise conversation summary for later context. "
+    "Preserve names, decisions, and open tasks. "
+    "Do not answer the user or continue the task. "
+    "Do not invent secrets, tokens, or credentials. "
+    "Return only the summary text."
+)
+
+_SECRET_IN_TEXT = re.compile(
+    r"(?i)(?:sk-[A-Za-z0-9]+|Bearer\s+\S+|api[_-]?key\s*[:=]\s*\S+)"
+)
 
 
 class CompactError(ValueError):
@@ -81,9 +102,10 @@ def _clip(text: str, limit: int = 240) -> str:
 
 
 def summarize_items(items: list[dict[str, Any]]) -> str:
-    """Deterministic extractive compact. No LLM, no secrets, no network.
+    """Deterministic extractive dump of a span (prompt material / tests).
 
-    UI-only status/info rows are skipped so summaries never re-inject chrome.
+    Not the compact bubble. UI-only status/info rows are skipped so chrome
+    never re-enters the summary prompt. No secrets, no network.
     """
     lines: list[str] = []
     real: list[dict[str, Any]] = []
@@ -101,6 +123,146 @@ def summarize_items(items: list[dict[str, Any]]) -> str:
     count = len(real)
     noun = "item" if count == 1 else "items"
     return f"Summary of {count} {noun}:\n" + "\n".join(lines)
+
+
+def build_compact_prompt(items: list[dict[str, Any]]) -> str:
+    """Transcript the compact LLM sees. Chrome skipped; bodies clipped."""
+    lines: list[str] = []
+    for item in items:
+        if item.get("kind") == "summary":
+            lines.append(f"[summary]: {_clip(str(item.get('body') or ''), 800)}")
+            continue
+        if is_ui_only_item(item):
+            continue
+        role = item.get("role") or "user"
+        content = item.get("content") or item.get("text") or ""
+        lines.append(f"{role}: {_clip(str(content), 800)}")
+    return (
+        "Write a concise conversation summary for later context. "
+        "Preserve names, decisions, and open tasks. "
+        "Do not answer the user or continue the task.\n"
+        "Transcript:\n" + "\n".join(lines)
+    )
+
+
+def _public_llm_error(exc: BaseException) -> str:
+    raw = str(exc) or type(exc).__name__
+    cleaned = _SECRET_IN_TEXT.sub("[REDACTED]", raw)
+    try:
+        from swarm.utils.redact import redact_uri_credentials
+
+        cleaned = redact_uri_credentials(cleaned)
+    except Exception:
+        pass
+    cleaned = " ".join(cleaned.split())
+    if len(cleaned) > 200:
+        cleaned = cleaned[:199].rstrip() + "…"
+    return f"Compact summary failed: {cleaned}"
+
+
+def _blueprint_section_model(agent_id: str, config: dict[str, Any]) -> str | None:
+    """Model slug from ``blueprints.<agent>.llm_profile`` — names only, no secrets."""
+    agent = (agent_id or "").strip()
+    if not agent or agent.startswith("_"):
+        return None
+    blueprints = config.get("blueprints")
+    if not isinstance(blueprints, dict):
+        return None
+    bp = blueprints.get(agent)
+    if not isinstance(bp, dict):
+        return None
+    profile_name = (
+        bp.get("llm_profile") or bp.get("default_model") or bp.get("default_profile")
+    )
+    if not isinstance(profile_name, str) or not profile_name.strip():
+        return None
+    from swarm.core.llm_task_routing import model_id_for_profile
+
+    return model_id_for_profile(profile_name.strip(), config) or None
+
+
+def resolve_compact_model(agent_id: str = "") -> str:
+    """Agent LLM profile, else Settings / env default. Raises if none configured."""
+    env_model = (
+        (os.environ.get("LITELLM_MODEL") or "").strip()
+        or (os.environ.get("OPENAI_MODEL") or "").strip()
+        or (os.environ.get("DEFAULT_LLM") or "").strip()
+    )
+    config: dict[str, Any] | None = None
+    try:
+        from swarm.core.llm_task_routing import load_swarm_config
+
+        config = load_swarm_config()
+    except Exception:
+        logger.debug("compact model: swarm config unavailable")
+        config = None
+
+    if isinstance(config, dict):
+        agent_model = _blueprint_section_model(agent_id, config)
+        if agent_model:
+            return agent_model
+
+    if env_model:
+        return env_model
+
+    if isinstance(config, dict):
+        try:
+            from swarm.core.llm_task_routing import model_id_for_profile, resolve_chat_model
+
+            route = resolve_chat_model(config)
+            model = model_id_for_profile(route.profile, config)
+            if model:
+                return model
+        except Exception:
+            logger.debug("compact model: settings default unavailable")
+
+    raise CompactError(
+        "No default LLM is configured. Set a model in Settings → LLM profiles.",
+        status=400,
+    )
+
+
+def llm_summarize_items(items: list[dict[str, Any]], *, agent_id: str = "") -> str:
+    """Call the agent / Settings-default LLM. No secrets in logs. Fail closed."""
+    model = resolve_compact_model(agent_id)
+    prompt = build_compact_prompt(items)
+    logger.info("compact LLM summarise model=%s items=%s", model, len(items))
+    try:
+        from openai import OpenAI
+
+        from swarm.core.model_text import sanitize_model_text
+        from swarm.utils.env_utils import openai_client_kwargs
+
+        client = OpenAI(**openai_client_kwargs())
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": COMPACT_SYSTEM},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.2,
+            max_tokens=600,
+        )
+    except CompactError:
+        raise
+    except Exception as exc:
+        logger.warning("compact LLM failed: %s", type(exc).__name__)
+        raise CompactError(_public_llm_error(exc), status=502) from exc
+
+    content = ""
+    choices = getattr(resp, "choices", None) or []
+    if choices:
+        message = getattr(choices[0], "message", None)
+        content = getattr(message, "content", None) or ""
+        if isinstance(choices[0], dict):
+            content = ((choices[0].get("message") or {}).get("content")) or content
+    text = sanitize_model_text(str(content or "")).strip()
+    if not text:
+        raise CompactError(
+            "Compact summary failed: the model returned an empty summary.",
+            status=502,
+        )
+    return text
 
 
 def _message_item(message: dict[str, Any], offset: int) -> dict[str, Any]:
@@ -402,11 +564,16 @@ def compact_backlog(
     span_start: int | None = None,
     span_end: int | None = None,
     through_message_id: Any = None,
+    summarizer: Callable[..., str] | None = None,
 ) -> tuple[ConversationSummary, list[dict[str, str]]]:
     """Create a summary row covering ``span`` of the raw transcript.
 
     Does not delete JSON or ``ChatMessage`` rows. Nested compact sets
     ``parent_summary_id`` to the previous outermost summary inside the span.
+
+    The compact body is an LLM summary (``summarizer`` or
+    :func:`llm_summarize_items`). LLM failure raises :class:`CompactError`
+    and does not write a summary row.
     """
     chat, raw = ensure_transcript(user, conversation_id, agent_id, messages)
     if through_message_id is not None and through_message_id != "":
@@ -437,7 +604,27 @@ def compact_backlog(
     if not mix:
         raise CompactError("Nothing to compact in that span.")
 
-    body = summarize_items(mix)
+    summarize = summarizer or llm_summarize_items
+    try:
+        body = summarize(mix, agent_id=agent_id)
+    except CompactError:
+        raise
+    except TypeError:
+        # Test doubles that only accept items.
+        try:
+            body = summarize(mix)
+        except CompactError:
+            raise
+        except Exception as exc:
+            raise CompactError(_public_llm_error(exc), status=502) from exc
+    except Exception as exc:
+        raise CompactError(_public_llm_error(exc), status=502) from exc
+    body = (body or "").strip()
+    if not body:
+        raise CompactError(
+            "Compact summary failed: the model returned an empty summary.",
+            status=502,
+        )
     parent = choose_parent(existing, start, end)
     row = ConversationSummary.objects.create(
         conversation=chat,

--- a/src/swarm/views/chat_persist_views.py
+++ b/src/swarm/views/chat_persist_views.py
@@ -456,7 +456,7 @@ def chat_attachment_upload(request):
 @login_required
 @require_http_methods(["POST"])
 def chat_compact(request):
-    """Summarise the current backlog (or a selected span) into a nested summary."""
+    """LLM-summarise the current backlog (or a selected span) into a nested summary."""
     payload = _json_body(request)
     agent = chat_store.normalize_agent_id(
         payload.get("agent") or payload.get("agent_id") or request.POST.get("agent_id")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,19 @@ def pytest_collection_modifyitems(config, items):
 # TestCase/TransactionTestCase explicitly.
 
 @pytest.fixture
+def stub_compact_llm(monkeypatch):
+    """#672 — compact uses an LLM; tests stub it so no network / secrets."""
+    calls: list[dict] = []
+
+    def _fake(items, *, agent_id=""):
+        calls.append({"items": items, "agent_id": agent_id})
+        return "LLM digest of the compacted range."
+
+    monkeypatch.setattr("swarm.core.chat_compact.llm_summarize_items", _fake)
+    return calls
+
+
+@pytest.fixture
 def mock_openai_client():
     from openai import AsyncOpenAI
     client = MagicMock(spec=AsyncOpenAI)

--- a/tests/core/test_agent_sessions.py
+++ b/tests/core/test_agent_sessions.py
@@ -92,6 +92,7 @@ def test_compact_does_not_leak_across_sessions(db, tmp_path, monkeypatch):
         conversation_id=first.conversation_id,
         agent_id="jeeves",
         messages=messages,
+        summarizer=lambda items, **_kwargs: "LLM digest of the compacted range.",
     )
     assert ConversationSummary.objects.filter(conversation_id=first.conversation_id).exists()
     assert not ConversationSummary.objects.filter(conversation_id=second.conversation_id).exists()

--- a/tests/core/test_chat_compact.py
+++ b/tests/core/test_chat_compact.py
@@ -1,7 +1,8 @@
-"""REQ-37: nested conversation compact / summaries.
+"""REQ-37 / #672: nested conversation compact / LLM summaries.
 
-Compact replaces model context. Raw JSON + ChatMessage rows stay.
-Nested compact sets parent_summary_id. No Neon, no secrets.
+Compact replaces model context with an LLM-written digest (not a raw dump).
+Raw JSON + ChatMessage rows stay. Nested compact sets parent_summary_id.
+No Neon, no secrets.
 """
 
 from __future__ import annotations
@@ -13,9 +14,12 @@ from django.test import Client
 from swarm.core import chat_store
 from swarm.core.chat_compact import (
     CompactError,
+    build_compact_prompt,
     build_model_context,
     compact_backlog,
     context_for_conversation,
+    llm_summarize_items,
+    resolve_compact_model,
     summarize_items,
 )
 from swarm.models import ChatConversation, ChatMessage, ConversationSummary
@@ -47,7 +51,7 @@ def _seed_json(user, agent, messages, conversation_id):
 
 
 @pytest.mark.django_db
-def test_compact_replaces_model_context(user):
+def test_compact_replaces_model_context(user, stub_compact_llm):
     cid = "conv-compact-ctx"
     messages = _turns(
         ("user", "alpha question"),
@@ -72,7 +76,7 @@ def test_compact_replaces_model_context(user):
 
 
 @pytest.mark.django_db
-def test_nested_compact_sets_parent_summary_id(user):
+def test_nested_compact_sets_parent_summary_id(user, stub_compact_llm):
     cid = "conv-compact-nest"
     first = _turns(("user", "one"), ("assistant", "two"))
     _seed_json(user, "codey", first, cid)
@@ -94,7 +98,7 @@ def test_nested_compact_sets_parent_summary_id(user):
 
 
 @pytest.mark.django_db
-def test_compact_keeps_raw_json_and_chatmessage_rows(user):
+def test_compact_keeps_raw_json_and_chatmessage_rows(user, stub_compact_llm):
     cid = "conv-compact-raw"
     messages = _turns(("user", "keep me"), ("assistant", "still here"))
     _seed_json(user, "stewie", messages, cid)
@@ -113,7 +117,7 @@ def test_compact_keeps_raw_json_and_chatmessage_rows(user):
 
 
 @pytest.mark.django_db
-def test_compact_endpoint_and_thread_payload(client, user):
+def test_compact_endpoint_and_thread_payload(client, user, stub_compact_llm):
     cid = "conv-compact-api"
     messages = _turns(("user", "remember this"), ("assistant", "ok"))
     _seed_json(user, "jeeves", messages, cid)
@@ -133,6 +137,8 @@ def test_compact_endpoint_and_thread_payload(client, user):
     assert body["summary"]["span"] == {"start": 0, "end": 1}
     assert body["raw_count"] == 2
     assert body["context"][0]["role"] == "system"
+    assert body["summary"]["body"] == "LLM digest of the compacted range."
+    assert "remember this" not in body["summary"]["body"]
     assert len(body["context"]) == 1
     assert not any(m.get("role") == "user" for m in body["context"])
 
@@ -167,7 +173,7 @@ def test_compact_requires_login():
 
 
 @pytest.mark.django_db
-def test_compact_does_not_delete_existing_chatmessages(user):
+def test_compact_does_not_delete_existing_chatmessages(user, stub_compact_llm):
     cid = "conv-compact-keep-ids"
     chat = ChatConversation.objects.create(conversation_id=cid, student=user)
     first = ChatMessage.objects.create(conversation=chat, sender="user", content="original")
@@ -195,16 +201,31 @@ def test_summarize_items_is_extractive_no_secrets():
     assert "api_key" not in body
 
 
+def test_compact_prompt_is_transcript_not_task_continuation():
+    prompt = build_compact_prompt(
+        [
+            {"kind": "message", "role": "user", "content": "hello"},
+            {"kind": "summary", "body": "earlier digest"},
+        ]
+    )
+    assert "Do not answer the user" in prompt
+    assert "user: hello" in prompt
+    assert "[summary]: earlier digest" in prompt
+    assert "sk-" not in prompt
+
+
 @pytest.mark.django_db
-def test_second_compact_mixes_summary_and_raw(user):
+def test_second_compact_mixes_summary_and_raw(user, stub_compact_llm):
     cid = "conv-compact-mix"
     first = _turns(("user", "a"), ("assistant", "b"))
     s1, _ = compact_backlog(user=user, conversation_id=cid, agent_id="x", messages=first)
     later = first + _turns(("user", "fresh turn"), ("assistant", "fresh reply"))
     s2, _ = compact_backlog(user=user, conversation_id=cid, agent_id="x", messages=later)
     assert s2.parent_summary_id == s1.id
-    assert "fresh turn" in s2.body
-    assert "[summary]" in s2.body
+    assert s2.body == "LLM digest of the compacted range."
+    mix = stub_compact_llm[-1]["items"]
+    assert any(item.get("kind") == "summary" for item in mix)
+    assert any(item.get("content") == "fresh turn" for item in mix)
     assert ConversationSummary.objects.filter(conversation_id=cid).count() == 2
 
 
@@ -220,3 +241,194 @@ def test_compact_error_on_foreign_conversation(user, db):
             messages=_turns(("user", "nope"), ("assistant", "no")),
         )
     assert exc.value.status == 403
+
+
+@pytest.mark.django_db
+def test_compact_body_is_llm_summary_not_concat(user):
+    """#672 success: bubble is summary-shaped; char count ≪ raw dump."""
+    cid = "conv-compact-llm-shape"
+    long_q = "Please remember this planning thread. " * 40
+    long_a = "We decided to ship the demo on Friday and leave two open tasks. " * 40
+    messages = _turns(
+        ("user", long_q),
+        ("assistant", long_a),
+        ("user", "Also keep the API names."),
+        ("assistant", "Noted the API names."),
+    )
+    _seed_json(user, "jeeves", messages, cid)
+    raw_dump = summarize_items(
+        [{"kind": "message", "role": m["role"], "content": m["content"]} for m in messages]
+    )
+    summary_text = "Users planned a Friday demo and left two open tasks; keep API names."
+
+    def _llm(items, *, agent_id=""):
+        assert agent_id == "jeeves"
+        assert items
+        return summary_text
+
+    row, raw = compact_backlog(
+        user=user,
+        conversation_id=cid,
+        agent_id="jeeves",
+        messages=messages,
+        summarizer=_llm,
+    )
+    assert raw == messages
+    assert row.body == summary_text
+    assert "Summary of" not in row.body
+    assert "- user:" not in row.body
+    assert long_q not in row.body
+    assert len(row.body) < len(raw_dump) // 4
+    context = build_model_context(raw, [row])
+    assert context[0]["role"] == "system"
+    assert summary_text in context[0]["content"]
+    assert long_q not in context[0]["content"]
+
+
+@pytest.mark.django_db
+def test_compact_llm_failure_does_not_write_summary(user, client):
+    """#672: honest failure — no silent extractive fake-compact."""
+    cid = "conv-compact-llm-fail"
+    messages = _turns(("user", "alpha question"), ("assistant", "alpha answer"))
+    _seed_json(user, "jeeves", messages, cid)
+
+    def _boom(items, *, agent_id=""):
+        raise RuntimeError("gateway 502 using sk-secretTESTKEY999")
+
+    with pytest.raises(CompactError) as exc:
+        compact_backlog(
+            user=user,
+            conversation_id=cid,
+            agent_id="jeeves",
+            messages=messages,
+            summarizer=_boom,
+        )
+    assert exc.value.status == 502
+    assert "Compact summary failed" in str(exc.value)
+    assert "sk-secretTESTKEY999" not in str(exc.value)
+    assert "[REDACTED]" in str(exc.value)
+    assert ConversationSummary.objects.filter(conversation_id=cid).count() == 0
+
+    from unittest.mock import patch
+
+    with patch(
+        "swarm.core.chat_compact.llm_summarize_items",
+        side_effect=CompactError("Compact summary failed: model timeout", status=502),
+    ):
+        resp = client.post(
+            "/chat/compact/",
+            data={"conversation_id": cid, "agent": "jeeves", "messages": messages},
+            content_type="application/json",
+        )
+    assert resp.status_code == 502
+    assert resp.json()["error"] == "Compact summary failed: model timeout"
+    assert ConversationSummary.objects.filter(conversation_id=cid).count() == 0
+
+
+def test_llm_summarize_items_uses_resolved_model(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class _Msg:
+        content = "Short digest of the thread."
+
+    class _Choice:
+        message = _Msg()
+
+    class _Resp:
+        choices = [_Choice()]
+
+    class _Completions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return _Resp()
+
+    class _Chat:
+        completions = _Completions()
+
+    class _Client:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+
+        chat = _Chat()
+
+    monkeypatch.setenv("LITELLM_MODEL", "auxiliary")
+    monkeypatch.setattr("swarm.core.chat_compact.resolve_compact_model", lambda agent_id="": "aux-model")
+    monkeypatch.setattr("openai.OpenAI", _Client)
+    monkeypatch.setattr(
+        "swarm.utils.env_utils.openai_client_kwargs",
+        lambda: {"api_key": "ollama", "base_url": "http://litellm.local/v1"},
+    )
+
+    text = llm_summarize_items(
+        [{"kind": "message", "role": "user", "content": "hello there"}],
+        agent_id="jeeves",
+    )
+    assert text == "Short digest of the thread."
+    assert captured["model"] == "aux-model"
+    assert captured["messages"][0]["role"] == "system"
+    assert "Do not invent secrets" in captured["messages"][0]["content"]
+    assert "user: hello there" in captured["messages"][1]["content"]
+    # Client kwargs may include a key; we never log it from llm_summarize_items.
+    assert "sk-" not in text
+
+
+def test_llm_summarize_empty_response_is_failure(monkeypatch):
+    class _Msg:
+        content = "   "
+
+    class _Choice:
+        message = _Msg()
+
+    class _Resp:
+        choices = [_Choice()]
+
+    class _Client:
+        def __init__(self, **_kwargs):
+            pass
+
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**_kwargs):
+                    return _Resp()
+
+    monkeypatch.setattr("swarm.core.chat_compact.resolve_compact_model", lambda agent_id="": "m")
+    monkeypatch.setattr("openai.OpenAI", _Client)
+    monkeypatch.setattr("swarm.utils.env_utils.openai_client_kwargs", lambda: {})
+    with pytest.raises(CompactError) as exc:
+        llm_summarize_items([{"kind": "message", "role": "user", "content": "x"}])
+    assert exc.value.status == 502
+    assert "empty summary" in str(exc.value)
+
+
+def test_resolve_compact_model_prefers_agent_then_env(monkeypatch):
+    monkeypatch.setenv("LITELLM_MODEL", "env-model")
+    monkeypatch.setattr(
+        "swarm.core.llm_task_routing.load_swarm_config",
+        lambda: {
+            "blueprints": {"jeeves": {"llm_profile": "jeeves-fast"}},
+            "llm": {"jeeves-fast": {"model": "jeeves-mini"}},
+            "settings": {"default_llm_profile": "default"},
+        },
+    )
+    assert resolve_compact_model("jeeves") == "jeeves-mini"
+    monkeypatch.setattr(
+        "swarm.core.llm_task_routing.load_swarm_config",
+        lambda: {"llm": {}, "settings": {}},
+    )
+    assert resolve_compact_model("unknown-agent") == "env-model"
+
+
+def test_resolve_compact_model_missing_is_honest(monkeypatch):
+    monkeypatch.delenv("LITELLM_MODEL", raising=False)
+    monkeypatch.delenv("OPENAI_MODEL", raising=False)
+    monkeypatch.delenv("DEFAULT_LLM", raising=False)
+
+    def _boom():
+        raise RuntimeError("no config")
+
+    monkeypatch.setattr("swarm.core.llm_task_routing.load_swarm_config", _boom)
+    with pytest.raises(CompactError) as exc:
+        resolve_compact_model("jeeves")
+    assert "No default LLM" in str(exc.value)
+    assert exc.value.status == 400

--- a/tests/core/test_context_compress_policy.py
+++ b/tests/core/test_context_compress_policy.py
@@ -118,7 +118,7 @@ def test_settings_patch_50_is_read_by_helper():
 
 
 @pytest.mark.django_db
-def test_unknown_max_skips_auto_manual_compact_still_writes():
+def test_unknown_max_skips_auto_manual_compact_still_writes(stub_compact_llm):
     user = get_user_model().objects.create_user("compress-unknown", password="pw")
     cid = "conv-unknown-max"
     messages = _turns(
@@ -155,7 +155,7 @@ def test_unknown_max_skips_auto_manual_compact_still_writes():
 
 
 @pytest.mark.django_db
-def test_auto_compacts_when_over_threshold_and_max_known():
+def test_auto_compacts_when_over_threshold_and_max_known(stub_compact_llm):
     user = get_user_model().objects.create_user("compress-auto", password="pw")
     UserPreference.objects.create(
         user=user,
@@ -194,7 +194,7 @@ def test_auto_compacts_when_over_threshold_and_max_known():
 
 
 @pytest.mark.django_db
-def test_hover_to_here_keeps_later_messages_raw():
+def test_hover_to_here_keeps_later_messages_raw(stub_compact_llm):
     user = get_user_model().objects.create_user("compress-here", password="pw")
     cid = "conv-to-here"
     messages = _turns(

--- a/tests/core/test_req70_reconstruction.py
+++ b/tests/core/test_req70_reconstruction.py
@@ -129,7 +129,7 @@ def test_save_persists_chrome_in_ui_events(tmp_path):
 
 
 @pytest.mark.django_db
-def test_compact_backlog_summarises_turns_only():
+def test_compact_backlog_summarises_turns_only(stub_compact_llm):
     from django.contrib.auth import get_user_model
     from swarm.core import chat_store
 
@@ -151,7 +151,9 @@ def test_compact_backlog_summarises_turns_only():
     assert [item["role"] for item in raw] == ["user", "assistant"]
     assert STATUS_CLI not in row.body
     assert INFO_FAIL not in row.body
-    assert "remember this" in row.body
+    assert row.body == "LLM digest of the compacted range."
+    sent = stub_compact_llm[-1]["items"]
+    assert any(item.get("content") == "remember this" for item in sent)
     context = build_model_context(raw, [row])
     _assert_no_chrome(context)
 

--- a/tests/core/test_req70_ui_only_context.py
+++ b/tests/core/test_req70_ui_only_context.py
@@ -133,7 +133,7 @@ def test_summarize_items_skips_status_info():
 
 
 @pytest.mark.django_db
-def test_compact_backlog_summarises_real_messages_only():
+def test_compact_backlog_summarises_real_messages_only(stub_compact_llm):
     from django.contrib.auth import get_user_model
     from swarm.core import chat_store
 
@@ -155,7 +155,10 @@ def test_compact_backlog_summarises_real_messages_only():
     assert [item["role"] for item in raw] == ["user", "assistant"]
     assert STATUS_CLI not in row.body
     assert STATUS_FALLBACK not in row.body
-    assert "remember this" in row.body
+    assert row.body == "LLM digest of the compacted range."
+    sent = stub_compact_llm[-1]["items"]
+    assert any(item.get("content") == "remember this" for item in sent)
+    assert all(STATUS_CLI not in str(item.get("content") or "") for item in sent)
     context = build_model_context(raw, [row])
     blob = context_blob(context)
     assert STATUS_CLI not in blob

--- a/tests/views/test_chat_retention.py
+++ b/tests/views/test_chat_retention.py
@@ -134,6 +134,7 @@ def test_chat_thread_isolates_two_sessions_and_summaries(client, user):
             {"role": "user", "content": "alpha only"},
             {"role": "assistant", "content": "ok-a"},
         ],
+        summarizer=lambda items, **_kwargs: "LLM digest of the compacted range.",
     )
     alpha = client.get(
         f"/chat/thread/?agent=codey&conversation_id={first.conversation_id}"

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -1968,11 +1968,12 @@ const ChatPage = () => {
           })),
       })
       setSummariesByThread((prev) => ({ ...prev, [threadKey]: result.summaries }))
-    } catch {
+    } catch (err) {
+      const detail = err instanceof Error ? err.message.trim() : ''
       addToast({
         type: 'error',
         title: 'Compact failed',
-        message: 'Could not compact this chat. Sign in and try again.',
+        message: detail || 'Could not compact this chat. Sign in and try again.',
       })
     }
   }, [addToast, conversationId, messages, selectedBlueprint, teamFromUrl, threadKey])
@@ -2005,11 +2006,12 @@ const ChatPage = () => {
           spanEnd,
         })
         setSummariesByThread((prev) => ({ ...prev, [threadKey]: result.summaries }))
-      } catch {
+      } catch (err) {
+        const detail = err instanceof Error ? err.message.trim() : ''
         addToast({
           type: 'error',
           title: 'Compact failed',
-          message: 'Could not compact this chat. Sign in and try again.',
+          message: detail || 'Could not compact this chat. Sign in and try again.',
         })
       }
     },

--- a/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/webui/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -2618,7 +2618,7 @@ describe('ChatPage Compact empty/failure toasts (REQ-37 #365)', () => {
       fireEvent.click(screen.getByRole('menuitem', { name: 'Compact' }))
     })
     expect(await screen.findByText('Compact failed')).toBeInTheDocument()
-    expect(screen.getByText(/Could not compact this chat/i)).toBeInTheDocument()
+    expect(screen.getByText(/boom/i)).toBeInTheDocument()
   })
 
   it('drops the token meter after Compact replaces raw turns with a short summary', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #672.

## Issue (quoted)

**Intent:** Compact replaces older context with a short LLM-written summary (token-saving), not a stitched transcript blob.

**Success:**
1. Compact (manual + menu / auto path when wired) invokes the agent’s (or Settings default) LLM to produce a concise summary of the compacted range.
2. The resulting compact bubble is that **summary text**, not a concatenation of raw messages.
3. Subsequent model turns see the summary as context for the compacted range (raw turns removed or nested under the compact node per #350 contract).
4. Failure path is honest (LLM error shown; thread not silently “fake-compacted”).
5. Test: multi-turn thread → Compact → bubble content is summary-shaped; token/char count ≪ raw dump.

**Constraints:** Use existing LLM profile / default; no secrets in logs. Coordinate #444 for auto threshold. Own-diff CI. Cursor (runtime), not agy chrome.

## Feasibility

Feasible on the existing ChatPage / `POST /chat/compact/` / `#350` nested-summary contract. The defect was `summarize_items` writing an extractive dump as the compact body. Replacing that write with an LLM completion (agent blueprint profile, else Settings/env default) and failing closed meets all five success criteria without touching agy chrome or expanding into auto-threshold UI. Auto-compress (#444) should keep calling `compact_backlog` so it gets the same summariser when wired.

## What changed

- `compact_backlog` calls the agent or Settings-default LLM; the compact bubble is that digest.
- LLM / empty-response errors raise `CompactError` (no summary row; no extractive fallback).
- ChatPage Compact toast shows the server/LLM error instead of a generic sign-in line.
- Extractive `summarize_items` remains only as prompt/test material (chrome-filtered, no secrets).
- Logs: model name + item count + exception class only.

## Tests

- Multi-turn compact → LLM-shaped body, `len(body) ≪` raw dump; model context is the digest.
- LLM failure → 502 + redacted error; `ConversationSummary` count stays 0.
- Existing nested-parent / raw-JSON / REQ-70 chrome tests updated to stub the LLM.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f17846f4-ed73-4353-b067-a2840c897ed6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f17846f4-ed73-4353-b067-a2840c897ed6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

