### PR TITLE
Stop listing blueprints as agents on the AGENTS rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **REQ-170 rail is seats, not the blueprint catalog:** `GET /v1/blueprints/` emits `rail` (`metadata.rail`, default deny). AGENTS rail + Search Bots list only rail seats (Support, hide-seeded gate/skeptic, CLI / teams / remotes / Herdr / CoS). Demo recipes stay catalog-only (`?blueprint=` and `/v1/models` unchanged). Leftover `agent_sidebar.js` uses the same flag. Cleanup: `manage.py cleanup_blueprint_as_agents` (dry-run default, `--apply` archives leftover marketplace/custom demo clones, never deletes user agents). Editor: when display name equals the recipe, show `Recipe: {id}` instead of a labeled Blueprint heading. Fixes #595.
 - **REQ-123 local Compose Postgres:** `docker compose` starts official Postgres 16 (volume + healthcheck) and wires `swarm` to it via `DATABASE_URL`. Cloud operators override `DATABASE_URL` / `POSTGRES_*`. Neon is documented as test/CI/experiments only (free-tier ~day 17). Unreachable / quota Postgres **exits 78** with a clear redacted message. pytest stays on SQLite; CI adds a local Postgres `migrate` smoke job. Docs: `docs/DATABASE.md`. Fixes #508.
 
 ### Added

--- a/docs/BLUEPRINT_LIBRARY.md
+++ b/docs/BLUEPRINT_LIBRARY.md
@@ -5,6 +5,8 @@ to demonstrate a specific framework feature. Blueprints are **CLI/API only**:
 pick one by its `model` name over the OpenAI API, run it with
 `swarm-cli launch <name>`, or use it as a starting point for your own. They do
 not ship a webpage. The Grok-like WebUI (`/` + `/chat`) is the product chrome.
