### PR TITLE
One Herdr client for list and send

### DIFF
--- a/.github/workflows/req171c5-one-herdr-client.yml
+++ b/.github/workflows/req171c5-one-herdr-client.yml
@@ -1,0 +1,59 @@
+name: REQ-171C-5 one Herdr client
+
+on:
+  pull_request:
+    paths:
+      - "src/swarm/core/remotes.py"
+      - "src/swarm/core/remote_teams.py"
+      - "src/swarm/herdr/client.py"
+      - "src/swarm/herdr/remote.py"
+      - "src/swarm/views/herdr_api.py"
+      - "src/swarm/blueprints/agent_router/blueprint_agent_router.py"
+      - "tests/core/test_herdr_remote.py"
+      - "tests/core/test_herdr_ssh_remote.py"
+      - "tests/core/test_remote_teams.py"
+      - "tests/herdr/test_herdr_client.py"
+      - "tests/unit/test_req171c5_herdr_client.py"
+      - ".github/workflows/req171c5-one-herdr-client.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/swarm/core/remotes.py"
+      - "src/swarm/core/remote_teams.py"
+      - "src/swarm/herdr/client.py"
+      - "src/swarm/herdr/remote.py"
+      - "src/swarm/views/herdr_api.py"
+      - "src/swarm/blueprints/agent_router/blueprint_agent_router.py"
+      - "tests/core/test_herdr_remote.py"
+      - "tests/core/test_herdr_ssh_remote.py"
+      - "tests/core/test_remote_teams.py"
+      - "tests/herdr/test_herdr_client.py"
+      - "tests/unit/test_req171c5_herdr_client.py"
+      - ".github/workflows/req171c5-one-herdr-client.yml"
+
+jobs:
+  own-diff:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install Python deps
+        run: uv sync --all-extras
+
+      - name: Pytest C-H4 one Herdr client
+        run: |
+          uv run pytest \
+            tests/core/test_herdr_remote.py \
+            tests/core/test_herdr_ssh_remote.py \
+            tests/core/test_remote_teams.py \
+            tests/herdr/test_herdr_client.py \
+            tests/unit/test_req171c5_herdr_client.py
+        env:
+          DJANGO_ALLOW_ASYNC_UNSAFE: "true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - **Untrusted CLI argv (C-H8 / REQ-171C-6):** User prompts cannot become extra flags (`--` before positional prompts, or stdin / `-p=`). `{workdir}` is not substituted inside the prompt text. Session ids reject leading `-`, `.`, and `..`; `resume_cli_session_id` sanitizes. Fixes #615.
 
 ### Fixed
