### PR TITLE
feat(webui): CLI agent Folder as session cwd

### DIFF
--- a/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
+++ b/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
@@ -256,10 +256,21 @@ class CliAgentBlueprint(BlueprintBase):
         # Optional skill: `skill=<name>` prepends a discovered skill's
         # instructions to the prompt (portable across whichever CLI runs) and
         # stages any bundled assets into the workdir for write-mode CLIs.
+        from swarm.core.agent_folder import AgentFolderError, resolve_session_cwd
         from swarm.core.workdir import WorkdirEscapeError
 
         try:
-            workdir = support.resolve_workdir(params)
+            folder_cwd = resolve_session_cwd(
+                agent_id=str(params.get("agent") or params.get("agent_id") or self.blueprint_id),
+                params=params,
+            )
+            if folder_cwd:
+                workdir = folder_cwd
+            else:
+                workdir = support.resolve_workdir(params)
+        except AgentFolderError as e:
+            yield support.message_chunk(str(e), final=True)
+            return
         except WorkdirEscapeError as e:
             yield support.message_chunk(str(e), final=True)
             return

--- a/src/swarm/core/agent_folder.py
+++ b/src/swarm/core/agent_folder.py
@@ -1,0 +1,123 @@
+"""REQ-167 — CLI agent Folder as process cwd (Phase 1 of workspace binding).
+
+A user-configured Folder is an explicit working directory. It is not remapped
+under the workspaces root (that would be a silent wrong cwd). Blank / unset
+keeps the existing default — callers pass no cwd and keep prior behaviour.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+FOLDER_COMMENT_RE = re.compile(r"^# Folder:\s*(.+)\s*$", re.MULTILINE)
+
+# Mirror the SPA format check (Add-agent / manage Folder field).
+INVALID_FOLDER_CHARS_RE = re.compile(r'[\0*?"<>|\r\n]')
+
+
+class AgentFolderError(ValueError):
+    """Configured Folder cannot be used as cwd. Message is user-visible."""
+
+
+def folder_from_blueprint_code(code: str | None) -> str:
+    """Parse ``# Folder: <path>`` from custom-blueprint source, or ``""``."""
+    if not code:
+        return ""
+    match = FOLDER_COMMENT_RE.search(str(code))
+    if not match:
+        return ""
+    return match.group(1).strip()
+
+
+def raw_folder_from_params(params: dict[str, Any] | None) -> str:
+    """``params.folder`` when set; blank otherwise.
+
+    ``workdir`` / ``cwd`` stay on the confined per-request path. Folder is the
+    agent-bound working directory and must not be remapped.
+    """
+    if not params:
+        return ""
+    raw = params.get("folder")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return ""
+
+
+def lookup_agent_folder(
+    agent_id: str | None,
+    params: dict[str, Any] | None = None,
+) -> str:
+    """First non-blank Folder: request params, agent settings, blueprint comment."""
+    raw = raw_folder_from_params(params)
+    if raw:
+        return raw
+    agent = (agent_id or "").strip()
+    if not agent:
+        return ""
+    try:
+        from swarm.core.agent_settings import get_settings
+
+        stored = get_settings(agent).get("folder")
+        if isinstance(stored, str) and stored.strip():
+            return stored.strip()
+    except Exception:
+        pass
+    try:
+        from swarm.views.blueprint_library_views import get_user_blueprint_library
+
+        lib = get_user_blueprint_library()
+        for item in lib.get("custom") or []:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("id") or "") != agent:
+                continue
+            comment = folder_from_blueprint_code(item.get("code"))
+            if comment:
+                return comment
+    except Exception:
+        pass
+    return ""
+
+
+def resolve_agent_folder(raw: str | None) -> str | None:
+    """Resolve a user-configured Folder as process cwd.
+
+    * Blank / ``None`` → ``None`` (caller keeps the existing default).
+    * Set → expanduser and resolve; must exist and be a directory.
+    * Does not join under the workspaces root.
+    """
+    if raw is None or not str(raw).strip():
+        return None
+    text = str(raw).strip()
+    if INVALID_FOLDER_CHARS_RE.search(text):
+        raise AgentFolderError(
+            f"Folder {text!r} is not a valid directory path."
+        )
+    try:
+        path = Path(text).expanduser()
+        if not path.is_absolute():
+            path = Path.cwd() / path
+        resolved = path.resolve()
+    except OSError as exc:
+        raise AgentFolderError(f"Folder {text!r} could not be resolved: {exc}") from exc
+    if not resolved.exists():
+        raise AgentFolderError(
+            f"Folder {text!r} does not exist. Set a real directory or clear Folder."
+        )
+    if not resolved.is_dir():
+        raise AgentFolderError(f"Folder {text!r} is not a directory.")
+    return str(resolved)
+
+
+def resolve_session_cwd(
+    agent_id: str | None = None,
+    params: dict[str, Any] | None = None,
+    raw: str | None = None,
+) -> str | None:
+    """Folder cwd for CLI session start / attach, or ``None`` when unset."""
+    text = raw if raw is not None and str(raw).strip() else lookup_agent_folder(
+        agent_id, params
+    )
+    return resolve_agent_folder(text or None)

--- a/src/swarm/core/agent_settings.py
+++ b/src/swarm/core/agent_settings.py
@@ -14,7 +14,8 @@ Layout::
           "new_chat_per_task": false,
           "use_suggestions": false,
           "cli_session_id": null,
-          "remote_session_id": null
+          "remote_session_id": null,
+          "folder": null
         }
       }
     }
@@ -43,17 +44,20 @@ KEY_NEW_CHAT_PER_TASK = "new_chat_per_task"
 KEY_USE_SUGGESTIONS = "use_suggestions"
 KEY_CLI_SESSION = "cli_session_id"
 KEY_REMOTE_SESSION = "remote_session_id"
