### PR TITLE
Confine CLI/API write workdirs under SWARM_WORKSPACES_DIR

### DIFF
--- a/.github/workflows/req171c1-confine-workdirs.yml
+++ b/.github/workflows/req171c1-confine-workdirs.yml
@@ -1,0 +1,54 @@
+name: REQ-171C-1 confine CLI/API workdirs
+
+on:
+  pull_request:
+    paths:
+      - "src/swarm/core/workdir.py"
+      - "src/swarm/core/cli_adapter.py"
+      - "src/swarm/core/agent_folder.py"
+      - "src/swarm/blueprints/common/cli_fusion_support.py"
+      - "src/swarm/blueprints/cli_agent/blueprint_cli_agent.py"
+      - "docs/AUTH.md"
+      - "tests/core/test_workdir.py"
+      - "tests/blueprints/test_cli_agent.py"
+      - "tests/api/test_cli_fusion_api.py"
+      - ".github/workflows/req171c1-confine-workdirs.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/swarm/core/workdir.py"
+      - "src/swarm/core/cli_adapter.py"
+      - "src/swarm/core/agent_folder.py"
+      - "src/swarm/blueprints/common/cli_fusion_support.py"
+      - "src/swarm/blueprints/cli_agent/blueprint_cli_agent.py"
+      - "docs/AUTH.md"
+      - "tests/core/test_workdir.py"
+      - "tests/blueprints/test_cli_agent.py"
+      - "tests/api/test_cli_fusion_api.py"
+      - ".github/workflows/req171c1-confine-workdirs.yml"
+
+jobs:
+  own-diff:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install Python deps
+        run: uv sync --all-extras
+
+      - name: Pytest C-H1 / C-H2 confine workdirs
+        run: |
+          uv run pytest \
+            tests/core/test_workdir.py \
+            tests/blueprints/test_cli_agent.py \
+            tests/api/test_cli_fusion_api.py \
+            tests/core/test_agent_folder.py
+        env:
+          DJANGO_ALLOW_ASYNC_UNSAFE: "true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Security
+- **Confine CLI/API write workdirs (C-H1 + C-H2 / REQ-171C-1):** Blank `params.workdir`/`cwd` on `cli_agent` / fusion / WS chat mints a marked per-run temp under `SWARM_WORKSPACES_DIR` (or uses #588 Folder when set). `CliAdapter.stream_run` is not given process CWD on that path. `cleanup_run_workdir` / prune require `.swarm-auto-run`; a user `workspaces/run-<hex>` without the marker is kept. Fixes #610.
 - **Untrusted CLI argv (C-H8 / REQ-171C-6):** User prompts cannot become extra flags (`--` before positional prompts, or stdin / `-p=`). `{workdir}` is not substituted inside the prompt text. Session ids reject leading `-`, `.`, and `..`; `resume_cli_session_id` sanitizes. Fixes #615.
 
 ### Fixed

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -132,12 +132,14 @@ When API auth is off, the Explorer aligns with open REST (does not fail-closed-h
 
 ## 5. Workdir confinement
 
-Per-request `params.workdir` / `params.cwd` (hybrid MoA, MoA orchestrator, CLI fusion consumers) and `swarm-cli moa --workdir` / `--cwd`:
+Per-request `params.workdir` / `params.cwd` (`cli_agent`, hybrid MoA, MoA orchestrator, CLI fusion consumers, WS chat) and `swarm-cli moa --workdir` / `--cwd`:
 
 - Resolve under `SWARM_WORKSPACES_DIR` (default XDG `…/swarm/workspaces`).
 - Relative paths are fine; **absolute paths outside the root are rejected**.
 - Escape hatch: `ALLOW_UNRESTRICTED_WORKDIR=true` — for local CLI power users only; **keep off on API servers**.
-- Unset write workdirs get a per-run temp directory under that root.
+- Unset write workdirs mint a **marked** per-run temp (`run-<12 hex>` + `.swarm-auto-run`) under that root. The API/WS path never uses the Django process CWD (`CliAdapter.stream_run` receives that confined path; it does not fall back to `os.getcwd()` on this path).
+- Explicit **Folder** (`params.folder` / agent settings, REQ-167 / #588) is used as process cwd when set. It is **not** remapped under the workspaces root.
+- `cleanup_run_workdir` / `prune_stale_run_workdirs` delete only directories that contain `.swarm-auto-run`. A user dir named `workspaces/run-deadbeefcafe` **without** the marker is kept.
 
 ---
 

--- a/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
+++ b/src/swarm/blueprints/cli_agent/blueprint_cli_agent.py
@@ -257,17 +257,28 @@ class CliAgentBlueprint(BlueprintBase):
         # instructions to the prompt (portable across whichever CLI runs) and
         # stages any bundled assets into the workdir for write-mode CLIs.
         from swarm.core.agent_folder import AgentFolderError, resolve_session_cwd
-        from swarm.core.workdir import WorkdirEscapeError
+        from swarm.core.workdir import (
+            WorkdirEscapeError,
+            cleanup_run_workdir,
+            is_auto_workdir_request,
+        )
 
+        auto_workdir = False
+        workdir: str | None = None
         try:
             folder_cwd = resolve_session_cwd(
                 agent_id=str(params.get("agent") or params.get("agent_id") or self.blueprint_id),
                 params=params,
             )
             if folder_cwd:
+                # #588 Folder is an explicit cwd — do not remap or mint.
                 workdir = folder_cwd
             else:
-                workdir = support.resolve_workdir(params)
+                raw_wd = params.get(support.PARAM_WORKDIR) or params.get(support.PARAM_CWD)
+                auto_workdir = is_auto_workdir_request(raw_wd)
+                # Blank workdir/cwd mints a marked per-run temp under
+                # SWARM_WORKSPACES_DIR — never the Django process CWD.
+                workdir = support.resolve_workdir(params, required=True)
         except AgentFolderError as e:
             yield support.message_chunk(str(e), final=True)
             return
@@ -275,6 +286,23 @@ class CliAgentBlueprint(BlueprintBase):
             yield support.message_chunk(str(e), final=True)
             return
 
+        try:
+            async for chunk in self._run_cli_turn_in_workdir(
+                messages, params, prompt, workdir, **kwargs
+            ):
+                yield chunk
+        finally:
+            if auto_workdir:
+                cleanup_run_workdir(workdir)
+
+    async def _run_cli_turn_in_workdir(
+        self,
+        messages: list[dict[str, Any]],
+        params: dict[str, Any],
+        prompt: str,
+        workdir: str | None,
+        **kwargs: Any,
+    ) -> Any:
         if params.get(support.PARAM_SKILL):
             prompt, applied = support.apply_skill_to_prompt(
                 prompt, params, workdir=workdir

--- a/src/swarm/blueprints/common/cli_fusion_support.py
+++ b/src/swarm/blueprints/common/cli_fusion_support.py
@@ -34,15 +34,16 @@ def resolve_workdir(
     params: dict[str, Any] | None,
     *,
     create: bool = True,
-    required: bool = False,
+    required: bool = True,
 ) -> str | None:
     """Resolve ``params['workdir']`` / ``params['cwd']`` under the workspaces root.
 
     Confines client-supplied paths so WorkspaceTools and sandbox-bypassing CLIs
     cannot write outside ``SWARM_WORKSPACES_DIR`` / XDG ``workspaces/``. Blank
-    or missing values yield a fresh per-run directory when *required* is true;
-    otherwise ``None`` (callers that only optionally set a cwd keep prior
-    behavior). Raises :class:`~swarm.core.workdir.WorkdirEscapeError` on escape.
+    or missing values mint a marked per-run directory when *required* is true
+    (the default — API/WS write paths must not inherit the Django process CWD).
+    Pass ``required=False`` only for callers that truly have no cwd. Raises
+    :class:`~swarm.core.workdir.WorkdirEscapeError` on escape.
     """
     from swarm.core.workdir import resolve_confined_workdir
 

--- a/src/swarm/core/agent_folder.py
+++ b/src/swarm/core/agent_folder.py
@@ -2,7 +2,8 @@
 
 A user-configured Folder is an explicit working directory. It is not remapped
 under the workspaces root (that would be a silent wrong cwd). Blank / unset
-keeps the existing default — callers pass no cwd and keep prior behaviour.
+is not the Django process CWD: callers mint a marked per-run temp under
+``SWARM_WORKSPACES_DIR`` (see ``resolve_workdir`` / REQ-171C-1).
 """
 
 from __future__ import annotations
@@ -84,7 +85,7 @@ def lookup_agent_folder(
 def resolve_agent_folder(raw: str | None) -> str | None:
     """Resolve a user-configured Folder as process cwd.
 
-    * Blank / ``None`` → ``None`` (caller keeps the existing default).
+    * Blank / ``None`` → ``None`` (caller mints a confined per-run temp).
     * Set → expanduser and resolve; must exist and be a directory.
     * Does not join under the workspaces root.
     """

--- a/src/swarm/core/cli_adapter.py
+++ b/src/swarm/core/cli_adapter.py
@@ -527,11 +527,20 @@ class CliAdapter:
         adapters. Never raises for runtime failures.
         """
         cfg = self.config
-        effective_workdir = (
-            _apply_tokens(cfg.cwd, prompt, workdir or os.getcwd())
-            if cfg.cwd
-            else (workdir or os.getcwd())
-        )
+        # API/WS callers (cli_agent, fusion, chat WS) must pass a confined
+        # workdir. os.getcwd() remains only for local CLI / desktop (#576)
+        # when this adapter is invoked without a cwd.
+        if workdir:
+            effective_workdir = (
+                _apply_tokens(cfg.cwd, prompt, workdir) if cfg.cwd else workdir
+            )
+        else:
+            process_cwd = os.getcwd()
+            effective_workdir = (
+                _apply_tokens(cfg.cwd, prompt, process_cwd)
+                if cfg.cwd
+                else process_cwd
+            )
         argv, stdin_bytes = self._build_invocation(
             prompt, effective_workdir, session_id=session_id
         )

--- a/src/swarm/core/workdir.py
+++ b/src/swarm/core/workdir.py
@@ -6,8 +6,9 @@ Paths resolve under ``SWARM_WORKSPACES_DIR`` / ``WORKSPACES_DIR`` or the XDG
 user data ``workspaces/`` directory. Absolute paths outside that root are
 rejected unless ``ALLOW_UNRESTRICTED_WORKDIR=true`` (local power-user escape).
 
-Auto-minted ``run-*`` directories are marked and may be deleted via
-:func:`cleanup_run_workdir` after the request finishes.
+Auto-minted ``run-*`` directories are marked with :data:`AUTO_RUN_MARKER`.
+:func:`cleanup_run_workdir` and :func:`prune_stale_run_workdirs` delete only
+when that marker is present — a user dir named ``run-<hex>`` is kept.
 """
 
 from __future__ import annotations
@@ -28,15 +29,21 @@ ENV_WORKSPACES_DIR_ALT = "WORKSPACES_DIR"
 ENV_ALLOW_UNRESTRICTED = "ALLOW_UNRESTRICTED_WORKDIR"
 ENV_RUN_WORKDIR_MAX_AGE_DAYS = "SWARM_RUN_WORKDIR_MAX_AGE_DAYS"
 
-#: Marker written into auto-minted run directories (cleanup requires this or name match).
+#: Marker written into auto-minted run directories. Cleanup/prune require this file.
 AUTO_RUN_MARKER = ".swarm-auto-run"
 #: Default name prefix for auto-minted dirs (``run-<12 hex>``).
 DEFAULT_RUN_PREFIX = "run-"
 #: Default age before opportunistic prune of leftover auto run dirs.
 DEFAULT_PRUNE_DAYS = 7.0
 
+#: Minted directory names still look like ``run-<12 hex>``; cleanup ignores the name.
 _AUTO_RUN_NAME = re.compile(r"^run-[0-9a-f]{12}$")
 _logger = logging.getLogger(__name__)
+
+
+def looks_like_auto_run_name(name: str) -> bool:
+    """True if *name* matches the minted ``run-<12 hex>`` pattern (not a delete grant)."""
+    return bool(_AUTO_RUN_NAME.match(name))
 
 
 class WorkdirEscapeError(ValueError):
@@ -91,14 +98,16 @@ def _mark_auto_run(path: Path) -> None:
         _logger.debug("failed to mark auto run workdir %s: %s", path, e)
 
 
-def _looks_like_auto_run_dir(path: Path) -> bool:
-    if (path / AUTO_RUN_MARKER).is_file():
-        return True
-    return bool(_AUTO_RUN_NAME.match(path.name))
+def _has_auto_run_marker(path: Path) -> bool:
+    """True only when the auto-run marker file exists.
+
+    A directory named ``run-<12 hex>`` without the marker is a user path.
+    """
+    return (path / AUTO_RUN_MARKER).is_file()
 
 
 def is_auto_run_workdir(path: str | os.PathLike[str] | Path) -> bool:
-    """True if *path* is under the workspaces root and looks auto-minted."""
+    """True if *path* is under the workspaces root and has :data:`AUTO_RUN_MARKER`."""
     root = get_workspaces_dir().expanduser().resolve()
     try:
         resolved = Path(path).expanduser().resolve()
@@ -108,16 +117,16 @@ def is_auto_run_workdir(path: str | os.PathLike[str] | Path) -> bool:
         return False
     if not resolved.is_dir():
         return False
-    return _looks_like_auto_run_dir(resolved)
+    return _has_auto_run_marker(resolved)
 
 
 def cleanup_run_workdir(path: str | os.PathLike[str] | Path | None) -> bool:
     """Delete an auto-minted run workdir.
 
     Returns True only when the path was removed. Refuses paths outside the
-    workspaces root, the root itself, and directories that do not look like
-    auto-created ``run-*`` dirs (marker file or ``run-<12 hex>`` name).
-    Never deletes user-provided workspace paths.
+    workspaces root, the root itself, and directories that lack
+    :data:`AUTO_RUN_MARKER`. A user dir named ``run-<12 hex>`` without the
+    marker is kept. Never deletes user-provided workspace paths.
     """
     if path is None:
         return False
@@ -128,7 +137,7 @@ def cleanup_run_workdir(path: str | os.PathLike[str] | Path | None) -> bool:
         return False
     if resolved == root or not _is_under(resolved, root):
         return False
-    if not resolved.is_dir() or not _looks_like_auto_run_dir(resolved):
+    if not resolved.is_dir() or not _has_auto_run_marker(resolved):
         return False
     try:
         shutil.rmtree(resolved)
@@ -154,10 +163,11 @@ def prune_stale_run_workdirs(
     max_age_days: float | None = None,
     root: Path | None = None,
 ) -> int:
-    """Best-effort delete of leftover auto ``run-*`` dirs older than *max_age_days*.
+    """Best-effort delete of leftover marked auto-run dirs older than *max_age_days*.
 
-    Only inspects immediate children of the workspaces root. Returns the number
-    of directories removed. Errors are swallowed.
+    Only inspects immediate children of the workspaces root that contain
+    :data:`AUTO_RUN_MARKER`. Name match alone is not a delete grant. Returns
+    the number of directories removed. Errors are swallowed.
     """
     age_days = DEFAULT_PRUNE_DAYS if max_age_days is None else float(max_age_days)
     if age_days <= 0:
@@ -173,7 +183,7 @@ def prune_stale_run_workdirs(
         return 0
     for child in children:
         try:
-            if not child.is_dir() or not _looks_like_auto_run_dir(child):
+            if not child.is_dir() or not _has_auto_run_marker(child):
                 continue
             if not _is_under(child.resolve(), base):
                 continue

--- a/tests/api/test_cli_fusion_api.py
+++ b/tests/api/test_cli_fusion_api.py
@@ -124,7 +124,7 @@ def test_cli_agent_api_blank_workdir_is_confined(client, tmp_path, monkeypatch):
     script = tmp_path / "cwd_cli.py"
     script.write_text("import os\nprint(os.getcwd())\n", encoding="utf-8")
     cfg = {
-        "cli_agents": {"cwdcli": {"cmd": [PY, str(script)], "parse": "text"}},
+        "cli_agents": {"cwdcli": {"cmd": [PY, str(script), "{prompt}"], "parse": "text"}},
         "cli_fusion": {"default_cli": "cwdcli"},
     }
     app = apps.get_app_config("swarm")

--- a/tests/api/test_cli_fusion_api.py
+++ b/tests/api/test_cli_fusion_api.py
@@ -112,6 +112,33 @@ def test_cli_agent_respects_cli_param_over_api(client, fake_cli_config):
     assert _content(resp) == "B:pick"
 
 
+@pytest.mark.django_db
+def test_cli_agent_api_blank_workdir_is_confined(client, tmp_path, monkeypatch):
+    """POST /v1/chat/completions cli_agent with no workdir stays under workspaces."""
+    from pathlib import Path
+
+    root = tmp_path / "workspaces"
+    monkeypatch.setenv("SWARM_WORKSPACES_DIR", str(root))
+    monkeypatch.delenv("ALLOW_UNRESTRICTED_WORKDIR", raising=False)
+    process_cwd = Path.cwd().resolve()
+    script = tmp_path / "cwd_cli.py"
+    script.write_text("import os\nprint(os.getcwd())\n", encoding="utf-8")
+    cfg = {
+        "cli_agents": {"cwdcli": {"cmd": [PY, str(script)], "parse": "text"}},
+        "cli_fusion": {"default_cli": "cwdcli"},
+    }
+    app = apps.get_app_config("swarm")
+    monkeypatch.setattr(app, "config", cfg, raising=False)
+    monkeypatch.setenv("SWARM_TEST_MODE", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-dummy-test-mode")
+
+    resp = _post(client, "cli_agent", "hi", params={"cli": "cwdcli", "failover": False})
+    assert resp.status_code == 200, resp.content[:300]
+    ran = Path(_content(resp)).resolve()
+    assert ran.is_relative_to(root.resolve())
+    assert ran != process_cwd
+
+
 def _sse_text(response):
     import asyncio as _asyncio
 

--- a/tests/blueprints/test_cli_agent.py
+++ b/tests/blueprints/test_cli_agent.py
@@ -669,21 +669,92 @@ async def test_param_consensus_overrides_config_to_single():
     assert "consensus agent" not in _progress_text(chunks)
 
 
-async def test_folder_param_used_as_cwd(tmp_path):
-    script = tmp_path / "cwd_cli.py"
-    script.write_text("import os\nprint(os.getcwd())\n", encoding="utf-8")
-    folder = tmp_path / "project"
-    folder.mkdir()
-    cfg = {
+def _cwd_echo_config(script):
+    return {
         "cli_agents": {
             "echo": {"cmd": [PY, str(script)], "parse": "text"},
         },
         "cli_fusion": {"default_cli": "echo"},
     }
+
+
+async def test_blank_workdir_is_confined_not_process_cwd(tmp_path, monkeypatch):
+    """API/WS-style cli_agent with no workdir/cwd must not use os.getcwd()."""
+    import os
+    from pathlib import Path
+
+    from swarm.core.workdir import AUTO_RUN_MARKER
+
+    root = tmp_path / "workspaces"
+    monkeypatch.setenv("SWARM_WORKSPACES_DIR", str(root))
+    monkeypatch.delenv("ALLOW_UNRESTRICTED_WORKDIR", raising=False)
+    process_cwd = Path.cwd().resolve()
+
+    script = tmp_path / "cwd_cli.py"
+    script.write_text("import os\nprint(os.getcwd())\n", encoding="utf-8")
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=_cwd_echo_config(script))
+    # WS chat / API often set agent but never workdir.
+    bp.set_params({"cli": "echo", "agent": "cli_agent", "failover": False})
+    chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
+    ran = Path(_final_content(chunks)).resolve()
+    assert ran.is_relative_to(root.resolve())
+    assert ran != process_cwd
+    assert not process_cwd.is_relative_to(root.resolve()) or ran != process_cwd
+    # Auto-minted dir is cleaned after the turn; leftover user run-* is not this path.
+    leftover = [p for p in root.iterdir() if p.is_dir()] if root.is_dir() else []
+    assert all(not (p / AUTO_RUN_MARKER).is_file() for p in leftover)
+    assert str(ran) != str(os.getcwd())
+
+
+async def test_blank_workdir_stream_run_does_not_use_getcwd(tmp_path, monkeypatch):
+    """Streaming API path must pass a confined workdir into stream_run."""
+    from pathlib import Path
+    from unittest.mock import patch
+
+    from swarm.core.cli_adapter import CliAdapter
+
+    root = tmp_path / "workspaces"
+    monkeypatch.setenv("SWARM_WORKSPACES_DIR", str(root))
+    process_cwd = Path.cwd().resolve()
+    seen: list[str | None] = []
+
+    orig = CliAdapter.stream_run
+
+    async def _spy(self, prompt, *, workdir=None, **kwargs):
+        seen.append(workdir)
+        async for chunk in orig(self, prompt, workdir=workdir, **kwargs):
+            yield chunk
+
+    script = tmp_path / "cwd_cli.py"
+    script.write_text("import os\nprint(os.getcwd())\n", encoding="utf-8")
+    bp = CliAgentBlueprint(blueprint_id="cli_agent", config=_cwd_echo_config(script))
+    bp.set_params({"cli": "echo", "failover": False})
+    with patch.object(CliAdapter, "stream_run", _spy):
+        chunks = await _collect(bp.run([{"role": "user", "content": "hi"}], stream=True))
+    assert seen and seen[0]
+    confined = Path(seen[0]).resolve()
+    assert confined.is_relative_to(root.resolve())
+    assert confined != process_cwd
+    ran = Path(_final_content(chunks)).resolve()
+    assert ran.is_relative_to(root.resolve())
+
+
+async def test_folder_param_used_as_cwd(tmp_path, monkeypatch):
+    from pathlib import Path
+
+    root = tmp_path / "workspaces"
+    monkeypatch.setenv("SWARM_WORKSPACES_DIR", str(root))
+    script = tmp_path / "cwd_cli.py"
+    script.write_text("import os\nprint(os.getcwd())\n", encoding="utf-8")
+    folder = tmp_path / "project"
+    folder.mkdir()
+    cfg = _cwd_echo_config(script)
     bp = CliAgentBlueprint(blueprint_id="cli_agent", config=cfg)
     bp.set_params({"cli": "echo", "folder": str(folder), "failover": False})
     chunks = await _collect(bp.run([{"role": "user", "content": "hi"}]))
     assert _final_content(chunks) == str(folder.resolve())
+    # Folder is used as-is; it is not remapped under the workspaces root.
+    assert not Path(folder).resolve().is_relative_to(root.resolve())
 
 
 async def test_bad_folder_is_visible_error_not_wrong_cwd(tmp_path):

--- a/tests/blueprints/test_cli_agent.py
+++ b/tests/blueprints/test_cli_agent.py
@@ -672,7 +672,7 @@ async def test_param_consensus_overrides_config_to_single():
 def _cwd_echo_config(script):
     return {
         "cli_agents": {
-            "echo": {"cmd": [PY, str(script)], "parse": "text"},
+            "echo": {"cmd": [PY, str(script), "{prompt}"], "parse": "text"},
         },
         "cli_fusion": {"default_cli": "echo"},
     }

--- a/tests/core/test_workdir.py
+++ b/tests/core/test_workdir.py
@@ -15,6 +15,7 @@ from swarm.core.workdir import (
     get_workspaces_dir,
     is_auto_run_workdir,
     is_auto_workdir_request,
+    looks_like_auto_run_name,
     prune_stale_run_workdirs,
     resolve_confined_workdir,
     unrestricted_workdir_allowed,
@@ -111,8 +112,11 @@ def test_cli_fusion_support_resolve_workdir(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("SWARM_WORKSPACES_DIR", str(root))
     monkeypatch.delenv("ALLOW_UNRESTRICTED_WORKDIR", raising=False)
 
-    assert support.resolve_workdir({}) is None
-    assert support.resolve_workdir({}, required=True).startswith(str(root.resolve()))
+    minted = support.resolve_workdir({})
+    assert minted is not None
+    assert Path(minted).is_relative_to(root.resolve())
+    assert (Path(minted) / AUTO_RUN_MARKER).is_file()
+    assert support.resolve_workdir({}, required=False) is None
     got = support.resolve_workdir({"workdir": "rel-ok"})
     assert Path(got).is_relative_to(root.resolve())
 
@@ -168,6 +172,32 @@ def test_cleanup_run_workdir_none_and_missing(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("SWARM_WORKSPACES_DIR", str(root))
     assert cleanup_run_workdir(None) is False
     assert cleanup_run_workdir(root / "run-deadbeefcafe") is False
+
+
+def test_cleanup_and_prune_keep_user_run_hex_without_marker(tmp_path: Path, monkeypatch):
+    """A user dir named run-<12 hex> without AUTO_RUN_MARKER must survive."""
+    root = tmp_path / "workspaces"
+    root.mkdir()
+    monkeypatch.setenv("SWARM_WORKSPACES_DIR", str(root))
+
+    user = root / "run-deadbeefcafe"
+    user.mkdir()
+    assert looks_like_auto_run_name(user.name)
+    keep = user / "notes.txt"
+    keep.write_text("user workspace\n", encoding="utf-8")
+    old = time.time() - (10 * 86400)
+    os.utime(user, (old, old))
+
+    assert (user / AUTO_RUN_MARKER).is_file() is False
+    assert cleanup_run_workdir(user) is False
+    assert user.is_dir()
+    assert keep.read_text(encoding="utf-8") == "user workspace\n"
+
+    removed = prune_stale_run_workdirs(max_age_days=7, root=root.resolve())
+    assert removed == 0
+    assert user.is_dir()
+    assert keep.read_text(encoding="utf-8") == "user workspace\n"
+    assert not is_auto_run_workdir(user)
 
 
 def test_prune_stale_run_workdirs(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #610 (REQ-171C-1 / C-H1 + C-H2).

## From the Issue

**Intent:** Write-capable CLI/API runs stay under `SWARM_WORKSPACES_DIR`. Unset workdir is a marked per-run temp (or an explicit Folder from #588), never the Django process CWD. Cleanup never deletes a user dir just because it is named `run-<hex>`.

**Success:**
1. Blank `params.workdir`/`cwd` on `cli_agent` / fusion / WS chat mints or requires a confined path; `CliAdapter.stream_run` does not fall back to `os.getcwd()` on the API/WS path.
2. `cleanup_run_workdir` / prune require `AUTO_RUN_MARKER`; an existing `workspaces/run-deadbeefcafe` without the marker survives.
3. AUTH.md matches the code.
4. Tests: API/WS CLI with no workdir is confined; user `run-*` dir is kept; #588 Folder when set is used.

**Constraints:** Coordinate #588 Folder UI — do not lock unset = process CWD. No Neon. No secrets. Own-diff CI only. Do not fight #576 desktop packaging. Do not re-file duplicates of #601/#607.

**Owner:** Cursor implement. CoS: Open Swarm.

## Feasibility

Verified in tree before coding: C-H1 was `resolve_workdir(..., required=False)` returning `None`, then `CliAdapter.stream_run` using `os.getcwd()`. C-H2 was `_looks_like_auto_run_dir` treating name `run-<12hex>` as a delete grant without `.swarm-auto-run`. #844 already uses Folder as cwd when set; this PR only changes the unset default.

## What changed

- `resolve_workdir` now defaults to minting a marked per-run temp under `SWARM_WORKSPACES_DIR` (pass `required=False` only when a caller truly has no cwd).
- `cli_agent` uses #588 Folder when set; otherwise mints a confined path and never passes `None` into `stream_run` on the API/WS path. Auto-minted dirs are cleaned after the turn.
- `cleanup_run_workdir` / `prune_stale_run_workdirs` require `.swarm-auto-run`. A user `workspaces/run-deadbeefcafe` without the marker is kept.
- `docs/AUTH.md` §5 matches: unset mints a marked temp; Folder is used as-is; cleanup is marker-only.
- Own-diff CI: `.github/workflows/req171c1-confine-workdirs.yml`.
- Tests: blank API/WS CLI is confined; stream_run receives a confined workdir; Folder is used when set; unmarked `run-*` survives cleanup and prune.

Out of scope: desktop packaging (#576), `software_dev` / MoA `--act-write` unconfined paths (audit C-H1 related, not this Issue’s success list), `cli_persona` / smoke_check CWD (C-M11). No live `:8001`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6ea7803-241e-401b-8242-fc2d0062aa75?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6ea7803-241e-401b-8242-fc2d0062aa75&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