+- **One Herdr client for list + send (C-H4 / REQ-171C-5):** `operate(..., "send")` and sidebar `chat_herdr` both use `HerdrClient.from_remote_config` so Settings and the rail share one client. Send is no longer a CLI-only stub. `chat_herdr` preflights blocked panes (`check_blocked=True`) and uses a single `--until idle`. Tests lock send argv (and leftover localhost list headers) against the configured remote. SSH shape (#463) unchanged; no live LAN. Fixes #614.
 - **REQ-171B Add-agent rail seat:** Completing Add-agent CLI/API persists `rail: true` plus a first-class CLI `command` (not only a `# Command:` comment). `GET /v1/blueprints/` merges those customs so the AGENTS rail / Search Bots filter can list them. Missing CLI command or a non-CLI/API kind returns honest copy. New seats land at the top of the unpinned list. ChatPage unchanged. Fixes #607.
 - **REQ-171C-7 Vitest PR gate:** `Python Tests` sibling `vitest` job runs `npm ci` then `npm test` so SPA contract tests cannot go red on `main` unnoticed. Golden-journey / `visual-regression.yml` stays HOLD (REQ-89). Shrunk `test_req133_*` source greps that only checked TSX testids — those are not coverage. Fixes #616.
 

--- a/FEATURE_STATUS.md
+++ b/FEATURE_STATUS.md
@@ -240,6 +240,7 @@ Open Swarm as a harness **for** other harnesses. Not a Grok-Bot chrome claim; no
 | Persisted members `kind=herdr` | ✅ | `HerdrAgent` model + migration `0012`; DRF `/v1/herdr-agents/` list/add/remove; discover from live `agent list` / `workspace list`. Settings + Teams + Django admin + SPA sidepane. Django DB (Compose Postgres or SQLite); no Neon |
 | Honesty | ✅ | [docs/HERDR.md](./docs/HERDR.md) — not Hermes/OMB/Rakazo; same-host default; `--remote` for other machines; blocked reject / `--wait` may finish an in-flight turn; CI must mock `herdr` |
 | Remotes kind + CLI `--remote` (REQ-64) | ✅ | `remotes.herdr` persist; Settings + Add; `HerdrClient.from_remote_config()`; stub HTTP health/list in `tests/core/test_herdr_remote.py` |
+| One Herdr client list + send (C-H4) | ✅ | `operate(..., "send")` and `chat_herdr` share `HerdrClient.from_remote_config` (`check_blocked=True`, single `--until idle`). Tests lock send argv/headers against the configured remote. Own-diff CI. Fixes #614. |
 | SSH-shaped remote Herdr (REQ-100) | ✅ | `SSHTransport` stub; `herdr_mode` local\|ssh; persist `ssh_host` / `ssh_user` / `ssh_identity_env`; operate list/send/interrogate. Tests: `tests/herdr/test_herdr_ssh.py`, `tests/core/test_herdr_ssh_remote.py` |
 
 ## 14. Durable database (REQ-123) — ✅

--- a/docs/HERDR.md
+++ b/docs/HERDR.md
@@ -142,4 +142,13 @@ assert extract_prompt_type(payload) == "agent_prompted"
 
 client = HerdrClient(remote="matthewh@10.0.0.36")
 client.agent_list()  # herdr --remote matthewh@10.0.0.36 agent list
+
+# Settings operate + sidebar chat share this factory (REQ-171C-5 / #614)
+client = HerdrClient.from_remote_config()  # remotes.herdr; raises if not added
+client.agent_prompt("w3:p1", "HERDR_PING_OK", check_blocked=True, wait=True, until="idle")
 ```
+
+`swarm.core.remotes.operate(..., "send")` and `chat_herdr` both call
+`HerdrClient.from_remote_config`. Chat preflights a blocked pane
+(`check_blocked=True`) and passes a **single** `--until idle` (herdr rejects
+two `--until` flags). Tests mock the CLI and lock argv — no live LAN.

--- a/docs/REMOTE_HARNESSES.md
+++ b/docs/REMOTE_HARNESSES.md
@@ -114,6 +114,8 @@ swarm-cli remotes operate hermes --op send --prompt "status"
 swarm-cli remotes operate omb --op list
 swarm-cli remotes operate omb --op send --prompt "hello" --target <botId>
 swarm-cli remotes operate rakazo --op list
+swarm-cli remotes operate herdr --op list
+swarm-cli remotes operate herdr --op send --target w3:p1 --prompt HERDR_PING_OK
 ```
 
 REST: `POST /v1/remotes/<id>/operate/` `{"op":"list"}` or `{"op":"send","prompt":"…","target":"…"}`.

--- a/src/swarm/blueprints/agent_router/blueprint_agent_router.py
+++ b/src/swarm/blueprints/agent_router/blueprint_agent_router.py
@@ -852,8 +852,9 @@ Remember to provide a clear, unified response to the user, even when multiple ag
             override = ""
         override = override[:120]
         if framework == "herdr" or transport == "herdr":
+            herdr_config = getattr(self, "_config", None)
             try:
-                live = await asyncio.to_thread(herdr_list_agents)
+                live = await asyncio.to_thread(herdr_list_agents, config=herdr_config)
             except Exception as exc:
                 yield {
                     "content": f"**Herdr** is not reachable (`{exc}`).\nInstall `herdr` on PATH and keep `herdr status` running.",
@@ -876,7 +877,9 @@ Remember to provide a clear, unified response to the user, even when multiple ag
                 }
                 return
             try:
-                text = await asyncio.to_thread(chat_herdr, prompt, target=target)
+                text = await asyncio.to_thread(
+                    chat_herdr, prompt, target=target, config=herdr_config
+                )
             except Exception as exc:
                 yield {
                     "content": f"[Herdr {target}] {exc}",

--- a/src/swarm/core/remote_teams.py
+++ b/src/swarm/core/remote_teams.py
@@ -659,28 +659,71 @@ def herdr_bin() -> str | None:
     return shutil.which("herdr")
 
 
-def herdr_list_agents(*, runner=subprocess.run) -> list[dict[str, Any]]:
-    exe = herdr_bin()
-    if not exe:
-        raise RuntimeError("herdr is not on PATH")
-    proc = runner(
-        [exe, "agent", "list"],
-        capture_output=True,
-        text=True,
-        timeout=10,
-        check=False,
-    )
-    if proc.returncode != 0:
-        err = (proc.stderr or proc.stdout or "").strip()[:400]
-        raise RuntimeError(f"herdr agent list failed: {err or proc.returncode}")
+def _adapt_herdr_runner(runner):
+    """Map subprocess.run-style callables onto HerdrClient's runner."""
+
+    def adapted(argv, timeout=None):
+        try:
+            return runner(
+                argv,
+                timeout=timeout,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except TypeError:
+            return runner(argv, timeout=timeout)
+
+    return adapted
+
+
+def herdr_client_from_settings(*, config: dict[str, Any] | None = None, runner=None):
+    """Same client Settings operate uses (``HerdrClient.from_remote_config``).
+
+    Falls back to local ``herdr`` when ``remotes.herdr`` is not added so
+    persisted ``kind=herdr`` members still work without a remotes card.
+    """
+    from swarm.core.remotes import RemoteError
+    from swarm.herdr.client import HerdrClient
+
+    kwargs: dict[str, Any] = {}
+    if runner is not None:
+        kwargs["runner"] = _adapt_herdr_runner(runner)
     try:
-        data = json.loads(proc.stdout or "{}")
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(f"herdr agent list returned non-JSON: {exc}") from exc
-    agents = (data.get("result") or {}).get("agents")
-    if not isinstance(agents, list):
+        return HerdrClient.from_remote_config(config, **kwargs)
+    except RemoteError:
+        if runner is None and not herdr_bin():
+            raise RuntimeError("herdr is not on PATH") from None
+        return HerdrClient(**kwargs)
+
+
+def _agent_dicts_from_list_payload(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [row for row in payload if isinstance(row, dict)]
+    if not isinstance(payload, dict):
         return []
-    return [a for a in agents if isinstance(a, dict)]
+    for key in ("agents", "items"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            return [row for row in value if isinstance(row, dict)]
+    for wrap in ("result", "data"):
+        inner = payload.get(wrap)
+        if inner is not None and inner is not payload:
+            found = _agent_dicts_from_list_payload(inner)
+            if found:
+                return found
+    return []
+
+
+def herdr_list_agents(*, runner=None, config: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    """``herdr agent list`` via the same client Settings operate uses."""
+    from swarm.herdr.client import HerdrCLIError
+
+    try:
+        payload = herdr_client_from_settings(config=config, runner=runner).agent_list()
+    except HerdrCLIError as exc:
+        raise RuntimeError(f"herdr agent list failed: {exc}") from exc
+    return _agent_dicts_from_list_payload(payload)
 
 
 def format_herdr_roster(agents: list[dict[str, Any]]) -> str:
@@ -724,39 +767,40 @@ def chat_herdr(
     *,
     target: str,
     timeout_ms: int = 120_000,
-    runner=subprocess.run,
+    runner=None,
+    config: dict[str, Any] | None = None,
 ) -> str:
-    """Submit *prompt* to a live Herdr pane and return recent terminal text."""
-    exe = herdr_bin()
-    if not exe:
-        raise RuntimeError("herdr is not on PATH")
+    """Submit *prompt* via ``HerdrClient.from_remote_config`` and read recent text.
+
+    Uses ``check_blocked=True`` and a single ``--until idle`` (herdr rejects
+    two ``--until`` flags). Sidebar and Settings share this client.
+    """
+    from swarm.herdr.client import HerdrBlockedError, HerdrCLIError
+
     if not target:
         raise RuntimeError("herdr target (pane id) is required")
-    wait = runner(
-        [
-            exe, "agent", "prompt", target, prompt,
-            "--wait", "--until", "idle", "--until", "done",
-            "--timeout", str(int(timeout_ms)),
-        ],
-        capture_output=True,
-        text=True,
-        timeout=max(5.0, timeout_ms / 1000 + 5),
-        check=False,
-    )
-    if wait.returncode != 0:
-        err = (wait.stderr or wait.stdout or "").strip()[:600]
-        raise RuntimeError(f"herdr agent prompt failed: {err or wait.returncode}")
-    read = runner(
-        [exe, "agent", "read", target, "--source", "recent", "--format", "text"],
-        capture_output=True,
-        text=True,
-        timeout=15,
-        check=False,
-    )
-    if read.returncode != 0:
-        err = (read.stderr or read.stdout or "").strip()[:400]
-        raise RuntimeError(f"herdr agent read failed: {err or read.returncode}")
-    return (read.stdout or "").strip() or (wait.stdout or "").strip()
+    client = herdr_client_from_settings(config=config, runner=runner)
+    try:
+        prompted = client.agent_prompt(
+            target,
+            prompt,
+            wait=True,
+            until="idle",
+            timeout_ms=int(timeout_ms),
+            check_blocked=True,
+        )
+        read = client.agent_read(target, source="recent", fmt="text")
+    except HerdrBlockedError as exc:
+        raise RuntimeError(str(exc)) from exc
+    except HerdrCLIError as exc:
+        raise RuntimeError(f"herdr agent prompt failed: {exc}") from exc
+    if isinstance(read, str) and read.strip():
+        return read.strip()
+    if isinstance(prompted, str) and prompted.strip():
+        return prompted.strip()
+    return ("" if read is None else str(read)).strip() or (
+        "" if prompted is None else str(prompted)
+    ).strip()
 
 
 DSH_DEFAULT_ORIGIN = "http://127.0.0.1:3080"

--- a/src/swarm/core/remotes.py
+++ b/src/swarm/core/remotes.py
@@ -1207,14 +1207,15 @@ def _extract_version(payload: Any) -> Any:
     return None
 
 
-def _herdr_cli_health(spec: RemoteSpec, timeout: float) -> HealthResult:  # noqa: ARG001
+def _herdr_cli_health(spec: RemoteSpec, timeout: float, config: dict[str, Any] | None = None) -> HealthResult:  # noqa: ARG001
     """Health via local herdr or SSH hop (never a guessed host)."""
-    from swarm.herdr.remote import herdr_client_from_spec, resolve_herdr_mode
+    from swarm.herdr.client import HerdrClient
+    from swarm.herdr.remote import resolve_herdr_mode
     from swarm.herdr.ssh import SSHNotConfiguredError
 
     mode = resolve_herdr_mode(spec)
     try:
-        client = herdr_client_from_spec(spec)
+        client = HerdrClient.from_remote_config(config)
         payload = client.workspace_list()
     except SSHNotConfiguredError as exc:
         return HealthResult(remote="herdr", ok=False, state="UNKNOWN", detail=str(exc))
@@ -1240,13 +1241,13 @@ def _herdr_cli_health(spec: RemoteSpec, timeout: float) -> HealthResult:  # noqa
     )
 
 
-def _herdr_health(spec: RemoteSpec, timeout: float) -> HealthResult | None:
+def _herdr_health(spec: RemoteSpec, timeout: float, config: dict[str, Any] | None = None) -> HealthResult | None:
     """SSH or local-CLI health. None means fall through to localhost HTTP."""
     from swarm.herdr.remote import uses_local_http_health
 
     if uses_local_http_health(spec):
         return None
-    return _herdr_cli_health(spec, timeout)
+    return _herdr_cli_health(spec, timeout, config)
 
 
 def check_health(remote_id: str, *, config: dict[str, Any] | None = None, timeout: float = _DEFAULT_TIMEOUT_S) -> HealthResult:
@@ -1260,7 +1261,7 @@ def check_health(remote_id: str, *, config: dict[str, Any] | None = None, timeou
         return HealthResult(remote=spec.id, ok=False, state="UNKNOWN", detail="remote not added")
 
     if spec.id == "herdr":
-        herdr_health = _herdr_health(spec, timeout)
+        herdr_health = _herdr_health(spec, timeout, config)
         if herdr_health is not None:
             return herdr_health
 
@@ -1765,10 +1766,10 @@ def _swarm_send(spec: RemoteSpec, prompt: str, target: str, timeout: float) -> O
     )
 
 
-def _herdr_list(spec: RemoteSpec, timeout: float) -> OperateResult:
+def _herdr_list(spec: RemoteSpec, timeout: float, config: dict[str, Any] | None = None) -> OperateResult:
+    from swarm.herdr.client import HerdrClient
     from swarm.herdr.remote import (
         LIST_PATH,
-        herdr_client_from_spec,
         members_from_http_list,
         resolve_herdr_mode,
         uses_local_http_health,
@@ -1812,7 +1813,7 @@ def _herdr_list(spec: RemoteSpec, timeout: float) -> OperateResult:
 
     mode = resolve_herdr_mode(spec)
     try:
-        client = herdr_client_from_spec(spec)
+        client = HerdrClient.from_remote_config(config)
         members = client.discover_members()
     except SSHNotConfiguredError as exc:
         return OperateResult(remote="herdr", op="list", ok=False, detail=str(exc))
@@ -1828,9 +1829,9 @@ def _herdr_list(spec: RemoteSpec, timeout: float) -> OperateResult:
     )
 
 
-def _herdr_send(spec: RemoteSpec, prompt: str, target: str, timeout: float) -> OperateResult:  # noqa: ARG001
-    from swarm.herdr.client import HerdrBlockedError, extract_prompt_type
-    from swarm.herdr.remote import herdr_client_from_spec, resolve_herdr_mode
+def _herdr_send(spec: RemoteSpec, prompt: str, target: str, timeout: float, config: dict[str, Any] | None = None) -> OperateResult:  # noqa: ARG001
+    from swarm.herdr.client import HerdrBlockedError, HerdrClient, extract_prompt_type
+    from swarm.herdr.remote import resolve_herdr_mode
     from swarm.herdr.ssh import SSHNotConfiguredError
 
     if not prompt.strip():
@@ -1844,7 +1845,7 @@ def _herdr_send(spec: RemoteSpec, prompt: str, target: str, timeout: float) -> O
         )
     mode = resolve_herdr_mode(spec)
     try:
-        client = herdr_client_from_spec(spec)
+        client = HerdrClient.from_remote_config(config)
         payload = client.agent_prompt(target.strip(), prompt)
     except SSHNotConfiguredError as exc:
         return OperateResult(remote="herdr", op="send", ok=False, detail=str(exc))
@@ -1862,9 +1863,10 @@ def _herdr_send(spec: RemoteSpec, prompt: str, target: str, timeout: float) -> O
     )
 
 
-def _herdr_interrogate(spec: RemoteSpec, target: str, timeout: float) -> OperateResult:  # noqa: ARG001
+def _herdr_interrogate(spec: RemoteSpec, target: str, timeout: float, config: dict[str, Any] | None = None) -> OperateResult:  # noqa: ARG001
     """Inspect one CLI/pane Herdr manages (agent get) over local or SSH hop."""
-    from swarm.herdr.remote import herdr_client_from_spec, resolve_herdr_mode
+    from swarm.herdr.client import HerdrClient
+    from swarm.herdr.remote import resolve_herdr_mode
     from swarm.herdr.ssh import SSHNotConfiguredError
 
     if not (target or "").strip():
@@ -1876,7 +1878,7 @@ def _herdr_interrogate(spec: RemoteSpec, target: str, timeout: float) -> Operate
         )
     mode = resolve_herdr_mode(spec)
     try:
-        client = herdr_client_from_spec(spec)
+        client = HerdrClient.from_remote_config(config)
         payload = client.agent_get(target.strip())
     except SSHNotConfiguredError as exc:
         return OperateResult(remote="herdr", op="interrogate", ok=False, detail=str(exc))
@@ -1929,10 +1931,10 @@ def operate(
             return OperateResult(remote=rid, op=action, ok=False, detail="remote not added")
         if rid == "herdr":
             if action == "list":
-                return _herdr_list(spec, timeout)
+                return _herdr_list(spec, timeout, config)
             if action == "interrogate":
-                return _herdr_interrogate(spec, target, timeout)
-            return _herdr_send(spec, prompt, target, timeout)
+                return _herdr_interrogate(spec, target, timeout, config)
+            return _herdr_send(spec, prompt, target, timeout, config)
         if not spec.base_url:
             return OperateResult(remote=rid, op=action, ok=False, detail="base_url is empty")
         if _looks_like_forbidden_llm_proxy(spec.base_url):

--- a/src/swarm/views/herdr_api.py
+++ b/src/swarm/views/herdr_api.py
@@ -27,6 +27,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from swarm.core.remotes import RemoteError
 from swarm.herdr.client import HerdrCLIError, HerdrClient
 from swarm.models import HerdrAgent
 from swarm.permissions import HasValidTokenOrSession
@@ -39,8 +40,17 @@ HERDR_API_PERMISSIONS = [HasValidTokenOrSession] if ENABLE_API_AUTH else [AllowA
 
 
 def herdr_client(remote: str = "") -> HerdrClient:
-    """Factory so tests can patch the CLI wrapper (never a live TUI in CI)."""
-    return HerdrClient(remote=remote)
+    """Same client Settings operate uses when ``remotes.herdr`` is configured.
+
+    Explicit ``?remote=`` still prefixes ``herdr --remote``. Missing remotes
+    card falls back to localhost (no ``--remote``). Tests patch this factory.
+    """
+    if (remote or "").strip():
+        return HerdrClient(remote=remote)
+    try:
+        return HerdrClient.from_remote_config()
+    except RemoteError:
+        return HerdrClient(remote="")
 
 
 def _lookup_agent(lookup: str) -> HerdrAgent | None:

--- a/tests/core/test_herdr_remote.py
+++ b/tests/core/test_herdr_remote.py
@@ -164,6 +164,113 @@ def test_herdr_health_and_list_stub_http(http_router, monkeypatch):
     assert listed.data["members"][0]["kind"] == "herdr"
 
 
+def test_operate_send_uses_from_remote_config_exact_argv(monkeypatch):
+    """C-H4: operate send is HerdrClient.from_remote_config, not a stub / 'prompt' in argv."""
+    import subprocess
+    from unittest.mock import patch
+
+    calls: list[list[str]] = []
+    from_remote_calls: list[object] = []
+
+    def runner(argv, timeout=None):
+        del timeout
+        calls.append(list(argv))
+        return subprocess.CompletedProcess(argv, 0, '{"type":"agent_prompted"}', "")
+
+    real = HerdrClient.from_remote_config
+
+    def spy(config=None, **kwargs):
+        from_remote_calls.append(config)
+        kwargs.setdefault("runner", runner)
+        return real(config, **kwargs)
+
+    cfg = {"remotes": {"herdr": {"herdr_mode": "local"}}}
+    monkeypatch.delenv("HERDR_BASE_URL", raising=False)
+    monkeypatch.delenv("HERDR_SSH_HOST", raising=False)
+    with patch.object(HerdrClient, "from_remote_config", side_effect=spy):
+        sent = remotes_core.operate(
+            "herdr",
+            "send",
+            prompt="HERDR_PING_OK",
+            target="w3:p1",
+            config=cfg,
+        )
+    assert sent.ok is True
+    assert from_remote_calls == [cfg]
+    assert calls == [["herdr", "agent", "prompt", "w3:p1", "HERDR_PING_OK"]]
+    assert "--remote" not in calls[0]
+    assert "gap" not in (sent.detail or "").lower()
+    assert getattr(sent, "gap", None) in (None, "")
+
+
+def test_operate_list_uses_from_remote_config_exact_argv(monkeypatch):
+    import subprocess
+    from unittest.mock import patch
+
+    calls: list[list[str]] = []
+    from_remote_calls: list[object] = []
+
+    def runner(argv, timeout=None):
+        del timeout
+        calls.append(list(argv))
+        if argv[-2:] == ["agent", "list"]:
+            return subprocess.CompletedProcess(
+                argv, 0, '{"agents":[{"pane_id":"w3:p1","state":"idle"}]}', ""
+            )
+        if argv[-2:] == ["workspace", "list"]:
+            return subprocess.CompletedProcess(argv, 0, '{"workspaces":[]}', "")
+        return subprocess.CompletedProcess(argv, 0, "{}", "")
+
+    real = HerdrClient.from_remote_config
+
+    def spy(config=None, **kwargs):
+        from_remote_calls.append(config)
+        kwargs.setdefault("runner", runner)
+        return real(config, **kwargs)
+
+    cfg = {"remotes": {"herdr": {"herdr_mode": "local"}}}
+    monkeypatch.delenv("HERDR_BASE_URL", raising=False)
+    with patch.object(HerdrClient, "from_remote_config", side_effect=spy):
+        listed = remotes_core.operate("herdr", "list", config=cfg)
+    assert listed.ok is True
+    assert from_remote_calls == [cfg]
+    assert calls == [
+        ["herdr", "agent", "list"],
+        ["herdr", "workspace", "list"],
+    ]
+
+
+def test_herdr_health_and_list_stub_http_sends_configured_auth(http_router, monkeypatch):
+    host, port, router = http_router
+    captured_auth: list[str] = []
+    orig_handle = router._handle
+
+    def _handle(self, method: str) -> None:
+        captured_auth.append(self.headers.get("Authorization") or "")
+        orig_handle(self, method)
+
+    monkeypatch.setattr(router, "_handle", _handle)
+    router.routes = {
+        ("GET", "/health"): (200, {"status": "ok", "app": "herdr"}),
+        (
+            "GET",
+            "/agents",
+        ): (
+            200,
+            {"agents": [{"pane_id": "w3:p1", "state": "idle", "name": "grok"}]},
+        ),
+    }
+    monkeypatch.setenv("HERDR_API_KEY", "test-herdr-token")
+    monkeypatch.delenv("HERDR_BASE_URL", raising=False)
+    cfg = {
+        "llm": {},
+        "remotes": {"herdr": {"base_url": f"http://{host}:{port}", "api_key": "${HERDR_API_KEY}"}},
+    }
+    listed = remotes_core.operate("herdr", "list", config=cfg)
+    assert listed.ok is True
+    assert any(header == "Bearer test-herdr-token" for header in captured_auth)
+
+
 def test_herdr_not_configured_constant_mentions_settings():
     assert "Settings" in HERDR_NOT_CONFIGURED
     assert "SSH" in HERDR_NOT_CONFIGURED

--- a/tests/core/test_remote_teams.py
+++ b/tests/core/test_remote_teams.py
@@ -243,21 +243,90 @@ def test_chat_herdr_prompt_then_read():
     from swarm.core.remote_teams import chat_herdr
 
     calls = []
+    cfg = {"remotes": {"herdr": {"herdr_mode": "local"}}}
 
     def fake_run(argv, **kwargs):
-        calls.append(argv)
+        calls.append(list(argv))
 
         class P:
             returncode = 0
-            stdout = "ok output" if "read" in argv else '{"ok":true}'
+            if "read" in argv:
+                stdout = "ok output"
+            elif "get" in argv:
+                stdout = '{"result":{"state":"idle"}}'
+            else:
+                stdout = '{"type":"agent_prompted"}'
             stderr = ""
         return P()
 
-    with patch("swarm.core.remote_teams.herdr_bin", return_value="/usr/bin/herdr"):
-        text = chat_herdr("do the thing", target="w7:p1", timeout_ms=1000, runner=fake_run)
+    text = chat_herdr(
+        "do the thing",
+        target="w7:p1",
+        timeout_ms=1000,
+        runner=fake_run,
+        config=cfg,
+    )
     assert text == "ok output"
-    assert any("prompt" in c for c in calls)
-    assert any("read" in c for c in calls)
+    assert calls == [
+        ["herdr", "agent", "get", "w7:p1"],
+        [
+            "herdr",
+            "agent",
+            "prompt",
+            "w7:p1",
+            "do the thing",
+            "--wait",
+            "--until",
+            "idle",
+            "--timeout",
+            "1000",
+        ],
+        ["herdr", "agent", "read", "w7:p1", "--source", "recent", "--format", "text"],
+    ]
+    assert calls[1].count("--until") == 1
+    assert "--remote" not in calls[1]
+
+
+def test_herdr_list_agents_uses_from_remote_config_exact_argv():
+    from swarm.core.remote_teams import herdr_list_agents
+
+    calls = []
+    cfg = {"remotes": {"herdr": {"herdr_mode": "local"}}}
+
+    def fake_run(argv, **kwargs):
+        calls.append(list(argv))
+
+        class P:
+            returncode = 0
+            stdout = '{"result":{"agents":[{"pane_id":"w3:p1","agent":"grok"}]}}'
+            stderr = ""
+        return P()
+
+    rows = herdr_list_agents(runner=fake_run, config=cfg)
+    assert rows == [{"pane_id": "w3:p1", "agent": "grok"}]
+    assert calls == [["herdr", "agent", "list"]]
+    assert "--remote" not in calls[0]
+
+
+def test_chat_herdr_blocked_does_not_prompt():
+    from swarm.core.remote_teams import chat_herdr
+
+    calls = []
+    cfg = {"remotes": {"herdr": {"herdr_mode": "local"}}}
+
+    def fake_run(argv, **kwargs):
+        calls.append(list(argv))
+
+        class P:
+            returncode = 0
+            stdout = '{"result":{"state":"blocked"}}'
+            stderr = ""
+        return P()
+
+    with pytest.raises(RuntimeError, match="blocked"):
+        chat_herdr("nope", target="w3:p1", timeout_ms=1000, runner=fake_run, config=cfg)
+    assert calls == [["herdr", "agent", "get", "w3:p1"]]
+    assert all("prompt" not in argv for argv in calls)
 
 
 def test_chat_remote_parses_openai_payload():

--- a/tests/unit/test_req171c5_herdr_client.py
+++ b/tests/unit/test_req171c5_herdr_client.py
@@ -1,0 +1,62 @@
+"""REQ-171C-5 / #614 — one Herdr client for list + send (C-H4).
+
+Source-lock: own-diff CI, no Neon, no :8001, no secrets, no Wave labels.
+SSH shape (#463) stays; this Issue is the configured stub actually sends.
+"""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+REMOTES = REPO / "src" / "swarm" / "core" / "remotes.py"
+TEAMS = REPO / "src" / "swarm" / "core" / "remote_teams.py"
+CI = REPO / ".github" / "workflows" / "req171c5-one-herdr-client.yml"
+CHANGELOG = REPO / "CHANGELOG.md"
+
+
+def _no_secrets(text: str) -> None:
+    lowered = text.lower()
+    for needle in ("sk-", "github_pat_", "ghp_"):
+        assert needle not in lowered
+
+
+def test_operate_send_calls_from_remote_config():
+    text = REMOTES.read_text(encoding="utf-8")
+    send_start = text.index("def _herdr_send")
+    send = text[send_start : send_start + 1800]
+    assert "HerdrClient.from_remote_config" in send
+    assert "herdr_send_via_cli" not in text
+    assert ":8001" not in send
+    assert "WAVE" not in send
+    _no_secrets(send)
+
+
+def test_chat_herdr_delegates_to_client_single_until():
+    text = TEAMS.read_text(encoding="utf-8")
+    start = text.index("def chat_herdr")
+    block = text[start : start + 1600]
+    assert "from_remote_config" in block
+    assert "check_blocked=True" in block
+    assert 'until="idle"' in block
+    assert '"--until", "done"' not in block
+    assert ":8001" not in block
+    _no_secrets(block)
+
+
+def test_own_diff_ci_exists():
+    text = CI.read_text(encoding="utf-8")
+    assert "REQ-171C-5" in text or "req171c5" in text.lower()
+    assert "own-diff" in text
+    assert "test_herdr_remote.py" in text
+    assert "test_remote_teams.py" in text
+    assert ":8001" not in text
+    assert "WAVE" not in text
+    assert "neon" not in text.lower()
+    _no_secrets(text)
+
+
+def test_changelog_fixes_614_without_wave():
+    text = CHANGELOG.read_text(encoding="utf-8")
+    assert "Fixes #614" in text
+    prefix = text.split("Fixes #614")[0][-400:]
+    assert "WAVE" not in prefix
+    assert ":8001" not in prefix


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Settings operate and sidebar chat now share one `HerdrClient` built from `remotes.herdr`.

## Intent
A configured `remotes.herdr` can list and send. Sidebar and Settings use the same client.

## Success
1. `operate(..., "send")` calls `HerdrClient.from_remote_config` (list/health/interrogate use it too). Local leftover HTTP list (`GET /agents`) stays for the REQ-64 stub.
2. `chat_herdr` delegates to that client (`check_blocked=True`, single `--until idle`). `herdr_list_agents` uses the same factory.
3. Tests assert send argv (and leftover localhost list `Authorization`) against the configured remote — not `"prompt" in argv`.

## Constraints
- Coordinates #463 SSH shape: this PR is “the stub works,” not a new SSH hop. `from_remote_config` still routes remote Herdr through the existing SSH transport.
- No live LAN in CI. CLI is mocked; SSH stays stubbed.
- Own-diff CI: `.github/workflows/req171c5-one-herdr-client.yml`
- No Neon, no secrets, no `:8001`.

Fixes #614

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-125f6351-4c71-47e0-95b9-a29f6c76ba96?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-125f6351-4c71-47e0-95b9-a29f6c76ba96&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

