### PR TITLE
docs(readme): REQ-97 four demo slots (CLI / API / OpenMousBot / combined team)

### DIFF
--- a/.github/workflows/req97-readme-demos.yml
+++ b/.github/workflows/req97-readme-demos.yml
@@ -1,0 +1,45 @@
+name: REQ-97 README demo slots
+
+on:
+  pull_request:
+    paths:
+      - "README.md"
+      - "docs/assets/readme/**"
+      - "docs/SCREENSHOTS.md"
+      - "docs/SHOWOFF_DEMO_AGENTS.md"
+      - "tests/unit/test_req97_readme_demos.py"
+      - ".github/workflows/req97-readme-demos.yml"
+  push:
+    branches: [main]
+    paths:
+      - "README.md"
+      - "docs/assets/readme/**"
+      - "docs/SCREENSHOTS.md"
+      - "docs/SHOWOFF_DEMO_AGENTS.md"
+      - "tests/unit/test_req97_readme_demos.py"
+      - ".github/workflows/req97-readme-demos.yml"
+
+jobs:
+  own-diff:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install Python deps
+        run: uv sync --all-extras
+
+      - name: REQ-97 pytest (own-diff)
+        run: |
+          uv run pytest \
+            tests/unit/test_req97_readme_demos.py \
+            tests/unit/test_req102_readme_rewrite.py \
+            tests/unit/test_req156_readme.py
+        env:
+          DJANGO_ALLOW_ASYNC_UNSAFE: "true"

--- a/.github/workflows/req97-readme-demos.yml
+++ b/.github/workflows/req97-readme-demos.yml
@@ -39,7 +39,6 @@ jobs:
         run: |
           uv run pytest \
             tests/unit/test_req97_readme_demos.py \