+The AGENTS rail lists **seats** (`metadata.rail: true`), not this whole catalog
+(REQ-170 / #595).
 
 **Status legend**
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -52,7 +52,7 @@ This is **not** the peer mailbox (`list_agents` / `send_message`, REQ-153 / #561
 
 A discoverable `BlueprintBase` subclass (`swarm.core.blueprint_base`) that defines a runnable agent workflow: agents, tools/MCP requirements, coordination, and optional config. Selected by OpenAI-compatible `model` id on `/v1/chat/completions` and `/v1/responses`, or launched with `swarm-cli`. Blueprints are **CLI/API only** — they do not ship a webpage; the Grok-like WebUI is product chrome. Live discovery lives in `swarm.core.blueprint_discovery` (the old `swarm.extensions.blueprint` path was removed). New recipes should subclass a [kind base](#kind-base-apikindbase--clikindbase--remotekindbase) (ADR-005). Do not add `kind=webui`.
 
-A Blueprint **catalog** row is a template. A Blueprint **agent** (ADR-006) is a seat that runs a chosen recipe. Do not list the whole catalog as rail “API agents” ([#595](https://github.com/matthewhand/open-swarm/issues/595)).
+A Blueprint **catalog** row is a template. A Blueprint **agent** (ADR-006) is a seat that runs a chosen recipe. The AGENTS rail and Search Bots list only recipes with `metadata.rail: true` (default deny). Catalog stays on `GET /v1/blueprints/`, Settings, and Add-agent ([#595](https://github.com/matthewhand/open-swarm/issues/595) / REQ-170).
 
 ## Team (handoff members — REQ-11)
 

--- a/docs/qa/REQ-170-blueprints-not-agents.md
+++ b/docs/qa/REQ-170-blueprints-not-agents.md
@@ -1,0 +1,38 @@
+# REQ-170 — Blueprints are not rail agents
+
+Implements [#595](https://github.com/matthewhand/open-swarm/issues/595). Coordinates [#419](https://github.com/matthewhand/open-swarm/issues/419) / [#828](https://github.com/matthewhand/open-swarm/pull/828) (`django_chat` package already gone). Look-only audit: [REQ-171-surface-b-rail-agents.md](./REQ-171-surface-b-rail-agents.md).
+
+## Diagnosis (why recipes appeared as agents)
+
+There is **no** Django “one Agent row per blueprint” seed. Live `:8001` (2026-09-04) had `GET /v1/blueprints/` ≈ 54 `object=blueprint` rows and `marketplace_blueprint` count **0**.
+
+The Grok AGENTS rail and Search Bots mapped that **filesystem catalog** (`get_available_blueprints()` under `src/swarm/blueprints/*`, plus aliases) through `exampleRoleAgents`. Display name is `metadata.name`, often the same as the id (39/54 on that sample) — so Name and Blueprint looked like clones.
+
+Archiving Django seed agents does nothing on that host. Deleting recipe packages would break `?blueprint=` and `/v1/models`. **Filter + optional leftover archive** is the fix. `#419` already retired `django_chat`; leftover ids stay denied on the rail if they reappear.
+
+## SoT: `metadata.rail` (default deny)
+
+`GET /v1/blueprints/` now includes `rail: true|false`. Missing metadata = **false** (catalog-only).
+
+**On the rail:** Support; hide-seeded gate / skeptic; CLI verify rows from `/v1/cli-agents/`; teams / remotes / Herdr / CoS from their own lists; any recipe that sets `rail: true`.
+
+**Off the rail (catalog only):** demo pack (`poets`, `chucks_angels`, MoA / `cli_fusion` aliases, `software_dev`, `codey`, …) and retired `django_chat`. Deep links and `/v1/models` still resolve.
+
+## Cleanup (idempotent, dry-run default)
+
+```bash
+# Report leftover marketplace / custom-library demo clones. No writes.
+uv run python manage.py cleanup_blueprint_as_agents
+uv run python manage.py cleanup_blueprint_as_agents --json
+
+# Archive leftovers only (never deletes user-created seats or recipe packages).
+uv run python manage.py cleanup_blueprint_as_agents --apply
+```
+
+User-created customs (id not in the demo denylist, `source=wizard|user|custom`, or `rail: true`) are kept. Already-inactive / `archived` rows are skipped.
+
+## Editor rule
+
+When the seat **display name** equals the assigned blueprint **id or name** (case-insensitive), hide the labeled “Blueprint” heading and show `Recipe: {id}` as secondary meta. The picker stays (accessible name still “Blueprint”) so the recipe can change. When the name differs from the recipe, keep the labeled Blueprint picker.
+
+Do not rename catalog slugs so name ≠ id.

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -48,6 +48,7 @@ Oracle from anything in this tree.
 | [REQ-156](./REQ-156.md) | [README — why openai-agents + 3 harness types + workflow diagrams](https://github.com/matthewhand/open-swarm/issues/564) |
 | [REQ-157](./REQ-157.md) | [CLI agents — empty until added; startup discover+prepopulate (no auth check)](https://github.com/matthewhand/open-swarm/issues/565) |
 | [REQ-159](./REQ-159.md) | [Three kind bases (API/CLI/remote) — Support builds from these](https://github.com/matthewhand/open-swarm/issues/570) |
+| [REQ-170](./REQ-170.md) | [Stop listing blueprints as agents; redundant name/blueprint pairing](https://github.com/matthewhand/open-swarm/issues/595) |
 
 ## Archived transcripts
 

--- a/docs/requirements/REQ-170.md
+++ b/docs/requirements/REQ-170.md
@@ -1,0 +1,5 @@
+# REQ-170 — Blueprints ≠ agents in the rail
+
+https://github.com/matthewhand/open-swarm/issues/595
+
+Editor rule and cleanup notes: [../qa/REQ-170-blueprints-not-agents.md](../qa/REQ-170-blueprints-not-agents.md).

--- a/src/swarm/blueprints/gate/blueprint_gate.py
+++ b/src/swarm/blueprints/gate/blueprint_gate.py
@@ -29,6 +29,7 @@ class GateBlueprint(BlueprintBase):
         "author": "Open Swarm Team",
         "tags": ["gate", "approval", "stub"],
         "role": "gate",
+        "rail": True,
         "required_mcp_servers": [],
         "env_vars": [],
     }

--- a/src/swarm/blueprints/skeptic/blueprint_skeptic.py
+++ b/src/swarm/blueprints/skeptic/blueprint_skeptic.py
@@ -29,6 +29,7 @@ class SkepticBlueprint(BlueprintBase):
         "author": "Open Swarm Team",
         "tags": ["skeptic", "retry", "stub"],
         "role": "skeptic",
+        "rail": True,
         "required_mcp_servers": [],
         "env_vars": [],
     }

--- a/src/swarm/blueprints/support/blueprint_support.py
+++ b/src/swarm/blueprints/support/blueprint_support.py
@@ -166,6 +166,7 @@ class SupportBlueprint(BlueprintBase):
         "author": "Open Swarm Team",
         "tags": ["support", "onboarding", "quickstart"],
         "role": "support",
+        "rail": True,
         "required_mcp_servers": [],
         "env_vars": [],
     }

--- a/src/swarm/core/rail_seats.py
+++ b/src/swarm/core/rail_seats.py
@@ -1,0 +1,256 @@
+"""REQ-170: rail seats vs blueprint catalog.
+
+Discovery lists every ``blueprint_*.py`` as ``object=blueprint``. The AGENTS
+rail is an allowlist: ``metadata.rail is True``. Missing or false means
+catalog-only (Settings / Add-agent / ``?blueprint=`` / ``/v1/models``).
+
+This is not a Django Agent archive. Live ``:8001`` had
+``marketplace_blueprint`` count 0 — discovery *is* the seed. The cleanup
+helpers still archive leftover marketplace / custom-library clones of the
+demo recipe pack when those stores are non-empty, without deleting
+user-created seats. ``django_chat`` is already retired (#419 / #828); leftover
+ids stay in the denylist so a stale row cannot reappear as a rail agent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping
+
+# Role seats that belong on the Grok AGENTS rail (gate/skeptic stay hide-seeded).
+RAIL_ROLE_IDS = frozenset({"support", "gate", "tool_gate", "skeptic"})
+
+# Catalog recipes that must not be peer Agent rows (audit #595 / #599).
+# Includes retired django_chat leftover ids (#419 / #828).
+DEMO_CATALOG_IDS = frozenset(
+    {
+        "poets",
+        "chucks_angels",
+        "django_chat",
+        "django-chat",
+        "moa",
+        "mixture_of_agents",
+        "moa_orchestrator",
+        "moa-orch",
+        "hybrid_moa",
+        "moa_hybrid",
+        "hybrid-consensus",
+        "hybrid_team",
+        "hybrid_swarm",
+        "cli_fusion",
+        "cli_ensemble",
+        "cli_map",
+        "cli_recurse",
+        "cli_pipeline",
+        "cli_roundtable",
+        "cli_planner",
+        "cli_orchestrator",
+        "swarm_ensemble",
+        "swarm_map",
+        "swarm_recurse",
+        "swarm_pipeline",
+        "swarm_roundtable",
+        "swarm_planner",
+        "swarm_orchestrator",
+        "software_dev",
+        "software-dev",
+        "codey",
+        "stewie",
+        "geese",
+        "zeus",
+        "gawd",
+        "suggestion",
+        "fs_introspect",
+        "remote_harness",
+        "harness_fleet",
+        "persona_council",
+        "dynamic_team",
+        "agent_router",
+        "jeeves",
+        "rue_code",
+        "whiskeytango_foxtrot",
+        "cli_agent",
+        "chatbot",
+        "sdlc_handoff",
+    }
+)
+
+USER_SOURCE_MARKERS = frozenset({"user", "wizard", "custom", "add-agent"})
+
+
+def metadata_rail(meta: Mapping[str, Any] | None) -> bool:
+    """True only when discovery metadata explicitly opts the recipe onto the rail."""
+    if not meta:
+        return False
+    return meta.get("rail") is True
+
+
+def row_id(row: Mapping[str, Any] | None) -> str:
+    if not row:
+        return ""
+    return str(row.get("id") or row.get("name") or "").strip()
+
+
+def is_protected_user_agent(item: Mapping[str, Any] | None) -> bool:
+    """User-created seats must never be archived or deleted."""
+    if not item:
+        return False
+    ident = row_id(item).lower().replace("-", "_")
+    if ident in RAIL_ROLE_IDS:
+        return True
+    if item.get("rail") is True:
+        return True
+    if item.get("user_created") is True:
+        return True
+    source = str(item.get("source") or "").strip().lower()
+    if source in USER_SOURCE_MARKERS:
+        return True
+    if ident and ident not in DEMO_CATALOG_IDS:
+        return True
+    return False
+
+
+def is_seed_demo_row(item: Mapping[str, Any] | None) -> bool:
+    """True for leftover seed/demo catalog clones — not real user agents."""
+    if not item:
+        return False
+    if is_protected_user_agent(item):
+        return False
+    ident = row_id(item).lower().replace("-", "_")
+    return ident in DEMO_CATALOG_IDS
+
+
+def already_hidden(item: Mapping[str, Any] | None) -> bool:
+    if not item:
+        return True
+    if item.get("archived") is True:
+        return True
+    if item.get("is_active") is False:
+        return True
+    return False
+
+
+@dataclass(frozen=True)
+class CleanupAction:
+    store: str
+    id: str
+    action: str
+    reason: str
+
+
+@dataclass
+class CleanupPlan:
+    """Idempotent plan. Apply archives; never deletes."""
+
+    actions: list[CleanupAction] = field(default_factory=list)
+    kept: list[CleanupAction] = field(default_factory=list)
+    already: list[CleanupAction] = field(default_factory=list)
+    catalog_only: list[str] = field(default_factory=list)
+
+    @property
+    def archive_ids(self) -> list[str]:
+        return [row.id for row in self.actions if row.action == "archive"]
+
+
+def plan_blueprint_as_agent_cleanup(
+    *,
+    marketplace: Iterable[Mapping[str, Any]] | None = None,
+    custom: Iterable[Mapping[str, Any]] | None = None,
+    discovery: Mapping[str, Mapping[str, Any]] | None = None,
+) -> CleanupPlan:
+    """Plan archive/hide of seed/demo blueprint-as-agent leftovers.
+
+    Dry-run safe: this function never writes. User-created rows are kept.
+    Already-archived rows are skipped (idempotent).
+    """
+    plan = CleanupPlan()
+    _collect_store(plan, "marketplace", marketplace)
+    _collect_store(plan, "custom_library", custom)
+    if discovery:
+        for blueprint_id, info in discovery.items():
+            meta = info.get("metadata") if isinstance(info, Mapping) else {}
+            if not isinstance(meta, Mapping):
+                meta = {}
+            if metadata_rail(meta) or str(blueprint_id).lower() in RAIL_ROLE_IDS:
+                continue
+            plan.catalog_only.append(str(blueprint_id))
+        plan.catalog_only.sort()
+    return plan
+
+
+def _collect_store(
+    plan: CleanupPlan,
+    store: str,
+    rows: Iterable[Mapping[str, Any]] | None,
+) -> None:
+    for raw in rows or []:
+        if not isinstance(raw, Mapping):
+            continue
+        ident = row_id(raw) or "?"
+        if is_protected_user_agent(raw):
+            plan.kept.append(
+                CleanupAction(store, ident, "keep", "user-created or rail seat")
+            )
+            continue
+        if not is_seed_demo_row(raw):
+            plan.kept.append(
+                CleanupAction(store, ident, "keep", "not a demo catalog leftover")
+            )
+            continue
+        if already_hidden(raw):
+            plan.already.append(
+                CleanupAction(store, ident, "skip", "already archived or inactive")
+            )
+            continue
+        plan.actions.append(
+            CleanupAction(
+                store,
+                ident,
+                "archive",
+                "seed/demo blueprint-as-agent leftover",
+            )
+        )
+
+
+def apply_marketplace_archive(
+    rows: Iterable[Mapping[str, Any]],
+    plan: CleanupPlan,
+) -> list[dict[str, Any]]:
+    """Return updated marketplace dicts (is_active=False). Does not delete."""
+    archive = {
+        action.id.lower().replace("-", "_")
+        for action in plan.actions
+        if action.store == "marketplace"
+    }
+    updated: list[dict[str, Any]] = []
+    for raw in rows:
+        item = dict(raw)
+        ident = row_id(item).lower().replace("-", "_")
+        if ident in archive:
+            item["is_active"] = False
+            manifest = dict(item.get("manifest_data") or {})
+            manifest["archived_reason"] = "req-170-blueprint-as-agent"
+            item["manifest_data"] = manifest
+        updated.append(item)
+    return updated
+
+
+def apply_custom_library_archive(
+    items: Iterable[Mapping[str, Any]],
+    plan: CleanupPlan,
+) -> list[dict[str, Any]]:
+    """Return updated custom-library items (archived=True). Does not delete."""
+    archive = {
+        action.id.lower().replace("-", "_")
+        for action in plan.actions
+        if action.store == "custom_library"
+    }
+    updated: list[dict[str, Any]] = []
+    for raw in items:
+        item = dict(raw)
+        ident = row_id(item).lower().replace("-", "_")
+        if ident in archive:
+            item["archived"] = True
+            item["archived_reason"] = "req-170-blueprint-as-agent"
+        updated.append(item)
+    return updated

--- a/src/swarm/management/commands/cleanup_blueprint_as_agents.py
+++ b/src/swarm/management/commands/cleanup_blueprint_as_agents.py
@@ -1,0 +1,190 @@
+"""Archive leftover seed/demo blueprint-as-agent rows (REQ-170).
+
+Default is dry-run. Pass --apply to write. Never deletes user-created
+agents. Idempotent: already-archived / inactive rows are skipped.
+
+Discovery packages are not deleted — they stay on GET /v1/blueprints/ and
+``?blueprint=``. The rail filter (metadata.rail) is the display SoT.
+"""
+
+from __future__ import annotations
+
+import json
+from argparse import ArgumentParser
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from swarm.core.rail_seats import (
+    CleanupPlan,
+    apply_custom_library_archive,
+    apply_marketplace_archive,
+    plan_blueprint_as_agent_cleanup,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Dry-run (default) or --apply archive of leftover seed/demo "
+        "blueprint-as-agent rows. Does not delete user agents or recipe packages."
+    )
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Write archives. Default is dry-run (no writes).",
+        )
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            dest="as_json",
+            help="Print the plan as JSON (ids/reasons only; no secrets).",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        apply = bool(options.get("apply"))
+        as_json = bool(options.get("as_json"))
+        marketplace_rows = _load_marketplace()
+        custom_rows, library = _load_custom_library()
+        discovery = _load_discovery()
+        plan = plan_blueprint_as_agent_cleanup(
+            marketplace=marketplace_rows,
+            custom=custom_rows,
+            discovery=discovery,
+        )
+        if as_json:
+            self.stdout.write(json.dumps(_plan_payload(plan, apply), indent=2))
+        else:
+            _print_plan(self, plan, apply)
+        if not apply:
+            self.stdout.write(self.style.WARNING("Dry-run — no writes. Re-run with --apply to archive."))
+            return
+        _apply_plan(plan, marketplace_rows, custom_rows, library)
+        self.stdout.write(self.style.SUCCESS("Archive applied (idempotent; no deletes)."))
+
+
+def _load_marketplace() -> list[dict[str, Any]]:
+    try:
+        from swarm.models.core_models import Blueprint as MarketplaceBlueprint
+    except Exception:
+        return []
+    rows: list[dict[str, Any]] = []
+    try:
+        for obj in MarketplaceBlueprint.objects.all():
+            rows.append(
+                {
+                    "id": obj.name,
+                    "name": obj.name,
+                    "title": obj.title,
+                    "is_active": obj.is_active,
+                    "manifest_data": dict(obj.manifest_data or {}),
+                    "source": obj.source,
+                }
+            )
+    except Exception:
+        return []
+    return rows
+
+
+def _load_custom_library() -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    try:
+        from swarm.views.blueprint_library_views import get_user_blueprint_library
+    except Exception:
+        return [], {"installed": [], "custom": []}
+    try:
+        library = get_user_blueprint_library()
+    except Exception:
+        return [], {"installed": [], "custom": []}
+    custom = [item for item in library.get("custom", []) if isinstance(item, dict)]
+    return custom, library
+
+
+def _load_discovery() -> dict[str, Any]:
+    try:
+        from swarm.views.utils import _load_all_blueprint_metadata_sync
+    except Exception:
+        return {}
+    try:
+        found = _load_all_blueprint_metadata_sync()
+    except Exception:
+        return {}
+    return found if isinstance(found, dict) else {}
+
+
+def _apply_plan(
+    plan: CleanupPlan,
+    marketplace_rows: list[dict[str, Any]],
+    custom_rows: list[dict[str, Any]],
+    library: dict[str, Any],
+) -> None:
+    archive_market = {
+        action.id.lower().replace("-", "_")
+        for action in plan.actions
+        if action.store == "marketplace"
+    }
+    if archive_market:
+        try:
+            from swarm.models.core_models import Blueprint as MarketplaceBlueprint
+
+            for obj in MarketplaceBlueprint.objects.all():
+                ident = str(obj.name or "").strip().lower().replace("-", "_")
+                if ident not in archive_market:
+                    continue
+                obj.is_active = False
+                manifest = dict(obj.manifest_data or {})
+                manifest["archived_reason"] = "req-170-blueprint-as-agent"
+                obj.manifest_data = manifest
+                obj.save(update_fields=["is_active", "manifest_data", "updated_at"])
+        except Exception:
+            apply_marketplace_archive(marketplace_rows, plan)
+
+    archive_custom = {
+        action.id.lower().replace("-", "_")
+        for action in plan.actions
+        if action.store == "custom_library"
+    }
+    if archive_custom:
+        updated = apply_custom_library_archive(custom_rows, plan)
+        library["custom"] = updated
+        try:
+            from swarm.views.blueprint_library_views import save_user_blueprint_library
+
+            save_user_blueprint_library(library)
+        except Exception:
+            pass
+
+
+def _plan_payload(plan: CleanupPlan, apply: bool) -> dict[str, Any]:
+    return {
+        "dry_run": not apply,
+        "archive": [
+            {"store": a.store, "id": a.id, "action": a.action, "reason": a.reason}
+            for a in plan.actions
+        ],
+        "kept": [
+            {"store": a.store, "id": a.id, "reason": a.reason} for a in plan.kept
+        ],
+        "already": [
+            {"store": a.store, "id": a.id, "reason": a.reason} for a in plan.already
+        ],
+        "catalog_only_discovery": plan.catalog_only,
+        "deletes": [],
+    }
+
+
+def _print_plan(cmd: BaseCommand, plan: CleanupPlan, apply: bool) -> None:
+    mode = "APPLY" if apply else "DRY-RUN"
+    cmd.stdout.write(f"REQ-170 blueprint-as-agent cleanup ({mode})")
+    if not plan.actions:
+        cmd.stdout.write("Nothing to archive (idempotent).")
+    for action in plan.actions:
+        cmd.stdout.write(f"  archive {action.store}:{action.id} — {action.reason}")
+    for action in plan.kept:
+        cmd.stdout.write(f"  keep {action.store}:{action.id} — {action.reason}")
+    for action in plan.already:
+        cmd.stdout.write(f"  skip {action.store}:{action.id} — {action.reason}")
+    if plan.catalog_only:
+        cmd.stdout.write(
+            f"  catalog-only discovery ids (not deleted): {len(plan.catalog_only)}"
+        )

--- a/src/swarm/static/js/agent_sidebar.js
+++ b/src/swarm/static/js/agent_sidebar.js
@@ -535,9 +535,13 @@
             kind: "herdr",
             remote: row.remote || "",
             description: row.remote ? "Herdr · " + row.remote : "Herdr · localhost",
+            rail: true,
           };
         });
-        agents = blueprints.concat(herdrAgents);
+        var catalogSeats = blueprints.filter(function (row) {
+          return row && row.rail === true;
+        });
+        agents = catalogSeats.concat(herdrAgents);
         hiddenIds = seedHidden(agents);
         if (!agents.length && !teams.length) statusEl.textContent = "No agents yet.";
         loadTeams(render);

--- a/src/swarm/views/api_views.py
+++ b/src/swarm/views/api_views.py
@@ -10,6 +10,7 @@ from rest_framework.views import APIView
 
 from swarm.auth import api_permission_classes
 from swarm.core.agent_roles import blueprint_role_fields, is_webui_blueprint
+from swarm.core.rail_seats import metadata_rail
 from swarm.core.persona_parse import parse_openai_agent_personas, serialize_personas
 from swarm.services import github_topics_service as gh_service
 from swarm.settings import (
@@ -211,6 +212,8 @@ class BlueprintsListView(APIView):
                         "persona_count": parsed["count"],
                         "personas": parsed["personas"],
                         "webui": is_webui_blueprint(blueprint_id, meta),
+                        # REQ-170: missing/false = catalog-only (not an AGENTS rail seat).
+                        "rail": metadata_rail(meta),
                         **blueprint_role_fields(meta),
                     })
             else:

--- a/tests/blueprints/test_gate_skeptic.py
+++ b/tests/blueprints/test_gate_skeptic.py
@@ -16,6 +16,8 @@ async def _final(bp, messages=None):
 def test_roles():
     assert GateBlueprint.metadata["role"] == "gate"
     assert SkepticBlueprint.metadata["role"] == "skeptic"
+    assert GateBlueprint.metadata["rail"] is True
+    assert SkepticBlueprint.metadata["rail"] is True
 
 
 async def test_gate_stub_is_one_line():

--- a/tests/blueprints/test_support.py
+++ b/tests/blueprints/test_support.py
@@ -41,6 +41,7 @@ def _test_mode(monkeypatch):
 def test_metadata_role_is_support():
     assert SupportBlueprint.metadata["role"] == "support"
     assert SupportBlueprint.metadata["name"] == "support"
+    assert SupportBlueprint.metadata["rail"] is True
     assert issubclass(SupportBlueprint, BlueprintBase)
 
 

--- a/tests/core/test_rail_seats.py
+++ b/tests/core/test_rail_seats.py
@@ -1,0 +1,116 @@
+"""REQ-170: rail flag default-deny + cleanup dry-run (no deletes)."""
+
+from __future__ import annotations
+
+from swarm.core.rail_seats import (
+    DEMO_CATALOG_IDS,
+    apply_custom_library_archive,
+    apply_marketplace_archive,
+    is_protected_user_agent,
+    is_seed_demo_row,
+    metadata_rail,
+    plan_blueprint_as_agent_cleanup,
+)
+
+
+def test_metadata_rail_default_denies_missing_and_false():
+    assert metadata_rail(None) is False
+    assert metadata_rail({}) is False
+    assert metadata_rail({"rail": False}) is False
+    assert metadata_rail({"rail": "true"}) is False
+    assert metadata_rail({"rail": True}) is True
+
+
+def test_demo_catalog_ids_cover_audit_fixtures():
+    for ident in (
+        "poets",
+        "chucks_angels",
+        "django_chat",
+        "moa",
+        "mixture_of_agents",
+        "cli_fusion",
+        "swarm_ensemble",
+        "software_dev",
+        "codey",
+    ):
+        assert ident in DEMO_CATALOG_IDS
+
+
+def test_cleanup_dry_run_archives_demo_leftovers_keeps_user_agents():
+    marketplace = [
+        {"id": "codey", "name": "codey", "is_active": True},
+        {"id": "poets", "name": "poets", "is_active": True},
+        {"id": "chucks_angels", "name": "chucks_angels", "is_active": False},
+    ]
+    custom = [
+        {"id": "cli_fusion", "name": "cli_fusion", "code": ""},
+        {"id": "my_helper", "name": "My Helper", "code": "print('hi')"},
+        {"id": "desk_bot", "name": "Desk", "source": "wizard"},
+        {"id": "opt_in", "name": "poets", "rail": True},
+    ]
+    discovery = {
+        "poets": {"metadata": {"name": "poets"}},
+        "support": {"metadata": {"name": "support", "rail": True}},
+        "codey": {"metadata": {"name": "codey"}},
+    }
+
+    plan = plan_blueprint_as_agent_cleanup(
+        marketplace=marketplace,
+        custom=custom,
+        discovery=discovery,
+    )
+    archive_ids = {action.id for action in plan.actions}
+    assert "codey" in archive_ids
+    assert "poets" in archive_ids
+    assert "cli_fusion" in archive_ids
+    kept_ids = {action.id for action in plan.kept}
+    assert "my_helper" in kept_ids
+    assert "desk_bot" in kept_ids
+    assert "opt_in" in kept_ids
+    already_ids = {action.id for action in plan.already}
+    assert "chucks_angels" in already_ids
+    assert "poets" in plan.catalog_only
+    assert "codey" in plan.catalog_only
+    assert "support" not in plan.catalog_only
+
+    # Dry-run: planners do not mutate inputs.
+    assert marketplace[0]["is_active"] is True
+    assert "archived" not in custom[0]
+
+
+def test_cleanup_apply_is_idempotent_and_never_deletes():
+    marketplace = [
+        {"id": "codey", "name": "codey", "is_active": True, "manifest_data": {}},
+        {"id": "my_blueprint", "name": "my_blueprint", "is_active": True},
+    ]
+    custom = [
+        {"id": "poets", "name": "poets"},
+        {"id": "office_bot", "name": "Office Bot", "code": "class X: ..."},
+    ]
+    plan = plan_blueprint_as_agent_cleanup(marketplace=marketplace, custom=custom)
+    once = apply_marketplace_archive(marketplace, plan)
+    twice = apply_marketplace_archive(once, plan)
+    custom_once = apply_custom_library_archive(custom, plan)
+    custom_twice = apply_custom_library_archive(custom_once, plan)
+
+    by_id = {row["id"]: row for row in twice}
+    assert by_id["codey"]["is_active"] is False
+    assert by_id["my_blueprint"]["is_active"] is True
+    assert len(twice) == 2
+    custom_by_id = {row["id"]: row for row in custom_twice}
+    assert custom_by_id["poets"]["archived"] is True
+    assert "archived" not in custom_by_id["office_bot"]
+    assert len(custom_twice) == 2
+
+    again = plan_blueprint_as_agent_cleanup(marketplace=twice, custom=custom_twice)
+    assert again.actions == []
+    assert any(row.id == "codey" for row in again.already)
+    assert any(row.id == "poets" for row in again.already)
+
+
+def test_protected_user_agents_are_not_seed_demo_rows():
+    assert is_protected_user_agent({"id": "support"}) is True
+    assert is_protected_user_agent({"id": "my_helper"}) is True
+    assert is_protected_user_agent({"id": "poets", "rail": True}) is True
+    assert is_seed_demo_row({"id": "poets"}) is True
+    assert is_seed_demo_row({"id": "my_helper"}) is False

--- a/tests/core/test_req170_cleanup_command.py
+++ b/tests/core/test_req170_cleanup_command.py
@@ -1,0 +1,89 @@
+"""REQ-170: management command dry-run (no writes, no deletes)."""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+
+from swarm.core.rail_seats import CleanupAction, CleanupPlan
+
+
+def test_cleanup_command_dry_run_default_writes_nothing():
+    plan = CleanupPlan(
+        actions=[
+            CleanupAction("marketplace", "codey", "archive", "seed leftover"),
+        ],
+        kept=[
+            CleanupAction("custom_library", "my_helper", "keep", "user-created"),
+        ],
+        catalog_only=["poets", "cli_fusion"],
+    )
+    apply = []
+
+    def _capture(*args, **kwargs):
+        apply.append((args, kwargs))
+
+    with (
+        patch(
+            "swarm.management.commands.cleanup_blueprint_as_agents._load_marketplace",
+            return_value=[{"id": "codey", "is_active": True}],
+        ),
+        patch(
+            "swarm.management.commands.cleanup_blueprint_as_agents._load_custom_library",
+            return_value=([{"id": "my_helper"}], {"custom": [{"id": "my_helper"}]}),
+        ),
+        patch(
+            "swarm.management.commands.cleanup_blueprint_as_agents._load_discovery",
+            return_value={"poets": {"metadata": {}}},
+        ),
+        patch(
+            "swarm.management.commands.cleanup_blueprint_as_agents.plan_blueprint_as_agent_cleanup",
+            return_value=plan,
+        ),
+        patch(
+            "swarm.management.commands.cleanup_blueprint_as_agents._apply_plan",
+            side_effect=_capture,
+        ),
+    ):
+        out = StringIO()
+        call_command("cleanup_blueprint_as_agents", stdout=out)
+
+    text = out.getvalue()
+    assert "DRY-RUN" in text
+    assert "codey" in text
+    assert "my_helper" in text
+    assert apply == []
+
+
+def test_cleanup_command_json_dry_run_has_no_deletes():
+    plan = CleanupPlan(
+        actions=[CleanupAction("marketplace", "poets", "archive", "demo")],
+        catalog_only=["poets"],
+    )
+    with (
+        patch(
+            "swarm.management.commands.cleanup_blueprint_as_agents._load_marketplace",
+            return_value=[],
+        ),
+        patch(
+            "swarm.management.commands.cleanup_blueprint_as_agents._load_custom_library",
+            return_value=([], {"custom": []}),
+        ),
+        patch(
+            "swarm.management.commands.cleanup_blueprint_as_agents._load_discovery",
+            return_value={},
+        ),
+        patch(
+            "swarm.management.commands.cleanup_blueprint_as_agents.plan_blueprint_as_agent_cleanup",
+            return_value=plan,
+        ),
+    ):
+        out = StringIO()
+        call_command("cleanup_blueprint_as_agents", "--json", stdout=out)
+
+    payload = out.getvalue()
+    assert '"dry_run": true' in payload
+    assert '"deletes": []' in payload
+    assert "poets" in payload

--- a/tests/unit/test_req5_chrome_shell.py
+++ b/tests/unit/test_req5_chrome_shell.py
@@ -59,6 +59,7 @@ def test_agent_sidebar_js_hides_and_persists():
     assert "Unhide" in js
     assert "localStorage.setItem" in js
     assert "/v1/blueprints/" in js
+    assert "row.rail === true" in js
     assert "team_rosters.json" in js
     assert "/v1/teams/" not in js
     assert "/v1/herdr-agents/" in js

--- a/tests/views/test_api_views.py
+++ b/tests/views/test_api_views.py
@@ -234,6 +234,33 @@ class TestBlueprintsListView:
         assert response.json()["data"][0]["role"] == "support"
 
     @patch("swarm.views.api_views.get_available_blueprints")
+    def test_list_blueprints_exposes_rail_flag_default_deny(
+        self, mock_get_blueprints, api_client
+    ):
+        mock_get_blueprints.return_value = {
+            "support": {
+                "metadata": {
+                    "name": "Support",
+                    "description": "Onboarding. First team.",
+                    "role": "support",
+                    "rail": True,
+                }
+            },
+            "poets": {
+                "metadata": {
+                    "name": "poets",
+                    "description": "Poet swarm",
+                }
+            },
+        }
+        response = api_client.get("/v1/blueprints/")
+        assert response.status_code == status.HTTP_200_OK
+        by_id = {row["id"]: row for row in response.json()["data"]}
+        assert by_id["support"]["rail"] is True
+        assert by_id["poets"]["rail"] is False
+        assert len(response.json()["data"]) == 2
+
+    @patch("swarm.views.api_views.get_available_blueprints")
     def test_list_blueprints_includes_chief_of_staff_role(
         self, mock_get_blueprints, api_client
     ):

--- a/webui/frontend/e2e/chrome.spec.ts
+++ b/webui/frontend/e2e/chrome.spec.ts
@@ -13,6 +13,7 @@ const BLUEPRINTS = {
       tags: [],
       installed: true,
       compiled: true,
+      rail: true,
     },
     {
       id: 'stewie',
@@ -24,6 +25,7 @@ const BLUEPRINTS = {
       tags: [],
       installed: true,
       compiled: true,
+      rail: true,
     },
   ],
 }

--- a/webui/frontend/e2e/cli-dropdown.spec.ts
+++ b/webui/frontend/e2e/cli-dropdown.spec.ts
@@ -13,6 +13,7 @@ const BLUEPRINTS = {
       tags: [],
       installed: true,
       compiled: true,
+      rail: true,
     },
     {
       id: 'cli_agent',
@@ -24,6 +25,7 @@ const BLUEPRINTS = {
       tags: ['cli'],
       installed: true,
       compiled: true,
+      rail: true,
     },
   ],
 }

--- a/webui/frontend/e2e/definition-pane.spec.ts
+++ b/webui/frontend/e2e/definition-pane.spec.ts
@@ -15,6 +15,7 @@ const BLUEPRINTS = {
       tags: [],
       installed: true,
       compiled: true,
+      rail: true,
     },
   ],
 }

--- a/webui/frontend/e2e/dropdown-status.spec.ts
+++ b/webui/frontend/e2e/dropdown-status.spec.ts
@@ -29,6 +29,7 @@ const BLUEPRINTS = {
       tags: [],
       installed: true,
       compiled: true,
+      rail: true,
     },
   ],
 }

--- a/webui/frontend/e2e/navbar-routing-picker.spec.ts
+++ b/webui/frontend/e2e/navbar-routing-picker.spec.ts
@@ -11,6 +11,7 @@ const BLUEPRINTS = {
       tags: ['cli'],
       installed: true,
       compiled: true,
+      rail: true,
     },
     {
       id: 'codey',
@@ -20,6 +21,7 @@ const BLUEPRINTS = {
       tags: [],
       installed: true,
       compiled: true,
+      rail: true,
     },
   ],
 }

--- a/webui/frontend/e2e/overlays-remotes.spec.ts
+++ b/webui/frontend/e2e/overlays-remotes.spec.ts
@@ -18,6 +18,7 @@ const BLUEPRINTS = {
       tags: [],
       installed: true,
       compiled: true,
+      rail: true,
     },
   ],
 }

--- a/webui/frontend/e2e/req67-role-badge.spec.ts
+++ b/webui/frontend/e2e/req67-role-badge.spec.ts
@@ -15,6 +15,7 @@ const BLUEPRINTS = {
       tags: [],
       installed: true,
       compiled: true,
+      rail: true,
     },
     {
       id: 'cos',

--- a/webui/frontend/e2e/req72-merged-chrome.spec.ts
+++ b/webui/frontend/e2e/req72-merged-chrome.spec.ts
@@ -19,6 +19,7 @@ const BLUEPRINTS = {
       tags: [],
       installed: true,
       compiled: true,
+      rail: true,
     },
     {
       id: 'stewie',
@@ -30,6 +31,7 @@ const BLUEPRINTS = {
       tags: [],
       installed: true,
       compiled: true,
+      rail: true,
     },
     {
       id: 'cos',
@@ -42,6 +44,7 @@ const BLUEPRINTS = {
       tags: [],
       installed: true,
       compiled: true,
+      rail: true,
     },
   ],
 }

--- a/webui/frontend/e2e/req78-update-chrome.spec.ts
+++ b/webui/frontend/e2e/req78-update-chrome.spec.ts
@@ -17,6 +17,7 @@ const BLUEPRINTS = {
       tags: [],
       installed: true,
       compiled: true,
+      rail: true,
     },
   ],
 }

--- a/webui/frontend/e2e/teams-sidepane.spec.ts
+++ b/webui/frontend/e2e/teams-sidepane.spec.ts
@@ -13,6 +13,7 @@ const BLUEPRINTS = {
       tags: [],
       installed: true,
       compiled: true,
+      rail: true,
     },
   ],
 }

--- a/webui/frontend/src/App.rail.test.tsx
+++ b/webui/frontend/src/App.rail.test.tsx
@@ -40,6 +40,7 @@ const blueprints = [
     tags: [],
     installed: true,
     compiled: true,
+    rail: true,
   },
   {
     id: 'stewie',
@@ -51,6 +52,7 @@ const blueprints = [
     tags: [],
     installed: true,
     compiled: true,
+    rail: true,
   },
 ]
 

--- a/webui/frontend/src/components/AgentEditor.tsx
+++ b/webui/frontend/src/components/AgentEditor.tsx
@@ -45,6 +45,7 @@ import {
   catalogPickerLabel,
   exampleRoleAgents,
 } from '../lib/agentRoles'
+import { displayNameMatchesBlueprint } from '../lib/railSeats'
 import { ROLE_BRIEFS } from '../lib/definitionExplain'
 import { agentLabel, sessionKindForAgent } from '../lib/supportAgent'
 import { isCliBlueprintId } from '../lib/cliAgentContext'
@@ -364,6 +365,14 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
     openSettingsSheet({ section: 'blueprint', blueprintId: assigned })
   }
 
+  const recipeId = blueprintId || id
+  const assignedRecipe = catalog.find((item) => item.id === recipeId)
+  const nameMatchesRecipe = displayNameMatchesBlueprint(
+    name,
+    recipeId,
+    assignedRecipe?.name,
+  )
+
   return (
     <Modal
       isOpen={isOpen}
@@ -415,21 +424,32 @@ export default function AgentEditor({ isOpen, onClose, agentId }: AgentEditorPro
           </p>
         </div>
 
-        <Select
-          label="Blueprint"
-          name="agent-blueprint"
-          value={blueprintId}
-          onChange={(event) => persistBlueprint(event.target.value)}
-        >
-          {catalog.length === 0 || !catalog.some((item) => item.id === (blueprintId || id)) ? (
-            <option value={blueprintId || id}>{blueprintId || id || 'Loading…'}</option>
+        <div className="space-y-1">
+          <Select
+            label={nameMatchesRecipe ? undefined : 'Blueprint'}
+            aria-label="Blueprint"
+            name="agent-blueprint"
+            value={blueprintId}
+            onChange={(event) => persistBlueprint(event.target.value)}
+          >
+            {catalog.length === 0 || !catalog.some((item) => item.id === recipeId) ? (
+              <option value={recipeId}>{recipeId || 'Loading…'}</option>
+            ) : null}
+            {catalog.map((item) => (
+              <option key={item.id} value={item.id}>
+                {catalogPickerLabel(item)}
+              </option>
+            ))}
+          </Select>
+          {nameMatchesRecipe ? (
+            <p
+              className="text-xs text-base-content/60"
+              data-testid="blueprint-recipe-meta"
+            >
+              Recipe: {recipeId}
+            </p>
           ) : null}
-          {catalog.map((item) => (
-            <option key={item.id} value={item.id}>
-              {catalogPickerLabel(item)}
-            </option>
-          ))}
-        </Select>
+        </div>
 
         <InferenceOrderList
           seats={inferenceSeats}

--- a/webui/frontend/src/components/AgentSidebar.tsx
+++ b/webui/frontend/src/components/AgentSidebar.tsx
@@ -47,12 +47,12 @@ import {
 import AgentAvatar from './AgentAvatar'
 import {
   agentRole,
-  exampleRoleAgents,
   isChiefOfStaff,
   roleBadgeLabel,
   roleCssClass,
   roleFromAgent,
 } from '../lib/agentRoles'
+import { isNonCatalogRailPinId, railSeatAgents } from '../lib/railSeats'
 import {
   hasHiddenAgentsStorage,
   hideAgentId,
@@ -314,6 +314,7 @@ function toSidebarCli(row: CliRailAgent): SidebarAgent {
     compiled: true,
     kind,
     cli: row.cli,
+    rail: true,
   }
 }
 
@@ -339,6 +340,7 @@ function toSidebarHerdr(row: HerdrAgent): SidebarAgent {
     compiled: true,
     kind: 'herdr',
     remote: row.remote || '',
+    rail: true,
   }
 }
 
@@ -651,7 +653,7 @@ export default function AgentSidebar({
   const teams = teamsQuery.data ?? []
   const remotes = remotesQuery.data ?? []
   const agents = useMemo<SidebarAgent[]>(() => {
-    const fromBlueprints = exampleRoleAgents(catalog)
+    const fromBlueprints = railSeatAgents(catalog)
     const seen = new Set(fromBlueprints.map((a) => a.id))
     const fromRosters: SidebarAgent[] = []
     for (const roster of teams) {
@@ -672,6 +674,7 @@ export default function AgentSidebar({
           installed: true,
           compiled: true,
           role: 'chief_of_staff',
+          rail: true,
         })
       }
     }
@@ -880,12 +883,22 @@ export default function AgentSidebar({
     [orderedRows, sectionState],
   )
   const visibleRowIds = useMemo(() => orderedRows.map((row) => row.id), [orderedRows])
+  const knownRailIds = useMemo(() => new Set(agents.map((agent) => agent.id)), [agents])
+  const catalogById = useMemo(() => new Map(catalog.map((row) => [row.id, row])), [catalog])
+  const catalogReady = !blueprintsQuery.isPending
   const visiblePins = useMemo(
     () =>
-      pins.filter(
-        (pin) => !resolvedHiddenIds.includes(pin.id) && !isRailIdDeleted(pin.id, deletedIds),
-      ),
-    [pins, resolvedHiddenIds, deletedIds],
+      pins.filter((pin) => {
+        if (resolvedHiddenIds.includes(pin.id) || isRailIdDeleted(pin.id, deletedIds)) {
+          return false
+        }
+        if (knownRailIds.has(pin.id) || isNonCatalogRailPinId(pin.id)) return true
+        if (!catalogReady) return true
+        const catalogRow = catalogById.get(pin.id)
+        if (catalogRow && catalogRow.rail !== true) return false
+        return true
+      }),
+    [pins, resolvedHiddenIds, deletedIds, knownRailIds, catalogReady, catalogById],
   )
   const hotkeyTargets = useMemo(
     () => computeRailHotkeyTargets({ visiblePins, orderedRows }),

--- a/webui/frontend/src/components/SearchPalette.tsx
+++ b/webui/frontend/src/components/SearchPalette.tsx
@@ -16,7 +16,7 @@ import { fetchBlueprints } from '../lib/api'
 import { openChromeOverlay, type ChromeOverlay } from '../lib/chromeOverlay'
 import { openSettingsSheet } from './SettingsSheet'
 import { agentMarkIndex, loadHiddenAgentIds, unhideAgentId } from '../lib/hiddenAgents'
-import { exampleRoleAgents } from '../lib/agentRoles'
+import { railSeatAgents } from '../lib/railSeats'
 import { agentLabel } from '../lib/supportAgent'
 import { dispatchToggleTheme } from '../lib/theme'
 import { searchShortcutLabel } from '../lib/keybindingTips'
@@ -85,7 +85,7 @@ export default function SearchPalette({ open, onClose, options }: SearchPaletteP
     enabled: open,
     retry: 1,
   })
-  const agents = exampleRoleAgents(blueprintsQuery.data?.data ?? [])
+  const agents = railSeatAgents(blueprintsQuery.data?.data ?? [])
 
   const rows = useMemo<PaletteRow[]>(() => {
     const botRows: PaletteRow[] = agents.map((agent) => ({

--- a/webui/frontend/src/components/__tests__/AgentEditor.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentEditor.test.tsx
@@ -165,7 +165,9 @@ describe('AgentEditor (REQ-58)', () => {
     renderEditor({ agentId: 'codey' })
 
     const dialog = await screen.findByRole('dialog', { name: /Edit /i, hidden: true })
-    expect(within(dialog).getByLabelText('Name')).toHaveValue('Codey')
+    await waitFor(() => {
+      expect(within(dialog).getByLabelText('Name')).toHaveValue('Codey')
+    })
     expect(within(dialog).getByTestId('blueprint-recipe-meta')).toHaveTextContent('Recipe: codey')
     expect(within(dialog).queryByText('Blueprint', { selector: 'label' })).not.toBeInTheDocument()
     expect(within(dialog).getByLabelText('Blueprint')).toHaveValue('codey')

--- a/webui/frontend/src/components/__tests__/AgentEditor.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentEditor.test.tsx
@@ -160,6 +160,21 @@ describe('AgentEditor (REQ-58)', () => {
     expect(await within(dialog).findByRole('button', { name: /Edit blueprint/i })).toBeInTheDocument()
   })
 
+  it('REQ-170: when name equals the recipe, Blueprint is secondary Recipe meta', async () => {
+    stubCatalog()
+    renderEditor({ agentId: 'codey' })
+
+    const dialog = await screen.findByRole('dialog', { name: /Edit /i, hidden: true })
+    expect(within(dialog).getByLabelText('Name')).toHaveValue('Codey')
+    expect(within(dialog).getByTestId('blueprint-recipe-meta')).toHaveTextContent('Recipe: codey')
+    expect(within(dialog).queryByText('Blueprint', { selector: 'label' })).not.toBeInTheDocument()
+    expect(within(dialog).getByLabelText('Blueprint')).toHaveValue('codey')
+
+    fireEvent.change(within(dialog).getByLabelText('Name'), { target: { value: 'Desk' } })
+    expect(within(dialog).queryByTestId('blueprint-recipe-meta')).not.toBeInTheDocument()
+    expect(within(dialog).getByLabelText('Blueprint')).toBeInTheDocument()
+  })
+
   it('assigns a blueprint from the picker and persists it on that agent', async () => {
     stubCatalog()
     renderEditor({ agentId: 'support' })

--- a/webui/frontend/src/components/__tests__/AgentPinGrid.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentPinGrid.test.tsx
@@ -18,6 +18,7 @@ const blueprints = [
     tags: [],
     installed: true,
     compiled: true,
+    rail: true,
   },
   {
     id: 'stewie',
@@ -29,6 +30,7 @@ const blueprints = [
     tags: [],
     installed: true,
     compiled: true,
+    rail: true,
   },
 ]
 

--- a/webui/frontend/src/components/__tests__/AgentRolePillOverlay.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentRolePillOverlay.test.tsx
@@ -15,6 +15,7 @@ const blueprints = [
     role: 'chief_of_staff',
     installed: true,
     compiled: true,
+    rail: true,
   },
   {
     id: 'codey',
@@ -24,6 +25,7 @@ const blueprints = [
     role: 'default',
     installed: true,
     compiled: true,
+    rail: true,
   },
 ]
 

--- a/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
+++ b/webui/frontend/src/components/__tests__/AgentSidebar.test.tsx
@@ -35,6 +35,7 @@ function blueprint(
     compiled: true,
     ...(actualRole ? { role: actualRole } : {}),
     ...(actualAvatar ? { avatar_path: actualAvatar } : {}),
+    rail: true,
   }
 }
 
@@ -322,6 +323,66 @@ describe('AgentSidebar Grok rail', () => {
     expect(onOpenSearch).toHaveBeenCalled()
     expect(within(list).getByRole('link', { name: /Codey/ })).toBeInTheDocument()
     expect(within(list).getByRole('link', { name: /Stewie/ })).toBeInTheDocument()
+  })
+
+  it('REQ-170: catalog recipes without rail stay off the AGENTS rail', async () => {
+    const catalogOnly = [
+      blueprint('support', 'Support', 'Onboarding', 'support'),
+      {
+        ...blueprint('poets', 'Poets', 'Poet swarm'),
+        rail: false,
+      },
+      {
+        ...blueprint('chucks_angels', "Chuck's Angels", 'Demo'),
+        rail: false,
+      },
+      {
+        ...blueprint('django_chat', 'Django Chat', 'Retired webui leftover'),
+        rail: false,
+      },
+      {
+        ...blueprint('moa', 'mixture_of_agents', 'MoA'),
+        rail: false,
+      },
+      {
+        ...blueprint('cli_fusion', 'cli_fusion', 'CLI fusion'),
+        rail: false,
+      },
+      {
+        ...blueprint('codey', 'Codey', 'Code assistant'),
+        rail: false,
+      },
+    ]
+    vi.stubGlobal('fetch', mockFetch(catalogOnly))
+    renderSidebar('/chat')
+
+    const rail = await screen.findByTestId('os-agent-rail')
+    const list = screen.getByRole('navigation', { name: 'Agent list' })
+    expect(await within(list).findByRole('link', { name: /Support/ })).toBeInTheDocument()
+    expect(await within(list).findByRole('link', { name: /cli_agent/ })).toBeInTheDocument()
+    for (const name of ['Poets', "Chuck's Angels", 'Django Chat', 'mixture_of_agents', 'cli_fusion', 'Codey']) {
+      expect(within(rail).queryByRole('link', { name: new RegExp(name, 'i') })).not.toBeInTheDocument()
+    }
+  })
+
+  it('REQ-170: a leftover pin of a catalog-only id does not re-enter the list', async () => {
+    localStorage.setItem(
+      PINNED_AGENTS_STORAGE_KEY,
+      JSON.stringify([{ id: 'poets', name: 'Poets' }]),
+    )
+    const catalogOnly = [
+      blueprint('support', 'Support', 'Onboarding', 'support'),
+      { ...blueprint('poets', 'Poets', 'Poet swarm'), rail: false },
+    ]
+    vi.stubGlobal('fetch', mockFetch(catalogOnly))
+    renderSidebar('/chat')
+
+    const rail = await screen.findByTestId('os-agent-rail')
+    expect(await within(rail).findByRole('link', { name: /Support/ })).toBeInTheDocument()
+    await waitFor(() => {
+      expect(within(rail).queryByRole('link', { name: /Poets/i })).not.toBeInTheDocument()
+    })
+    expect(screen.queryByRole('link', { name: 'Poets' })).not.toBeInTheDocument()
   })
 
   it('paints the same custom face on the Codey rail tile as the header would', async () => {
@@ -1140,6 +1201,7 @@ describe('AgentSidebar special roles', () => {
       installed: true,
       compiled: true,
       role: null,
+      rail: true,
     },
     {
       id: 'skeptic',
@@ -1152,6 +1214,7 @@ describe('AgentSidebar special roles', () => {
       installed: true,
       compiled: true,
       role: 'skeptic',
+      rail: true,
     },
     {
       id: 'gate',
@@ -1164,6 +1227,7 @@ describe('AgentSidebar special roles', () => {
       installed: true,
       compiled: true,
       role: 'gate',
+      rail: true,
     },
     {
       id: 'support',
@@ -1176,6 +1240,7 @@ describe('AgentSidebar special roles', () => {
       installed: true,
       compiled: true,
       role: 'support',
+      rail: true,
     },
   ]
 
@@ -2141,6 +2206,7 @@ describe('AgentSidebar special roles', () => {
       installed: true,
       compiled: true,
       role: null,
+      rail: true,
     },
     {
       id: 'skeptic',
@@ -2153,6 +2219,7 @@ describe('AgentSidebar special roles', () => {
       installed: true,
       compiled: true,
       role: 'skeptic',
+      rail: true,
     },
     {
       id: 'gate',
@@ -2165,6 +2232,7 @@ describe('AgentSidebar special roles', () => {
       installed: true,
       compiled: true,
       role: 'gate',
+      rail: true,
     },
     {
       id: 'support',
@@ -2177,6 +2245,7 @@ describe('AgentSidebar special roles', () => {
       installed: true,
       compiled: true,
       role: 'support',
+      rail: true,
     },
   ]
 

--- a/webui/frontend/src/components/__tests__/RailContextMenuReq114.test.tsx
+++ b/webui/frontend/src/components/__tests__/RailContextMenuReq114.test.tsx
@@ -19,6 +19,7 @@ const blueprints = [
     tags: [] as string[],
     installed: true,
     compiled: true,
+    rail: true,
   },
 ]
 

--- a/webui/frontend/src/components/__tests__/RailContextMenuReq82.test.tsx
+++ b/webui/frontend/src/components/__tests__/RailContextMenuReq82.test.tsx
@@ -18,6 +18,7 @@ const blueprints = [
     tags: [] as string[],
     installed: true,
     compiled: true,
+    rail: true,
   },
   {
     id: 'stewie',
@@ -29,6 +30,7 @@ const blueprints = [
     tags: [] as string[],
     installed: true,
     compiled: true,
+    rail: true,
   },
 ]
 

--- a/webui/frontend/src/components/__tests__/SearchPalette.test.tsx
+++ b/webui/frontend/src/components/__tests__/SearchPalette.test.tsx
@@ -16,6 +16,7 @@ const blueprints = [
     tags: [],
     installed: true,
     compiled: true,
+    rail: true,
   },
 ]
 
@@ -93,7 +94,7 @@ describe('SearchPalette', () => {
     expect(screen.getByRole('tab', { name: 'Messages' })).toHaveAttribute('aria-selected', 'true')
   })
 
-  it('Bots tab lists Support + catalog agents and Enter chooses a /chat href (REQ-17 / #322)', async () => {
+  it('Bots tab lists Support + rail seats and Enter chooses a /chat href (REQ-17 / #322)', async () => {
     const { onClose } = renderPalette()
     expect(await screen.findByRole('option', { name: /Codey/ })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('tab', { name: 'Bots' }))
@@ -104,6 +105,110 @@ describe('SearchPalette', () => {
 
     fireEvent.keyDown(window, { key: 'Enter' })
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('REQ-170: Search Bots omit catalog recipes that are not rail seats', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          object: 'list',
+          data: [
+            {
+              id: 'support',
+              object: 'blueprint',
+              name: 'Support',
+              description: 'Onboarding',
+              abbreviation: null,
+              required_mcp_servers: [],
+              tags: [],
+              installed: true,
+              compiled: true,
+              rail: true,
+              role: 'support',
+            },
+            {
+              id: 'poets',
+              object: 'blueprint',
+              name: 'Poets',
+              description: 'Poet swarm',
+              abbreviation: null,
+              required_mcp_servers: [],
+              tags: [],
+              installed: true,
+              compiled: true,
+            },
+            {
+              id: 'chucks_angels',
+              object: 'blueprint',
+              name: "Chuck's Angels",
+              description: 'Demo',
+              abbreviation: null,
+              required_mcp_servers: [],
+              tags: [],
+              installed: true,
+              compiled: true,
+            },
+            {
+              id: 'django_chat',
+              object: 'blueprint',
+              name: 'Django Chat',
+              description: 'Retired leftover',
+              abbreviation: null,
+              required_mcp_servers: [],
+              tags: [],
+              installed: true,
+              compiled: true,
+            },
+            {
+              id: 'moa',
+              object: 'blueprint',
+              name: 'mixture_of_agents',
+              description: 'MoA',
+              abbreviation: null,
+              required_mcp_servers: [],
+              tags: [],
+              installed: true,
+              compiled: true,
+            },
+            {
+              id: 'cli_fusion',
+              object: 'blueprint',
+              name: 'cli_fusion',
+              description: 'CLI fusion',
+              abbreviation: null,
+              required_mcp_servers: [],
+              tags: [],
+              installed: true,
+              compiled: true,
+            },
+            {
+              id: 'codey',
+              object: 'blueprint',
+              name: 'Codey',
+              description: 'Code assistant',
+              abbreviation: null,
+              required_mcp_servers: [],
+              tags: [],
+              installed: true,
+              compiled: true,
+            },
+          ],
+        }),
+      } as Response),
+    )
+    renderPalette()
+    fireEvent.click(screen.getByRole('tab', { name: 'Bots' }))
+    expect(await screen.findByRole('option', { name: /Support/ })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /Poets/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /Chuck/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /Django Chat/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /mixture_of_agents/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /cli_fusion/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /Codey/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Actions' })).toBeInTheDocument()
   })
 
   it('Actions tab lists theme + Django operator destinations, not live remotes (REQ-17 / #322)', () => {

--- a/webui/frontend/src/lib/__tests__/railSeats.test.ts
+++ b/webui/frontend/src/lib/__tests__/railSeats.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import type { Blueprint } from '../api'
+import {
+  displayNameMatchesBlueprint,
+  isCatalogRailSeat,
+  isNonCatalogRailPinId,
+  isRailSeat,
+  railSeatAgents,
+} from '../railSeats'
+
+function recipe(id: string, rail?: boolean): Blueprint {
+  return {
+    id,
+    object: 'blueprint',
+    name: id,
+    description: `${id} recipe`,
+    abbreviation: null,
+    required_mcp_servers: [],
+    tags: [],
+    installed: true,
+    compiled: true,
+    ...(rail === undefined ? {} : { rail }),
+  }
+}
+
+describe('railSeats (REQ-170)', () => {
+  it('default-denies unknown catalog ids when rail is missing or false', () => {
+    expect(isCatalogRailSeat(recipe('poets'))).toBe(false)
+    expect(isCatalogRailSeat(recipe('codey', false))).toBe(false)
+    expect(isCatalogRailSeat({ rail: null })).toBe(false)
+    expect(isRailSeat(recipe('chucks_angels'))).toBe(false)
+    expect(isRailSeat(recipe('django_chat'))).toBe(false)
+    expect(isRailSeat(recipe('moa'))).toBe(false)
+    expect(isRailSeat(recipe('cli_fusion'))).toBe(false)
+    expect(isRailSeat(recipe('software_dev'))).toBe(false)
+  })
+
+  it('allows explicit rail seats and CLI / Herdr / API kind rows', () => {
+    expect(isCatalogRailSeat(recipe('support', true))).toBe(true)
+    expect(isRailSeat({ rail: true })).toBe(true)
+    expect(isRailSeat({ kind: 'cli' })).toBe(true)
+    expect(isRailSeat({ kind: 'herdr' })).toBe(true)
+    expect(isRailSeat({ kind: 'api' })).toBe(true)
+  })
+
+  it('railSeatAgents drops the demo catalog and keeps injected role seats', () => {
+    const agents = railSeatAgents([
+      recipe('poets'),
+      recipe('chucks_angels'),
+      recipe('django_chat'),
+      recipe('moa'),
+      recipe('cli_fusion'),
+      recipe('codey'),
+      recipe('support', true),
+    ])
+    const ids = agents.map((agent) => agent.id)
+    expect(ids).toContain('support')
+    expect(ids).toContain('gate')
+    expect(ids).toContain('skeptic')
+    expect(ids).not.toContain('poets')
+    expect(ids).not.toContain('chucks_angels')
+    expect(ids).not.toContain('django_chat')
+    expect(ids).not.toContain('moa')
+    expect(ids).not.toContain('cli_fusion')
+    expect(ids).not.toContain('codey')
+  })
+
+  it('matches display name to blueprint id or name for the editor rule', () => {
+    expect(displayNameMatchesBlueprint('codey', 'codey', 'codey')).toBe(true)
+    expect(displayNameMatchesBlueprint('Codey', 'codey', 'Codey')).toBe(true)
+    expect(displayNameMatchesBlueprint('Support', 'support', 'Support')).toBe(true)
+    expect(displayNameMatchesBlueprint('Desk', 'support', 'Support')).toBe(false)
+    expect(displayNameMatchesBlueprint('Support', 'codey', 'Codey')).toBe(false)
+    expect(isNonCatalogRailPinId('team:office')).toBe(true)
+    expect(isNonCatalogRailPinId('codey')).toBe(false)
+  })
+})

--- a/webui/frontend/src/lib/agentRoles.ts
+++ b/webui/frontend/src/lib/agentRoles.ts
@@ -48,6 +48,7 @@ export const SYNTHETIC_GATE: Blueprint = {
   installed: true,
   compiled: true,
   role: 'gate',
+  rail: true,
 }
 
 export const SYNTHETIC_SKEPTIC: Blueprint = {
@@ -61,6 +62,7 @@ export const SYNTHETIC_SKEPTIC: Blueprint = {
   installed: true,
   compiled: true,
   role: 'skeptic',
+  rail: true,
 }
 
 const SYNTHETICS: Record<ExampleRole, Blueprint> = {

--- a/webui/frontend/src/lib/api.ts
+++ b/webui/frontend/src/lib/api.ts
@@ -247,6 +247,8 @@ export interface Blueprint {
   workflow?: BlueprintWorkflow | string | null
   /** Leftover webui/django-chat recipe. Pickers must hide these (REQ-75). */
   webui?: boolean | null
+  /** REQ-170: true = AGENTS rail seat. Missing/false = catalog-only. */
+  rail?: boolean | null
   kind?: string | null
   urls_module?: string | null
   url_prefix?: string | null

--- a/webui/frontend/src/lib/railSeats.ts
+++ b/webui/frontend/src/lib/railSeats.ts
@@ -1,0 +1,51 @@
+import type { Blueprint } from './api'
+import { exampleRoleAgents } from './agentRoles'
+
+/**
+ * REQ-170: a catalog recipe is a rail seat only when the API sets `rail: true`.
+ * Missing / false = Settings / Add-agent catalog only. CLI / Herdr / named API
+ * kind rows from other endpoints stay seats.
+ */
+export function isRailSeat(row: {
+  rail?: boolean | null
+  kind?: string | null
+}): boolean {
+  const kind = String(row.kind || '').trim().toLowerCase()
+  if (kind === 'cli' || kind === 'herdr' || kind === 'api') return true
+  return row.rail === true
+}
+
+/** Discovery catalog rows that may appear on the AGENTS rail. Default deny. */
+export function isCatalogRailSeat(row: { rail?: boolean | null }): boolean {
+  return row.rail === true
+}
+
+/** Inject example roles after dropping catalog-only recipes. */
+export function railSeatAgents(catalog: Blueprint[]): Blueprint[] {
+  return exampleRoleAgents(catalog.filter(isCatalogRailSeat))
+}
+
+/**
+ * Editor rule (REQ-170): when the seat display name equals the assigned
+ * blueprint id or name, the labeled "Blueprint" heading is redundant.
+ */
+export function displayNameMatchesBlueprint(
+  displayName: string,
+  blueprintId: string,
+  blueprintName?: string | null,
+): boolean {
+  const name = displayName.trim().toLowerCase()
+  if (!name) return false
+  if (name === blueprintId.trim().toLowerCase()) return true
+  const recipe = (blueprintName || '').trim().toLowerCase()
+  return Boolean(recipe) && name === recipe
+}
+
+/** Pin / team / remote / herdr ids that are not catalog recipes. */
+export function isNonCatalogRailPinId(id: string): boolean {
+  return (
+    id.startsWith('team:') ||
+    id.startsWith('remote:') ||
+    id.startsWith('herdr:')
+  )
+}

--- a/webui/frontend/src/lib/supportAgent.ts
+++ b/webui/frontend/src/lib/supportAgent.ts
@@ -30,6 +30,7 @@ function stubBlueprint(
     installed: true,
     compiled: true,
     role,
+    rail: true,
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #595 (REQ-170).

## Feasibility

**Feasible.** Engineer look-only on `:8001` (issue comment + [REQ-171 surface B](https://github.com/matthewhand/open-swarm/pull/599)) already closed the “Django seed Agent rows” hypothesis. The rail *is* filesystem discovery. Preferred SoT is `metadata.rail: true` (default deny) plus a dry-run leftover archive. No Neon, no live `:8001` deploy, no recipe-package deletes. Coordinates #419 / #828 (`django_chat` already retired; leftover ids stay denied).

## Issue quote

**Intent:** Rail and Search show **agents** (instances you chat with). Blueprints stay a **template picker** on create/edit — not duplicate rail entries whose name equals the blueprint.

**Success:**
1. Diagnose why blueprint-shaped rows appear as agents (seed/demo/webui leftovers) — non-binding; verified in-tree.
2. Safe cleanup path: migration/script or admin action with dry-run to archive/hide/remove seed/demo blueprint-as-agent rows without deleting real user agents; idempotent.
3. List filter: AGENTS rail + Search agents only include real agent instances; blueprint catalog stays under Settings / Add-agent flows.
4. Editor UX: when display name would equal blueprint name, pick one coherent rule and document it.
5. Tests for “blueprint catalog not in rail” + cleanup dry-run.

**Constraints:** Prefer cleanup + filter over renaming every blueprint. Coordinate #419. No secrets. Own-diff CI only. GitHub PR only — do not deploy or touch live `:8001`.

## Diagnosis (Success 1)

There is **no** one-Agent-per-blueprint Django seed. Live `:8001` (2026-09-04) had `GET /v1/blueprints/` ≈ 54 `object=blueprint` rows and `marketplace_blueprint` count **0**.

`BlueprintsListView` lists `get_available_blueprints()` (filesystem `src/swarm/blueprints/*` + aliases). The Grok rail and Search Bots mapped that catalog through `exampleRoleAgents`. Display name is `metadata.name`, often equal to the id — hence the redundant Name / Blueprint pairing.

Archiving Django “seed agents” does nothing on that host. Deleting packages would break `?blueprint=` / `/v1/models`. **Filter + leftover archive** is the fix. `#419` already removed `django_chat`; leftover ids stay off the rail if they reappear.

## What landed

- **SoT:** `metadata.rail: true` on Support / gate / skeptic. `GET /v1/blueprints/` emits `rail` (missing = `false`).
- **Filter:** SPA `railSeatAgents` on AGENTS rail + Search Bots. Leftover `agent_sidebar.js` uses the same flag. CLI / teams / remotes / Herdr / CoS unchanged. Deep links and `/v1/models` unchanged.
- **Cleanup:** `manage.py cleanup_blueprint_as_agents` (dry-run default; `--apply` archives leftover marketplace / custom-library demo clones). Never deletes user-created seats or recipe packages. Idempotent.
- **Editor rule:** When display name equals the assigned recipe id or name, hide the labeled “Blueprint” heading and show `Recipe: {id}` as secondary meta. Documented in `docs/qa/REQ-170-blueprints-not-agents.md`.

## Tests

- RTL: catalog fixture (`poets`, `chucks_angels`, `django_chat`, `moa`, `cli_fusion`, `codey`) absent from `[data-testid=os-agent-rail]` and Search Bots; Support + CLI verify row remain.
- Unit: `isRailSeat` / `metadata.rail` default-deny; cleanup dry-run keeps user agents; apply is idempotent and never deletes.
- API: `rail` present; `poets` is false; `support` is true.

## Out of scope

B-03 (`openBlueprintEditor`), B-04 (Add-agent seat-store), B-05 (pin href kinds — already on main). No live `:8001`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11f76e04-cb72-4c6f-a7b9-06f0f41d737a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11f76e04-cb72-4c6f-a7b9-06f0f41d737a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