+KEY_FOLDER = "folder"
 
 DEFAULTS: dict[str, Any] = {
     KEY_NEW_CHAT_PER_TASK: False,
     KEY_USE_SUGGESTIONS: False,
     KEY_CLI_SESSION: None,
     KEY_REMOTE_SESSION: None,
+    KEY_FOLDER: None,
 }
 
 _ALLOWED_KEYS = frozenset(DEFAULTS)
 _BOOL_KEYS = frozenset({KEY_NEW_CHAT_PER_TASK, KEY_USE_SUGGESTIONS})
 _ID_KEYS = frozenset({KEY_CLI_SESSION, KEY_REMOTE_SESSION})
+_PATH_KEYS = frozenset({KEY_FOLDER})
 
 _cache: dict[str, Any] | None = None
 
@@ -134,7 +138,7 @@ def _normalize_value(key: str, value: Any) -> Any:
             if lowered in ("false", "0", "no", "off", ""):
                 return False
         raise ValueError(f"{key} must be a boolean.")
-    if key in _ID_KEYS:
+    if key in _ID_KEYS or key in _PATH_KEYS:
         if value is None:
             return None
         text = str(value).strip()
@@ -157,6 +161,7 @@ def public_settings(raw: dict[str, Any] | None = None) -> dict[str, Any]:
         KEY_USE_SUGGESTIONS: bool(merged[KEY_USE_SUGGESTIONS]),
         KEY_CLI_SESSION: merged[KEY_CLI_SESSION],
         KEY_REMOTE_SESSION: merged[KEY_REMOTE_SESSION],
+        KEY_FOLDER: merged[KEY_FOLDER],
     }
 
 
@@ -215,3 +220,12 @@ def set_cli_session_id(agent_id: str, session_id: str | None) -> dict[str, Any]:
 
 def set_remote_session_id(agent_id: str, session_id: str | None) -> dict[str, Any]:
     return update_settings(agent_id, {KEY_REMOTE_SESSION: session_id})
+
+
+def stored_folder(agent_id: str) -> str | None:
+    value = get_settings(agent_id).get(KEY_FOLDER)
+    return str(value) if value else None
+
+
+def set_folder(agent_id: str, folder: str | None) -> dict[str, Any]:
+    return update_settings(agent_id, {KEY_FOLDER: folder})

--- a/src/swarm/core/cli_session_select.py
+++ b/src/swarm/core/cli_session_select.py
@@ -369,6 +369,22 @@ def _list_cwd(cli_name: str, config: dict[str, Any] | None) -> str | None:
     return None
 
 
+def _session_list_cwd(
+    cli_name: str,
+    config: dict[str, Any] | None,
+    *,
+    agent_id: str | None = None,
+    folder: str | None = None,
+) -> str | None:
+    """REQ-167: agent Folder wins; otherwise the existing catalog list cwd."""
+    from swarm.core.agent_folder import resolve_session_cwd
+
+    folder_cwd = resolve_session_cwd(agent_id=agent_id, raw=folder)
+    if folder_cwd:
+        return folder_cwd
+    return _list_cwd(cli_name, config)
+
+
 def _parse_warning(stdout: str, rows: list[dict[str, Any]]) -> str | None:
     text = (stdout or "").strip()
     if rows or not text:
@@ -384,6 +400,8 @@ def list_provider_sessions(
     config: dict[str, Any] | None = None,
     run_list: RunList | None = None,
     timeout: float | None = None,
+    folder: str | None = None,
+    agent_id: str | None = None,
 ) -> tuple[bool, list[dict[str, Any]], str | None]:
     """Run the CLI list command or enumerate the provider store.
 
@@ -396,9 +414,12 @@ def list_provider_sessions(
         if resolved_exe is None and run_list is None:
             return True, [], f"{cli_name}: CLI not installed (no {argv[0]!r} on PATH)"
         resolved = [resolved_exe or argv[0], *argv[1:]]
+        list_cwd = _session_list_cwd(
+            cli_name, config, agent_id=agent_id, folder=folder
+        )
         runner = run_list or (
             lambda command, limit: _default_run_list(
-                command, limit, cwd=_list_cwd(cli_name, config)
+                command, limit, cwd=list_cwd
             )
         )
         code, stdout, stderr = runner(list(resolved), float(timeout or LIST_TIMEOUT))
@@ -458,10 +479,19 @@ def list_cli_sessions(
     config: dict[str, Any] | None = None,
     run_list: RunList | None = None,
     base_dir: Path | None = None,
+    folder: str | None = None,
 ) -> dict[str, Any]:
     """Picker payload: provider list (if any) + recent swarm-touch rows."""
+    from swarm.core.agent_folder import resolve_session_cwd
+
+    # Validate Folder before listing so a bad path never silently uses another cwd.
+    resolve_session_cwd(agent_id=agent_id, raw=folder)
     can_list, provider, warning = list_provider_sessions(
-        cli_name, config=config, run_list=run_list
+        cli_name,
+        config=config,
+        run_list=run_list,
+        folder=folder,
+        agent_id=agent_id,
     )
     recents = swarm_recent_sessions(user_key, agent_id, cli_name, base_dir=base_dir)
     sessions = merge_session_rows(provider, recents, limit=50)
@@ -566,13 +596,18 @@ def select_cli_session(
     base_dir: Path | None = None,
     title: str = "",
     snippet: str = "",
+    folder: str | None = None,
 ) -> dict[str, Any]:
     """Design A: bind a new swarm conversation to a CLI session (or start fresh).
 
     Old thread is left on disk. Differing prior content becomes a prior-history
     pill on the new conversation. Old compressions are not copied.
     """
+    from swarm.core.agent_folder import resolve_session_cwd
+
     agent = chat_store.normalize_agent_id(agent_id)
+    # Fail before minting a conversation when Folder is set but unusable.
+    resolve_session_cwd(agent_id=agent, raw=folder)
     cli = chat_store.normalize_agent_id(cli_name)
     sid = None if start_new else sanitize_cli_session_id(session_id)
     if not start_new and session_id and sid is None:

--- a/src/swarm/views/agent_settings_api.py
+++ b/src/swarm/views/agent_settings_api.py
@@ -54,6 +54,7 @@ def _payload(agent_id: str, settings: dict, request) -> dict:
         "use_suggestions": bool(settings.get("use_suggestions")),
         "cli_session_id": settings.get("cli_session_id"),
         "remote_session_id": settings.get("remote_session_id"),
+        "folder": settings.get("folder"),
         "active_sessions": sessions,
     }
 

--- a/src/swarm/views/cli_sessions_api.py
+++ b/src/swarm/views/cli_sessions_api.py
@@ -65,16 +65,23 @@ class CliSessionListAPIView(APIView):
         responses={200: OpenApiTypes.OBJECT},
     )
     def get(self, request, *_args, **_kwargs):
+        from swarm.core.agent_folder import AgentFolderError
         from swarm.core.cli_session_select import list_cli_sessions
 
         agent = normalize_agent_id(request.query_params.get("agent") or "cli_agent")
         cli = _resolve_cli(agent, request.query_params.get("cli"))
-        payload = list_cli_sessions(
-            _user_key(request),
-            agent,
-            cli,
-            config=_swarm_config(),
-        )
+        raw_folder = request.query_params.get("folder")
+        folder = raw_folder.strip() if isinstance(raw_folder, str) else None
+        try:
+            payload = list_cli_sessions(
+                _user_key(request),
+                agent,
+                cli,
+                config=_swarm_config(),
+                folder=folder,
+            )
+        except AgentFolderError as exc:
+            return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         return Response(payload, status=status.HTTP_200_OK)
 
 
@@ -90,6 +97,7 @@ class CliSessionSelectAPIView(APIView):
         responses={200: OpenApiTypes.OBJECT, 400: OpenApiTypes.OBJECT},
     )
     def post(self, request, *_args, **_kwargs):
+        from swarm.core.agent_folder import AgentFolderError
         from swarm.core.cli_session_select import select_cli_session
 
         body = request.data if isinstance(request.data, dict) else {}
@@ -109,6 +117,8 @@ class CliSessionSelectAPIView(APIView):
             from_cid = raw_from.strip()
         title = str(body.get("title") or "")[:200]
         snippet = str(body.get("snippet") or "")[:240]
+        raw_folder = body.get("folder")
+        folder = raw_folder.strip() if isinstance(raw_folder, str) else None
         user = getattr(request, "user", None)
         try:
             payload = select_cli_session(
@@ -121,7 +131,10 @@ class CliSessionSelectAPIView(APIView):
                 user=user,
                 title=title,
                 snippet=snippet,
+                folder=folder,
             )
+        except AgentFolderError as exc:
+            return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         except ValueError as exc:
             return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         except OSError:

--- a/tests/blueprints/test_cli_agent.py
+++ b/tests/blueprints/test_cli_agent.py
@@ -669,6 +669,33 @@ async def test_param_consensus_overrides_config_to_single():
     assert "consensus agent" not in _progress_text(chunks)
 
 
+async def test_folder_param_used_as_cwd(tmp_path):
+    script = tmp_path / "cwd_cli.py"
+    script.write_text("import os\nprint(os.getcwd())\n", encoding="utf-8")
+    folder = tmp_path / "project"
+    folder.mkdir()
+    cfg = {
+        "cli_agents": {
+            "echo": {"cmd": [PY, str(script)], "parse": "text"},
+        },
+        "cli_fusion": {"default_cli": "echo"},
+    }
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    bp.set_params({"cli": "echo", "folder": str(folder), "failover": False})
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+    assert _final_content(chunks) == str(folder.resolve())
+
+
+async def test_bad_folder_is_visible_error_not_wrong_cwd(tmp_path):
+    cfg = _echo_config()
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
+    bp.set_params({"cli": "echo", "folder": str(tmp_path / "missing"), "failover": False})
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+    text = _final_content(chunks) or ""
+    assert "does not exist" in text
+    assert "ECHO:" not in text
+
+
 async def test_hop_fixture_transcript_seeds_new_cli_prompt(tmp_path, monkeypatch):
     """Fixture transcript → hop CLI → new session receives the injection payload."""
     monkeypatch.setenv("SWARM_CHAT_DIR", str(tmp_path))

--- a/tests/core/test_agent_folder.py
+++ b/tests/core/test_agent_folder.py
@@ -1,0 +1,72 @@
+"""REQ-167 — CLI agent Folder resolve / persist / session cwd."""
+
+from __future__ import annotations
+
+import pytest
+
+from swarm.core import agent_settings as store
+from swarm.core.agent_folder import (
+    AgentFolderError,
+    folder_from_blueprint_code,
+    resolve_agent_folder,
+    resolve_session_cwd,
+)
+
+
+def test_blank_folder_keeps_existing_default():
+    assert resolve_agent_folder(None) is None
+    assert resolve_agent_folder("") is None
+    assert resolve_agent_folder("   ") is None
+    assert resolve_session_cwd(agent_id="cli_agent", raw="") is None
+
+
+def test_existing_directory_resolves(tmp_path):
+    folder = tmp_path / "project"
+    folder.mkdir()
+    assert resolve_agent_folder(str(folder)) == str(folder.resolve())
+
+
+def test_missing_path_is_visible_error(tmp_path):
+    missing = tmp_path / "nope"
+    with pytest.raises(AgentFolderError, match="does not exist"):
+        resolve_agent_folder(str(missing))
+
+
+def test_file_is_not_a_directory(tmp_path):
+    file_path = tmp_path / "notes.txt"
+    file_path.write_text("x\n", encoding="utf-8")
+    with pytest.raises(AgentFolderError, match="not a directory"):
+        resolve_agent_folder(str(file_path))
+
+
+def test_invalid_format_is_visible_error():
+    with pytest.raises(AgentFolderError, match="not a valid directory path"):
+        resolve_agent_folder("/bad/*/path")
+
+
+def test_folder_comment_parse():
+    code = "# CLI agent: Tool\n# Command: my-cli\n# Folder: /tmp/ws\n"
+    assert folder_from_blueprint_code(code) == "/tmp/ws"
+    assert folder_from_blueprint_code("") == ""
+
+
+def test_settings_folder_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("SWARM_AGENT_SETTINGS_PATH", str(tmp_path / "agent_settings.json"))
+    store.reset_agent_settings_cache()
+    updated = store.update_settings("cli_agent", {"folder": "  /home/dev/tool  "})
+    assert updated["folder"] == "/home/dev/tool"
+    store.reset_agent_settings_cache()
+    assert store.stored_folder("cli_agent") == "/home/dev/tool"
+    store.update_settings("cli_agent", {"folder": ""})
+    assert store.stored_folder("cli_agent") is None
+    store.reset_agent_settings_cache()
+
+
+def test_lookup_uses_settings_when_params_blank(tmp_path, monkeypatch):
+    monkeypatch.setenv("SWARM_AGENT_SETTINGS_PATH", str(tmp_path / "agent_settings.json"))
+    store.reset_agent_settings_cache()
+    folder = tmp_path / "bound"
+    folder.mkdir()
+    store.update_settings("my_cli", {"folder": str(folder)})
+    assert resolve_session_cwd(agent_id="my_cli") == str(folder.resolve())
+    store.reset_agent_settings_cache()

--- a/tests/core/test_agent_settings.py
+++ b/tests/core/test_agent_settings.py
@@ -37,3 +37,12 @@ def test_rejects_unknown_keys(tmp_path, monkeypatch):
         assert "Unknown" in str(exc)
     else:
         raise AssertionError("expected ValueError")
+
+
+def test_folder_persists_on_agent_record(tmp_path, monkeypatch):
+    _isolate(tmp_path, monkeypatch)
+    updated = store.update_settings("cli_agent", {"folder": "/tmp/ws"})
+    assert updated["folder"] == "/tmp/ws"
+    store.reset_agent_settings_cache()
+    assert store.get_settings("cli_agent")["folder"] == "/tmp/ws"
+    assert store.get_settings("other")["folder"] is None

--- a/tests/core/test_cli_session_select.py
+++ b/tests/core/test_cli_session_select.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import sys
 
+import pytest
+
 from swarm.core import agent_settings as settings_store
 from swarm.core import chat_store
 from swarm.core.cli_adapter import CliAdapter
@@ -445,3 +447,53 @@ def test_parse_provider_sessions_accepts_conversation_id():
     rows = parse_provider_sessions(raw, cli_name="agy")
     assert rows[0]["id"] == "3b4a1d20-3968-4ed2-90b3-00eea3060b02"
     assert rows[0]["title"] == "Cloud Run"
+
+
+def test_list_uses_folder_as_cwd(tmp_path, monkeypatch):
+    from swarm.core.agent_folder import AgentFolderError
+
+    captured: dict[str, str | None] = {}
+
+    def fake_run(argv, timeout, cwd=None):
+        captured["cwd"] = cwd
+        return 0, json.dumps([{"id": "sid-1", "title": "One"}]), ""
+
+    monkeypatch.setattr(
+        "swarm.core.cli_session_select._default_run_list", fake_run
+    )
+    folder = tmp_path / "ws"
+    folder.mkdir()
+    payload = list_cli_sessions(
+        "u1",
+        "cli_agent",
+        "echo",
+        config=_list_config(str(tmp_path / "unused.py")),
+        base_dir=tmp_path,
+        folder=str(folder),
+    )
+    assert captured["cwd"] == str(folder.resolve())
+    assert payload["sessions"][0]["id"] == "sid-1"
+
+    with pytest.raises(AgentFolderError, match="does not exist"):
+        list_cli_sessions(
+            "u1",
+            "cli_agent",
+            "echo",
+            config=_list_config(str(tmp_path / "unused.py")),
+            base_dir=tmp_path,
+            folder=str(tmp_path / "missing"),
+        )
+
+
+def test_select_rejects_bad_folder(tmp_path):
+    from swarm.core.agent_folder import AgentFolderError
+
+    with pytest.raises(AgentFolderError, match="does not exist"):
+        select_cli_session(
+            "u1",
+            "cli_agent",
+            "echo",
+            start_new=True,
+            folder=str(tmp_path / "missing"),
+            base_dir=tmp_path,
+        )

--- a/tests/views/test_agent_settings_api.py
+++ b/tests/views/test_agent_settings_api.py
@@ -29,6 +29,19 @@ def test_get_defaults_off(api_client):
     assert body["object"] == "agent_settings"
     assert body["agent_id"] == "worker"
     assert body["new_chat_per_task"] is False
+    assert body.get("folder") is None
+
+
+def test_patch_folder_roundtrip(api_client):
+    response = api_client.patch(
+        "/v1/agents/cli_agent/settings/",
+        {"folder": " /tmp/ws "},
+        format="json",
+    )
+    assert response.status_code == 200
+    assert response.json()["folder"] == "/tmp/ws"
+    again = api_client.get("/v1/agents/cli_agent/settings/")
+    assert again.json()["folder"] == "/tmp/ws"
 
 
 def test_patch_toggle_on(api_client):

--- a/tests/views/test_cli_sessions_api.py
+++ b/tests/views/test_cli_sessions_api.py
@@ -108,3 +108,44 @@ def test_select_requires_id_or_start_new(api_client):
         format="json",
     )
     assert response.status_code == 400
+
+
+def test_select_bad_folder_is_400(api_client, tmp_path):
+    response = api_client.post(
+        "/v1/cli-sessions/select/",
+        {
+            "agent": "cli_agent",
+            "cli": "echo",
+            "start_new": True,
+            "folder": str(tmp_path / "missing"),
+        },
+        format="json",
+    )
+    assert response.status_code == 400
+    assert "does not exist" in response.json()["error"]
+
+
+def test_list_bad_folder_is_400(api_client, tmp_path):
+    response = api_client.get(
+        "/v1/cli-sessions/",
+        {"agent": "cli_agent", "cli": "echo", "folder": str(tmp_path / "missing")},
+    )
+    assert response.status_code == 400
+    assert "does not exist" in response.json()["error"]
+
+
+def test_select_good_folder_starts(api_client, tmp_path):
+    folder = tmp_path / "project"
+    folder.mkdir()
+    response = api_client.post(
+        "/v1/cli-sessions/select/",
+        {
+            "agent": "cli_agent",
+            "cli": "echo",
+            "start_new": True,
+            "folder": str(folder),
+        },
+        format="json",
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "Started a new echo session."

--- a/webui/frontend/src/components/AddAgentWizard.tsx
+++ b/webui/frontend/src/components/AddAgentWizard.tsx
@@ -13,6 +13,8 @@ import {
 } from '../lib/api'
 import { OPENMOUSBOT_LABEL } from '../lib/remotesCatalog'
 import { loadAgentEdit, saveAgentEdit } from '../lib/agentEdits'
+import { FOLDER_FORMAT_ERROR, isValidFolderPath } from '../lib/agentFolder'
+import { saveAgentSettings } from '../lib/agentSettings'
 import { RemoteSelect } from './RemoteSelect'
 import { configuredRemotes } from '../lib/remotes'
 import { remotesListForSelect, saveAgentRemoteBinding } from '../lib/agentRemote'
@@ -26,11 +28,7 @@ export interface AddAgentWizardProps {
   onSelectAgent?: (agentId: string) => void
 }
 
-export function isValidFolderPath(path: string): boolean {
-  if (!path.trim()) return true
-  if (/[\0*?"<>|\r\n]/.test(path)) return false
-  return true
-}
+export { isValidFolderPath } from '../lib/agentFolder'
 
 export interface ManageAgentItem {
   id: string
@@ -324,7 +322,7 @@ export default function AddAgentWizard({
     setError(null)
 
     if (selectedKind === 'cli' && cliFolder.trim() && !isValidFolderPath(cliFolder)) {
-      setFolderError('Please enter a valid directory path (e.g. /path/to/dir or ./dir)')
+      setFolderError(FOLDER_FORMAT_ERROR)
       return
     }
 
@@ -359,6 +357,7 @@ ${folderComment}`
             command,
             folder,
           })
+          await saveAgentSettings(created.id, { folder })
 
           await queryClient.invalidateQueries({ queryKey: ['blueprints'] })
           await queryClient.invalidateQueries({ queryKey: ['custom-blueprints'] })
@@ -371,6 +370,7 @@ ${folderComment}`
             command,
             folder,
           })
+          await saveAgentSettings(editingAgentId, { folder })
 
           try {
             await updateCustomBlueprint(editingAgentId, {
@@ -831,9 +831,7 @@ ${folderComment}`
                       const val = e.target.value
                       setCliFolder(val)
                       if (val && !isValidFolderPath(val)) {
-                        setFolderError(
-                          'Please enter a valid directory path (e.g. /path/to/dir or ./dir)',
-                        )
+                        setFolderError(FOLDER_FORMAT_ERROR)
                       } else {
                         setFolderError(null)
                       }

--- a/webui/frontend/src/components/AgentEditor.tsx
+++ b/webui/frontend/src/components/AgentEditor.tsx
@@ -28,6 +28,7 @@ import {
   saveAgentEdit,
   saveInferenceList,
 } from '../lib/agentEdits'
+import { FOLDER_FORMAT_ERROR, isValidFolderPath } from '../lib/agentFolder'
 import type { InferenceSeat } from '../lib/inferenceList'
 import {
   NEW_CHAT_PER_TASK_LABEL,
@@ -108,6 +109,8 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
   const [boundRemoteId, setBoundRemoteId] = useState('')
   const [inferenceSeats, setInferenceSeats] = useState<InferenceSeat[]>([])
   const [avatarPrompt, setAvatarPrompt] = useState('')
+  const [folder, setFolder] = useState('')
+  const [folderError, setFolderError] = useState<string | null>(null)
 
   const blueprintsQuery = useQuery({
     queryKey: ['blueprints'],
@@ -225,6 +228,8 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
     setProfileOverride(edit.profileOverride || '')
     setBoundRemoteId(loadAgentRemoteBinding(id)?.id || '')
     setInferenceSeats(loadInferenceList(id))
+    setFolder(edit.folder || '')
+    setFolderError(null)
     const catalogNameForPrompt = catalogAgent?.name || id
     const roleForPrompt = edit.role || agentRole({ id, name: catalogAgent?.name, role: catalogAgent?.role })
     setAvatarPrompt(defaultAvatarPrompt(edit.name || catalogNameForPrompt, roleForPrompt))
@@ -235,6 +240,9 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
       if (!cancelled) {
         setNewChatPerTask(settings.new_chat_per_task)
         setUseSuggestions(settings.use_suggestions)
+        if (!edit.folder && settings.folder) {
+          setFolder(settings.folder)
+        }
       }
     })()
     return () => {
@@ -586,6 +594,43 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
                   ))}
                 </select>
               </div>
+            </div>
+
+            <div className="form-control">
+              <label className="label py-1">
+                <span className="label-text text-xs">
+                  Folder <span className="font-normal text-base-content/60">(optional)</span>
+                </span>
+              </label>
+              <input
+                type="text"
+                className={`input input-sm input-bordered w-full font-mono text-xs ${
+                  folderError ? 'input-error' : ''
+                }`}
+                placeholder="/path/to/working/directory or ./project"
+                value={folder}
+                onChange={(event) => {
+                  const next = event.target.value
+                  setFolder(next)
+                  if (next && !isValidFolderPath(next)) {
+                    setFolderError(FOLDER_FORMAT_ERROR)
+                    return
+                  }
+                  setFolderError(null)
+                  saveAgentEdit(id, { folder: next })
+                  void saveAgentSettings(id, { folder: next.trim() })
+                }}
+                aria-label="Folder"
+                data-testid="input-cli-folder"
+              />
+              <span className="block text-[11px] text-base-content/60 mt-1">
+                Working directory for this CLI agent
+              </span>
+              {folderError ? (
+                <span className="block text-xs text-error" data-testid="folder-error">
+                  {folderError}
+                </span>
+              ) : null}
             </div>
           </div>
         )}

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -937,19 +937,26 @@ export default function AgentSidebar({
           emptyReason: list.empty_reason,
           loading: false,
         })
-      } catch {
+      } catch (err) {
+        const message = err instanceof Error && err.message
+          ? err.message
+          : "This CLI can't list sessions"
+        const folderFailed = /folder/i.test(message)
+        if (folderFailed) {
+          toast?.error('Could not list CLI sessions', message)
+        }
         setCliPicker({
           agentId,
           agentName,
           cli: cliName,
           sessions: [],
           canList: false,
-          emptyReason: "This CLI can't list sessions",
+          emptyReason: folderFailed ? message : "This CLI can't list sessions",
           loading: false,
         })
       }
     },
-    [],
+    [toast],
   )
 
   const applyCliSession = useCallback(
@@ -976,15 +983,19 @@ export default function AgentSidebar({
         })
         navigate(sessionHref(opts.agentId, result.conversation_id))
         onClose?.()
-      } catch {
+      } catch (err) {
+        const message = err instanceof Error && err.message
+          ? err.message
+          : 'Could not switch session'
+        toast?.error('Could not start CLI session', message)
         setCliPicker((current) =>
           current
-            ? { ...current, emptyReason: current.emptyReason || 'Could not switch session' }
+            ? { ...current, emptyReason: message }
             : current,
         )
       }
     },
-    [navigate, onClose],
+    [navigate, onClose, toast],
   )
 
   const continueCliSessionOn = useCallback(

--- a/webui/frontend/src/components/__tests__/AgentEditor.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentEditor.test.tsx
@@ -370,13 +370,19 @@ describe('AgentEditor (REQ-58)', () => {
       expect(within(modelSelect).queryByRole('option', { name: 'Stewie' })).not.toBeInTheDocument()
 
       expect(within(dialog).getByTestId('default-llm-label')).toBeInTheDocument()
+      expect(within(dialog).getByTestId('input-cli-folder')).toBeInTheDocument()
+      expect(within(dialog).getByText(/Working directory for this CLI agent/i)).toBeInTheDocument()
 
       // Save override
       fireEvent.change(cliSelect, { target: { value: 'copilot' } })
       fireEvent.change(modelSelect, { target: { value: 'gpt-4o' } })
+      fireEvent.change(within(dialog).getByTestId('input-cli-folder'), {
+        target: { value: '/home/dev/tool' },
+      })
       const stored = JSON.parse(localStorage.getItem(AGENT_EDITS_KEY) || '{}')['cli_agent']
       expect(stored.cliOverride).toBe('copilot')
       expect(stored.llmOverride).toBe('gpt-4o')
+      expect(stored.folder).toBe('/home/dev/tool')
     })
 
     it('API agent: renders profiles and models, not agents from catalog', async () => {

--- a/webui/frontend/src/lib/__tests__/agentEdits.test.ts
+++ b/webui/frontend/src/lib/__tests__/agentEdits.test.ts
@@ -39,6 +39,13 @@ describe('agentEdits', () => {
     expect(loadAgentEdit('support')).toEqual({ name: 'Desk', role: 'gate' })
   })
 
+  it('persists CLI Folder on the agent record', () => {
+    saveAgentEdit('cli_agent', { folder: '  /home/dev/tool  ' })
+    expect(loadAgentEdit('cli_agent')).toEqual({ folder: '/home/dev/tool' })
+    saveAgentEdit('cli_agent', { folder: '' })
+    expect(loadAgentEdit('cli_agent')).toEqual({})
+  })
+
   it('records an explicit role override separately from the value', () => {
     saveAgentEdit('codey', { role: 'engineer', roleOverridden: true, workflow: 'handoff' })
     expect(loadAgentEdit('codey')).toEqual({

--- a/webui/frontend/src/lib/__tests__/agentFolder.test.ts
+++ b/webui/frontend/src/lib/__tests__/agentFolder.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { AGENT_EDITS_KEY, saveAgentEdit } from '../agentEdits'
+import {
+  chatFolderParams,
+  folderRequestValue,
+  isValidFolderPath,
+  loadAgentFolder,
+} from '../agentFolder'
+
+describe('agentFolder (REQ-167)', () => {
+  afterEach(() => {
+    localStorage.removeItem(AGENT_EDITS_KEY)
+  })
+
+  it('persists folder on the agent edit record', () => {
+    saveAgentEdit('cli_agent', { folder: '  /home/dev/tool  ' })
+    expect(loadAgentFolder('cli_agent')).toBe('/home/dev/tool')
+    expect(folderRequestValue('cli_agent')).toBe('/home/dev/tool')
+    expect(chatFolderParams('cli_agent')).toEqual({ folder: '/home/dev/tool' })
+  })
+
+  it('omits folder from session/chat params when unset', () => {
+    expect(loadAgentFolder('cli_agent')).toBe('')
+    expect(folderRequestValue('cli_agent')).toBeUndefined()
+    expect(chatFolderParams('cli_agent')).toBeUndefined()
+  })
+
+  it('rejects invalid path format', () => {
+    expect(isValidFolderPath('')).toBe(true)
+    expect(isValidFolderPath('/home/dev/tool')).toBe(true)
+    expect(isValidFolderPath('./project')).toBe(true)
+    expect(isValidFolderPath('/invalid/*/path')).toBe(false)
+  })
+})

--- a/webui/frontend/src/lib/__tests__/cliSessions.test.ts
+++ b/webui/frontend/src/lib/__tests__/cliSessions.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AGENT_EDITS_KEY, saveAgentEdit } from '../agentEdits'
+import * as api from '../api'
 import {
+  fetchCliSessions,
   filterCliSessions,
   formatActivityAge,
   looksLikeSessionId,
   sanitizeCliSessionId,
+  selectCliSession,
   type CliProviderSession,
 } from '../cliSessions'
 
@@ -65,5 +69,76 @@ describe('filterCliSessions', () => {
     expect(filterCliSessions(sessions, 'hello').map((s) => s.id)).toEqual(['sid-1'])
     expect(filterCliSessions(sessions, 'sid-2').map((s) => s.id)).toEqual(['sid-2'])
     expect(filterCliSessions(sessions, '')).toHaveLength(2)
+  })
+})
+
+describe('CLI session Folder cwd (REQ-167)', () => {
+  afterEach(() => {
+    localStorage.removeItem(AGENT_EDITS_KEY)
+    vi.restoreAllMocks()
+  })
+
+  it('list and select send Folder when the agent record has one', async () => {
+    saveAgentEdit('cli_agent', { folder: '/home/dev/tool' })
+    const getSpy = vi.spyOn(api, 'apiGet').mockResolvedValue({
+      object: 'cli_session_list',
+      agent_id: 'cli_agent',
+      cli: 'grok',
+      can_list: false,
+      sessions: [],
+      recent: [],
+      empty_reason: null,
+      activity_sot: 'swarm',
+    } as any)
+    const postSpy = vi.spyOn(api, 'apiPost').mockResolvedValue({
+      object: 'cli_session_select',
+      agent_id: 'cli_agent',
+      cli: 'grok',
+      conversation_id: 'cli-1',
+      cli_session_id: null,
+      messages: [],
+      status: 'Started a new grok session.',
+      collapsed_prior: false,
+      import: 'none',
+    } as any)
+
+    await fetchCliSessions('cli_agent', 'grok')
+    expect(getSpy).toHaveBeenCalledWith(expect.stringContaining('folder=%2Fhome%2Fdev%2Ftool'))
+
+    await selectCliSession({ agentId: 'cli_agent', cli: 'grok', startNew: true })
+    expect(postSpy).toHaveBeenCalledWith(
+      '/v1/cli-sessions/select/',
+      expect.objectContaining({ folder: '/home/dev/tool', start_new: true }),
+    )
+  })
+
+  it('list and select omit Folder when unset', async () => {
+    const getSpy = vi.spyOn(api, 'apiGet').mockResolvedValue({
+      object: 'cli_session_list',
+      agent_id: 'cli_agent',
+      cli: 'grok',
+      can_list: false,
+      sessions: [],
+      recent: [],
+      empty_reason: null,
+      activity_sot: 'swarm',
+    } as any)
+    const postSpy = vi.spyOn(api, 'apiPost').mockResolvedValue({
+      object: 'cli_session_select',
+      agent_id: 'cli_agent',
+      cli: 'grok',
+      conversation_id: 'cli-1',
+      cli_session_id: null,
+      messages: [],
+      status: 'Started a new grok session.',
+      collapsed_prior: false,
+      import: 'none',
+    } as any)
+
+    await fetchCliSessions('cli_agent', 'grok')
+    expect(getSpy.mock.calls[0][0]).not.toContain('folder=')
+
+    await selectCliSession({ agentId: 'cli_agent', cli: 'grok', startNew: true })
+    expect(postSpy.mock.calls[0][1]).not.toHaveProperty('folder')
   })
 })

--- a/webui/frontend/src/lib/agentFolder.ts
+++ b/webui/frontend/src/lib/agentFolder.ts
@@ -1,0 +1,34 @@
+/**
+ * REQ-167 — CLI agent Folder (working directory).
+ *
+ * Persist lives on the agent edit record (and server settings). Session
+ * start / attach send the value as `folder` so the process cwd is explicit.
+ */
+
+import { loadAgentEdit } from './agentEdits'
+
+export const FOLDER_FORMAT_ERROR =
+  'Please enter a valid directory path (e.g. /path/to/dir or ./dir)'
+
+export function isValidFolderPath(path: string): boolean {
+  if (!path.trim()) return true
+  if (/[\0*?"<>|\r\n]/.test(path)) return false
+  return true
+}
+
+export function loadAgentFolder(agentId: string): string {
+  if (!agentId) return ''
+  return (loadAgentEdit(agentId).folder || '').trim()
+}
+
+/** Query/body value for session list + select. Undefined when unset. */
+export function folderRequestValue(agentId: string): string | undefined {
+  const folder = loadAgentFolder(agentId)
+  return folder || undefined
+}
+
+/** Chat WS params so cli_agent uses Folder as cwd. */
+export function chatFolderParams(agentId: string): { folder: string } | undefined {
+  const folder = folderRequestValue(agentId)
+  return folder ? { folder } : undefined
+}

--- a/webui/frontend/src/lib/agentSettings.ts
+++ b/webui/frontend/src/lib/agentSettings.ts
@@ -28,6 +28,7 @@ export interface AgentSettings {
   use_suggestions: boolean
   cli_session_id?: string | null
   remote_session_id?: string | null
+  folder?: string | null
   active_sessions?: string[]
 }
 
@@ -283,6 +284,7 @@ function asSettings(
       typeof data?.use_suggestions === 'boolean' ? data.use_suggestions : fallback.use_suggestions,
     cli_session_id: data?.cli_session_id ?? null,
     remote_session_id: data?.remote_session_id ?? null,
+    folder: typeof data?.folder === 'string' && data.folder.trim() ? data.folder.trim() : null,
     active_sessions: Array.isArray(data?.active_sessions) ? data.active_sessions : [],
   }
 }
@@ -312,7 +314,7 @@ export async function fetchAgentSettings(agentId: string): Promise<AgentSettings
 
 export async function saveAgentSettings(
   agentId: string,
-  patch: { new_chat_per_task?: boolean; use_suggestions?: boolean },
+  patch: { new_chat_per_task?: boolean; use_suggestions?: boolean; folder?: string | null },
 ): Promise<AgentSettings> {
   const agent = agentIdFromBlueprint(agentId)
   if (patch.new_chat_per_task !== undefined) {

--- a/webui/frontend/src/lib/cliSessions.ts
+++ b/webui/frontend/src/lib/cliSessions.ts
@@ -5,6 +5,7 @@
  * Prior foreign history is a UI pill (`kind: prior_history`), not CLI turns.
  */
 
+import { folderRequestValue } from './agentFolder'
 import { apiGet, apiPost } from './api'
 import {
   agentIdFromBlueprint,
@@ -76,9 +77,13 @@ export interface CliSessionSelectResult {
 }
 
 export async function fetchCliSessions(agentId: string, cli: string): Promise<CliSessionList> {
-  const agent = encodeURIComponent(agentIdFromBlueprint(agentId))
-  const name = encodeURIComponent(cli)
-  return apiGet<CliSessionList>(`/v1/cli-sessions/?agent=${agent}&cli=${name}`)
+  const folder = folderRequestValue(agentId)
+  const qs = new URLSearchParams({
+    agent: agentIdFromBlueprint(agentId),
+    cli,
+  })
+  if (folder) qs.set('folder', folder)
+  return apiGet<CliSessionList>(`/v1/cli-sessions/?${qs.toString()}`)
 }
 
 export async function selectCliSession(opts: {
@@ -92,6 +97,7 @@ export async function selectCliSession(opts: {
 }): Promise<CliSessionSelectResult> {
   const from =
     (opts.fromConversationId || '').trim() || conversationIdForAgent(opts.agentId)
+  const folder = folderRequestValue(opts.agentId)
   const data = await apiPost<CliSessionSelectResult>('/v1/cli-sessions/select/', {
     agent: agentIdFromBlueprint(opts.agentId),
     cli: opts.cli,
@@ -100,6 +106,7 @@ export async function selectCliSession(opts: {
     from_conversation_id: from,
     title: opts.title || '',
     snippet: opts.snippet || '',
+    ...(folder ? { folder } : {}),
   })
   if (data.conversation_id) {
     setConversationIdForAgent(opts.agentId, data.conversation_id)

--- a/webui/frontend/src/pages/ChatPage.tsx
+++ b/webui/frontend/src/pages/ChatPage.tsx
@@ -190,6 +190,7 @@ import { isExperimentalEnabled } from '../experimental/flags'
 import { ChatMessageActions } from '../experimental/ChatMessageActions'
 import { agentRole, exampleRoleAgents, isChiefOfStaff, isExampleRole } from '../lib/agentRoles'
 import { assignedBlueprintId, AGENT_EDITS_CHANGED_EVENT, editedAgentLabel, loadInferenceList } from '../lib/agentEdits'
+import { chatFolderParams } from '../lib/agentFolder'
 import { TEAM_EDITS_CHANGED_EVENT } from '../lib/teamEdits'
 import { nextInferenceIndex, serializeInferenceList } from '../lib/inferenceList'
 import {
@@ -1539,6 +1540,7 @@ const ChatPage = () => {
         inferenceIndex = nextInferenceIndex(agentIdForInference, inferenceSeats.length)
         scaleSeat = inferenceSeats[inferenceIndex]
       }
+      const folderParams = chatFolderParams(agentIdForInference)
       const cliParams = isCliAgent
         ? {
             cli: currentCli,
@@ -1565,8 +1567,8 @@ const ChatPage = () => {
         buildChatWsFrame(
           trimmed,
           runtimeBlueprint || selectedBlueprint || undefined,
-          supportParams || cliParams || inferenceParams || pluginParams
-            ? { ...cliParams, ...inferenceParams, ...supportParams, ...pluginParams }
+          supportParams || cliParams || inferenceParams || pluginParams || folderParams
+            ? { ...cliParams, ...inferenceParams, ...supportParams, ...pluginParams, ...folderParams }
             : undefined,
         ),
       )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #588 (REQ-167). Phase 1 of workspace binding (#589 / #166): optional **Folder** on CLI agents is used as process cwd on session start/attach.

## From the Issue

**Intent:** When you talk to a CLI agent, the process should start in a configured directory when one is set.

**Success:**
1. Create + edit CLI agent (Add-agent wizard / manage) includes optional Folder path field.
2. Value persists on the agent record; shown on edit.
3. CLI session start / attach uses Folder as cwd when set; unset → existing default.
4. Bad path: user-visible error (toast or inline), no silent wrong cwd.
5. Tests: persist + session cwd mocked. DaisyUI/React + backend as needed. No secrets. Does **not** implement GitHub repo or worktrees.

**Constraints:** Placement of `+` is #585; manage list is #586 — implement Folder field on those surfaces when they exist, or thin follow-up PR. GitHub then `:8001`. This is Phase 1 only.

## Feasibility

Feasible on existing surfaces. Phase 0 UI (#590 / #597) already had the Folder field on the Add-agent wizard. This PR wires persistence through to session start/attach and surfaces bad paths.

## What changed

- Persist Folder on the agent settings record (plus existing local edit + `# Folder:` comment).
- Add-agent wizard and AgentEditor (CLI) show the optional Folder field; edit reloads the saved value.
- `GET/POST /v1/cli-sessions/` accept `folder` and use it as list/start cwd. Missing or non-directory paths return **400** with a user-visible error.
- Chat WS / `cli_agent` uses Folder as process cwd when set. Unset keeps the existing default (`resolve_workdir` → adapter fallback). Folder is **not** remapped under the workspaces root (that would be a silent wrong cwd).
- Sidebar toasts Folder errors on list/select. Inline format errors stay on the form.
- Tests: persist round-trip, mocked session list cwd, select/list 400 on bad path, cli_agent cwd + visible error.

## Verification

- Backend: 97 passed (`test_agent_folder`, `test_agent_settings`, `test_cli_session_select`, `test_cli_sessions_api`, `test_cli_agent`, `test_agent_settings_api`).
- Frontend: 38 passed (wizard, editor, agentEdits, agentFolder, cliSessions).

Out of scope: GitHub repo bind, worktrees, changing the unset default to a confined temp (#610 / C-H1). No live `:8001` deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac96c37f-8510-464d-b1d0-c51292b2b041?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac96c37f-8510-464d-b1d0-c51292b2b041&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