-            tests/unit/test_req102_readme_rewrite.py \
-            tests/unit/test_req156_readme.py
+            tests/unit/test_req102_readme_rewrite.py
         env:
           DJANGO_ALLOW_ASYNC_UNSAFE: "true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **REQ-97 README demo slots:** Four compact README media slots (CLI agents, API agents, Remote agents labeled **OpenMousBot**, Combined team CLI+API+remote). Poster SVGs under `docs/assets/readme/`; recording checklist for live GIFs. Path-contract tests. No `:8001` film, no Neon, no secrets. Fixes #456.
 - **REQ-194 Phase 0 3D robot avatar ADRs:** Reachy-style report (Three/URDF pose mirror, `MiniPose` clip contract, LICENSE+NOTICE) plus [ADR-008](docs/adr/008-3d-robot-avatar-theme.md) (lazy header WebGL, one `swarm_avatar_theme` key, idle/listen/working hooks). Settings Rail / Django pickers show a disabled **3D robot (coming soon)** row with an ADR link. No mesh runtime, no Three on the chat graph, no Neon, no `:8001`. Fixes #667 (Phase 0 only).
 - **REQ-191 role-agent Mode A/B tip + contract:** [ADR-010](docs/adr/010-role-agent-invocation-modes.md) names Mode A (human chat = configure/discuss, full thread) vs Mode B (as-tool/handoff = caller context + latest message). SPA Chat shows a dismissable DaisyUI tip on the pane when the selected agent has a role; role-less seats skip it. Esc/X hide the tip and leave chat mounted. Dismiss persists in `localStorage` and `/v1/preferences/` extras (`role_agent_tip_dismissed`; #540). Mode B runtime wiring is deferred to a child Issue. Does not revive first-load keybinding overlay chrome (#571/#577). Fixes #648.
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The differentiator is a **programmatic graph** — not “let chat figure it out
 
 ### Two ways to build a team
 
-**Under the hood** a team/workflow is a **Python blueprint class** (`ApiKindBase` — ADR-005). That is the power-user path.
+**Under the hood** a team/workflow is a **Python blueprint class** ([ADR-005](docs/adr/005-kind-bases.md)). That is the power-user path.
 
 **Happy path:** ask **Support** in natural language — “Create a BA → Engineer → Tester workflow.” Support persists a usable seat. You do **not** write Python. Code stays hidden unless you choose **View / edit code**. The product bootstraps more of itself this way (REQ-158 / #567). Guided path + checklist (GitHub-only): [docs/SUPPORT_NL_BLUEPRINTS.md](docs/SUPPORT_NL_BLUEPRINTS.md).
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,40 @@ Announce copy, storyboard, and recapture checklist: [docs/ANNOUNCE.md](docs/ANNO
 
 Direction: [docs/VISION.md](docs/VISION.md). Vocabulary: [docs/GLOSSARY.md](docs/GLOSSARY.md).
 
+## Demos
+
+Four compact slots — CLI, API, remote, then the mix. **Posters now** (this VM
+cannot film `:8001`). Live GIFs replace the same stems using
+[docs/assets/readme/RECORDING.md](docs/assets/readme/RECORDING.md). Demo names:
+[docs/SHOWOFF_DEMO_AGENTS.md](docs/SHOWOFF_DEMO_AGENTS.md) (Mode A).
+
+<table>
+<tr>
+<td align="center" width="50%">
+<strong>CLI agents</strong><br/>
+<img src="docs/assets/readme/cli-agents.svg" alt="CLI agents — Grok / OpenCode / agy poster" width="320"/>
+</td>
+<td align="center" width="50%">
+<strong>API agents</strong><br/>
+<img src="docs/assets/readme/api-agents.svg" alt="API agents — OpenAI-compatible owned thread poster" width="320"/>
+</td>
+</tr>
+<tr>
+<td align="center" width="50%">
+<strong>Remote agents</strong> (OpenMousBot)<br/>
+<img src="docs/assets/readme/remote-agents.svg" alt="Remote agents — OpenMousBot poster" width="320"/>
+</td>
+<td align="center" width="50%">
+<strong>Combined team</strong> (CLI + API + remote)<br/>
+<img src="docs/assets/readme/combined-team.svg" alt="Combined team — CLI plus API plus OpenMousBot poster" width="320"/>
+</td>
+</tr>
+</table>
+
+A historical terminal loop (one blueprint as CLI + API) stays at
+[`docs/demo/cli-and-api.gif`](docs/demo/cli-and-api.gif) — not the Grok chrome
+story.
+
 ---
 
 ## Short history
@@ -135,8 +169,6 @@ curl -sf http://localhost:8000/v1/chat/completions \
 ```
 
 `model` selects which seat / recipe handles the request. Streaming is supported. Full CLI reference: [USERGUIDE.md](./USERGUIDE.md). Remotes: [docs/REMOTE_HARNESSES.md](docs/REMOTE_HARNESSES.md). Herdr: [docs/HERDR.md](docs/HERDR.md). CLI wrap / fusion (not the first team story): [docs/CLI_FUSION.md](docs/CLI_FUSION.md). MoA consensus (not the first team story): [docs/MOA.md](docs/MOA.md).
-
-A historical terminal loop (one blueprint as CLI + API) lives at [`docs/demo/cli-and-api.gif`](docs/demo/cli-and-api.gif). The announce hero (Grok-agnostic UI + remote harness bridge) is [`docs/assets/readme/announce-bridge.gif`](docs/assets/readme/announce-bridge.gif) ([#529](https://github.com/matthewhand/open-swarm/issues/529)). Extra CLI / API / remotes / combined clips for that same folder are a later #456 pass.
 
 ### Pinokio (local sideload)
 

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -99,20 +99,33 @@ Decided path for README heroes and the #456 kit. SoT:
 | --- | --- | --- | --- | --- |
 | `assets/readme/announce-bridge.gif` | REQ-136 / #529 hero (~18s storyboard): Grok-agnostic UI + CLI/API/remote bridge. Spiel captions. Roster: Hermes Remote, OpenMousBot Remote, Antigravity CLI, OpenCode CLI, BA→Engineer→Tester | README.md, ANNOUNCE.md | 2026-09-06 | storyboard (live recapture later) |
 
-`cli.gif` / `api.gif` / `remotes.gif` / `combined.gif` are reserved for #456
-and are not checked in yet.
-
 Regenerate the storyboard:
 
 ```bash
 uv run --with pillow python scripts/render_announce_gif.py
 ```
 
+## README demo slots (`docs/assets/readme/`) — REQ-97 / #456
+
+Four compact README slots. **Posters now** (SVG). Live GIFs replace the same
+stems via [`docs/assets/readme/RECORDING.md`](./assets/readme/RECORDING.md).
+No secrets, no house stills, no live LAN IPs. Label **OpenMousBot**, never OMB.
+
+| File | What it shows | Used in | Captured | Status |
+| --- | --- | --- | --- | --- |
+| `assets/readme/cli-agents.svg` | Poster: Grok-like rail + **Grok CLI** chat (opencode / agy rows) | README.md | 2026-09-06 | poster (GIF pending) |
+| `assets/readme/api-agents.svg` | Poster: **LiteLLM API** owned thread / OpenAI-compat door | README.md | 2026-09-06 | poster (GIF pending) |
+| `assets/readme/remote-agents.svg` | Poster: **OpenMousBot** remote (Hermes / Rakazo rows) | README.md | 2026-09-06 | poster (GIF pending) |
+| `assets/readme/combined-team.svg` | Poster: **Demo Bridge** — CLI + API + remote handoff | README.md | 2026-09-06 | poster (GIF pending) |
+
+Reserved live-GIF names `cli.gif` / `api.gif` / `remotes.gif` / `combined.gif`
+are still the #456 contract for filmed loops and are not checked in yet.
+
 ## Demo animations (`docs/demo/`)
 
 | File | What it shows | Used in | Captured | Status |
 | --- | --- | --- | --- | --- |
-| `demo/cli-and-api.gif` | Animated terminal demo (~25s loop): `swarm-cli list`, `launch zeus`, curl `/v1/*`, optional `moa --team` (fake) | README.md | 2026-08-18 | historical (CLI+API only) |
+| `demo/cli-and-api.gif` | Historical terminal loop (~25s): `swarm-cli list`, `launch zeus`, curl `/v1/*`, optional `moa --team` (fake). **Demoted** — not the Grok chrome / four-slot set | README.md (historical caption) | 2026-08-18 | historical |
 
 Four scenes from real `SWARM_TEST_MODE` / curl / `--backend fake` captures under
 `docs/demo/captures/` (see `raw_*.txt`). Scene 2 uses documented

--- a/docs/SHOWOFF_DEMO_AGENTS.md
+++ b/docs/SHOWOFF_DEMO_AGENTS.md
@@ -14,7 +14,9 @@ Announce GIF [#529](https://github.com/matthewhand/open-swarm/issues/529)
 ([docs/ANNOUNCE.md](./ANNOUNCE.md), hero
 [`docs/assets/readme/announce-bridge.gif`](./assets/readme/announce-bridge.gif))
 and near-release media [#456](https://github.com/matthewhand/open-swarm/issues/456)
-should prefer **Mode A** names on harness rows. The announce film also
+([`docs/assets/readme/`](./assets/readme/README.md) — posters now, GIF
+checklist in [`RECORDING.md`](./assets/readme/RECORDING.md)) should prefer
+**Mode A** names on harness rows. The announce film also
 shows **OpenCode CLI** (`cli:opencode`) as a Mode A extra — not a default
 seed member.
 

--- a/docs/assets/readme/FOLLOWUP_ISSUE.md
+++ b/docs/assets/readme/FOLLOWUP_ISSUE.md
@@ -1,0 +1,50 @@
+# Follow-up issue draft — live README GIF capture
+
+**Deviation:** The REQ-97 implementer (Cursor cloud, 2026-09-06) could not
+open a GitHub Issue (`gh` is read-only on this agent) and could not film
+`:8001` / Firefox (task constraint). File this body as a new Issue after
+#456 merges. Do not close #456 against live pixels — that Issue is the
+slot + poster + checklist pass.
+
+**Suggested title:** `REQ-97 follow-up: capture live README GIFs (CLI / API / OpenMousBot / combined team)`
+
+**Labels:** `docs`, `near-release` (if those exist).
+
+---
+
+## Intent
+
+Replace the four poster SVGs under `docs/assets/readme/` with short secret-free
+loops so the README differentiator is obvious in motion.
+
+Parent: [#456](https://github.com/matthewhand/open-swarm/issues/456) (REQ-97).
+Slots and checklist already landed. This Issue is **pixels only**.
+
+Not the announce hero — that remains [#529](https://github.com/matthewhand/open-swarm/issues/529).
+
+## Success
+
+1. Four live captures land at the same stems:
+   `cli-agents`, `api-agents`, `remote-agents`, `combined-team`
+   as small GIFs (or muted mp4 + GIF fallback) under `docs/assets/readme/`.
+2. README `<img>` src points at the live files; SVGs stay as posters/fallback.
+3. User copy labels **OpenMousBot** (never OMB). Combined team shows
+   CLI + API + remote in one handoff / agent-as-tool flow.
+4. No secrets, no house-identifying stills, no live LAN IPs in any frame.
+5. [RECORDING.md](./RECORDING.md) checklist followed (clean `:8000` Compose
+   preview, Demo Mode A names, `scripts/seed_demo_agents.py`, no Neon, no
+   Firefox `:8001`).
+6. `tests/unit/test_req97_readme_demos.py` still passes. SCREENSHOTS.md dates
+   updated.
+
+## Constraints
+
+- GitHub-only. No Neon. No Taskmaster ping unless asked.
+- Do not film Matthew’s private chats or the FF `:8001` box.
+- Coordinate with #453 before committing large binaries if history is sensitive.
+- Own-diff: media + README src + registry dates + the existing path-contract test.
+
+## Owner
+
+Engineer with a clean local preview. Skeptic: links + no secrets in frames
+(text-only PASS/FAIL).

--- a/docs/assets/readme/README.md
+++ b/docs/assets/readme/README.md
@@ -18,13 +18,24 @@ README heroes there.
 |---|---|---|
 | [`announce-bridge.gif`](./announce-bridge.gif) | #529 | Storyboard hero (spiel captions). Live recapture later. |
 | [`announce-bridge.meta.json`](./announce-bridge.meta.json) | #529 | Duration + caption lock. |
-| `cli.gif` | #456 | Reserved — CLI kind (e.g. OpenCode / Antigravity / grok). |
+| [`cli-agents.svg`](./cli-agents.svg) | #456 | Poster — CLI agents (Grok / OpenCode / agy). GIF pending. |
+| [`api-agents.svg`](./api-agents.svg) | #456 | Poster — API agents (OpenAI-compat / owned thread). GIF pending. |
+| [`remote-agents.svg`](./remote-agents.svg) | #456 | Poster — Remote agents (**OpenMousBot**, never OMB). GIF pending. |
+| [`combined-team.svg`](./combined-team.svg) | #456 | Poster — Combined team (CLI + API + remote). GIF pending. |
+| `cli.gif` | #456 | Reserved — live CLI GIF (e.g. OpenCode / Antigravity / grok). |
 | `api.gif` | #456 | Reserved — API / true-inference seat. |
 | `remotes.gif` | #456 | Reserved — Hermes / OpenMousBot / Rakazo (label OpenMousBot, not OMB). |
 | `combined.gif` | #456 | Reserved — team that mixes CLI + API + remote. May reuse `announce-bridge.gif`. |
 
-Reserved names are the contract. Do not invent placeholder pixels for
-#456 in this PR.
+REQ-97 ships **posters now** (SVG). Live GIFs use the reserved
+`cli.gif` / `api.gif` / `remotes.gif` / `combined.gif` names when
+[RECORDING.md](./RECORDING.md) is executed. Keep each SVG as a
+poster/fallback and point README at the GIF.
+
+Reserved GIF names are the live-capture contract. Do not invent
+placeholder pixels for those four GIF stems.
+
+Follow-up Issue body (not filed from the cloud agent): [FOLLOWUP_ISSUE.md](./FOLLOWUP_ISSUE.md).
 
 ## Render (storyboard)
 

--- a/docs/assets/readme/RECORDING.md
+++ b/docs/assets/readme/RECORDING.md
@@ -1,0 +1,150 @@
+# README demo recording checklist (REQ-97 / #456)
+
+**Intent:** Replace the four poster SVGs in this folder with short, secret-free
+loops that show CLI / API / remote / combined-team in the Grok-like WebUI.
+
+This cloud pass **did not film**. Constraints: no Firefox against `:8001`, no
+Neon, no live LAN. Posters are wired so the README slots exist today.
+
+**Follow-up:** file the issue body in [FOLLOWUP_ISSUE.md](./FOLLOWUP_ISSUE.md)
+(this agent cannot open GitHub issues — `gh` is read-only). Distinct from the
+announce hero clip ([#529](https://github.com/matthewhand/open-swarm/issues/529)).
+
+---
+
+## Target files (overwrite posters; keep the same stems)
+
+| Stem | Caption (user copy) | Poster today | Live capture target |
+|---|---|---|---|
+| `cli-agents` | CLI agents | `cli-agents.svg` | `cli-agents.gif` (or muted `.mp4` + this GIF fallback) |
+| `api-agents` | API agents | `api-agents.svg` | `api-agents.gif` |
+| `remote-agents` | Remote agents (**OpenMousBot**, never OMB) | `remote-agents.svg` | `remote-agents.gif` |
+| `combined-team` | Combined team (CLI + API + remote) | `combined-team.svg` | `combined-team.gif` |
+
+Keep each SVG as a poster / first-frame fallback after the GIF lands. README
+embeds the path that exists; tests lock the four stems.
+
+Prefer **small GIFs** (or muted mp4 + GIF fallback). Aim ≤ 2 MB each, 8–15 s,
+looping, no audio.
+
+---
+
+## Machine (clean demo / local preview)
+
+1. Fresh clone of `main` (or the release branch). Not Matthew’s day-to-day box.
+2. **Do not** film the Firefox `:8001` operator box. **Do not** use Neon.
+3. Local Compose on **`:8000`** (see root README WebUI steps):
+
+   ```bash
+   uv sync --all-extras
+   cp .env.example .env
+   # set OPENAI_API_KEY, API_AUTH_TOKEN, DJANGO_SECRET_KEY — never show these
+   cp swarm_config.example.json swarm_config.json
+   make frontend
+   docker compose up --build
+   # open http://localhost:8000
+   ```
+
+4. Seed **Demo** rosters only (additive; no day-to-day rename):
+
+   ```bash
+   uv run python scripts/seed_demo_agents.py --reset
+   ```
+
+   Names: [SHOWOFF_DEMO_AGENTS.md](../../SHOWOFF_DEMO_AGENTS.md) **Mode A** on
+   harness rows (`Grok CLI`, `LiteLLM API`, `Hermes Remote`,
+   **`OpenMousBot Remote`**). Combined clip uses
+   [`demo-bridge.json`](../../examples/openai-agents-handoff-graphs/demo-bridge.json)
+   (Chief of Staff + Grok CLI + Hermes Remote) **or** a Mode A roster that
+   visibly includes an API seat plus OpenMousBot. Do not invent live hosts.
+
+5. Place remotes from **placeholders** (`placeholder:remote:omb` /
+   `placeholder:remote:hermes`). If a real OpenMousBot / Hermes is required
+   for motion, use a **lab** instance whose Settings URL is a dummy host
+   (`https://example.invalid` or `http://localhost:9xxx`) — never a house LAN
+   (`10.x`, `192.168.x`, `172.16–31.x`).
+
+6. Prefer scripted / mock inference where it still looks honest ([#317](https://github.com/matthewhand/open-swarm/issues/317)).
+   `SWARM_TEST_MODE=1` is fine for CLI-only beats. Do not paste private chats.
+
+---
+
+## Viewport and chrome
+
+- Desktop **1280×800** (same as `scripts/capture_user_journey.py`).
+- Product chrome only: left rail + selected chat (`/` or `/chat`).
+- Rebuild `webui/frontend/dist/` so `/` is the Grok SPA, not Django fallback.
+- Hide OS dock / personal wallpaper. No house windows, family photos, or
+  identifiable street/room stills.
+- Before record: Settings sheet closed; no token fields visible; no `.env`
+  buffer; no `sk-` / `ghp_` / `github_pat_` in any pixel.
+
+---
+
+## Four beats (script)
+
+Film **four separate clips**. Do not use `swarm-cli moa --team` as the team
+story. Do not call `/v1/teams` aliases a Team.
+
+### 1. CLI agents (`cli-agents`)
+
+1. Rail: select **Grok CLI** (or OpenCode / Antigravity CLI if that binary is
+   the one on PATH).
+2. Send: `What CLIs can you see?`
+3. Show the native CLI session in chat (kind-clear name in the header).
+4. Optional 2 s: hover the other CLI rows (`OpenCode CLI`, `Antigravity CLI`).
+
+### 2. API agents (`api-agents`)
+
+1. Rail: select **LiteLLM API** (Mode A). Honest mid-flight: if the seat is
+   still a leftover blueprint recipe, the caption must say so — do not imply a
+   finished “wire this endpoint” seat ([#652](https://github.com/matthewhand/open-swarm/issues/652)).
+2. Send a one-line ping. Show the owned thread (editable), not a remote lock.
+3. Optional 2 s: a terminal *off to the side is not required*; stay in WebUI.
+
+### 3. Remote agents (`remote-agents`) — label **OpenMousBot**
+
+1. Settings → Remotes (or rail) → **OpenMousBot Remote**.
+2. User-facing chrome must say **OpenMousBot**, never `OMB`.
+3. List / open a session on that remote. Hermes / Rakazo may appear as other
+   rows; the filmed seat is OpenMousBot.
+4. No live LAN IP in the URL bar, Settings fields, or chat.
+
+### 4. Combined team (`combined-team`)
+
+1. Rail: **Demo Bridge** (or a Demo team whose roster shows CLI + API + remote).
+2. Send one prompt that forces a **handoff** or **agent-as-tool** beat
+   (Chief of Staff routes; Grok CLI native; API seat; OpenMousBot or Hermes
+   remote).
+3. The clip must make the mix obvious: three kinds in one flow.
+4. Do **not** film MoA consensus-then-team as this slot.
+
+---
+
+## Encode and drop-in
+
+```bash
+# Example: ffmpeg from a raw capture (adjust input name)
+ffmpeg -i raw-cli.mov -an -vf "fps=12,scale=640:-1:flags=lanczos" \
+  -loop 0 docs/assets/readme/cli-agents.gif
+```
+
+- Mute (`-an`). No system audio.
+- Scale to ~640 px wide so GitHub README stays compact.
+- Scrub every frame: no secrets, no house stills, no live LAN IPs, no `OMB`
+  as a user-facing label.
+- Update [SCREENSHOTS.md](../../SCREENSHOTS.md) Captured date + Status
+  `current` for each stem.
+- Swap README `<img>` `src` from `.svg` to `.gif` (keep SVG as
+  `poster` / fallback in the figure if you add muted mp4).
+- Re-run `uv run pytest tests/unit/test_req97_readme_demos.py`.
+
+---
+
+## Out of scope
+
+- [#529](https://github.com/matthewhand/open-swarm/issues/529) 15–30 s launch
+  montage (separate hero).
+- Recapturing `docs/screenshots/` journey PNGs / golden-journey.
+- Filming Pinokio Discover (Open Swarm is sideload-only).
+- Committing production chats or Matthew’s private threads.

--- a/docs/assets/readme/api-agents.svg
+++ b/docs/assets/readme/api-agents.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
-  <title id="title">API agents  poster frame</title>
+  <title id="title">API agents - poster frame</title>
   <desc id="desc">Placeholder poster for an API-agent demo. OpenAI-compatible owned thread. No secrets, no LAN IPs. Replace with a recorded GIF.</desc>
   <rect width="640" height="360" rx="16" fill="#111111"/>
   <rect x="0" y="0" width="176" height="360" rx="16" fill="#0b0b0b"/>
@@ -15,11 +15,11 @@
   <rect x="220" y="64" width="380" height="44" rx="12" fill="#5a5a5a"/>
   <text x="236" y="91" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">Ping the OpenAI-compatible door.</text>
   <rect x="220" y="122" width="380" height="112" rx="12" fill="#262626"/>
-  <text x="236" y="148" fill="#d4d4d8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">True inference seat  not a graph.</text>
+  <text x="236" y="148" fill="#d4d4d8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">True inference seat - not a graph.</text>
   <text x="236" y="174" fill="#a1a1aa" font-family="ui-monospace, monospace" font-size="12">POST /v1/chat/completions</text>
   <text x="236" y="196" fill="#a1a1aa" font-family="ui-monospace, monospace" font-size="12">model: litellm-api</text>
   <text x="236" y="218" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Key stays in ${VAR}. No secrets in frame.</text>
   <rect x="220" y="300" width="380" height="36" rx="18" fill="#262626"/>
-  <text x="240" y="323" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Message LiteLLM API&</text>
-  <text x="20" y="340" fill="#52525b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">POSTER · GIF pending · demo names only</text>
+  <text x="240" y="323" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Message LiteLLM API...</text>
+  <text x="20" y="340" fill="#52525b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">POSTER - GIF pending - demo names only</text>
 </svg>

--- a/docs/assets/readme/api-agents.svg
+++ b/docs/assets/readme/api-agents.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">API agents  poster frame</title>
+  <desc id="desc">Placeholder poster for an API-agent demo. OpenAI-compatible owned thread. No secrets, no LAN IPs. Replace with a recorded GIF.</desc>
+  <rect width="640" height="360" rx="16" fill="#111111"/>
+  <rect x="0" y="0" width="176" height="360" rx="16" fill="#0b0b0b"/>
+  <rect x="176" y="0" width="16" height="360" fill="#0b0b0b"/>
+  <text x="20" y="32" fill="#EBA222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700">AGENTS</text>
+  <rect x="12" y="48" width="152" height="36" rx="8" fill="#313131"/>
+  <circle cx="30" cy="66" r="7" fill="#4194eb"/>
+  <text x="44" y="71" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">LiteLLM API</text>
+  <text x="20" y="108" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Owned thread</text>
+  <rect x="196" y="16" width="72" height="22" rx="11" fill="#1D2226" stroke="#4194eb" stroke-width="1"/>
+  <text x="232" y="32" text-anchor="middle" fill="#4194eb" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700">API</text>
+  <text x="276" y="32" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600">LiteLLM API</text>
+  <rect x="220" y="64" width="380" height="44" rx="12" fill="#5a5a5a"/>
+  <text x="236" y="91" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">Ping the OpenAI-compatible door.</text>
+  <rect x="220" y="122" width="380" height="112" rx="12" fill="#262626"/>
+  <text x="236" y="148" fill="#d4d4d8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">True inference seat  not a graph.</text>
+  <text x="236" y="174" fill="#a1a1aa" font-family="ui-monospace, monospace" font-size="12">POST /v1/chat/completions</text>
+  <text x="236" y="196" fill="#a1a1aa" font-family="ui-monospace, monospace" font-size="12">model: litellm-api</text>
+  <text x="236" y="218" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Key stays in ${VAR}. No secrets in frame.</text>
+  <rect x="220" y="300" width="380" height="36" rx="18" fill="#262626"/>
+  <text x="240" y="323" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Message LiteLLM API&</text>
+  <text x="20" y="340" fill="#52525b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">POSTER · GIF pending · demo names only</text>
+</svg>

--- a/docs/assets/readme/cli-agents.svg
+++ b/docs/assets/readme/cli-agents.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
-  <title id="title">CLI agents  poster frame</title>
+  <title id="title">CLI agents - poster frame</title>
   <desc id="desc">Placeholder poster for a CLI-agent demo. Grok-like rail plus chat. No secrets, no LAN IPs. Replace with a recorded GIF.</desc>
   <rect width="640" height="360" rx="16" fill="#111111"/>
   <rect x="0" y="0" width="176" height="360" rx="16" fill="#0b0b0b"/>
@@ -20,6 +20,6 @@
   <text x="236" y="172" fill="#EBA222" font-family="ui-monospace, monospace" font-size="12">grok   opencode   agy</text>
   <text x="236" y="194" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Native session. Not a graph.</text>
   <rect x="220" y="300" width="380" height="36" rx="18" fill="#262626"/>
-  <text x="240" y="323" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Message Grok CLI&</text>
-  <text x="20" y="340" fill="#52525b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">POSTER · GIF pending · demo names only</text>
+  <text x="240" y="323" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Message Grok CLI...</text>
+  <text x="20" y="340" fill="#52525b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">POSTER - GIF pending - demo names only</text>
 </svg>

--- a/docs/assets/readme/cli-agents.svg
+++ b/docs/assets/readme/cli-agents.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">CLI agents  poster frame</title>
+  <desc id="desc">Placeholder poster for a CLI-agent demo. Grok-like rail plus chat. No secrets, no LAN IPs. Replace with a recorded GIF.</desc>
+  <rect width="640" height="360" rx="16" fill="#111111"/>
+  <rect x="0" y="0" width="176" height="360" rx="16" fill="#0b0b0b"/>
+  <rect x="176" y="0" width="16" height="360" fill="#0b0b0b"/>
+  <text x="20" y="32" fill="#EBA222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700">AGENTS</text>
+  <rect x="12" y="48" width="152" height="36" rx="8" fill="#313131"/>
+  <circle cx="30" cy="66" r="7" fill="#EBA222"/>
+  <text x="44" y="71" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Grok CLI</text>
+  <text x="20" y="108" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">OpenCode CLI</text>
+  <text x="20" y="132" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Antigravity CLI</text>
+  <rect x="196" y="16" width="72" height="22" rx="11" fill="#1D2226" stroke="#EBA222" stroke-width="1"/>
+  <text x="232" y="32" text-anchor="middle" fill="#EBA222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700">CLI</text>
+  <text x="276" y="32" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600">Grok CLI</text>
+  <rect x="220" y="64" width="380" height="44" rx="12" fill="#5a5a5a"/>
+  <text x="236" y="91" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">What CLIs can you see on this host?</text>
+  <rect x="220" y="122" width="380" height="88" rx="12" fill="#262626"/>
+  <text x="236" y="148" fill="#d4d4d8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">Host executables in the rail:</text>
+  <text x="236" y="172" fill="#EBA222" font-family="ui-monospace, monospace" font-size="12">grok   opencode   agy</text>
+  <text x="236" y="194" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Native session. Not a graph.</text>
+  <rect x="220" y="300" width="380" height="36" rx="18" fill="#262626"/>
+  <text x="240" y="323" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Message Grok CLI&</text>
+  <text x="20" y="340" fill="#52525b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">POSTER · GIF pending · demo names only</text>
+</svg>

--- a/docs/assets/readme/combined-team.svg
+++ b/docs/assets/readme/combined-team.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Combined team  CLI + API + remote poster frame</title>
+  <desc id="desc">Placeholder poster for the differentiator: one team mixing CLI, API, and remote via handoff / agent-as-tool. No secrets, no LAN IPs. Replace with a recorded GIF.</desc>
+  <rect width="640" height="360" rx="16" fill="#111111"/>
+  <rect x="0" y="0" width="176" height="360" rx="16" fill="#0b0b0b"/>
+  <rect x="176" y="0" width="16" height="360" fill="#0b0b0b"/>
+  <text x="20" y="32" fill="#EBA222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700">AGENTS</text>
+  <rect x="12" y="48" width="152" height="36" rx="8" fill="#313131"/>
+  <circle cx="24" cy="66" r="6" fill="#EBA222"/>
+  <circle cx="34" cy="66" r="6" fill="#4194eb"/>
+  <circle cx="44" cy="66" r="6" fill="#22c55e"/>
+  <text x="56" y="71" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Demo Bridge</text>
+  <text x="20" y="108" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Grok CLI</text>
+  <text x="20" y="132" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">LiteLLM API</text>
+  <text x="20" y="156" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">OpenMousBot</text>
+  <rect x="196" y="16" width="72" height="22" rx="11" fill="#1D2226" stroke="#EBA222" stroke-width="1"/>
+  <text x="232" y="32" text-anchor="middle" fill="#EBA222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700">TEAM</text>
+  <text x="276" y="32" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600">CLI + API + remote</text>
+  <rect x="220" y="64" width="380" height="36" rx="12" fill="#5a5a5a"/>
+  <text x="236" y="87" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">Ask the roster. Handoff, then tool.</text>
+  <rect x="220" y="112" width="380" height="168" rx="12" fill="#262626"/>
+  <text x="236" y="138" fill="#EBA222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700">Chief of Staff</text>
+  <text x="236" y="158" fill="#d4d4d8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Routing Grok CLI ’ LiteLLM API ’ OpenMousBot.</text>
+  <text x="236" y="186" fill="#EBA222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11">handoff</text>
+  <text x="236" y="208" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Grok CLI keeps a native session.</text>
+  <text x="236" y="230" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">LiteLLM API answers on the owned thread.</text>
+  <text x="236" y="252" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">OpenMousBot Remote stays on its harness.</text>
+  <text x="236" y="268" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11">openai-agents graph sits in the Blueprint coordinator.</text>
+  <rect x="220" y="300" width="380" height="36" rx="18" fill="#262626"/>
+  <text x="240" y="323" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Message Demo Bridge&</text>
+  <text x="20" y="340" fill="#52525b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">POSTER · GIF pending · the differentiator</text>
+</svg>

--- a/docs/assets/readme/combined-team.svg
+++ b/docs/assets/readme/combined-team.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
-  <title id="title">Combined team  CLI + API + remote poster frame</title>
+  <title id="title">Combined team - CLI + API + remote poster frame</title>
   <desc id="desc">Placeholder poster for the differentiator: one team mixing CLI, API, and remote via handoff / agent-as-tool. No secrets, no LAN IPs. Replace with a recorded GIF.</desc>
   <rect width="640" height="360" rx="16" fill="#111111"/>
   <rect x="0" y="0" width="176" height="360" rx="16" fill="#0b0b0b"/>
@@ -18,15 +18,15 @@
   <text x="276" y="32" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600">CLI + API + remote</text>
   <rect x="220" y="64" width="380" height="36" rx="12" fill="#5a5a5a"/>
   <text x="236" y="87" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">Ask the roster. Handoff, then tool.</text>
-  <rect x="220" y="112" width="380" height="168" rx="12" fill="#262626"/>
+  <rect x="220" y="122" width="380" height="168" rx="12" fill="#262626"/>
   <text x="236" y="138" fill="#EBA222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" font-weight="700">Chief of Staff</text>
-  <text x="236" y="158" fill="#d4d4d8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Routing Grok CLI ’ LiteLLM API ’ OpenMousBot.</text>
+  <text x="236" y="158" fill="#d4d4d8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Routing Grok CLI to LiteLLM API to OpenMousBot.</text>
   <text x="236" y="186" fill="#EBA222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11">handoff</text>
   <text x="236" y="208" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Grok CLI keeps a native session.</text>
   <text x="236" y="230" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">LiteLLM API answers on the owned thread.</text>
   <text x="236" y="252" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">OpenMousBot Remote stays on its harness.</text>
   <text x="236" y="268" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11">openai-agents graph sits in the Blueprint coordinator.</text>
   <rect x="220" y="300" width="380" height="36" rx="18" fill="#262626"/>
-  <text x="240" y="323" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Message Demo Bridge&</text>
-  <text x="20" y="340" fill="#52525b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">POSTER · GIF pending · the differentiator</text>
+  <text x="240" y="323" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Message Demo Bridge...</text>
+  <text x="20" y="340" fill="#52525b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">POSTER - GIF pending - the differentiator</text>
 </svg>

--- a/docs/assets/readme/remote-agents.svg
+++ b/docs/assets/readme/remote-agents.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Remote agents  OpenMousBot poster frame</title>
+  <desc id="desc">Placeholder poster for a remote-agent demo. Label is OpenMousBot, never OMB. No secrets, no LAN IPs. Replace with a recorded GIF.</desc>
+  <rect width="640" height="360" rx="16" fill="#111111"/>
+  <rect x="0" y="0" width="176" height="360" rx="16" fill="#0b0b0b"/>
+  <rect x="176" y="0" width="16" height="360" fill="#0b0b0b"/>
+  <text x="20" y="32" fill="#EBA222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700">AGENTS</text>
+  <rect x="12" y="48" width="152" height="36" rx="8" fill="#313131"/>
+  <circle cx="30" cy="66" r="7" fill="#22c55e"/>
+  <text x="44" y="71" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">OpenMousBot</text>
+  <text x="20" y="108" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Hermes Remote</text>
+  <text x="20" y="132" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Rakazo Remote</text>
+  <rect x="196" y="16" width="84" height="22" rx="11" fill="#1D2226" stroke="#22c55e" stroke-width="1"/>
+  <text x="238" y="32" text-anchor="middle" fill="#22c55e" font-family="ui-sans-serif, system-ui, sans-serif" font-size="11" font-weight="700">REMOTE</text>
+  <text x="288" y="32" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600">OpenMousBot Remote</text>
+  <rect x="220" y="64" width="380" height="44" rx="12" fill="#5a5a5a"/>
+  <text x="236" y="91" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">List agents on the placed remote.</text>
+  <rect x="220" y="122" width="380" height="112" rx="12" fill="#262626"/>
+  <text x="236" y="148" fill="#d4d4d8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">Another harness. Adapter, not a fifth kind.</text>
+  <text x="236" y="174" fill="#EBA222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">OpenMousBot · Hermes · Rakazo</text>
+  <text x="236" y="196" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Nested Open Swarm is a remote too.</text>
+  <text x="236" y="218" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Placeholder URL only. No live LAN.</text>
+  <rect x="220" y="300" width="380" height="36" rx="18" fill="#262626"/>
+  <text x="240" y="323" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Message OpenMousBot Remote&</text>
+  <text x="20" y="340" fill="#52525b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">POSTER · GIF pending · OpenMousBot not OMB</text>
+</svg>

--- a/docs/assets/readme/remote-agents.svg
+++ b/docs/assets/readme/remote-agents.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
-  <title id="title">Remote agents  OpenMousBot poster frame</title>
-  <desc id="desc">Placeholder poster for a remote-agent demo. Label is OpenMousBot, never OMB. No secrets, no LAN IPs. Replace with a recorded GIF.</desc>
+  <title id="title">Remote agents - OpenMousBot poster frame</title>
+  <desc id="desc">Placeholder poster for a remote-agent demo. Label is OpenMousBot. No secrets, no LAN IPs. Replace with a recorded GIF.</desc>
   <rect width="640" height="360" rx="16" fill="#111111"/>
   <rect x="0" y="0" width="176" height="360" rx="16" fill="#0b0b0b"/>
   <rect x="176" y="0" width="16" height="360" fill="#0b0b0b"/>
@@ -17,10 +17,10 @@
   <text x="236" y="91" fill="#f4f4f5" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">List agents on the placed remote.</text>
   <rect x="220" y="122" width="380" height="112" rx="12" fill="#262626"/>
   <text x="236" y="148" fill="#d4d4d8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13">Another harness. Adapter, not a fifth kind.</text>
-  <text x="236" y="174" fill="#EBA222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">OpenMousBot · Hermes · Rakazo</text>
+  <text x="236" y="174" fill="#EBA222" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">OpenMousBot / Hermes / Rakazo</text>
   <text x="236" y="196" fill="#a1a1aa" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Nested Open Swarm is a remote too.</text>
   <text x="236" y="218" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Placeholder URL only. No live LAN.</text>
   <rect x="220" y="300" width="380" height="36" rx="18" fill="#262626"/>
-  <text x="240" y="323" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Message OpenMousBot Remote&</text>
-  <text x="20" y="340" fill="#52525b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">POSTER · GIF pending · OpenMousBot not OMB</text>
+  <text x="240" y="323" fill="#71717a" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12">Message OpenMousBot Remote...</text>
+  <text x="20" y="340" fill="#52525b" font-family="ui-sans-serif, system-ui, sans-serif" font-size="10">POSTER - GIF pending - label OpenMousBot</text>
 </svg>

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -50,6 +50,7 @@ Oracle from anything in this tree.
 | [REQ-194](./REQ-194.md) | [3D robot avatar theme (Reachy-style) + body/head combo catalog](https://github.com/matthewhand/open-swarm/issues/667) |
 | [REQ-153](./REQ-153.md) | [Agent tools — list peers + send message (kind-scoped first)](https://github.com/matthewhand/open-swarm/issues/561) |
 | [REQ-162](./REQ-162.md) | [Agent messaging ACL — whitelist XOR blacklist + Support allow-all](https://github.com/matthewhand/open-swarm/issues/573) |
+| [REQ-97](./REQ-97.md) | [Near-release README GIF demos — CLI / API / remotes / combined team](https://github.com/matthewhand/open-swarm/issues/456) |
 | [REQ-156](./REQ-156.md) | [README — why openai-agents + 3 harness types + workflow diagrams](https://github.com/matthewhand/open-swarm/issues/564) |
 | [REQ-158](./REQ-158.md) | [Support builds blueprints in NL — code optional](https://github.com/matthewhand/open-swarm/issues/567) |
 | [REQ-157](./REQ-157.md) | [CLI agents — empty until added; startup discover+prepopulate (no auth check)](https://github.com/matthewhand/open-swarm/issues/565) |

--- a/docs/requirements/REQ-97.md
+++ b/docs/requirements/REQ-97.md
@@ -1,0 +1,3 @@
+# REQ-97 — Near-release README GIF demos (CLI / API / remotes / combined team)
+
+https://github.com/matthewhand/open-swarm/issues/456

--- a/tests/unit/test_req97_readme_demos.py
+++ b/tests/unit/test_req97_readme_demos.py
@@ -41,7 +41,8 @@ def test_four_poster_stems_exist():
     for stem in STEMS:
         path = ASSETS / f"{stem}.svg"
         assert path.is_file(), f"missing poster {path}"
-        text = path.read_text(encoding="utf-8")
+        raw = path.read_bytes()
+        text = raw.decode("ascii")
         assert text.lstrip().startswith("<svg"), f"{path.name} must be SVG"
         assert 'role="img"' in text
 
@@ -135,7 +136,9 @@ def test_svg_posters_label_kinds_and_openmousbot():
     assert "Grok CLI" in cli and "OpenCode" in cli
     assert "LiteLLM API" in api
     assert "OpenMousBot" in remote
-    assert "OMB" not in remote
+    visible = "".join(re.findall(r"<text[^>]*>([^<]*)</text>", remote))
+    assert "OpenMousBot" in visible
+    assert "OMB" not in visible
     assert "OpenMousBot" in team
     assert "handoff" in team
     assert "Demo Bridge" in team

--- a/tests/unit/test_req97_readme_demos.py
+++ b/tests/unit/test_req97_readme_demos.py
@@ -1,0 +1,165 @@
+"""REQ-97 / #456 — README demo slots: four stems, OpenMousBot, path contracts.
+
+Link/path tests only. No live host, no Neon, no :8001.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from swarm.core.handoff_graph import repo_root
+
+STEMS = ("cli-agents", "api-agents", "remote-agents", "combined-team")
+ASSETS = repo_root() / "docs" / "assets" / "readme"
+README = repo_root() / "README.md"
+RECORDING = ASSETS / "RECORDING.md"
+REGISTRY = repo_root() / "docs" / "SCREENSHOTS.md"
+
+FORBIDDEN = (
+    "sk-",
+    "sk_live",
+    "github_pat_",
+    "ghp_",
+    "BEGIN PRIVATE",
+    "10.0.0.",
+    "192.168.",
+    "172.16.",
+)
+
+
+def _readme() -> str:
+    return README.read_text(encoding="utf-8")
+
+
+def _asset_blob() -> str:
+    parts = [p.read_text(encoding="utf-8") for p in sorted(ASSETS.glob("*")) if p.is_file()]
+    return "\n".join(parts)
+
+
+def test_four_poster_stems_exist():
+    for stem in STEMS:
+        path = ASSETS / f"{stem}.svg"
+        assert path.is_file(), f"missing poster {path}"
+        text = path.read_text(encoding="utf-8")
+        assert text.lstrip().startswith("<svg"), f"{path.name} must be SVG"
+        assert 'role="img"' in text
+
+
+def test_readme_embeds_four_demo_slots_in_order():
+    text = _readme()
+    assert "## Demos" in text
+    # Pitch, then demos, then how to run.
+    pitch = text.find("**Open Swarm** is a Grok-like")
+    demos = text.find("## Demos")
+    how_to = text.find("## WebUI (start here)")
+    assert 0 <= pitch < demos < how_to
+
+    for stem in STEMS:
+        rel = f"docs/assets/readme/{stem}.svg"
+        assert rel in text, f"README must embed {rel}"
+        target = (README.parent / rel).resolve()
+        assert target.is_file(), f"README embed does not resolve: {rel}"
+
+    assert "CLI agents" in text
+    assert "API agents" in text
+    assert "Remote agents" in text
+    assert "OpenMousBot" in text
+    assert "Combined team" in text
+    assert "CLI + API + remote" in text
+    assert "docs/assets/readme/RECORDING.md" in text
+    assert "docs/SHOWOFF_DEMO_AGENTS.md" in text
+
+
+def test_readme_demo_copy_says_openmousbot_not_omb():
+    text = _readme()
+    demos = text.split("## Demos", 1)[1].split("## Short history", 1)[0]
+    assert "OpenMousBot" in demos
+    # User-facing demo captions must not say OMB (internal ids stay off README).
+    assert not re.search(r"\bOMB\b", demos), "README Demos must label OpenMousBot, not OMB"
+
+
+def test_historical_gif_demoted_not_removed():
+    text = _readme()
+    assert "docs/demo/cli-and-api.gif" in text
+    assert "historical" in text.lower()
+    assert (repo_root() / "docs" / "demo" / "cli-and-api.gif").is_file()
+    # Old "later media pass (#456)" deferral is gone — slots are wired.
+    assert "later media pass" not in text
+
+
+def test_recording_checklist_is_exact_and_honest():
+    text = RECORDING.read_text(encoding="utf-8")
+    for stem in STEMS:
+        assert stem in text
+    assert "OpenMousBot" in text
+    assert not re.search(r"label[^\n]*\bOMB\b", text, re.I)
+    assert "localhost:8000" in text or ":8000" in text
+    assert "seed_demo_agents.py" in text
+    assert "No secrets" in text or "no secrets" in text.lower()
+    assert "192.168" in text  # named as forbidden, not as a live example host
+    assert "docker compose" in text.lower()
+    assert "1280" in text and "800" in text
+    assert "handoff" in text.lower()
+    assert "agent-as-tool" in text.lower()
+    assert "#529" in text
+    assert "Do not" in text or "do not" in text
+    # Filming :8001 is explicitly out.
+    assert ":8001" in text
+    assert "Neon" in text
+
+
+def test_media_and_docs_have_no_secrets_or_lan():
+    """Posters + README must not contain live secrets or LAN. Checklist may name bans."""
+    allow_ban_mentions = {RECORDING, ASSETS / "FOLLOWUP_ISSUE.md"}
+    for path in [README, REGISTRY, *ASSETS.glob("*")]:
+        if not path.is_file():
+            continue
+        blob = path.read_text(encoding="utf-8")
+        lowered = blob.lower()
+        for needle in FORBIDDEN:
+            if needle not in blob and needle not in lowered:
+                continue
+            if path in allow_ban_mentions:
+                continue
+            if needle == "sk-" and "${VAR}" in blob:
+                continue
+            raise AssertionError(f"{path.relative_to(repo_root())} contains {needle!r}")
+
+
+def test_svg_posters_label_kinds_and_openmousbot():
+    cli = (ASSETS / "cli-agents.svg").read_text(encoding="utf-8")
+    api = (ASSETS / "api-agents.svg").read_text(encoding="utf-8")
+    remote = (ASSETS / "remote-agents.svg").read_text(encoding="utf-8")
+    team = (ASSETS / "combined-team.svg").read_text(encoding="utf-8")
+    assert "Grok CLI" in cli and "OpenCode" in cli
+    assert "LiteLLM API" in api
+    assert "OpenMousBot" in remote
+    assert "OMB" not in remote
+    assert "OpenMousBot" in team
+    assert "handoff" in team
+    assert "Demo Bridge" in team
+    for text in (cli, api, remote, team):
+        assert "10.0.0." not in text
+        assert "192.168." not in text
+        assert "sk-" not in text.lower()
+
+
+def test_screenshot_registry_lists_four_stems():
+    text = REGISTRY.read_text(encoding="utf-8")
+    assert "REQ-97" in text or "#456" in text
+    for stem in STEMS:
+        assert f"assets/readme/{stem}.svg" in text
+    assert "OpenMousBot" in text
+    assert "poster" in text.lower()
+
+
+def test_followup_issue_draft_documents_gh_readonly_deviation():
+    draft = ASSETS / "FOLLOWUP_ISSUE.md"
+    text = draft.read_text(encoding="utf-8")
+    assert draft.is_file()
+    assert "gh" in text.lower() and "read-only" in text.lower()
+    assert "#456" in text
+    assert "OpenMousBot" in text
+    for stem in STEMS:
+        assert stem in text

--- a/tests/unit/test_req97_readme_demos.py
+++ b/tests/unit/test_req97_readme_demos.py
@@ -32,8 +32,15 @@ def _readme() -> str:
     return README.read_text(encoding="utf-8")
 
 
+_TEXT_SKIP_SUFFIXES = {".gif", ".png", ".jpg", ".jpeg", ".webp", ".mp4", ".webm"}
+
+
 def _asset_blob() -> str:
-    parts = [p.read_text(encoding="utf-8") for p in sorted(ASSETS.glob("*")) if p.is_file()]
+    parts = [
+        p.read_text(encoding="utf-8")
+        for p in sorted(ASSETS.glob("*"))
+        if p.is_file() and p.suffix.lower() not in _TEXT_SKIP_SUFFIXES
+    ]
     return "\n".join(parts)
 
 
@@ -115,6 +122,8 @@ def test_media_and_docs_have_no_secrets_or_lan():
     allow_ban_mentions = {RECORDING, ASSETS / "FOLLOWUP_ISSUE.md"}
     for path in [README, REGISTRY, *ASSETS.glob("*")]:
         if not path.is_file():
+            continue
+        if path.suffix.lower() in _TEXT_SKIP_SUFFIXES:
             continue
         blob = path.read_text(encoding="utf-8")
         lowered = blob.lower()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Near-release README should show the differentiator without a wall of text: **CLI**, **API**, **remote**, then a **combined team**.

This VM cannot film `:8001` (and must not use Firefox against that box or Neon). So this PR ships **poster SVGs + an exact recording checklist**, wires the README to those paths, and leaves a ready-to-file follow-up Issue body for live GIFs.

## Success

1. README `# Demos` (after the pitch, before how-to-run) has four compact slots:
   - CLI agents (Grok / OpenCode / agy)
   - API agents (OpenAI-compat / owned thread)
   - Remote agents labeled **OpenMousBot** (never OMB)
   - Combined team (CLI + API + remote, handoff / agent-as-tool)
2. Assets live under `docs/assets/readme/`. Posters are stylized Grok chrome — no secrets, no house stills, no live LAN IPs.
3. `docs/assets/readme/RECORDING.md` is the capture script (clean `:8000` Compose, Demo Mode A names, `seed_demo_agents.py`).
4. Path-contract tests: `tests/unit/test_req97_readme_demos.py`. Own-diff CI: `.github/workflows/req97-readme-demos.yml`.
5. Historical `docs/demo/cli-and-api.gif` stays, demoted (not the Grok chrome story).

Fixes #456.

## Verification

`uv run pytest tests/unit/test_req97_readme_demos.py tests/unit/test_req102_readme_rewrite.py` — **14 passed**.

[Four README demo poster slots](https://cursor.com/agents/bc-b7861e61-5b4d-4c95-ab40-5e375c58ea1b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freadme_four_demo_slots.png)

## Deviation (live pixels + follow-up Issue)

- **No live GIF/mp4** — filming `:8001` / FF is out of scope for this agent. Posters + checklist stand in.
- **Follow-up Issue not filed from this agent** — `gh` is read-only. Paste [docs/assets/readme/FOLLOWUP_ISSUE.md](docs/assets/readme/FOLLOWUP_ISSUE.md) as a new Issue after merge. Distinct from the #529 announce hero clip.

## Out of scope

- Recapturing journey PNGs / golden-journey
- #529 15–30s launch montage
- Neon, Firefox `:8001`, private chats, Pinokio Discover listing


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7861e61-5b4d-4c95-ab40-5e375c58ea1b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7861e61-5b4d-4c95-ab40-5e375c58ea1b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

